### PR TITLE
fix memory leak

### DIFF
--- a/examples/simple_compression.c
+++ b/examples/simple_compression.c
@@ -127,6 +127,6 @@ int main(int argc, const char** argv)
 
     const char* const outFilename = createOutFilename_orDie(inFilename);
     compress_orDie(inFilename, outFilename);
-
+    free(outFilename);
     return 0;
 }


### PR DESCRIPTION
there was a small issue of memory leak for output file name in the example, simple free() should fix it