### PR TITLE
Make -T0 mean "number of physical cores"

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -147,12 +147,10 @@ typedef struct {
 
 
 
-#ifndef MIN
-#   define MIN(a,b)    ((a) < (b) ? (a) : (b))
-#endif
-#ifndef MAX
-#   define MAX(a,b)    ((a) > (b) ? (a) : (b))
-#endif
+#undef MIN
+#undef MAX
+#define MIN(a,b)    ((a) < (b) ? (a) : (b))
+#define MAX(a,b)    ((a) > (b) ? (a) : (b))
 
 static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                         const char* displayName, int cLevel,

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -146,8 +146,13 @@ typedef struct {
 } blockParam_t;
 
 
-#define MIN(a,b) ((a)<(b) ? (a) : (b))
-#define MAX(a,b) ((a)>(b) ? (a) : (b))
+
+#ifndef MIN
+#   define MIN(a,b)    ((a) < (b) ? (a) : (b))
+#endif
+#ifndef MAX
+#   define MAX(a,b)    ((a) > (b) ? (a) : (b))
+#endif
 
 static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                         const char* displayName, int cLevel,

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -89,7 +89,9 @@ unsigned DiB_isError(size_t errorCode) { return ERR_isError(errorCode); }
 
 const char* DiB_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
 
-#define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
+#ifndef MIN
+#   define MIN(a,b)    ((a) < (b) ? (a) : (b))
+#endif
 
 
 /* ********************************************************

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -89,9 +89,8 @@ unsigned DiB_isError(size_t errorCode) { return ERR_isError(errorCode); }
 
 const char* DiB_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
 
-#ifndef MIN
-#   define MIN(a,b)    ((a) < (b) ? (a) : (b))
-#endif
+#undef MIN
+#define MIN(a,b)    ((a) < (b) ? (a) : (b))
 
 
 /* ********************************************************

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -96,9 +96,8 @@ void FIO_setNotificationLevel(unsigned level) { g_displayLevel=level; }
 static const clock_t refreshRate = CLOCKS_PER_SEC * 15 / 100;
 static clock_t g_time = 0;
 
-#ifndef MIN
-#   define MIN(a,b)    ((a) < (b) ? (a) : (b))
-#endif
+#undef MIN
+#define MIN(a,b)    ((a) < (b) ? (a) : (b))
 
 /* ************************************************************
 * Avoid fseek()'s 2GiB barrier with MSVC, MacOS, *BSD, MinGW

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -96,7 +96,9 @@ void FIO_setNotificationLevel(unsigned level) { g_displayLevel=level; }
 static const clock_t refreshRate = CLOCKS_PER_SEC * 15 / 100;
 static clock_t g_time = 0;
 
-#define MIN(a,b)    ((a) < (b) ? (a) : (b))
+#ifndef MIN
+#   define MIN(a,b)    ((a) < (b) ? (a) : (b))
+#endif
 
 /* ************************************************************
 * Avoid fseek()'s 2GiB barrier with MSVC, MacOS, *BSD, MinGW

--- a/programs/util.h
+++ b/programs/util.h
@@ -601,7 +601,7 @@ UTIL_STATIC int UTIL_countPhysicalCores(void)
 
     if (numPhysicalCores != 0) return numPhysicalCores;
 
-    numPhysicalCores = sysconf(_SC_NPROCESSORS_ONLN);
+    numPhysicalCores = (int)sysconf(_SC_NPROCESSORS_ONLN);
     if (numPhysicalCores == -1) {
         /* value not queryable, fall back on 1 */
         return numPhysicalCores = 1;

--- a/programs/util.h
+++ b/programs/util.h
@@ -536,12 +536,16 @@ UTIL_STATIC int UTIL_countPhysicalCores(void)
             }
         }
 
-        while (byteOffset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) <= returnLength) {
-            ptr = buffer;
+        ptr = buffer;
 
-            if (ptr->RelationShip == RelationProcessorCore) {
+        while (byteOffset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) <= returnLength) {
+
+            if (ptr->Relationship == RelationProcessorCore) {
                 numPhysicalCores++;
             }
+
+            ptr++;
+            byteOffset += sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
         }
 
         free(buffer);
@@ -551,10 +555,11 @@ UTIL_STATIC int UTIL_countPhysicalCores(void)
 
 failed:
     /* try to fall back on GetSystemInfo */
-    SYSTEM_INFO sysinfo;
-    GetSystemInfo(&sysinfo);
-    numPhysicalCores = sysinfo.dwNumberOfProcessors;
-    if (numPhysicalCores == 0) numPhysicalCores = 1; /* just in case */
+    {   SYSTEM_INFO sysinfo;
+        GetSystemInfo(&sysinfo);
+        numPhysicalCores = sysinfo.dwNumberOfProcessors;
+        if (numPhysicalCores == 0) numPhysicalCores = 1; /* just in case */
+    }
     return numPhysicalCores;
 }
 

--- a/programs/util.h
+++ b/programs/util.h
@@ -25,6 +25,7 @@ extern "C" {
 #include <stdlib.h>       /* malloc */
 #include <stddef.h>       /* size_t, ptrdiff_t */
 #include <stdio.h>        /* fprintf */
+#include <string.h>       /* strncmp */
 #include <sys/types.h>    /* stat, utime */
 #include <sys/stat.h>     /* stat */
 #if defined(_MSC_VER)
@@ -488,6 +489,177 @@ UTIL_STATIC void UTIL_freeFileList(const char** filenameTable, char* allocatedBu
     if (filenameTable) free((void*)filenameTable);
 }
 
+/* count the number of physical cores */
+#if defined(_WIN32) || defined(WIN32)
+
+#include <windows.h>
+
+typedef BOOL(WINAPI* LPFN_GLPI)(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION, PDWORD);
+
+UTIL_STATIC int UTIL_countPhysicalCores(void)
+{
+    static int numPhysicalCores;
+    if (numPhysicalCores != 0) return numPhysicalCores;
+
+    {   LPFN_GLPI glpi;
+        BOOL done = FALSE;
+        PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer = NULL;
+        PSYSTEM_LOGICAL_PROCESSOR_INFORMATION ptr = NULL;
+        DWORD returnLength = 0;
+        size_t byteOffset = 0;
+
+        glpi = (LPFN_GLPI)GetProcAddress(GetModuleHandle(TEXT("kernel32")),
+                                         "GetLogicalProcessorInformation");
+
+        if (glpi == NULL) {
+            goto failed;
+        }
+
+        while(!done) {
+            DWORD rc = glpi(buffer, &returnLength);
+            if (FALSE == rc) {
+                if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+                    if (buffer)
+                        free(buffer);
+                    buffer = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)malloc(returnLength);
+
+                    if (buffer == NULL) {
+                        perror("zstd");
+                        exit(1);
+                    }
+                } else {
+                    /* some other error */
+                    goto failed;
+                }
+            } else {
+                done = TRUE;
+            }
+        }
+
+        while (byteOffset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) <= returnLength) {
+            ptr = buffer;
+
+            if (ptr->RelationShip == RelationProcessorCore) {
+                numPhysicalCores++;
+            }
+        }
+
+        free(buffer);
+
+        return numPhysicalCores;
+    }
+
+failed:
+    /* try to fall back on GetSystemInfo */
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    numPhysicalCores = sysinfo.dwNumberOfProcessors;
+    if (numPhysicalCores == 0) numPhysicalCores = 1; /* just in case */
+    return numPhysicalCores;
+}
+
+#elif defined(__APPLE__)
+
+#include <sys/sysctl.h>
+
+/* Use apple-provided syscall
+ * see: man 3 sysctl */
+UTIL_STATIC int UTIL_countPhysicalCores(void)
+{
+    static S32 numPhysicalCores; /* apple specifies int32_t */
+    if (numPhysicalCores != 0) return numPhysicalCores;
+
+    {   int const ret = sysctlbyname("hw.physicalcpu", &numPhysicalCores, sizeof(int), NULL, 0);
+        if (ret != 0) {
+            if (errno == ENOENT) {
+                /* entry not present, fall back on 1 */
+                numPhysicalCores = 1;
+            } else {
+                perror("zstd: can't get number of physical cpus");
+                exit(1);
+            }
+        }
+
+        return numPhysicalCores;
+    }
+}
+
+#elif defined(__linux__)
+
+/* parse /proc/cpuinfo
+ * siblings / cpu cores should give hyperthreading ratio
+ * otherwise fall back on sysconf */
+UTIL_STATIC int UTIL_countPhysicalCores(void)
+{
+    static int numPhysicalCores;
+
+    if (numPhysicalCores != 0) return numPhysicalCores;
+
+    numPhysicalCores = sysconf(_SC_NPROCESSORS_ONLN);
+    if (numPhysicalCores == -1) {
+        /* value not queryable, fall back on 1 */
+        return numPhysicalCores = 1;
+    }
+
+    /* try to determine if there's hyperthreading */
+    {   FILE* const cpuinfo = fopen("/proc/cpuinfo", "r");
+        size_t const BUF_SIZE = 80;
+        char buff[BUF_SIZE];
+
+        int siblings = 0;
+        int cpu_cores = 0;
+        int ratio = 1;
+
+        if (cpuinfo == NULL) {
+            /* fall back on the sysconf value */
+            return numPhysicalCores;
+        }
+
+        /* assume the cpu cores/siblings values will be constant across all
+         * present processors */
+        while (!feof(cpuinfo)) {
+            if (fgets(buff, BUF_SIZE, cpuinfo) != NULL) {
+                if (strncmp(buff, "siblings", 8) == 0) {
+                    const char* const sep = strchr(buff, ':');
+                    if (*sep == '\0') {
+                        /* formatting was broken? */
+                        goto failed;
+                    }
+
+                    siblings = atoi(sep + 1);
+                }
+                if (strncmp(buff, "cpu cores", 9) == 0) {
+                    const char* const sep = strchr(buff, ':');
+                    if (*sep == '\0') {
+                        /* formatting was broken? */
+                        goto failed;
+                    }
+
+                    cpu_cores = atoi(sep + 1);
+                }
+            } else if (ferror(cpuinfo)) {
+                /* fall back on the sysconf value */
+                goto failed;
+            }
+        }
+        if (siblings && cpu_cores) {
+            ratio = siblings / cpu_cores;
+        }
+failed:
+        fclose(cpuinfo);
+        return numPhysicalCores = numPhysicalCores / ratio;
+    }
+}
+
+#else
+
+UTIL_STATIC int UTIL_countPhysicalCores(void)
+{
+    /* assume 1 */
+    return 1;
+}
+
+#endif
 
 #if defined (__cplusplus)
 }

--- a/programs/util.h
+++ b/programs/util.h
@@ -498,7 +498,7 @@ typedef BOOL(WINAPI* LPFN_GLPI)(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION, PDWORD);
 
 UTIL_STATIC int UTIL_countPhysicalCores(void)
 {
-    static int numPhysicalCores;
+    static int numPhysicalCores = 0;
     if (numPhysicalCores != 0) return numPhysicalCores;
 
     {   LPFN_GLPI glpi;
@@ -571,7 +571,7 @@ failed:
  * see: man 3 sysctl */
 UTIL_STATIC int UTIL_countPhysicalCores(void)
 {
-    static S32 numPhysicalCores; /* apple specifies int32_t */
+    static S32 numPhysicalCores = 0; /* apple specifies int32_t */
     if (numPhysicalCores != 0) return numPhysicalCores;
 
     {   size_t size = sizeof(S32);
@@ -597,7 +597,7 @@ UTIL_STATIC int UTIL_countPhysicalCores(void)
  * otherwise fall back on sysconf */
 UTIL_STATIC int UTIL_countPhysicalCores(void)
 {
-    static int numPhysicalCores;
+    static int numPhysicalCores = 0;
 
     if (numPhysicalCores != 0) return numPhysicalCores;
 

--- a/programs/util.h
+++ b/programs/util.h
@@ -569,7 +569,8 @@ UTIL_STATIC int UTIL_countPhysicalCores(void)
     static S32 numPhysicalCores; /* apple specifies int32_t */
     if (numPhysicalCores != 0) return numPhysicalCores;
 
-    {   int const ret = sysctlbyname("hw.physicalcpu", &numPhysicalCores, sizeof(int), NULL, 0);
+    {   size_t size = sizeof(S32);
+        int const ret = sysctlbyname("hw.physicalcpu", &numPhysicalCores, &size, NULL, 0);
         if (ret != 0) {
             if (errno == ENOENT) {
                 /* entry not present, fall back on 1 */

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -602,6 +602,11 @@ int main(int argCount, const char* argv[])
     DISPLAYLEVEL(4, "PLATFORM_POSIX_VERSION defined: %ldL\n", (long) PLATFORM_POSIX_VERSION);
 #endif
 
+    if (nbThreads == 0) {
+        /* try to guess */
+        nbThreads = UTIL_countPhysicalCores();
+        DISPLAYLEVEL(3, "Note: %d physical core(s) detected\n", nbThreads);
+    }
 
     g_utilDisplayLevel = g_displayLevel;
     if (!followLinks) {


### PR DESCRIPTION
Need separate core counting routines for windows, OS X, and Linux.

Tested on (HT: HyperThreading):
Mac, HT
Linux, HT
Linux, no HT
Windows, no HT
Linux, Aarch64, no HT