### PR TITLE
libzstd.pc.in: Change to use variables for libdir and includedir

### DIFF
--- a/lib/libzstd.pc.in
+++ b/lib/libzstd.pc.in
@@ -10,5 +10,5 @@ Name: zstd
 Description: lossless compression algorithm library
 URL: https://github.com/facebook/zstd
 Version: @VERSION@
-Libs: -L@LIBDIR@ -lzstd
-Cflags: -I@INCLUDEDIR@
+Libs: -L${libdir} -lzstd
+Cflags: -I${includedir}


### PR DESCRIPTION
It is safe to use such variables for future maintainance.