### PR TITLE
[pzstd] Add logging statements to tests

### DIFF
--- a/contrib/pzstd/utils/test/ThreadPoolTest.cpp
+++ b/contrib/pzstd/utils/test/ThreadPoolTest.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 #include <atomic>
+#include <iostream>
 #include <thread>
 #include <vector>
 
@@ -34,16 +35,19 @@ TEST(ThreadPool, AllJobsFinished) {
   std::atomic<unsigned> numFinished{0};
   std::atomic<bool> start{false};
   {
+    std::cerr << "Creating executor" << std::endl;
     ThreadPool executor(5);
     for (int i = 0; i < 10; ++i) {
       executor.add([ &numFinished, &start ] {
         while (!start.load()) {
-          // spin
+          std::this_thread::yield();
         }
         ++numFinished;
       });
     }
+    std::cerr << "Starting" << std::endl;
     start.store(true);
+    std::cerr << "Finishing" << std::endl;
   }
   EXPECT_EQ(10, numFinished.load());
 }

--- a/contrib/pzstd/utils/test/WorkQueueTest.cpp
+++ b/contrib/pzstd/utils/test/WorkQueueTest.cpp
@@ -10,6 +10,7 @@
 #include "utils/WorkQueue.h"
 
 #include <gtest/gtest.h>
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -201,11 +202,13 @@ TEST(WorkQueue, BoundedSizeMPMC) {
   WorkQueue<int> queue(10);
   std::vector<int> results(200, -1);
   std::mutex mutex;
+  std::cerr << "Creating popperThreads" << std::endl;
   std::vector<std::thread> popperThreads;
   for (int i = 0; i < 4; ++i) {
     popperThreads.emplace_back(Popper{&queue, results.data(), &mutex});
   }
 
+  std::cerr << "Creating pusherThreads" << std::endl;
   std::vector<std::thread> pusherThreads;
   for (int i = 0; i < 2; ++i) {
     auto min = i * 100;
@@ -218,15 +221,19 @@ TEST(WorkQueue, BoundedSizeMPMC) {
         });
   }
 
+  std::cerr << "Joining pusherThreads" << std::endl;
   for (auto& thread : pusherThreads) {
     thread.join();
   }
+  std::cerr << "Finishing queue" << std::endl;
   queue.finish();
 
+  std::cerr << "Joining popperThreads" << std::endl;
   for (auto& thread : popperThreads) {
     thread.join();
   }
 
+  std::cerr << "Inspecting results" << std::endl;
   for (int i = 0; i < 200; ++i) {
     EXPECT_EQ(i, results[i]);
   }


### PR DESCRIPTION
The tests sometimes hang on Appveyor. Add logging statements to the tests that have hung to find out where it is hanging.