### PR TITLE
[pzstd] Fix potential deadlock in the case of errors

### DIFF
--- a/contrib/pzstd/Pzstd.cpp
+++ b/contrib/pzstd/Pzstd.cpp
@@ -585,7 +585,10 @@ std::uint64_t writeFile(
   std::uint64_t bytesWritten = 0;
   std::shared_ptr<BufferWorkQueue> out;
   // Grab the output queue for each decompression job (in order).
-  while (outs.pop(out) && !errorHolder.hasError()) {
+  while (outs.pop(out)) {
+    if (errorHolder.hasError()) {
+      continue;
+    }
     if (!decompress) {
       // If we are compressing and want to write skippable frames we can't
       // start writing before compression is done because we need to know the


### PR DESCRIPTION
The `outs` queue is bounded, so if an error occurs, one or more threads could be waiting to push something onto the queue, so we need to pop things off. It won't infinite loop, since there is an error. We know that the producer won't push more than 1 more thing onto the queue, and will call `finish()`.

Fixes #720.