### PR TITLE
Make zstd build out of the box properly on FreeBSD

### DIFF
--- a/contrib/pzstd/Options.cpp
+++ b/contrib/pzstd/Options.cpp
@@ -22,18 +22,12 @@
     defined(__CYGWIN__)
 #include <io.h> /* _isatty */
 #define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))
-#else
-#if defined(_POSIX_C_SOURCE) || defined(_XOPEN_SOURCE) ||                      \
-    defined(_POSIX_SOURCE) ||                                                  \
-    (defined(__APPLE__) &&                                                     \
-     defined(                                                                  \
-         __MACH__)) /* https://sourceforge.net/p/predef/wiki/OperatingSystems/ \
-                       */
+#elif defined(_POSIX_C_SOURCE) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE) || (defined(__APPLE__) && defined(__MACH__)) || \
+      defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  /* https://sourceforge.net/p/predef/wiki/OperatingSystems/ */
 #include <unistd.h> /* isatty */
 #define IS_CONSOLE(stdStream) isatty(fileno(stdStream))
 #else
 #define IS_CONSOLE(stdStream) 0
-#endif
 #endif
 
 namespace pzstd {

--- a/programs/util.h
+++ b/programs/util.h
@@ -98,7 +98,7 @@ extern "C" {
 #    define SET_HIGH_PRIORITY /* disabled */
 #  endif
 #  define UTIL_sleep(s) sleep(s)
-#  if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 199309L)
+#  if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 199309L))
 #      define UTIL_sleepMilli(milli) { struct timespec t; t.tv_sec=0; t.tv_nsec=milli*1000000ULL; nanosleep(&t, NULL); }
 #  else
 #      define UTIL_sleepMilli(milli) /* disabled */

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -43,7 +43,8 @@
 #if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(_WIN32) || defined(__CYGWIN__)
 #  include <io.h>       /* _isatty */
 #  define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))
-#elif defined(_POSIX_C_SOURCE) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE) || (defined(__APPLE__) && defined(__MACH__))  /* https://sourceforge.net/p/predef/wiki/OperatingSystems/ */
+#elif defined(_POSIX_C_SOURCE) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE) || (defined(__APPLE__) && defined(__MACH__)) || \
+      defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  /* https://sourceforge.net/p/predef/wiki/OperatingSystems/ */
 #  include <unistd.h>   /* isatty */
 #  define IS_CONSOLE(stdStream) isatty(fileno(stdStream))
 #else

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -31,8 +31,10 @@ case "$OS" in
     ;;
 esac
 
-case "$OSTYPE" in
-  darwin*) MD5SUM="md5 -r" ;;
+UNAME=$(uname)
+case "$UNAME" in
+  Darwin) MD5SUM="md5 -r" ;;
+  FreeBSD) MD5SUM="gmd5sum" ;;
   *) MD5SUM="md5sum" ;;
 esac
 
@@ -228,8 +230,8 @@ cp ../programs/*.h dirTestDict
 $MD5SUM dirTestDict/* > tmph1
 $ZSTD -f --rm dirTestDict/* -D tmpDictC
 $ZSTD -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by default
-case "$OSTYPE" in
-  darwin*) $ECHO "md5sum -c not supported on OS-X : test skipped" ;;  # not compatible with OS-X's md5
+case "$UNAME" in
+  Darwin) $ECHO "md5sum -c not supported on OS-X : test skipped" ;;  # not compatible with OS-X's md5
   *) $MD5SUM -c tmph1 ;;
 esac
 rm -rf dirTestDict


### PR DESCRIPTION
* Add `-D_POSIX_C_SOURCE=200112L` to enable POSIX functionality
* Remove last bashism from `tests/playTests.sh`
* Use `gmd5sum` from the sysutils/coreutils port
