### PR TITLE
CMake improvements

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -18,6 +18,9 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 INCLUDE(AddZstdCompilationFlags)
 ADD_ZSTD_COMPILATION_FLAGS()
 
+# Always hide XXHash symbols
+ADD_DEFINITIONS(-DXXH_NAMESPACE=ZSTD_)
+
 #-----------------------------------------------------------------------------
 # Options
 #-----------------------------------------------------------------------------
@@ -30,6 +33,9 @@ ENDIF (UNIX)
 OPTION(ZSTD_BUILD_PROGRAMS "BUILD PROGRAMS" ON)
 OPTION(ZSTD_BUILD_CONTRIB "BUILD CONTRIB" OFF)
 OPTION(ZSTD_BUILD_TESTS "BUILD TESTS" OFF)
+if (MSVC)
+    OPTION(ZSTD_USE_STATIC_RUNTIME "LINK TO STATIC RUN-TIME LIBRARIES" OFF)
+endif ()
 
 IF (ZSTD_LEGACY_SUPPORT)
     MESSAGE(STATUS "ZSTD_LEGACY_SUPPORT defined!")
@@ -45,6 +51,10 @@ ENDIF (ZSTD_LEGACY_SUPPORT)
 ADD_SUBDIRECTORY(lib)
 
 IF (ZSTD_BUILD_PROGRAMS)
+    IF (NOT ZSTD_BUILD_STATIC)
+        MESSAGE(SEND_ERROR "You need to build static library to build zstd CLI")
+    ENDIF (NOT ZSTD_BUILD_STATIC)
+
     ADD_SUBDIRECTORY(programs)
 ENDIF (ZSTD_BUILD_PROGRAMS)
 

--- a/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
+++ b/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
@@ -34,27 +34,11 @@ MACRO(ADD_ZSTD_COMPILATION_FLAGS)
         EnableCompilerFlag("-Wcast-qual" true true)
         EnableCompilerFlag("-Wstrict-prototypes" true false)
     elseif (MSVC) # Add specific compilation flags for Windows Visual
-        EnableCompilerFlag("/Wall" true true)
-
-        # Only for DEBUG version
-        EnableCompilerFlag("/RTC1" true true)
-        EnableCompilerFlag("/Zc:forScope" true true)
-        EnableCompilerFlag("/Gd" true true)
-        EnableCompilerFlag("/analyze:stacksize25000" true true)
-
-        if (MSVC80 OR MSVC90 OR MSVC10 OR MSVC11)
-            # To avoid compiler warning (level 4) C4571, compile with /EHa if you still want
-            # your catch(...) blocks to catch structured exceptions.
-            EnableCompilerFlag("/EHa" false true)
-        endif (MSVC80 OR MSVC90 OR MSVC10 OR MSVC11)
 
         set(ACTIVATE_MULTITHREADED_COMPILATION "ON" CACHE BOOL "activate multi-threaded compilation (/MP flag)")
-        if (ACTIVATE_MULTITHREADED_COMPILATION)
+        if (CMAKE_GENERATOR MATCHES "Visual Studio" AND ACTIVATE_MULTITHREADED_COMPILATION)
             EnableCompilerFlag("/MP" true true)
         endif ()
-
-        #For exceptions
-        EnableCompilerFlag("/EHsc" true true)
         
         # UNICODE SUPPORT
         EnableCompilerFlag("/D_UNICODE" true true)
@@ -71,15 +55,12 @@ MACRO(ADD_ZSTD_COMPILATION_FLAGS)
         string(REPLACE ";" " " ${flag_var} "${${flag_var}}")
     ENDFOREACH (flag_var)
 
-    if (MSVC)
-        # Replace /MT to /MD flag
-        # Replace /O2 to /O3 flag
+    if (MSVC AND ZSTD_USE_STATIC_RUNTIME)
         FOREACH (flag_var CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
                  CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
                  CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
                  CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            STRING(REGEX REPLACE "/MT" "/MD" ${flag_var} "${${flag_var}}")
-            STRING(REGEX REPLACE "/O2" "/Ox" ${flag_var} "${${flag_var}}")
+            STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
         ENDFOREACH (flag_var)
     endif ()
 

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -13,7 +13,12 @@
 PROJECT(libzstd)
 
 SET(CMAKE_INCLUDE_CURRENT_DIR TRUE)
-OPTION(ZSTD_BUILD_STATIC "BUILD STATIC LIBRARIES" OFF)
+OPTION(ZSTD_BUILD_STATIC "BUILD STATIC LIBRARIES" ON)
+OPTION(ZSTD_BUILD_SHARED "BUILD SHARED LIBRARIES" ON)
+
+IF(NOT ZSTD_BUILD_SHARED AND NOT ZSTD_BUILD_STATIC)
+    MESSAGE(SEND_ERROR "You need to build at least one flavor of libstd")
+ENDIF()
 
 # Define library directory, where sources and header files are located
 SET(LIBRARY_DIR ${ZSTD_SOURCE_DIR}/lib)
@@ -90,43 +95,44 @@ IF (MSVC)
 ENDIF (MSVC)
 
 # Split project to static and shared libraries build
-ADD_LIBRARY(libzstd_shared SHARED ${Sources} ${Headers} ${PlatformDependResources})
+IF (ZSTD_BUILD_SHARED)
+    ADD_LIBRARY(libzstd_shared SHARED ${Sources} ${Headers} ${PlatformDependResources})
+ENDIF (ZSTD_BUILD_SHARED)
 IF (ZSTD_BUILD_STATIC)
     ADD_LIBRARY(libzstd_static STATIC ${Sources} ${Headers})
 ENDIF (ZSTD_BUILD_STATIC)
 
 # Add specific compile definitions for MSVC project
 IF (MSVC)
-    SET_PROPERTY(TARGET libzstd_shared APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_DLL_EXPORT=1;ZSTD_HEAPMODE=0;_CONSOLE;_CRT_SECURE_NO_WARNINGS")
+    IF (ZSTD_BUILD_SHARED)
+        SET_PROPERTY(TARGET libzstd_shared APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_DLL_EXPORT=1;ZSTD_HEAPMODE=0;_CONSOLE;_CRT_SECURE_NO_WARNINGS")
+    ENDIF (ZSTD_BUILD_SHARED)
     IF (ZSTD_BUILD_STATIC)
         SET_PROPERTY(TARGET libzstd_static APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_HEAPMODE=0;_CRT_SECURE_NO_WARNINGS")
     ENDIF (ZSTD_BUILD_STATIC)
 ENDIF (MSVC)
 
-# Define library base name
+# With MSVC static library needs to be renamed to avoid conflict with import library
 IF (MSVC)
-
-    IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
-        SET(LIBRARY_BASE_NAME "zstdlib_x64")
-    ELSE ()
-        SET(LIBRARY_BASE_NAME "zstdlib_x86")
-    ENDIF (CMAKE_SIZEOF_VOID_P MATCHES "8")
+    SET(STATIC_LIBRARY_BASE_NAME zstd_static)
 ELSE ()
-    SET(LIBRARY_BASE_NAME zstd)
+    SET(STATIC_LIBRARY_BASE_NAME zstd)
 ENDIF (MSVC)
 
 # Define static and shared library names
-SET_TARGET_PROPERTIES(
-        libzstd_shared
-        PROPERTIES
-        OUTPUT_NAME ${LIBRARY_BASE_NAME}
-        SOVERSION ${LIBVER_MAJOR}.${LIBVER_MINOR}.${LIBVER_RELEASE})
+IF (ZSTD_BUILD_SHARED)
+    SET_TARGET_PROPERTIES(
+            libzstd_shared
+            PROPERTIES
+            OUTPUT_NAME zstd
+            SOVERSION ${LIBVER_MAJOR}.${LIBVER_MINOR}.${LIBVER_RELEASE})
+ENDIF (ZSTD_BUILD_SHARED)
 
 IF (ZSTD_BUILD_STATIC)
     SET_TARGET_PROPERTIES(
             libzstd_static
             PROPERTIES
-            OUTPUT_NAME ${LIBRARY_BASE_NAME})
+            OUTPUT_NAME ${STATIC_LIBRARY_BASE_NAME})
 ENDIF (ZSTD_BUILD_STATIC)
 
 IF (UNIX)
@@ -141,20 +147,29 @@ IF (UNIX)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig.cmake"
             COMMENT "Creating pkg-config file")
 
-    # install target
-    INSTALL(FILES ${LIBRARY_DIR}/zstd.h ${LIBRARY_DIR}/deprecated/zbuff.h ${LIBRARY_DIR}/dictBuilder/zdict.h DESTINATION "include")
     INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/libzstd.pc" DESTINATION "share/pkgconfig")
-    INSTALL(TARGETS libzstd_shared LIBRARY DESTINATION "lib")
-    IF (ZSTD_BUILD_STATIC)
-        INSTALL(TARGETS libzstd_static ARCHIVE DESTINATION "lib")
-    ENDIF (ZSTD_BUILD_STATIC)
-
-    # uninstall target
-    CONFIGURE_FILE(
-            "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-            "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-            IMMEDIATE @ONLY)
-
-    ADD_CUSTOM_TARGET(uninstall
-            COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 ENDIF (UNIX)
+
+# install target
+INSTALL(FILES 
+    ${LIBRARY_DIR}/zstd.h 
+    ${LIBRARY_DIR}/deprecated/zbuff.h 
+    ${LIBRARY_DIR}/dictBuilder/zdict.h 
+    ${LIBRARY_DIR}/common/zstd_errors.h
+    DESTINATION "include")
+
+IF (ZSTD_BUILD_SHARED)
+    INSTALL(TARGETS libzstd_shared RUNTIME DESTINATION "bin" LIBRARY DESTINATION "lib" ARCHIVE DESTINATION "lib")
+ENDIF()
+IF (ZSTD_BUILD_STATIC)
+    INSTALL(TARGETS libzstd_static ARCHIVE DESTINATION "lib")
+ENDIF (ZSTD_BUILD_STATIC)
+
+# uninstall target
+CONFIGURE_FILE(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
+
+ADD_CUSTOM_TARGET(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/build/cmake/programs/CMakeLists.txt
+++ b/build/cmake/programs/CMakeLists.txt
@@ -30,14 +30,16 @@ IF (MSVC)
 ENDIF (MSVC)
 
 ADD_EXECUTABLE(zstd ${PROGRAMS_DIR}/zstdcli.c ${PROGRAMS_DIR}/fileio.c ${PROGRAMS_DIR}/bench.c ${PROGRAMS_DIR}/datagen.c ${PROGRAMS_DIR}/dibio.c ${PlatformDependResources})
-TARGET_LINK_LIBRARIES(zstd libzstd_shared)
-ADD_CUSTOM_TARGET(zstdcat ALL ${CMAKE_COMMAND} -E create_symlink zstd zstdcat DEPENDS zstd COMMENT "Creating zstdcat symlink")
-ADD_CUSTOM_TARGET(unzstd ALL ${CMAKE_COMMAND} -E create_symlink zstd unzstd DEPENDS zstd COMMENT "Creating unzstd symlink")
+TARGET_LINK_LIBRARIES(zstd libzstd_static)
 INSTALL(TARGETS zstd RUNTIME DESTINATION "bin")
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/zstdcat DESTINATION "bin")
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/unzstd DESTINATION "bin")
 
 IF (UNIX)
+    ADD_CUSTOM_TARGET(zstdcat ALL ${CMAKE_COMMAND} -E create_symlink zstd zstdcat DEPENDS zstd COMMENT "Creating zstdcat symlink")
+    ADD_CUSTOM_TARGET(unzstd ALL ${CMAKE_COMMAND} -E create_symlink zstd unzstd DEPENDS zstd COMMENT "Creating unzstd symlink")
+    INSTALL(TARGETS zstd RUNTIME DESTINATION "bin")
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/zstdcat DESTINATION "bin")
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/unzstd DESTINATION "bin")
+
     ADD_CUSTOM_TARGET(zstd.1 ALL
         ${CMAKE_COMMAND} -E copy ${PROGRAMS_DIR}/zstd.1 .
         COMMENT "Copying manpage zstd.1")
@@ -48,7 +50,7 @@ IF (UNIX)
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/unzstd.1 DESTINATION "share/man/man1")
 
     ADD_EXECUTABLE(zstd-frugal ${PROGRAMS_DIR}/zstdcli.c ${PROGRAMS_DIR}/fileio.c)
-    TARGET_LINK_LIBRARIES(zstd-frugal libzstd_shared)
+    TARGET_LINK_LIBRARIES(zstd-frugal libzstd_static)
     SET_PROPERTY(TARGET zstd-frugal APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_NOBENCH;ZSTD_NODICT")
 ENDIF (UNIX)
 


### PR DESCRIPTION
Several fixes and improvements to CMake build. Quick overview:

- Ensure XXHash symbols are hidden.
- Add option to disable build of shared library.
- Link zstd CLI to static library, as it uses symbols that are not public interface of libzstd. This helps to avoid any dllexport or so visibility issues. Fixes #707.
- Rework MSVC flag handling
    -  Remove most of them as CMake defaults are pretty good as is. This fixes /RTC1-in-release problem described in #707 and prevents bunch of unnecessary warnings.
    - Add option allowing linking to static run-time library

- Enable install target on Windows.
- Install zstd_errors.h (currently it is installed by makefile, but not in CMake)
- Rename static library when compiling with MSVC to avoid name conflict with import library.