### PR TITLE
[pzstd] Fix memory usage issues

### DIFF
--- a/contrib/pzstd/Makefile
+++ b/contrib/pzstd/Makefile
@@ -63,7 +63,9 @@ googletest:
 	@cd googletest/build && cmake .. && make
 
 test: libzstd.a Pzstd.o Options.o SkippableFrame.o
+	$(MAKE) -C utils/test clean
 	$(MAKE) -C utils/test test
+	$(MAKE) -C test clean
 	$(MAKE) -C test test
 
 clean:

--- a/contrib/pzstd/utils/WorkQueue.h
+++ b/contrib/pzstd/utils/WorkQueue.h
@@ -100,6 +100,19 @@ class WorkQueue {
   }
 
   /**
+   * Sets the maximum queue size.  If `maxSize == 0` then it is unbounded.
+   *
+   * @param maxSize The new maximum queue size.
+   */
+  void setMaxSize(std::size_t maxSize) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      maxSize_ = maxSize;
+    }
+    writerCv_.notify_all();
+  }
+
+  /**
    * Promise that `push()` won't be called again, so once the queue is empty
    * there will never any more work.
    */
@@ -147,6 +160,10 @@ class BufferWorkQueue {
       size_.fetch_sub(buffer.size());
     }
     return result;
+  }
+
+  void setMaxSize(std::size_t maxSize) {
+    queue_.setMaxSize(maxSize);
   }
 
   void finish() {

--- a/contrib/pzstd/utils/test/WorkQueueTest.cpp
+++ b/contrib/pzstd/utils/test/WorkQueueTest.cpp
@@ -175,6 +175,27 @@ TEST(WorkQueue, BoundedSizePushAfterFinish) {
   pusher.join();
 }
 
+TEST(WorkQueue, SetMaxSize) {
+  WorkQueue<int> queue(2);
+  int result;
+  queue.push(5);
+  queue.push(6);
+  queue.setMaxSize(1);
+  std::thread pusher([&queue] {
+    queue.push(7);
+  });
+  // Dirtily try and make sure that pusher has run.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  queue.finish();
+  EXPECT_TRUE(queue.pop(result));
+  EXPECT_EQ(5, result);
+  EXPECT_TRUE(queue.pop(result));
+  EXPECT_EQ(6, result);
+  EXPECT_FALSE(queue.pop(result));
+
+  pusher.join();
+}
+
 TEST(WorkQueue, BoundedSizeMPMC) {
   WorkQueue<int> queue(100);
   std::vector<int> results(10000, -1);


### PR DESCRIPTION
The memory usage was linear in the size of the file.  It is now linear in the number of threads and the compression level.

To achieve this, I limited how far ahed the reading/(de)compression threads can get from the writer thread.

This is an initial fix for issue #331, the memory usage can likely still be reduced without reducing performance.  However this gets pzstd 90% of the way there, and even increases performance.