### PR TITLE
zstdless: add shebang and quote $@

### DIFF
--- a/programs/zstdless
+++ b/programs/zstdless
@@ -1,1 +1,2 @@
-zstdcat $@ | less
+#!/bin/sh
+zstdcat "$@" | less


### PR DESCRIPTION
Fixes #496.

Adds a shebang line to `zstdless` so it works under more environments.

Quotes the `$@` variable to protect against spaces etc in the input filenames.