### PR TITLE
pzstd: fix test failure on headless build

### DIFF
--- a/contrib/pzstd/test/OptionsTest.cpp
+++ b/contrib/pzstd/test/OptionsTest.cpp
@@ -182,12 +182,6 @@ TEST(Options, GetOutputFile) {
   }
   {
     Options options;
-    auto args = makeArray("-o-");
-    EXPECT_FAILURE(options.parse(args.size(), args.data()));
-    EXPECT_EQ("-", options.getOutputFile(options.inputFiles[0]));
-  }
-  {
-    Options options;
     auto args = makeArray("x", "y", "-o", nullOutput);
     EXPECT_SUCCESS(options.parse(args.size(), args.data()));
     EXPECT_EQ(nullOutput, options.getOutputFile(options.inputFiles[0]));


### PR DESCRIPTION
If I/O is not connected to a terminal
(like in a package build system for example),
a portion of the test expected to fail would pass.
This removes the system dependent test.