### PR TITLE
Zero pointers after freeing

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2970,9 +2970,13 @@ size_t ZSTD_freeCStream(ZSTD_CStream* zcs)
     if (zcs==NULL) return 0;   /* support free on NULL */
     {   ZSTD_customMem const cMem = zcs->customMem;
         ZSTD_freeCCtx(zcs->cctx);
+        zcs->cctx = NULL;
         ZSTD_freeCDict(zcs->cdictLocal);
+        zcs->cdictLocal = NULL;
         ZSTD_free(zcs->inBuff, cMem);
+        zcs->inBuff = NULL;
         ZSTD_free(zcs->outBuff, cMem);
+        zcs->outBuff = NULL;
         ZSTD_free(zcs, cMem);
         return 0;
     }

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -2209,9 +2209,13 @@ size_t ZSTD_freeDStream(ZSTD_DStream* zds)
     if (zds==NULL) return 0;   /* support free on null */
     {   ZSTD_customMem const cMem = zds->customMem;
         ZSTD_freeDCtx(zds->dctx);
+        zds->dctx = NULL;
         ZSTD_freeDDict(zds->ddictLocal);
+        zds->ddictLocal = NULL;
         ZSTD_free(zds->inBuff, cMem);
+        zds->inBuff = NULL;
         ZSTD_free(zds->outBuff, cMem);
+        zds->outBuff = NULL;
 #if defined(ZSTD_LEGACY_SUPPORT) && (ZSTD_LEGACY_SUPPORT >= 1)
         if (zds->legacyContext)
             ZSTD_freeLegacyStreamContext(zds->legacyContext, zds->previousLegacyVersion);


### PR DESCRIPTION
Set pointers to `NULL` after freeing, to help make use after free errors more obvious in optimized builds.