### PR TITLE
Fix ZSTD_initCStream_usingCDict() and ZSTD_compress_usingCDict()

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3069,7 +3069,6 @@ size_t ZSTD_initCStream_usingCDict(ZSTD_CStream* zcs, const ZSTD_CDict* cdict)
     ZSTD_parameters const params = ZSTD_getParamsFromCDict(cdict);
     size_t const initError =  ZSTD_initCStream_advanced(zcs, NULL, 0, params, 0);
     zcs->cdict = cdict;
-    zcs->cctx->dictID = params.fParams.noDictIDFlag ? 0 : cdict->refContext->dictID;
     if (ZSTD_isError(initError)) return initError;
     return ZSTD_resetCStream_internal(zcs, 0);
 }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2921,6 +2921,8 @@ size_t ZSTD_compress_usingCDict(ZSTD_CCtx* cctx,
     if (cdict->refContext->params.fParams.contentSizeFlag==1) {
         cctx->params.fParams.contentSizeFlag = 1;
         cctx->frameContentSize = srcSize;
+    } else {
+        cctx->params.fParams.contentSizeFlag = 0;
     }
 
     return ZSTD_compressEnd(cctx, dst, dstCapacity, src, srcSize);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3068,7 +3068,8 @@ size_t ZSTD_initCStream_usingCDict(ZSTD_CStream* zcs, const ZSTD_CDict* cdict)
     size_t const initError =  ZSTD_initCStream_advanced(zcs, NULL, 0, params, 0);
     zcs->cdict = cdict;
     zcs->cctx->dictID = params.fParams.noDictIDFlag ? 0 : cdict->refContext->dictID;
-    return initError;
+    if (ZSTD_isError(initError)) return initError;
+    return ZSTD_resetCStream_internal(zcs, 0);
 }
 
 size_t ZSTD_initCStream_usingDict(ZSTD_CStream* zcs, const void* dict, size_t dictSize, int compressionLevel)


### PR DESCRIPTION
* Fix `ZSTD_initCStream_usingCDict()` to use the dictionary
* Make `ZSTD_compress_usingCDict()` respect contentSizeFlag.