### PR TITLE
Change type of ZSTD_freeCStream to void

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2806,14 +2806,13 @@ ZSTD_CStream* ZSTD_createCStream_advanced(ZSTD_customMem customMem)
     return zcs;
 }
 
-size_t ZSTD_freeCStream(ZSTD_CStream* zcs)
+void ZSTD_freeCStream(ZSTD_CStream* zcs)
 {
-    if (zcs==NULL) return 0;   /* support free on NULL */
+    if (zcs==NULL) return;   /* support free on NULL */
     ZSTD_freeCCtx(zcs->zc);
     if (zcs->inBuff) zcs->customMem.customFree(zcs->customMem.opaque, zcs->inBuff);
     if (zcs->outBuff) zcs->customMem.customFree(zcs->customMem.opaque, zcs->outBuff);
     zcs->customMem.customFree(zcs->customMem.opaque, zcs);
-    return 0;
 }
 
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -375,7 +375,7 @@ typedef struct ZSTD_outBuffer_s {
 
 typedef struct ZSTD_CStream_s ZSTD_CStream;
 ZSTD_CStream* ZSTD_createCStream(void);
-size_t ZSTD_freeCStream(ZSTD_CStream* zcs);
+void ZSTD_freeCStream(ZSTD_CStream* zcs);
 
 size_t ZSTD_CStreamInSize(void);    /**< recommended size for input buffer */
 size_t ZSTD_CStreamOutSize(void);   /**< recommended size for output buffer */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -295,8 +295,7 @@ static void FIO_freeCResources(cRess_t ress)
     free(ress.srcBuffer);
     free(ress.dstBuffer);
     free(ress.dictBuffer);
-    errorCode = ZSTD_freeCStream(ress.cctx);
-    if (ZSTD_isError(errorCode)) EXM_THROW(38, "zstd: error : can't release ZSTD_CStream : %s", ZSTD_getErrorName(errorCode));
+    ZSTD_freeCStream(ress.cctx);
 }
 
 


### PR DESCRIPTION
There is no way this function can fail, so having its return type
suggest that it can is misleading. On top of which almost no uses
of it in the code base actually checked its result anyway :-)