### PR TITLE
Portable way to avoid empty unit warning in threading.c

### DIFF
--- a/lib/common/threading.c
+++ b/lib/common/threading.c
@@ -15,10 +15,11 @@
  * This file will hold wrapper for systems, which do not support pthreads
  */
 
-/* ======   Compiler specifics   ====== */
-#if defined(_MSC_VER)
-#  pragma warning(disable : 4206)        /* disable: C4206: translation unit is empty (when ZSTD_MULTITHREAD is not defined) */
-#endif
+/* When ZSTD_MULTITHREAD is not defined, this file would become an empty translation unit.
+* Include some ISO C header code to prevent this and portably avoid related warnings.
+* (Visual C++: C4206 / GCC: -Wpedantic / Clang: -Wempty-translation-unit)
+*/
+#include <stddef.h>
 
 
 #if defined(ZSTD_MULTITHREAD) && defined(_WIN32)


### PR DESCRIPTION
When ZSTD_MULTITHREAD is not defined, `lib/common/threading.c ` triggers empty translation unit warning, which is currently suppressed only under MSVC++.

It may be worth to consider building lib in strict standards mode, and this is currently the only warning generated by `-pedantic` under GCC and Clang. It could be suppressed for GCC/Clang another `#pragma`, but proposed commit avoids this problem in a portable way by including one of standard C headers.