### PR TITLE
Fix compression segfault

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2277,7 +2277,7 @@ static size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
         if (cctx->lowLimit > (1<<30)) {
             U32 const btplus = (cctx->params.cParams.strategy == ZSTD_btlazy2) | (cctx->params.cParams.strategy == ZSTD_btopt) | (cctx->params.cParams.strategy == ZSTD_btopt2);
             U32 const chainMask = (1 << (cctx->params.cParams.chainLog - btplus)) - 1;
-            U32 const supLog = MAX(MAX(cctx->params.cParams.chainLog, 17 /* blockSize */), cctx->params.cParams.windowLog);
+            U32 const supLog = MAX(cctx->params.cParams.windowLog, 17 /* blockSize */);
             U32 const newLowLimit = (cctx->lowLimit & chainMask) + (1 << supLog);   /* preserve position % chainSize, ensure current-repcode doesn't underflow */
             U32 const correction = cctx->lowLimit - newLowLimit;
             ZSTD_reduceIndex(cctx, correction);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2277,7 +2277,7 @@ static size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
         if (cctx->lowLimit > (1<<30)) {
             U32 const btplus = (cctx->params.cParams.strategy == ZSTD_btlazy2) | (cctx->params.cParams.strategy == ZSTD_btopt) | (cctx->params.cParams.strategy == ZSTD_btopt2);
             U32 const chainMask = (1 << (cctx->params.cParams.chainLog - btplus)) - 1;
-            U32 const supLog = MAX(cctx->params.cParams.chainLog, 17 /* blockSize */);
+            U32 const supLog = MAX(MAX(cctx->params.cParams.chainLog, 17 /* blockSize */), cctx->params.cParams.windowLog);
             U32 const newLowLimit = (cctx->lowLimit & chainMask) + (1 << supLog);   /* preserve position % chainSize, ensure current-repcode doesn't underflow */
             U32 const correction = cctx->lowLimit - newLowLimit;
             ZSTD_reduceIndex(cctx, correction);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -11,6 +11,7 @@ datagen
 paramgrill
 paramgrill32
 roundTripCrash
+longmatch
 
 # Tmp test directory
 zstdtest

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -124,6 +124,9 @@ datagen : $(PRGDIR)/datagen.c datagencli.c
 roundTripCrash : $(ZSTD_FILES) roundTripCrash.c
 	$(CC)      $(FLAGS) $^ -o $@$(EXT)
 
+longmatch  : $(ZSTD_FILES) longmatch.c
+	$(CC)      $(FLAGS) $^ -o $@$(EXT)
+
 namespaceTest:
 	if $(CC) namespaceTest.c ../lib/common/xxhash.c -o $@ ; then echo compilation should fail; exit 1 ; fi
 	$(RM) $@
@@ -140,7 +143,7 @@ clean:
         fullbench-lib$(EXT) fullbench-dll$(EXT) \
         fuzzer$(EXT) fuzzer32$(EXT) zbufftest$(EXT) zbufftest32$(EXT) \
 		zstreamtest$(EXT) zstreamtest32$(EXT) \
-        datagen$(EXT) paramgrill$(EXT) roundTripCrash$(EXT)
+        datagen$(EXT) paramgrill$(EXT) roundTripCrash$(EXT) longmatch$(EXT)
 	@echo Cleaning completed
 
 
@@ -180,7 +183,7 @@ zstd-playTests: datagen
 	file $(ZSTD)
 	ZSTD="$(QEMU_SYS) $(ZSTD)" ./playTests.sh $(ZSTDRTTEST)
 
-test: test-zstd test-fullbench test-fuzzer test-zstream
+test: test-zstd test-fullbench test-fuzzer test-zstream test-longmatch
 
 test32: test-zstd32 test-fullbench32 test-fuzzer32 test-zstream32
 
@@ -236,5 +239,8 @@ test-zstream: zstreamtest
 
 test-zstream32: zstreamtest32
 	$(QEMU_SYS) ./zstreamtest32 $(ZSTREAM_TESTTIME)
+
+test-longmatch: longmatch
+	$(QEMU_SYS) ./longmatch
 
 endif

--- a/tests/longmatch.c
+++ b/tests/longmatch.c
@@ -1,8 +1,10 @@
 #define ZSTD_STATIC_LINKING_ONLY
-#include <zstd.h>
+#include "zstd.h"
+#include "mem.h"
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 void compress(ZSTD_CStream *ctx, ZSTD_outBuffer out, const void *data, size_t size) {
   ZSTD_inBuffer in = { data, size, 0 };
@@ -39,8 +41,8 @@ int main() {
   rc = ZSTD_initCStream_advanced(ctx, NULL, 0, params, 0);
   if (ZSTD_isError(rc)) { return 2; }
   {
-    uint64_t compressed = 0;
-    const uint64_t toCompress = ((uint64_t)1) << 33;
+    U64 compressed = 0;
+    const U64 toCompress = ((U64)1) << 33;
     const size_t size = 1 << windowLog;
     size_t pos = 0;
     char *srcBuffer = (char*) malloc(1 << windowLog);

--- a/tests/longmatch.c
+++ b/tests/longmatch.c
@@ -6,29 +6,35 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-void compress(ZSTD_CStream *ctx, ZSTD_outBuffer out, const void *data, size_t size) {
+int compress(ZSTD_CStream *ctx, ZSTD_outBuffer out, const void *data, size_t size) {
   ZSTD_inBuffer in = { data, size, 0 };
   while (in.pos < in.size) {
     ZSTD_outBuffer tmp = out;
     const size_t rc = ZSTD_compressStream(ctx, &tmp, &in);
     if (ZSTD_isError(rc)) {
-      exit(5);
+      return 1;
     }
   }
-  ZSTD_outBuffer tmp = out;
-  const size_t rc = ZSTD_flushStream(ctx, &tmp);
-  if (rc != 0) { exit(6); }
+  {
+    ZSTD_outBuffer tmp = out;
+    const size_t rc = ZSTD_flushStream(ctx, &tmp);
+    if (rc != 0) { return 1; }
+  }
+  return 0;
 }
 
-int main() {
+int main(int argc, const char** argv) {
   ZSTD_CStream *ctx;
-  ZSTD_parameters params = {};
+  ZSTD_parameters params;
   size_t rc;
   unsigned windowLog;
+  (void)argc;
+  (void)argv;
   /* Create stream */
   ctx = ZSTD_createCStream();
   if (!ctx) { return 1; }
   /* Set parameters */
+  memset(&params, 0, sizeof(params));
   params.cParams.windowLog = 18;
   params.cParams.chainLog = 13;
   params.cParams.hashLog = 14;
@@ -50,25 +56,31 @@ int main() {
     ZSTD_outBuffer out = { dstBuffer, ZSTD_compressBound(1 << windowLog), 0 };
     const char match[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const size_t randomData = (1 << windowLog) - 2*sizeof(match);
-    for (size_t i = 0; i < sizeof(match); ++i) {
+    size_t i;
+    for (i = 0; i < sizeof(match); ++i) {
       srcBuffer[i] = match[i];
     }
-    for (size_t i = 0; i < randomData; ++i) {
+    for (i = 0; i < randomData; ++i) {
       srcBuffer[sizeof(match) + i] = (char)(rand() & 0xFF);
     }
-    for (size_t i = 0; i < sizeof(match); ++i) {
+    for (i = 0; i < sizeof(match); ++i) {
       srcBuffer[sizeof(match) + randomData + i] = match[i];
     }
-    compress(ctx, out, srcBuffer, size);
+    if (compress(ctx, out, srcBuffer, size)) {
+      return 1;
+    }
     compressed += size;
     while (compressed < toCompress) {
       const size_t block = rand() % (size - pos + 1);
       if (pos == size) { pos = 0; }
-      compress(ctx, out, srcBuffer + pos, block);
+      if (compress(ctx, out, srcBuffer + pos, block)) {
+        return 1;
+      }
       pos += block;
       compressed += block;
     }
     free(srcBuffer);
     free(dstBuffer);
   }
+  return 0;
 }

--- a/tests/longmatch.c
+++ b/tests/longmatch.c
@@ -1,0 +1,72 @@
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+void compress(ZSTD_CStream *ctx, ZSTD_outBuffer out, const void *data, size_t size) {
+  ZSTD_inBuffer in = { data, size, 0 };
+  while (in.pos < in.size) {
+    ZSTD_outBuffer tmp = out;
+    const size_t rc = ZSTD_compressStream(ctx, &tmp, &in);
+    if (ZSTD_isError(rc)) {
+      exit(5);
+    }
+  }
+  ZSTD_outBuffer tmp = out;
+  const size_t rc = ZSTD_flushStream(ctx, &tmp);
+  if (rc != 0) { exit(6); }
+}
+
+int main() {
+  ZSTD_CStream *ctx;
+  ZSTD_parameters params = {};
+  size_t rc;
+  unsigned windowLog;
+  /* Create stream */
+  ctx = ZSTD_createCStream();
+  if (!ctx) { return 1; }
+  /* Set parameters */
+  params.cParams.windowLog = 18;
+  params.cParams.chainLog = 13;
+  params.cParams.hashLog = 14;
+  params.cParams.searchLog = 1;
+  params.cParams.searchLength = 7;
+  params.cParams.targetLength = 16;
+  params.cParams.strategy = ZSTD_fast;
+  windowLog = params.cParams.windowLog;
+  /* Initialize stream */
+  rc = ZSTD_initCStream_advanced(ctx, NULL, 0, params, 0);
+  if (ZSTD_isError(rc)) { return 2; }
+  {
+    uint64_t compressed = 0;
+    const uint64_t toCompress = ((uint64_t)1) << 33;
+    const size_t size = 1 << windowLog;
+    size_t pos = 0;
+    char *srcBuffer = (char*) malloc(1 << windowLog);
+    char *dstBuffer = (char*) malloc(ZSTD_compressBound(1 << windowLog));
+    ZSTD_outBuffer out = { dstBuffer, ZSTD_compressBound(1 << windowLog), 0 };
+    const char match[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const size_t randomData = (1 << windowLog) - 2*sizeof(match);
+    for (size_t i = 0; i < sizeof(match); ++i) {
+      srcBuffer[i] = match[i];
+    }
+    for (size_t i = 0; i < randomData; ++i) {
+      srcBuffer[sizeof(match) + i] = (char)(rand() & 0xFF);
+    }
+    for (size_t i = 0; i < sizeof(match); ++i) {
+      srcBuffer[sizeof(match) + randomData + i] = match[i];
+    }
+    compress(ctx, out, srcBuffer, size);
+    compressed += size;
+    while (compressed < toCompress) {
+      const size_t block = rand() % (size - pos + 1);
+      if (pos == size) { pos = 0; }
+      compress(ctx, out, srcBuffer + pos, block);
+      pos += block;
+      compressed += block;
+    }
+    free(srcBuffer);
+    free(dstBuffer);
+  }
+}


### PR DESCRIPTION
The bug is exposed by [test.c](https://gist.github.com/terrelln/6b7c01740fc05b0bcf5b3572056c9869), and the test case is fixed after the patch.  I'm still unfamiliar with the compression code, so there maybe be consequences that I don't see, but I think this patch works.

When the overflow protection kicks in, it makes sure that `ip - ctx->base` isn't too large. However, it didn't ensure that saved offsets are still valid. This change ensures that any valid offsets (<= windowLog) are still representable after the update.

The bug would shop up on line 1056, when `offset_1 > current + 1`, which causes an underflow. This in turn, would cause a segfault on line 1063.

The input must necessarily be longer than 1 GB for this issue to occur. Even then, it only occurs if one of the last 3 matches is larger than the chain size and block size.