### PR TITLE
Add nodejs native module binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@ here is a list of known bindings and their authors :
 | __Python__   | Sergey Dryabzhinsky | https://pypi.python.org/pypi/zstd     |
 | __PHP__      | Kamijo              | https://github.com/kjdev/php-ext-zstd |
 | __Node.js__  | albertdb            | https://www.npmjs.com/package/node-zstandard
+| __Node.js__  | Zwb                 | https://www.npmjs.com/package/node-zstd
 | __Ruby__     | Jarred Holman       | https://github.com/jarredholman/ruby-zstd
 | __Ada__      | John Marino         | https://github.com/jrmarino/zstd-ada  |
 | __Go__       | Vianney Tran        | https://github.com/DataDog/zstd       |


### PR DESCRIPTION
This package is different from **node-zstandard**. 
It's nodejs native module binding ZSTD's API.