### PR TITLE
zstdcli: fix writing 2GB+ sparse files under Windows

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -109,9 +109,9 @@ static clock_t g_time = 0;
             method = FILE_BEGIN;
 
         if (SetFilePointerEx((HANDLE) _get_osfhandle(_fileno(file)), off, NULL, method))
-                return 0;
+            return 0;
         else
-                return -1;
+            return -1;
     }
 #else
 #   define LONG_SEEK fseek

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -91,6 +91,32 @@ static clock_t g_time = 0;
 
 #define MIN(a,b)    ((a) < (b) ? (a) : (b))
 
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+#   define LONG_SEEK _fseeki64
+#elif defined(__MINGW32__) && !defined(__STRICT_ANSI__) && !defined(__NO_MINGW_LFS) && defined(__MSVCRT__)
+#   define LONG_SEEK fseeko64
+#elif defined(_WIN32) && !defined(__DJGPP__)
+#   include <windows.h>
+    static int LONG_SEEK(FILE* file, __int64 offset, int origin) {
+        LARGE_INTEGER off;
+        DWORD method;
+        off.QuadPart = offset;
+        if (origin == SEEK_END)
+            method = FILE_END;
+        else if (origin == SEEK_CUR)
+            method = FILE_CURRENT;
+        else
+            method = FILE_BEGIN;
+
+        if (SetFilePointerEx((HANDLE) _get_osfhandle(_fileno(file)), off, NULL, method))
+                return 0;
+        else
+                return -1;
+    }
+#else
+#   define LONG_SEEK fseek
+#endif
+
 
 /*-*************************************
 *  Local Parameters - Not thread safe
@@ -598,7 +624,7 @@ static unsigned FIO_fwriteSparse(FILE* file, const void* buffer, size_t bufferSi
 
     /* avoid int overflow */
     if (storedSkips > 1 GB) {
-        int const seekResult = fseek(file, 1 GB, SEEK_CUR);
+        int const seekResult = LONG_SEEK(file, 1 GB, SEEK_CUR);
         if (seekResult != 0) EXM_THROW(71, "1 GB skip error (sparse file support)");
         storedSkips -= 1 GB;
     }
@@ -614,7 +640,7 @@ static unsigned FIO_fwriteSparse(FILE* file, const void* buffer, size_t bufferSi
         storedSkips += (unsigned)(nb0T * sizeof(size_t));
 
         if (nb0T != seg0SizeT) {   /* not all 0s */
-            int const seekResult = fseek(file, storedSkips, SEEK_CUR);
+            int const seekResult = LONG_SEEK(file, storedSkips, SEEK_CUR);
             if (seekResult) EXM_THROW(72, "Sparse skip error ; try --no-sparse");
             storedSkips = 0;
             seg0SizeT -= nb0T;
@@ -634,7 +660,7 @@ static unsigned FIO_fwriteSparse(FILE* file, const void* buffer, size_t bufferSi
             for ( ; (restPtr < restEnd) && (*restPtr == 0); restPtr++) ;
             storedSkips += (unsigned) (restPtr - restStart);
             if (restPtr != restEnd) {
-                int seekResult = fseek(file, storedSkips, SEEK_CUR);
+                int seekResult = LONG_SEEK(file, storedSkips, SEEK_CUR);
                 if (seekResult) EXM_THROW(74, "Sparse skip error ; try --no-sparse");
                 storedSkips = 0;
                 {   size_t const sizeCheck = fwrite(restPtr, 1, restEnd - restPtr, file);
@@ -647,7 +673,7 @@ static unsigned FIO_fwriteSparse(FILE* file, const void* buffer, size_t bufferSi
 static void FIO_fwriteSparseEnd(FILE* file, unsigned storedSkips)
 {
     if (storedSkips-->0) {   /* implies g_sparseFileSupport>0 */
-        int const seekResult = fseek(file, storedSkips, SEEK_CUR);
+        int const seekResult = LONG_SEEK(file, storedSkips, SEEK_CUR);
         if (seekResult != 0) EXM_THROW(69, "Final skip error (sparse file)\n");
         {   const char lastZeroByte[1] = { 0 };
             size_t const sizeCheck = fwrite(lastZeroByte, 1, 1, file);


### PR DESCRIPTION
There is another bug related to large files on Windows (MinGW, likely also VC++).

### How to reproduce this problem
1. Generate zero-filled file larger than 2048 MB
`dd if=/dev/zero of=testfile bs=1M count=2049`
(see [other solutions](http://stackoverflow.com/questions/982659/quickly-create-large-file-on-a-windows-system) if you don't have dd)
2. Create compressed test file
`zstd -1 testfile -o testfile.zst`
3. Attempt to decompress or test it
`zstd --test testfile.zst`
sample result:
`Decoded : 2005 MB...     Error 71 : 1 GB skip error (sparse file support)`

### Cause
`fseek()` fails if file position indicator is over 2GB (even for small relative offset). This leads to skip errors in `FIO_fwriteSparse()`/`FIO_fwriteSparseEnd()` during decompression of large sparse files.
`_FILE_OFFSET_BITS=64` does not help there, even for MinGW versions supporting this option.

### Fix
Replace `fseek()` in `FIO_fwriteSparse()` and `FIO_fwriteSparseEnd()` with macro expanding to 64-bit fseek version provided by current platform (includes  fallback workaround using Win32 API).

### Note
While I suspect that problem directly relates to MSVCRT (thus affects also Visual C++ biulds) and have roughly verified all conditionally enabled solutions under MinGW (`_fseeki64()` is available in MinGW-w64), **this still needs proper confirmation under Visual C++**.