### PR TITLE
Export ZBUFF_isError() and ZBUFF_getErrorName()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       os: linux
       sudo: false
 
-    - env: Ubu=12.04cont Cmd="make zlibwrapper && make clean && make -C tests test-zstd-nolegacy && make clean && make cmaketest && make clean && make -C contrib/pzstd googletest pzstd tests check && make -C contrib/pzstd clean"
+    - env: Ubu=12.04cont Cmd="make zlibwrapper && make clean && make -C tests test-symbols && make clean && make -C tests test-zstd-nolegacy && make clean && make cmaketest && make clean && make -C contrib/pzstd googletest pzstd tests check && make -C contrib/pzstd clean"
       os: linux
       sudo: false
       language: cpp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,8 @@ build_script:
       make -v &&
       cc -v &&
       ECHO make %MAKE_PARAMS% &&
-      make %MAKE_PARAMS%
+      make %MAKE_PARAMS% &&
+      make -C tests test-symbols
     )
   - if [%COMPILER%]==[gcc] if [%PLATFORM%]==[mingw64] (
       COPY programs\zstd.exe bin\zstd.exe &&

--- a/build/VS2005/zstdlib/zstdlib.vcproj
+++ b/build/VS2005/zstdlib/zstdlib.vcproj
@@ -360,6 +360,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\..\lib\deprecated\zbuff_common.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\lib\deprecated\zbuff_compress.c"
 				>
 			</File>

--- a/build/VS2010/libzstd-dll/libzstd-dll.vcxproj
+++ b/build/VS2010/libzstd-dll/libzstd-dll.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="..\..\..\lib\compress\zstd_compress.c" />
     <ClCompile Include="..\..\..\lib\decompress\huf_decompress.c" />
     <ClCompile Include="..\..\..\lib\decompress\zstd_decompress.c" />
+    <ClCompile Include="..\..\..\lib\deprecated\zbuff_common.c" />
     <ClCompile Include="..\..\..\lib\deprecated\zbuff_compress.c" />
     <ClCompile Include="..\..\..\lib\deprecated\zbuff_decompress.c" />
     <ClCompile Include="..\..\..\lib\dictBuilder\divsufsort.c" />

--- a/build/VS2010/libzstd/libzstd.vcxproj
+++ b/build/VS2010/libzstd/libzstd.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="..\..\..\lib\compress\zstd_compress.c" />
     <ClCompile Include="..\..\..\lib\decompress\huf_decompress.c" />
     <ClCompile Include="..\..\..\lib\decompress\zstd_decompress.c" />
+    <ClCompile Include="..\..\..\lib\deprecated\zbuff_common.c" />
     <ClCompile Include="..\..\..\lib\deprecated\zbuff_compress.c" />
     <ClCompile Include="..\..\..\lib\deprecated\zbuff_decompress.c" />
     <ClCompile Include="..\..\..\lib\dictBuilder\divsufsort.c" />

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -69,6 +69,7 @@ SET(Sources
         ${LIBRARY_DIR}/decompress/zstd_decompress.c
         ${LIBRARY_DIR}/dictBuilder/divsufsort.c
         ${LIBRARY_DIR}/dictBuilder/zdict.c
+        ${LIBRARY_DIR}/deprecated/zbuff_common.c
         ${LIBRARY_DIR}/deprecated/zbuff_compress.c
         ${LIBRARY_DIR}/deprecated/zbuff_decompress.c)
 

--- a/lib/common/zstd_common.c
+++ b/lib/common/zstd_common.c
@@ -43,10 +43,6 @@ ZSTD_ErrorCode ZSTD_getErrorCode(size_t code) { return ERR_getErrorCode(code); }
 *   provides error code string from enum */
 const char* ZSTD_getErrorString(ZSTD_ErrorCode code) { return ERR_getErrorName(code); }
 
-/* ---   ZBUFF Error Management  (deprecated)   --- */
-unsigned ZBUFF_isError(size_t errorCode) { return ERR_isError(errorCode); }
-const char* ZBUFF_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
-
 
 /*=**************************************************************
 *  Custom allocator

--- a/lib/common/zstd_errors.h
+++ b/lib/common/zstd_errors.h
@@ -18,6 +18,20 @@ extern "C" {
 #include <stddef.h>   /* size_t */
 
 
+/* =====   ZSTDERRORLIB_API : control library symbols visibility   ===== */
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+#  define ZSTDERRORLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#else
+#  define ZSTDERRORLIB_VISIBILITY
+#endif
+#if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#  define ZSTDERRORLIB_API __declspec(dllexport) ZSTDERRORLIB_VISIBILITY
+#elif defined(ZSTD_DLL_IMPORT) && (ZSTD_DLL_IMPORT==1)
+#  define ZSTDERRORLIB_API __declspec(dllimport) ZSTDERRORLIB_VISIBILITY /* It isn't required but allows to generate better code, saving a function pointer load from the IAT and an indirect jump.*/
+#else
+#  define ZSTDERRORLIB_API ZSTDERRORLIB_VISIBILITY
+#endif
+
 /*-****************************************
 *  error codes list
 ******************************************/
@@ -49,8 +63,8 @@ typedef enum {
 /*! ZSTD_getErrorCode() :
     convert a `size_t` function result into a `ZSTD_ErrorCode` enum type,
     which can be used to compare directly with enum list published into "error_public.h" */
-ZSTD_ErrorCode ZSTD_getErrorCode(size_t functionResult);
-const char* ZSTD_getErrorString(ZSTD_ErrorCode code);
+ZSTDERRORLIB_API ZSTD_ErrorCode ZSTD_getErrorCode(size_t functionResult);
+ZSTDERRORLIB_API const char* ZSTD_getErrorString(ZSTD_ErrorCode code);
 
 
 #if defined (__cplusplus)

--- a/lib/deprecated/zbuff_common.c
+++ b/lib/deprecated/zbuff_common.c
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/*-*************************************
+*  Dependencies
+***************************************/
+#include "error_private.h"
+#include "zbuff.h"
+
+/*-****************************************
+*  ZBUFF Error Management  (deprecated)
+******************************************/
+
+/*! ZBUFF_isError() :
+*   tells if a return value is an error code */
+unsigned ZBUFF_isError(size_t errorCode) { return ERR_isError(errorCode); }
+/*! ZBUFF_getErrorName() :
+*   provides error code string from function result (useful for debugging) */
+const char* ZBUFF_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
+

--- a/lib/dictBuilder/zdict.h
+++ b/lib/dictBuilder/zdict.h
@@ -19,15 +19,18 @@ extern "C" {
 #include <stddef.h>  /* size_t */
 
 
-/*======  Export for Windows  ======*/
-/*!
-*  ZSTD_DLL_EXPORT :
-*  Enable exporting of functions when building a Windows DLL
-*/
-#if defined(_WIN32) && defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
-#  define ZDICTLIB_API __declspec(dllexport)
+/* =====   ZDICTLIB_API : control library symbols visibility   ===== */
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+#  define ZDICTLIB_VISIBILITY __attribute__ ((visibility ("default")))
 #else
-#  define ZDICTLIB_API
+#  define ZDICTLIB_VISIBILITY
+#endif
+#if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#  define ZDICTLIB_API __declspec(dllexport) ZDICTLIB_VISIBILITY
+#elif defined(ZSTD_DLL_IMPORT) && (ZSTD_DLL_IMPORT==1)
+#  define ZDICTLIB_API __declspec(dllimport) ZDICTLIB_VISIBILITY /* It isn't required but allows to generate better code, saving a function pointer load from the IAT and an indirect jump.*/
+#else
+#  define ZDICTLIB_API ZDICTLIB_VISIBILITY
 #endif
 
 
@@ -79,7 +82,7 @@ typedef struct {
               or an error code, which can be tested by ZDICT_isError().
     note : ZDICT_trainFromBuffer_advanced() will send notifications into stderr if instructed to, using notificationLevel>0.
 */
-size_t ZDICT_trainFromBuffer_advanced(void* dictBuffer, size_t dictBufferCapacity,
+ZDICTLIB_API size_t ZDICT_trainFromBuffer_advanced(void* dictBuffer, size_t dictBufferCapacity,
                                 const void* samplesBuffer, const size_t* samplesSizes, unsigned nbSamples,
                                 ZDICT_params_t parameters);
 
@@ -97,7 +100,7 @@ size_t ZDICT_trainFromBuffer_advanced(void* dictBuffer, size_t dictBufferCapacit
     starting from its beginning.
     @return : size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`).
 */
-size_t ZDICT_addEntropyTablesFromBuffer(void* dictBuffer, size_t dictContentSize, size_t dictBufferCapacity,
+ZDICTLIB_API size_t ZDICT_addEntropyTablesFromBuffer(void* dictBuffer, size_t dictContentSize, size_t dictBufferCapacity,
                                         const void* samplesBuffer, const size_t* samplesSizes, unsigned nbSamples);
 
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -20,13 +20,16 @@ extern "C" {
 
 /* =====   ZSTDLIB_API : control library symbols visibility   ===== */
 #if defined(__GNUC__) && (__GNUC__ >= 4)
-#  define ZSTDLIB_API __attribute__ ((visibility ("default")))
-#elif defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
-#  define ZSTDLIB_API __declspec(dllexport)
-#elif defined(ZSTD_DLL_IMPORT) && (ZSTD_DLL_IMPORT==1)
-#  define ZSTDLIB_API __declspec(dllimport) /* It isn't required but allows to generate better code, saving a function pointer load from the IAT and an indirect jump.*/
+#  define ZSTDLIB_VISIBILITY __attribute__ ((visibility ("default")))
 #else
-#  define ZSTDLIB_API
+#  define ZSTDLIB_VISIBILITY
+#endif
+#if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#  define ZSTDLIB_API __declspec(dllexport) ZSTDLIB_VISIBILITY
+#elif defined(ZSTD_DLL_IMPORT) && (ZSTD_DLL_IMPORT==1)
+#  define ZSTDLIB_API __declspec(dllimport) ZSTDLIB_VISIBILITY /* It isn't required but allows to generate better code, saving a function pointer load from the IAT and an indirect jump.*/
+#else
+#  define ZSTDLIB_API ZSTDLIB_VISIBILITY
 #endif
 
 
@@ -463,13 +466,13 @@ ZSTDLIB_API size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  *  Provides the dictID stored within dictionary.
  *  if @return == 0, the dictionary is not conformant with Zstandard specification.
  *  It can still be loaded, but as a content-only dictionary. */
-unsigned ZSTD_getDictID_fromDict(const void* dict, size_t dictSize);
+ZSTDLIB_API unsigned ZSTD_getDictID_fromDict(const void* dict, size_t dictSize);
 
 /*! ZSTD_getDictID_fromDDict() :
  *  Provides the dictID of the dictionary loaded into `ddict`.
  *  If @return == 0, the dictionary is not conformant to Zstandard specification, or empty.
  *  Non-conformant dictionaries can still be loaded, but as content-only dictionaries. */
-unsigned ZSTD_getDictID_fromDDict(const ZSTD_DDict* ddict);
+ZSTDLIB_API unsigned ZSTD_getDictID_fromDDict(const ZSTD_DDict* ddict);
 
 /*! ZSTD_getDictID_fromFrame() :
  *  Provides the dictID required to decompressed the frame stored within `src`.
@@ -481,7 +484,7 @@ unsigned ZSTD_getDictID_fromDDict(const ZSTD_DDict* ddict);
  *  - `srcSize` is too small, and as a result, the frame header could not be decoded (only possible if `srcSize < ZSTD_FRAMEHEADERSIZE_MAX`).
  *  - This is not a Zstandard frame.
  *  When identifying the exact failure cause, it's possible to used ZSTD_getFrameParams(), which will provide a more precise error code. */
-unsigned ZSTD_getDictID_fromFrame(const void* src, size_t srcSize);
+ZSTDLIB_API unsigned ZSTD_getDictID_fromFrame(const void* src, size_t srcSize);
 
 
 /********************************************************************

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -12,6 +12,7 @@ paramgrill
 paramgrill32
 roundTripCrash
 longmatch
+symbols
 
 # Tmp test directory
 zstdtest

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,7 @@ PYTHON ?= python3
 TESTARTEFACT := versionsTest namespaceTest
 
 
-CPPFLAGS= -I$(ZSTDDIR) -I$(ZSTDDIR)/common -I$(ZSTDDIR)/dictBuilder -I$(PRGDIR)
+CPPFLAGS= -I$(ZSTDDIR) -I$(ZSTDDIR)/common -I$(ZSTDDIR)/dictBuilder -I$(ZSTDDIR)/deprecated -I$(PRGDIR)
 CFLAGS ?= -O3
 CFLAGS += -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 \
           -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef
@@ -127,6 +127,15 @@ roundTripCrash : $(ZSTD_FILES) roundTripCrash.c
 longmatch  : $(ZSTD_FILES) longmatch.c
 	$(CC)      $(FLAGS) $^ -o $@$(EXT)
 
+symbols  : symbols.c
+	$(MAKE) -C $(ZSTDDIR) libzstd
+ifneq (,$(filter Windows%,$(OS)))
+	cp $(ZSTDDIR)/dll/libzstd.dll .
+	$(CC) $(FLAGS) $^ -o $@$(EXT) -DZSTD_DLL_IMPORT=1 libzstd.dll
+else
+	$(CC) $(FLAGS) $^ -o $@$(EXT) -Wl,-rpath=$(ZSTDDIR) $(ZSTDDIR)/libzstd.so
+endif
+
 namespaceTest:
 	if $(CC) namespaceTest.c ../lib/common/xxhash.c -o $@ ; then echo compilation should fail; exit 1 ; fi
 	$(RM) $@
@@ -142,8 +151,9 @@ clean:
         fullbench$(EXT) fullbench32$(EXT) \
         fullbench-lib$(EXT) fullbench-dll$(EXT) \
         fuzzer$(EXT) fuzzer32$(EXT) zbufftest$(EXT) zbufftest32$(EXT) \
-		zstreamtest$(EXT) zstreamtest32$(EXT) \
-        datagen$(EXT) paramgrill$(EXT) roundTripCrash$(EXT) longmatch$(EXT)
+        zstreamtest$(EXT) zstreamtest32$(EXT) \
+        datagen$(EXT) paramgrill$(EXT) roundTripCrash$(EXT) longmatch$(EXT) \
+        symbols$(EXT)
 	@echo Cleaning completed
 
 
@@ -242,5 +252,8 @@ test-zstream32: zstreamtest32
 
 test-longmatch: longmatch
 	$(QEMU_SYS) ./longmatch
+
+test-symbols: symbols
+	$(QEMU_SYS) ./symbols
 
 endif

--- a/tests/symbols.c
+++ b/tests/symbols.c
@@ -1,0 +1,144 @@
+#include <stdio.h>
+#include "zstd_errors.h"
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd.h"
+#define ZBUFF_DISABLE_DEPRECATE_WARNINGS
+#define ZBUFF_STATIC_LINKING_ONLY
+#include "zbuff.h"
+#define ZDICT_STATIC_LINKING_ONLY
+#include "zdict.h"
+
+static const void *symbols[] = {
+/* zstd.h */
+  &ZSTD_versionNumber,
+  &ZSTD_compress,
+  &ZSTD_decompress,
+  &ZSTD_getDecompressedSize,
+  &ZSTD_maxCLevel,
+  &ZSTD_compressBound,
+  &ZSTD_isError,
+  &ZSTD_getErrorName,
+  &ZSTD_createCCtx,
+  &ZSTD_freeCCtx,
+  &ZSTD_compressCCtx,
+  &ZSTD_createDCtx,
+  &ZSTD_freeDCtx,
+  &ZSTD_decompressDCtx,
+  &ZSTD_compress_usingDict,
+  &ZSTD_decompress_usingDict,
+  &ZSTD_createCDict,
+  &ZSTD_freeCDict,
+  &ZSTD_compress_usingCDict,
+  &ZSTD_createDDict,
+  &ZSTD_freeDDict,
+  &ZSTD_decompress_usingDDict,
+  &ZSTD_createCStream,
+  &ZSTD_freeCStream,
+  &ZSTD_initCStream,
+  &ZSTD_compressStream,
+  &ZSTD_flushStream,
+  &ZSTD_endStream,
+  &ZSTD_CStreamInSize,
+  &ZSTD_CStreamOutSize,
+  &ZSTD_createDStream,
+  &ZSTD_freeDStream,
+  &ZSTD_initDStream,
+  &ZSTD_decompressStream,
+  &ZSTD_DStreamInSize,
+  &ZSTD_DStreamOutSize,
+/* zstd.h: advanced functions */
+  &ZSTD_estimateCCtxSize,
+  &ZSTD_createCCtx_advanced,
+  &ZSTD_sizeof_CCtx,
+  &ZSTD_createCDict_advanced,
+  &ZSTD_sizeof_CDict,
+  &ZSTD_getCParams,
+  &ZSTD_getParams,
+  &ZSTD_checkCParams,
+  &ZSTD_adjustCParams,
+  &ZSTD_compress_advanced,
+  &ZSTD_isFrame,
+  &ZSTD_estimateDCtxSize,
+  &ZSTD_createDCtx_advanced,
+  &ZSTD_sizeof_DCtx,
+  &ZSTD_sizeof_DDict,
+  &ZSTD_getDictID_fromDict,
+  &ZSTD_getDictID_fromDDict,
+  &ZSTD_getDictID_fromFrame,
+  &ZSTD_createCStream_advanced,
+  &ZSTD_initCStream_srcSize,
+  &ZSTD_initCStream_usingDict,
+  &ZSTD_initCStream_advanced,
+  &ZSTD_initCStream_usingCDict,
+  &ZSTD_resetCStream,
+  &ZSTD_sizeof_CStream,
+  &ZSTD_createDStream_advanced,
+  &ZSTD_initDStream_usingDict,
+  &ZSTD_setDStreamParameter,
+  &ZSTD_initDStream_usingDDict,
+  &ZSTD_resetDStream,
+  &ZSTD_sizeof_DStream,
+  &ZSTD_compressBegin,
+  &ZSTD_compressBegin_usingDict,
+  &ZSTD_compressBegin_advanced,
+  &ZSTD_copyCCtx,
+  &ZSTD_compressContinue,
+  &ZSTD_compressEnd,
+  &ZSTD_getFrameParams,
+  &ZSTD_decompressBegin,
+  &ZSTD_decompressBegin_usingDict,
+  &ZSTD_copyDCtx,
+  &ZSTD_nextSrcSizeToDecompress,
+  &ZSTD_decompressContinue,
+  &ZSTD_nextInputType,
+  &ZSTD_getBlockSizeMax,
+  &ZSTD_compressBlock,
+  &ZSTD_decompressBlock,
+  &ZSTD_insertBlock,
+/* zstd_errors.h */
+  &ZSTD_getErrorCode,
+  &ZSTD_getErrorString,
+/* zbuff.h */
+  &ZBUFF_createCCtx,
+  &ZBUFF_freeCCtx,
+  &ZBUFF_compressInit,
+  &ZBUFF_compressInitDictionary,
+  &ZBUFF_compressContinue,
+  &ZBUFF_compressFlush,
+  &ZBUFF_compressEnd,
+  &ZBUFF_createDCtx,
+  &ZBUFF_freeDCtx,
+  &ZBUFF_decompressInit,
+  &ZBUFF_decompressInitDictionary,
+  &ZBUFF_decompressContinue,
+  &ZBUFF_isError,
+  &ZBUFF_getErrorName,
+  &ZBUFF_recommendedCInSize,
+  &ZBUFF_recommendedCOutSize,
+  &ZBUFF_recommendedDInSize,
+  &ZBUFF_recommendedDOutSize,
+/* zbuff.h: advanced functions */
+  &ZBUFF_createCCtx_advanced,
+  &ZBUFF_createDCtx_advanced,
+  &ZBUFF_compressInit_advanced,
+/* zdict.h */
+  &ZDICT_trainFromBuffer,
+  &ZDICT_getDictID,
+  &ZDICT_isError,
+  &ZDICT_getErrorName,
+/* zdict.h: advanced functions */
+  &ZDICT_trainFromBuffer_advanced,
+  &ZDICT_addEntropyTablesFromBuffer,
+  NULL,
+};
+
+int main(int argc, const char** argv) {
+  const void **symbol;
+  (void)argc;
+  (void)argv;
+
+  for (symbol = symbols; *symbol != NULL; ++symbol) {
+    printf("%p\n", *symbol);
+  }
+  return 0;
+}


### PR DESCRIPTION
In `zstd_common.c`, since `zbuff.h` wasn't included, the symbols are by default
hidden in the shared library, and the exported symbols aren't defined.