### PR TITLE
Fix typo in libzstd.a-mt make rules

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -73,7 +73,7 @@ libzstd.a: $(ZSTD_OBJ)
 	@echo compiling static library
 	@$(AR) $(ARFLAGS) $@ $^
 
-libzstd.a-mt: CPPFLAGS += -DZSTD_MULTHREAD
+libzstd.a-mt: CPPFLAGS += -DZSTD_MULTITHREAD
 libzstd.a-mt: libzstd.a
 
 $(LIBZSTD): LDFLAGS += -shared -fPIC -fvisibility=hidden


### PR DESCRIPTION
The macro name is ZSTD_MULTITHREAD, not ZSTD_MULTHREAD.

Fixes: ca6fae78080d ("Add MT enabled targets for libzstd")