### PR TITLE
Change zlib include to be a system include

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -67,7 +67,7 @@ endif
 
 # zlib detection
 VOID = /dev/null
-HAVE_ZLIB := $(shell echo "int main(){}" | $(CC) -o $(VOID) -x c - -lz 2> $(VOID) && echo 1 || echo 0)
+HAVE_ZLIB := $(shell echo "\#include <zlib.h>\nint main(){}" | $(CC) -o $(VOID) -x c - -lz 2> $(VOID) && echo 1 || echo 0)
 ifeq ($(HAVE_ZLIB), 1)
 ZLIBCPP = -DZSTD_GZDECOMPRESS
 ZLIBLD = -lz

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -39,7 +39,7 @@
 #  include "zstdmt_compress.h"
 #endif
 #ifdef ZSTD_GZDECOMPRESS
-#  include "zlib.h"
+#  include <zlib.h>
 #  if !defined(z_const)
 #    define z_const
 #  endif


### PR DESCRIPTION
I'm not sure how to test this. I tried adding the flag `-nostdinc` and them adding back in the standard includes with `-isystem`, which supposedly doesn't add paths to the quotes include path, but gcc and clang both still allowed `"zlib.h"` to be included.

However, we can ensure that `#include <zlib.h>` works in the `HAVE_ZLIB` test.