### PR TITLE
Dictionary Builder: offcodeMax is too small for 3 dictionary sizes

### DIFF
--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -681,6 +681,9 @@ static size_t ZDICT_analyzeEntropy(void*  dstBuffer, size_t maxDstSize,
         DISPLAYLEVEL(1, "Not enough memory \n");
         goto _cleanup;
     }
+    if (dictBufferSize + 128 KB > ((size_t)1 << (offcodeMax + 1)) - 4) {
+        ++offcodeMax;
+    }
     if (offcodeMax>OFFCODE_MAX) { eSize = ERROR(dictionary_wrong); goto _cleanup; }   /* too large dictionary */
     for (u=0; u<256; u++) countLit[u]=1;   /* any character must be described */
     for (u=0; u<=offcodeMax; u++) offcodeCount[u]=1;


### PR DESCRIPTION
If `2^N - 4 < dictContentSize + 128 KB < 2^N` then the dictionaries
`offcodeMax` will be too small to represent a offset from the end
of the first block back to the beginning of the dictionary content.
Not that this offset is useful, since the offset is more bits than
the match could possibly be.