### PR TITLE
Fix failing test due to deprecation warning

### DIFF
--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -837,7 +837,7 @@ size_t ZDICT_finalizeDictionary(void* dictBuffer, size_t dictBufferCapacity,
     U32 const notificationLevel = params.notificationLevel;
 
     /* check conditions */
-    if (dictBufferCapacity <= dictContentSize) return ERROR(dstSize_tooSmall);
+    if (dictBufferCapacity < dictContentSize) return ERROR(dstSize_tooSmall);
     if (dictContentSize < ZDICT_CONTENTSIZE_MIN) return ERROR(srcSize_wrong);
     if (dictBufferCapacity < ZDICT_DICTSIZE_MIN) return ERROR(dstSize_tooSmall);
 
@@ -863,7 +863,7 @@ size_t ZDICT_finalizeDictionary(void* dictBuffer, size_t dictBufferCapacity,
     }
 
     /* copy elements in final buffer ; note : src and dst buffer can overlap */
-    if (hSize + dictContentSize < dictBufferCapacity) dictContentSize = dictBufferCapacity - hSize;
+    if (hSize + dictContentSize > dictBufferCapacity) dictContentSize = dictBufferCapacity - hSize;
     {   size_t const dictSize = hSize + dictContentSize;
         char* dictEnd = (char*)dictBuffer + dictSize;
         memmove(dictEnd - dictContentSize, customDictContent, dictContentSize);

--- a/lib/dictBuilder/zdict.h
+++ b/lib/dictBuilder/zdict.h
@@ -118,20 +118,20 @@ ZDICTLIB_API size_t ZDICT_finalizeDictionary(void* dictBuffer, size_t dictBuffer
    or _CRT_SECURE_NO_WARNINGS in Visual.
    Otherwise, it's also possible to manually define ZDICT_DISABLE_DEPRECATE_WARNINGS */
 #ifdef ZDICT_DISABLE_DEPRECATE_WARNINGS
-#  define ZDICT_DEPRECATED(message)   /* disable deprecation warnings */
+#  define ZDICT_DEPRECATED(message) ZDICTLIB_API   /* disable deprecation warnings */
 #else
 #  define ZDICT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #  if defined (__cplusplus) && (__cplusplus >= 201402) /* C++14 or greater */
-#    define ZDICT_DEPRECATED(message) [[deprecated(message)]]
+#    define ZDICT_DEPRECATED(message) ZDICTLIB_API [[deprecated(message)]]
 #  elif (ZDICT_GCC_VERSION >= 405) || defined(__clang__)
-#    define ZDICT_DEPRECATED(message) __attribute__((deprecated(message)))
+#    define ZDICT_DEPRECATED(message) ZDICTLIB_API __attribute__((deprecated(message)))
 #  elif (ZDICT_GCC_VERSION >= 301)
-#    define ZDICT_DEPRECATED(message) __attribute__((deprecated))
+#    define ZDICT_DEPRECATED(message) ZDICTLIB_API __attribute__((deprecated))
 #  elif defined(_MSC_VER)
-#    define ZDICT_DEPRECATED(message) __declspec(deprecated(message))
+#    define ZDICT_DEPRECATED(message) ZDICTLIB_API __declspec(deprecated(message))
 #  else
 #    pragma message("WARNING: You need to implement ZDICT_DEPRECATED for this compiler")
-#    define ZDICT_DEPRECATED(message)
+#    define ZDICT_DEPRECATED(message) ZDICTLIB_API
 #  endif
 #endif /* ZDICT_DISABLE_DEPRECATE_WARNINGS */
 

--- a/lib/dictBuilder/zdict.h
+++ b/lib/dictBuilder/zdict.h
@@ -96,7 +96,7 @@ ZDICTLIB_API size_t ZDICT_trainFromBuffer_advanced(void* dictBuffer, size_t dict
     supplied with an array of sizes `samplesSizes`, providing the size of each sample in order.
 
     dictContentSize must be > ZDICT_CONTENTSIZE_MIN bytes.
-    maxDictSize must be > dictContentSize, and must be > ZDICT_DICTSIZE_MIN bytes.
+    maxDictSize must be >= dictContentSize, and must be > ZDICT_DICTSIZE_MIN bytes.
 
     @return : size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`),
               or an error code, which can be tested by ZDICT_isError().

--- a/tests/symbols.c
+++ b/tests/symbols.c
@@ -5,6 +5,7 @@
 #define ZBUFF_DISABLE_DEPRECATE_WARNINGS
 #define ZBUFF_STATIC_LINKING_ONLY
 #include "zbuff.h"
+#define ZDICT_DISABLE_DEPRECATE_WARNINGS
 #define ZDICT_STATIC_LINKING_ONLY
 #include "zdict.h"
 


### PR DESCRIPTION
1.  `ZDICT_DEPRECATED` needs to include `ZDICTLIB_API` or the symbols won't be exported
2.  `symbols.c` needs `ZDICT_DISABLE_DEPRECATE_WARNINGS` defined
3.  `ZDICT_finalizeDictionary()` had a comparison that was flipped
4.  Allow `dictBufferCapacity == dictContentSize`