### PR TITLE
Add alternate Python bindings

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,7 @@ here is a list of known bindings and their authors :
 | __Java__     | Luben Karavelov     | https://github.com/luben/zstd-jni     |
 | __Rust__     | Alexandre Bury      | https://crates.io/crates/zstd         |
 | __C#__       | SKB Kontur          | https://github.com/skbkontur/ZstdNet  |
+| __Python__   | Gregory Szorc       | https://pypi.python.org/pypi/zstandard
 | __Python__   | Sergey Dryabzhinsky | https://pypi.python.org/pypi/zstd     |
 | __PHP__      | Kamijo              | https://github.com/kjdev/php-ext-zstd |
 | __Node.js__  | albertdb            | https://www.npmjs.com/package/node-zstandard


### PR DESCRIPTION
When zstd 1.0 was released, I got very excited.

When I looked at the existing Python bindings, I was less excited. The existing Python bindings only support the simple compression API. They don't support streaming nor do they support dictionary compression: two features that are important to me.

In addition, the existing bindings have their own framing (they add a 32 bit length field at the beginning of output), making them incompatible with the zstd 1.0 framing protocol and other zstd implementations.

Long story short, I decided that it would be easier to create my own Python bindings than attempt to bring the existing bindings into a state I was happy with. So I did.

I feel my bindings are at least as good as the existing Python bindings and am requesting they be listed on the official project page. I'm requesting they be listed before the existing bindings because they have more features and conform to the zstd 1.0 framing protocol.