### PR TITLE
Remove test-longmatch from test target and only run it once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 
 
     # Standard Ubuntu 12.04 LTS Server Edition 64 bit
-    - env: Ubu=12.04 Cmd="make -C programs zstd-small zstd-decompress zstd-compress && make -C programs clean && make -C tests versionsTest"
+    - env: Ubu=12.04 Cmd="make -C programs zstd-small zstd-decompress zstd-compress && make -C programs clean && make -C tests versionsTest test-longmatch"
       os: linux
       sudo: required
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -225,7 +225,7 @@ zstd-playTests: datagen
 	file $(ZSTD)
 	ZSTD="$(QEMU_SYS) $(ZSTD)" ./playTests.sh $(ZSTDRTTEST)
 
-test: test-zstd test-fullbench test-fuzzer test-zstream test-longmatch test-invalidDictionaries test-pool
+test: test-zstd test-fullbench test-fuzzer test-zstream test-invalidDictionaries test-pool
 
 test32: test-zstd32 test-fullbench32 test-fuzzer32 test-zstream32
 


### PR DESCRIPTION
It was timing out in `qemu` runs.

The travis file should be ok, but it doesn't run the modified test on my branch, so the PR tests will determine if it is ok.