### PR TITLE
ZSTD_execSequence() accepts match in last 7 bytes

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -31,6 +31,16 @@
 #  endif /* __STDC_VERSION__ */
 #endif
 
+#ifdef _MSC_VER
+#  define FORCE_NOINLINE static __declspec(noinline)
+#else
+#  ifdef __GNUC__
+#    define FORCE_NOINLINE static __attribute__((__noinline__))
+#  else
+#    define FORCE_NOINLINE static
+#  endif
+#endif
+
 
 /*-*************************************
 *  Dependencies

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -840,6 +840,53 @@ static seq_t ZSTD_decodeSequence(seqState_t* seqState)
 }
 
 
+FORCE_NOINLINE
+size_t ZSTD_execSequenceLast7(BYTE* op,
+                              BYTE* const oend, seq_t sequence,
+                              const BYTE** litPtr, const BYTE* const litLimit_w,
+                              const BYTE* const base, const BYTE* const vBase, const BYTE* const dictEnd)
+{
+    BYTE* const oLitEnd = op + sequence.litLength;
+    size_t const sequenceLength = sequence.litLength + sequence.matchLength;
+    BYTE* const oMatchEnd = op + sequenceLength;   /* risk : address space overflow (32-bits) */
+    BYTE* const oend_w = oend - WILDCOPY_OVERLENGTH;
+    const BYTE* const iLitEnd = *litPtr + sequence.litLength;
+    const BYTE* match = oLitEnd - sequence.offset;
+
+    /* check */
+    if (oMatchEnd>oend) return ERROR(dstSize_tooSmall); /* last match must start at a minimum distance of WILDCOPY_OVERLENGTH from oend */
+    if (iLitEnd > litLimit_w) return ERROR(corruption_detected);   /* over-read beyond lit buffer */
+    if (oLitEnd <= oend_w) return ERROR(GENERIC);   /* Precondition */
+
+    /* copy literals */
+    if (op < oend_w) {
+        ZSTD_wildcopy(op, *litPtr, oend_w - op);
+        *litPtr += oend_w - op;
+        op = oend_w;
+    }
+    while (op < oLitEnd) *op++ = *(*litPtr)++;
+
+    /* copy Match */
+    if (sequence.offset > (size_t)(oLitEnd - base)) {
+        /* offset beyond prefix */
+        if (sequence.offset > (size_t)(oLitEnd - vBase)) return ERROR(corruption_detected);
+        match = dictEnd - (base-match);
+        if (match + sequence.matchLength <= dictEnd) {
+            memmove(oLitEnd, match, sequence.matchLength);
+            return sequenceLength;
+        }
+        /* span extDict & currentPrefixSegment */
+        {   size_t const length1 = dictEnd - match;
+            memmove(oLitEnd, match, length1);
+            op = oLitEnd + length1;
+            sequence.matchLength -= length1;
+            match = base;
+    }   }
+    while (op < oMatchEnd) *op++ = *match++;
+    return sequenceLength;
+}
+
+
 FORCE_INLINE
 size_t ZSTD_execSequence(BYTE* op,
                                 BYTE* const oend, seq_t sequence,
@@ -854,8 +901,9 @@ size_t ZSTD_execSequence(BYTE* op,
     const BYTE* match = oLitEnd - sequence.offset;
 
     /* check */
-    if ((oLitEnd>oend_w) | (oMatchEnd>oend)) return ERROR(dstSize_tooSmall); /* last match must start at a minimum distance of WILDCOPY_OVERLENGTH from oend */
+    if (oMatchEnd>oend) return ERROR(dstSize_tooSmall); /* last match must start at a minimum distance of WILDCOPY_OVERLENGTH from oend */
     if (iLitEnd > litLimit_w) return ERROR(corruption_detected);   /* over-read beyond lit buffer */
+    if (oLitEnd>oend_w) return ZSTD_execSequenceLast7(op, oend, sequence, litPtr, litLimit_w, base, vBase, dictEnd);
 
     /* copy Literals */
     ZSTD_copy8(op, *litPtr);


### PR DESCRIPTION
The zstd reference compressor will not emit a match in the last 7bytes of a block.  The decompressor will also not accept a match in the last 7 bytes.  This patch makes the decompressor accept a match in the last 7 bytes.

Something strange happens if you leave the check on line 904 as `(oLitEnd>oend_w) | (oMatchEnd>oend)`, which makes line 906 dead code.  Compiling with gcc, the decompressor runs more than 1% faster across the board.  It must be triggering some optimization pass that isn't triggered otherwise.

Benchmarks show that it slows decompression down slightly for levels 1-3 and 17-19, but speeds it up on the rest.  I'm not really sure why it would speed up though...

gcc

    > ./zstd.base -b1 -e19 -i10 && ./zstd -b1 -e19 -i10
     1#Synthetic 50%     :  10000000 ->   3141927 (3.183), 392.8 MB/s ,1541.1 MB/s
     2#Synthetic 50%     :  10000000 ->   3117895 (3.207), 278.3 MB/s ,1488.3 MB/s
     3#Synthetic 50%     :  10000000 ->   3225549 (3.100), 172.7 MB/s ,1147.2 MB/s
     4#Synthetic 50%     :  10000000 ->   3315485 (3.016), 141.0 MB/s , 960.0 MB/s
     5#Synthetic 50%     :  10000000 ->   3266969 (3.061),  97.3 MB/s , 954.4 MB/s
     6#Synthetic 50%     :  10000000 ->   3310330 (3.021),  78.8 MB/s , 861.0 MB/s
     7#Synthetic 50%     :  10000000 ->   3321301 (3.011),  72.0 MB/s , 819.5 MB/s
     8#Synthetic 50%     :  10000000 ->   3312641 (3.019),  59.0 MB/s , 819.7 MB/s
     9#Synthetic 50%     :  10000000 ->   3315475 (3.016),  37.9 MB/s , 798.1 MB/s
    10#Synthetic 50%     :  10000000 ->   3315231 (3.016),  44.0 MB/s , 799.7 MB/s
    11#Synthetic 50%     :  10000000 ->   3347098 (2.988),  27.8 MB/s , 721.8 MB/s
    12#Synthetic 50%     :  10000000 ->   3347040 (2.988),  27.7 MB/s , 722.0 MB/s
    13#Synthetic 50%     :  10000000 ->   3347015 (2.988),  19.5 MB/s , 715.5 MB/s
    14#Synthetic 50%     :  10000000 ->   3346973 (2.988),  19.6 MB/s , 715.3 MB/s
    15#Synthetic 50%     :  10000000 ->   3346280 (2.988),  12.6 MB/s , 728.7 MB/s
    16#Synthetic 50%     :  10000000 ->   3363862 (2.973),  10.0 MB/s , 685.4 MB/s
    17#Synthetic 50%     :  10000000 ->   3059184 (3.269),   8.7 MB/s ,1482.4 MB/s
    18#Synthetic 50%     :  10000000 ->   3060154 (3.268),   6.6 MB/s ,1478.4 MB/s
    19#Synthetic 50%     :  10000000 ->   3108159 (3.217),   3.8 MB/s ,1282.5 MB/s

    > ./zstd -b1 -e19 -i10
     1#Synthetic 50%     :  10000000 ->   3141927 (3.183), 392.0 MB/s ,1536.3 MB/s
     2#Synthetic 50%     :  10000000 ->   3117895 (3.207), 277.3 MB/s ,1482.1 MB/s
     3#Synthetic 50%     :  10000000 ->   3225549 (3.100), 172.5 MB/s ,1143.1 MB/s
     4#Synthetic 50%     :  10000000 ->   3315485 (3.016), 140.7 MB/s , 961.2 MB/s
     5#Synthetic 50%     :  10000000 ->   3266969 (3.061),  97.2 MB/s , 956.9 MB/s
     6#Synthetic 50%     :  10000000 ->   3310330 (3.021),  78.8 MB/s , 865.7 MB/s
     7#Synthetic 50%     :  10000000 ->   3321301 (3.011),  72.1 MB/s , 825.6 MB/s
     8#Synthetic 50%     :  10000000 ->   3312641 (3.019),  58.5 MB/s , 825.7 MB/s
     9#Synthetic 50%     :  10000000 ->   3315475 (3.016),  37.6 MB/s , 804.8 MB/s
    10#Synthetic 50%     :  10000000 ->   3315231 (3.016),  43.8 MB/s , 806.2 MB/s
    11#Synthetic 50%     :  10000000 ->   3347098 (2.988),  27.7 MB/s , 729.4 MB/s
    12#Synthetic 50%     :  10000000 ->   3347040 (2.988),  27.2 MB/s , 729.4 MB/s
    13#Synthetic 50%     :  10000000 ->   3347015 (2.988),  19.6 MB/s , 723.0 MB/s
    14#Synthetic 50%     :  10000000 ->   3346973 (2.988),  19.5 MB/s , 722.8 MB/s
    15#Synthetic 50%     :  10000000 ->   3346280 (2.988),  12.6 MB/s , 735.7 MB/s
    16#Synthetic 50%     :  10000000 ->   3363862 (2.973),  10.0 MB/s , 694.9 MB/s
    17#Synthetic 50%     :  10000000 ->   3059184 (3.269),   8.8 MB/s ,1474.3 MB/s
    18#Synthetic 50%     :  10000000 ->   3060154 (3.268),   6.6 MB/s ,1471.9 MB/s
    19#Synthetic 50%     :  10000000 ->   3108159 (3.217),   3.8 MB/s ,1276.2 MB/s

    > ./zstd.base -b1 -e19 -i10 ../silesia.tar
     1#silesia.tar       : 211988480 ->  73656930 (2.878), 320.5 MB/s , 930.3 MB/s
     2#silesia.tar       : 211988480 ->  70162842 (3.021), 252.4 MB/s , 848.7 MB/s
     3#silesia.tar       : 211988480 ->  66997986 (3.164), 196.4 MB/s , 815.0 MB/s
     4#silesia.tar       : 211988480 ->  66002591 (3.212), 177.5 MB/s , 793.9 MB/s
     5#silesia.tar       : 211988480 ->  65008480 (3.261), 120.6 MB/s , 785.3 MB/s
     6#silesia.tar       : 211988480 ->  62979643 (3.366),  91.6 MB/s , 813.4 MB/s
     7#silesia.tar       : 211988480 ->  61974560 (3.421),  75.0 MB/s , 826.3 MB/s
     8#silesia.tar       : 211988480 ->  61028308 (3.474),  58.1 MB/s , 854.4 MB/s
     9#silesia.tar       : 211988480 ->  60416751 (3.509),  46.2 MB/s , 856.2 MB/s
    10#silesia.tar       : 211988480 ->  60174239 (3.523),  38.8 MB/s , 865.6 MB/s
    11#silesia.tar       : 211988480 ->  59532145 (3.561),  30.6 MB/s , 856.3 MB/s
    12#silesia.tar       : 211988480 ->  59129037 (3.585),  23.0 MB/s , 864.9 MB/s
    13#silesia.tar       : 211988480 ->  58804892 (3.605),  18.7 MB/s , 866.2 MB/s
    14#silesia.tar       : 211988480 ->  58447987 (3.627),  13.1 MB/s , 873.6 MB/s
    15#silesia.tar       : 211988480 ->  58015895 (3.654),   9.2 MB/s , 891.5 MB/s
    16#silesia.tar       : 211988480 ->  57270333 (3.702),   7.5 MB/s , 883.7 MB/s
    17#silesia.tar       : 211988480 ->  56647318 (3.742),   6.7 MB/s , 860.6 MB/s
    18#silesia.tar       : 211988480 ->  55170121 (3.842),   4.7 MB/s , 859.4 MB/s
    19#silesia.tar       : 211988480 ->  53917809 (3.932),   3.9 MB/s , 837.4 MB/s

    > ./zstd -b1 -e19 -i10 ../silesia.tar
     1#silesia.tar       : 211988480 ->  73656930 (2.878), 330.1 MB/s , 926.1 MB/s
     2#silesia.tar       : 211988480 ->  70162842 (3.021), 260.9 MB/s , 846.6 MB/s
     3#silesia.tar       : 211988480 ->  66997986 (3.164), 200.8 MB/s , 816.4 MB/s
     4#silesia.tar       : 211988480 ->  66002591 (3.212), 180.8 MB/s , 797.1 MB/s
     5#silesia.tar       : 211988480 ->  65008480 (3.261), 124.1 MB/s , 786.2 MB/s
     6#silesia.tar       : 211988480 ->  62979643 (3.366),  92.4 MB/s , 816.4 MB/s
     7#silesia.tar       : 211988480 ->  61974560 (3.421),  75.7 MB/s , 830.5 MB/s
     8#silesia.tar       : 211988480 ->  61028308 (3.474),  58.6 MB/s , 858.0 MB/s
     9#silesia.tar       : 211988480 ->  60416751 (3.509),  46.7 MB/s , 861.2 MB/s
    10#silesia.tar       : 211988480 ->  60174239 (3.523),  38.9 MB/s , 871.1 MB/s
    11#silesia.tar       : 211988480 ->  59532145 (3.561),  30.8 MB/s , 863.1 MB/s
    12#silesia.tar       : 211988480 ->  59129037 (3.585),  23.3 MB/s , 872.2 MB/s
    13#silesia.tar       : 211988480 ->  58804892 (3.605),  18.7 MB/s , 874.2 MB/s
    14#silesia.tar       : 211988480 ->  58447987 (3.627),  13.2 MB/s , 881.9 MB/s
    15#silesia.tar       : 211988480 ->  58015895 (3.654),   9.3 MB/s , 899.6 MB/s
    16#silesia.tar       : 211988480 ->  57270333 (3.702),   7.5 MB/s , 889.8 MB/s
    17#silesia.tar       : 211988480 ->  56647318 (3.742),   6.7 MB/s , 864.5 MB/s
    18#silesia.tar       : 211988480 ->  55170121 (3.842),   4.7 MB/s , 863.8 MB/s
    19#silesia.tar       : 211988480 ->  53917809 (3.932),   3.9 MB/s , 835.1 MB/s

clang

    > ./zstd.base -b1 -e10 -i10
     1#Synthetic 50%     :  10000000 ->   3141927 (3.183), 407.0 MB/s ,1033.0 MB/s
     2#Synthetic 50%     :  10000000 ->   3117895 (3.207), 298.4 MB/s ,1012.9 MB/s
     3#Synthetic 50%     :  10000000 ->   3225549 (3.100), 175.7 MB/s , 844.0 MB/s
     4#Synthetic 50%     :  10000000 ->   3315485 (3.016), 142.9 MB/s , 755.3 MB/s
     5#Synthetic 50%     :  10000000 ->   3266969 (3.061),  99.9 MB/s , 756.4 MB/s
     6#Synthetic 50%     :  10000000 ->   3310330 (3.021),  80.3 MB/s , 707.9 MB/s
     7#Synthetic 50%     :  10000000 ->   3321301 (3.011),  72.1 MB/s , 685.3 MB/s
     8#Synthetic 50%     :  10000000 ->   3312641 (3.019),  58.1 MB/s , 685.7 MB/s
     9#Synthetic 50%     :  10000000 ->   3315475 (3.016),  37.6 MB/s , 673.3 MB/s
    10#Synthetic 50%     :  10000000 ->   3315231 (3.016),  43.0 MB/s , 674.0 MB/s
    11#Synthetic 50%     :  10000000 ->   3347098 (2.988),  27.2 MB/s , 624.0 MB/s
    12#Synthetic 50%     :  10000000 ->   3347040 (2.988),  27.0 MB/s , 624.4 MB/s
    13#Synthetic 50%     :  10000000 ->   3347015 (2.988),  19.2 MB/s , 620.6 MB/s
    14#Synthetic 50%     :  10000000 ->   3346973 (2.988),  19.1 MB/s , 620.6 MB/s
    15#Synthetic 50%     :  10000000 ->   3346280 (2.988),  14.5 MB/s , 628.5 MB/s
    16#Synthetic 50%     :  10000000 ->   3363862 (2.973),  11.3 MB/s , 600.5 MB/s
    17#Synthetic 50%     :  10000000 ->   3059184 (3.269),   9.9 MB/s ,1013.3 MB/s
    18#Synthetic 50%     :  10000000 ->   3060154 (3.268),   7.2 MB/s ,1011.8 MB/s
    19#Synthetic 50%     :  10000000 ->   3108159 (3.217),   4.0 MB/s , 917.3 MB/s
    > ./zstd -b1 -e10 -i10
     1#Synthetic 50%     :  10000000 ->   3141927 (3.183), 408.1 MB/s ,1029.3 MB/s
     2#Synthetic 50%     :  10000000 ->   3117895 (3.207), 297.5 MB/s ,1009.2 MB/s
     3#Synthetic 50%     :  10000000 ->   3225549 (3.100), 175.4 MB/s , 843.1 MB/s
     4#Synthetic 50%     :  10000000 ->   3315485 (3.016), 142.8 MB/s , 751.9 MB/s
     5#Synthetic 50%     :  10000000 ->   3266969 (3.061),  99.3 MB/s , 755.4 MB/s
     6#Synthetic 50%     :  10000000 ->   3310330 (3.021),  79.9 MB/s , 706.4 MB/s
     7#Synthetic 50%     :  10000000 ->   3321301 (3.011),  71.8 MB/s , 684.7 MB/s
     8#Synthetic 50%     :  10000000 ->   3312641 (3.019),  57.6 MB/s , 685.3 MB/s
     9#Synthetic 50%     :  10000000 ->   3315475 (3.016),  37.3 MB/s , 673.7 MB/s
    10#Synthetic 50%     :  10000000 ->   3315231 (3.016),  43.0 MB/s , 674.9 MB/s
    11#Synthetic 50%     :  10000000 ->   3347098 (2.988),  27.0 MB/s , 627.5 MB/s
    12#Synthetic 50%     :  10000000 ->   3347040 (2.988),  26.9 MB/s , 627.9 MB/s
    13#Synthetic 50%     :  10000000 ->   3347015 (2.988),  19.2 MB/s , 624.1 MB/s
    14#Synthetic 50%     :  10000000 ->   3346973 (2.988),  19.2 MB/s , 624.2 MB/s
    15#Synthetic 50%     :  10000000 ->   3346280 (2.988),  14.5 MB/s , 632.0 MB/s
    16#Synthetic 50%     :  10000000 ->   3363862 (2.973),  11.3 MB/s , 604.4 MB/s
    17#Synthetic 50%     :  10000000 ->   3059184 (3.269),   9.8 MB/s ,1010.1 MB/s
    18#Synthetic 50%     :  10000000 ->   3060154 (3.268),   7.2 MB/s ,1008.2 MB/s
    19#Synthetic 50%     :  10000000 ->   3108159 (3.217),   4.0 MB/s , 913.5 MB/s