### PR TITLE
Specify that dictionary ID is little-endian

### DIFF
--- a/zstd_compression_format.md
+++ b/zstd_compression_format.md
@@ -301,6 +301,7 @@ This is a variable size field, which contains
 the ID of the dictionary required to properly decode the frame.
 Note that this field is optional. When it's not present,
 it's up to the caller to make sure it uses the correct dictionary.
+Format is little-endian.
 
 Field size depends on `Dictionary_ID_flag`.
 1 byte can represent an ID 0-255.


### PR DESCRIPTION
I noticed that the wiki and `zstd_compression_format.md` are out of sync.  Is there a clean way to have the wiki track this file, or should we just have that part of the wiki link to this file?