### PR TITLE
[linux-kernel] Minor formatting changes

### DIFF
--- a/contrib/linux-kernel/kernelize.sh
+++ b/contrib/linux-kernel/kernelize.sh
@@ -96,6 +96,7 @@ then
   check_not_present_in_file STATIC_ASSERT ${LIB}mem.h
   check_not_present_in_file "#define ZSTD_STATIC_ASSERT" ${LIB}compress.c
   check_not_present MEM_STATIC
+  check_not_present FSE_COMMONDEFS_ONLY
   check_not_present "#if 0"
   check_not_present "#if 1"
   check_not_present _MSC_VER

--- a/contrib/linux-kernel/lib/zstd/compress.c
+++ b/contrib/linux-kernel/lib/zstd/compress.c
@@ -2412,9 +2412,8 @@ static size_t ZSTD_writeFrameHeader(void *dst, size_t dstCapacity, ZSTD_paramete
 	U32 const windowSize = 1U << params.cParams.windowLog;
 	U32 const singleSegment = params.fParams.contentSizeFlag && (windowSize >= pledgedSrcSize);
 	BYTE const windowLogByte = (BYTE)((params.cParams.windowLog - ZSTD_WINDOWLOG_ABSOLUTEMIN) << 3);
-	U32 const fcsCode = params.fParams.contentSizeFlag ? (pledgedSrcSize >= 256) + (pledgedSrcSize >= 65536 + 256) + (pledgedSrcSize >= 0xFFFFFFFFU)
-							   : /* 0-3 */
-				0;
+	U32 const fcsCode =
+	    params.fParams.contentSizeFlag ? (pledgedSrcSize >= 256) + (pledgedSrcSize >= 65536 + 256) + (pledgedSrcSize >= 0xFFFFFFFFU) : 0; /* 0-3 */
 	BYTE const frameHeaderDecriptionByte = (BYTE)(dictIDSizeCode + (checksumFlag << 2) + (singleSegment << 5) + (fcsCode << 6));
 	size_t pos;
 

--- a/contrib/linux-kernel/lib/zstd/decompress.c
+++ b/contrib/linux-kernel/lib/zstd/decompress.c
@@ -2300,7 +2300,6 @@ size_t ZSTD_decompressStream(ZSTD_DStream *zds, ZSTD_outBuffer *output, ZSTD_inB
 				ip += toLoad;
 				break;
 			}
-		}
 
 			/* check for single-pass mode opportunity */
 			if (zds->fParams.frameContentSize && zds->fParams.windowSize /* skippable frame if == 0 */
@@ -2355,6 +2354,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream *zds, ZSTD_outBuffer *output, ZSTD_inB
 				}
 			}
 			zds->stage = zdss_read;
+		}
 		/* pass-through */
 
 		case zdss_read: {

--- a/contrib/linux-kernel/lib/zstd/fse.h
+++ b/contrib/linux-kernel/lib/zstd/fse.h
@@ -536,8 +536,6 @@ ZSTD_STATIC BYTE FSE_decodeSymbolFast(FSE_DState_t *DStatePtr, BIT_DStream_t *bi
 
 ZSTD_STATIC unsigned FSE_endOfDState(const FSE_DState_t *DStatePtr) { return DStatePtr->state == 0; }
 
-#ifndef FSE_COMMONDEFS_ONLY
-
 /* **************************************************************
 *  Tuning parameters
 ****************************************************************/
@@ -566,8 +564,6 @@ ZSTD_STATIC unsigned FSE_endOfDState(const FSE_DState_t *DStatePtr) { return DSt
 #define FSE_FUNCTION_TYPE BYTE
 #define FSE_FUNCTION_EXTENSION
 #define FSE_DECODE_TYPE FSE_decode_t
-
-#endif /* !FSE_COMMONDEFS_ONLY */
 
 /* ***************************************************************
 *  Constants

--- a/contrib/linux-kernel/lib/zstd/fse_compress.c
+++ b/contrib/linux-kernel/lib/zstd/fse_compress.c
@@ -180,8 +180,6 @@ size_t FSE_buildCTable_wksp(FSE_CTable *ct, const short *normalizedCounter, unsi
 	return 0;
 }
 
-#ifndef FSE_COMMONDEFS_ONLY
-
 /*-**************************************************************
 *  FSE NCount encoding-decoding
 ****************************************************************/
@@ -857,5 +855,3 @@ size_t FSE_compress_wksp(void *dst, size_t dstSize, const void *src, size_t srcS
 
 	return op - ostart;
 }
-
-#endif /* FSE_COMMONDEFS_ONLY */

--- a/contrib/linux-kernel/lib/zstd/fse_decompress.c
+++ b/contrib/linux-kernel/lib/zstd/fse_decompress.c
@@ -161,8 +161,6 @@ size_t FSE_buildDTable(FSE_DTable *dt, const short *normalizedCounter, unsigned 
 	return 0;
 }
 
-#ifndef FSE_COMMONDEFS_ONLY
-
 /*-*******************************************************
 *  Decompression (Byte symbols)
 *********************************************************/
@@ -313,5 +311,3 @@ size_t FSE_decompress_wksp(void *dst, size_t dstCapacity, const void *cSrc, size
 
 	return FSE_decompress_usingDTable(dst, dstCapacity, ip, cSrcSize, workSpace); /* always return, even if it is an error code */
 }
-
-#endif /* FSE_COMMONDEFS_ONLY */

--- a/contrib/linux-kernel/lib/zstd/huf_compress.c
+++ b/contrib/linux-kernel/lib/zstd/huf_compress.c
@@ -305,9 +305,8 @@ static U32 HUF_setMaxHeight(nodeElt *huffNode, U32 lastNonNull, U32 maxNbBits)
 					}
 				}
 				/* only triggered when no more rank 1 symbol left => find closest one (note : there is necessarily at least one !) */
-				while (
-				    (nBitsToDecrease <= HUF_TABLELOG_MAX) &&
-				    (rankLast[nBitsToDecrease] == noSymbol)) /* HUF_MAX_TABLELOG test just to please gcc 5+; but it should not be necessary */
+				/* HUF_MAX_TABLELOG test just to please gcc 5+; but it should not be necessary */
+				while ((nBitsToDecrease <= HUF_TABLELOG_MAX) && (rankLast[nBitsToDecrease] == noSymbol))
 					nBitsToDecrease++;
 				totalCost -= 1 << (nBitsToDecrease - 1);
 				if (rankLast[nBitsToDecrease - 1] == noSymbol)

--- a/contrib/linux-kernel/lib/zstd/huf_decompress.c
+++ b/contrib/linux-kernel/lib/zstd/huf_decompress.c
@@ -573,9 +573,8 @@ static U32 HUF_decodeLastSymbolX4(void *op, BIT_DStream_t *DStream, const HUF_DE
 		if (DStream->bitsConsumed < (sizeof(DStream->bitContainer) * 8)) {
 			BIT_skipBits(DStream, dt[val].nbBits);
 			if (DStream->bitsConsumed > (sizeof(DStream->bitContainer) * 8))
-				DStream->bitsConsumed =
-				    (sizeof(DStream->bitContainer) *
-				     8); /* ugly hack; works only because it's the last symbol. Note : can't easily extract nbBits from just this symbol */
+				/* ugly hack; works only because it's the last symbol. Note : can't easily extract nbBits from just this symbol */
+				DStream->bitsConsumed = (sizeof(DStream->bitContainer) * 8);
 		}
 	}
 	return 1;

--- a/lib/compress/huf_compress.c
+++ b/lib/compress/huf_compress.c
@@ -266,7 +266,8 @@ static U32 HUF_setMaxHeight(nodeElt* huffNode, U32 lastNonNull, U32 maxNbBits)
                         if (highTotal <= lowTotal) break;
                 }   }
                 /* only triggered when no more rank 1 symbol left => find closest one (note : there is necessarily at least one !) */
-                while ((nBitsToDecrease<=HUF_TABLELOG_MAX) && (rankLast[nBitsToDecrease] == noSymbol))  /* HUF_MAX_TABLELOG test just to please gcc 5+; but it should not be necessary */
+                /* HUF_MAX_TABLELOG test just to please gcc 5+; but it should not be necessary */
+                while ((nBitsToDecrease<=HUF_TABLELOG_MAX) && (rankLast[nBitsToDecrease] == noSymbol))
                     nBitsToDecrease ++;
                 totalCost -= 1 << (nBitsToDecrease-1);
                 if (rankLast[nBitsToDecrease-1] == noSymbol)

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1950,8 +1950,8 @@ U32 ZSTD_insertAndFindFirstIndex (ZSTD_CCtx* zc, const BYTE* ip, U32 mls)
 }
 
 
-
-FORCE_INLINE /* inlining is important to hardwire a hot branch (template emulation) */
+/* inlining is important to hardwire a hot branch (template emulation) */
+FORCE_INLINE
 size_t ZSTD_HcFindBestMatch_generic (
                         ZSTD_CCtx* zc,   /* Index table will be updated */
                         const BYTE* const ip, const BYTE* const iLimit,
@@ -2557,8 +2557,7 @@ static size_t ZSTD_writeFrameHeader(void* dst, size_t dstCapacity,
     U32   const singleSegment = params.fParams.contentSizeFlag && (windowSize >= pledgedSrcSize);
     BYTE  const windowLogByte = (BYTE)((params.cParams.windowLog - ZSTD_WINDOWLOG_ABSOLUTEMIN) << 3);
     U32   const fcsCode = params.fParams.contentSizeFlag ?
-                     (pledgedSrcSize>=256) + (pledgedSrcSize>=65536+256) + (pledgedSrcSize>=0xFFFFFFFFU) :   /* 0-3 */
-                      0;
+                     (pledgedSrcSize>=256) + (pledgedSrcSize>=65536+256) + (pledgedSrcSize>=0xFFFFFFFFU) : 0;  /* 0-3 */
     BYTE  const frameHeaderDecriptionByte = (BYTE)(dictIDSizeCode + (checksumFlag<<2) + (singleSegment<<5) + (fcsCode<<6) );
     size_t pos;
 

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -545,7 +545,8 @@ static U32 HUF_decodeLastSymbolX4(void* op, BIT_DStream_t* DStream, const HUF_DE
         if (DStream->bitsConsumed < (sizeof(DStream->bitContainer)*8)) {
             BIT_skipBits(DStream, dt[val].nbBits);
             if (DStream->bitsConsumed > (sizeof(DStream->bitContainer)*8))
-                DStream->bitsConsumed = (sizeof(DStream->bitContainer)*8);   /* ugly hack; works only because it's the last symbol. Note : can't easily extract nbBits from just this symbol */
+                /* ugly hack; works only because it's the last symbol. Note : can't easily extract nbBits from just this symbol */
+                DStream->bitsConsumed = (sizeof(DStream->bitContainer)*8);
     }   }
     return 1;
 }


### PR DESCRIPTION
* Delete `FSE_COMMONDEFS_ONLY` from kernel code.
* Fix clang-formatting edge cases. Change `/lib` as well.
* `ZSTD_decompressStream()` ends a scope for a case early, clang-format doesn't like that, so extend that scope.
* Whitespace only changes for `/lib`.