### PR TITLE
[pzstd] Remove appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,6 @@
       SCRIPT:   ""
       TEST:     "cmake"
 
-    - COMPILER: "gcc"
-      HOST:     "mingw"
-      PLATFORM: "x64"
-      SCRIPT:   ""
-      TEST:     "pzstd"
-
     - COMPILER: "visual"
       HOST:     "visual"
       PLATFORM: "x64"
@@ -156,13 +150,6 @@
       cmake -G "Visual Studio 14 2015 Win64" .. &&
       cd ..\..\.. &&
       make clean
-    )
-  - if [%TEST%]==[pzstd] (
-      make -C contrib\pzstd googletest-mingw64 &&
-      make -C contrib\pzstd pzstd.exe &&
-      make -C contrib\pzstd tests &&
-      make -C contrib\pzstd check &&
-      make -C contrib\pzstd clean
     )
   - SET "FUZZERTEST=-T30s"
   - if [%HOST%]==[visual] if [%CONFIGURATION%]==[Release] (

--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -89,6 +89,10 @@ Benchmark file(s) using compression level #
 \fB\-\-train FILEs\fR
 Use FILEs as a training set to create a dictionary\. The training set should contain a lot of small files (> 100)\.
 .
+.TP
+\fB\-l\fR, \fB\-\-list\fR
+Display information related to a zstd compressed file, such as size, ratio, and checksum\. Some of these fields may not be available\. This command can be augmented with the \fB\-v\fR modifier\.
+.
 .SS "Operation modifiers"
 .
 .TP
@@ -252,7 +256,7 @@ set process priority to real\-time
 Specify a strategy used by a match finder\.
 .
 .IP
-There are 8 strategies numbered from 0 to 7, from faster to stronger: 0=ZSTD_fast, 1=ZSTD_dfast, 2=ZSTD_greedy, 3=ZSTD_lazy, 4=ZSTD_lazy2, 5=ZSTD_btlazy2, 6=ZSTD_btopt, 7=ZSTD_btultra\.
+There are 8 strategies numbered from 1 to 8, from faster to stronger: 1=ZSTD_fast, 2=ZSTD_dfast, 3=ZSTD_greedy, 4=ZSTD_lazy, 5=ZSTD_lazy2, 6=ZSTD_btlazy2, 7=ZSTD_btopt, 8=ZSTD_btultra\.
 .
 .TP
 \fBwindowLog\fR=\fIwlog\fR, \fBwlog\fR=\fIwlog\fR

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -96,7 +96,7 @@ the last one takes effect.
 * `-l`, `--list`:
     Display information related to a zstd compressed file, such as size, ratio, and checksum.
     Some of these fields may not be available.
-    This command can be augmented with the `-v` modifier. 
+    This command can be augmented with the `-v` modifier.
 
 ### Operation modifiers
 
@@ -254,7 +254,7 @@ The list of available _options_:
 - `strategy`=_strat_, `strat`=_strat_:
     Specify a strategy used by a match finder.
 
-    There are 8 strategies numbered from 0 to 7, from faster to stronger:
+    There are 8 strategies numbered from 1 to 8, from faster to stronger:
     1=ZSTD\_fast, 2=ZSTD\_dfast, 3=ZSTD\_greedy, 4=ZSTD\_lazy,
     5=ZSTD\_lazy2, 6=ZSTD\_btlazy2, 7=ZSTD\_btopt, 8=ZSTD\_btultra.
 


### PR DESCRIPTION
* The appveyor tests sometimes hang, and pzstd is now deprecated in favor of zstdmt, so delete the tests.
* Update the zstd man page to reflect that strategies start from 1.