### PR TITLE
Add Erlang binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@ here is a list of known bindings and their authors :
 | __OCaml__    | ygrek               | https://opam.ocaml.org/packages/zstd/ |
 | __Delphi__   | Razor12911          | http://encode.ru/threads/2119-Zstandard?p=49075&viewfull=1#post49075
 | __Perl__     | Jiro Nishiguchi     | https://metacpan.org/release/Compress-Zstd |
+| __Erlang__   | Yuki Ito            | https://hex.pm/packages/zstd          |
 
 [than reference C]:https://github.com/facebook/zstd
 


### PR DESCRIPTION
I've released the Erlang binding. Could you add it to the list?

https://hex.pm/packages/zstd