### PR TITLE
Update .gitignore for new location of msbuild projects

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,7 +1,7 @@
 *Copy
 
 # Visual C++
-build/
+bin/
 VS2005/
 VS2008/
 VS2010/


### PR DESCRIPTION
It seems that when the projects folder was moved to the new path in cfe5fe45819804b6ef148dc8524fcec1fcd1fc43, the `build/bin` was changed to `build/` instead of `bin/` and building makes a lot of stuff show up in git.