### PR TITLE
Memory optimisations for ZSTDMT

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 v1.3.1
+perf: substantially decreased memory usage in Multi-threading mode, thanks to reports by Tino Reichardt
 build: fix Visual compilation for non x86/x64 targets, reported by Greg Slazinski (#718)
-API exp : breaking change : ZSTD_getframeHeader() 
+API exp : breaking change : ZSTD_getframeHeader() provides more information
 
 v1.3.0
 cli : new : `--list` command, by Paul Cruz

--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -92,7 +92,7 @@ POOL_ctx *POOL_create(size_t numThreads, size_t queueSize) {
      * and full queues.
      */
     ctx->queueSize = queueSize + 1;
-    ctx->queue = (POOL_job *)malloc(ctx->queueSize * sizeof(POOL_job));
+    ctx->queue = (POOL_job*) malloc(ctx->queueSize * sizeof(POOL_job));
     ctx->queueHead = 0;
     ctx->queueTail = 0;
     pthread_mutex_init(&ctx->queueMutex, NULL);
@@ -100,7 +100,7 @@ POOL_ctx *POOL_create(size_t numThreads, size_t queueSize) {
     pthread_cond_init(&ctx->queuePopCond, NULL);
     ctx->shutdown = 0;
     /* Allocate space for the thread handles */
-    ctx->threads = (pthread_t *)malloc(numThreads * sizeof(pthread_t));
+    ctx->threads = (pthread_t*)malloc(numThreads * sizeof(pthread_t));
     ctx->numThreads = 0;
     /* Check for errors */
     if (!ctx->threads || !ctx->queue) { POOL_free(ctx); return NULL; }
@@ -153,8 +153,8 @@ size_t POOL_sizeof(POOL_ctx *ctx) {
         + ctx->numThreads * sizeof(pthread_t);
 }
 
-void POOL_add(void *ctxVoid, POOL_function function, void *opaque) {
-    POOL_ctx *ctx = (POOL_ctx *)ctxVoid;
+void POOL_add(void* ctxVoid, POOL_function function, void *opaque) {
+    POOL_ctx* const ctx = (POOL_ctx*)ctxVoid;
     if (!ctx) { return; }
 
     pthread_mutex_lock(&ctx->queueMutex);
@@ -183,22 +183,22 @@ struct POOL_ctx_s {
   int data;
 };
 
-POOL_ctx *POOL_create(size_t numThreads, size_t queueSize) {
+POOL_ctx* POOL_create(size_t numThreads, size_t queueSize) {
   (void)numThreads;
   (void)queueSize;
-  return (POOL_ctx *)malloc(sizeof(POOL_ctx));
+  return (POOL_ctx*)malloc(sizeof(POOL_ctx));
 }
 
-void POOL_free(POOL_ctx *ctx) {
-  if (ctx) free(ctx);
+void POOL_free(POOL_ctx* ctx) {
+    free(ctx);
 }
 
-void POOL_add(void *ctx, POOL_function function, void *opaque) {
+void POOL_add(void* ctx, POOL_function function, void* opaque) {
   (void)ctx;
   function(opaque);
 }
 
-size_t POOL_sizeof(POOL_ctx *ctx) {
+size_t POOL_sizeof(POOL_ctx* ctx) {
     if (ctx==NULL) return 0;  /* supports sizeof NULL */
     return sizeof(*ctx);
 }

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -19,11 +19,11 @@ extern "C" {
 typedef struct POOL_ctx_s POOL_ctx;
 
 /*! POOL_create() :
-    Create a thread pool with at most `numThreads` threads.
-    `numThreads` must be at least 1.
-    The maximum number of queued jobs before blocking is `queueSize`.
-    `queueSize` must be at least 1.
-    @return : The POOL_ctx pointer on success else NULL.
+ *  Create a thread pool with at most `numThreads` threads.
+ * `numThreads` must be at least 1.
+ *  The maximum number of queued jobs before blocking is `queueSize`.
+ * `queueSize` must be at least 1.
+ * @return : POOL_ctx pointer on success, else NULL.
 */
 POOL_ctx *POOL_create(size_t numThreads, size_t queueSize);
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -377,7 +377,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned v
                 return ERROR(compressionParameter_unsupported);
             ZSTDMT_freeCCtx(cctx->mtctx);
             cctx->nbThreads = 1;
-            cctx->mtctx = ZSTDMT_createCCtx(value);
+            cctx->mtctx = ZSTDMT_createCCtx_advanced(value, cctx->customMem);
             if (cctx->mtctx == NULL) return ERROR(memory_allocation);
         }
         cctx->nbThreads = value;

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -763,10 +763,10 @@ static size_t ZSTDMT_createCompressionJob(ZSTDMT_CCtx* zcs, size_t srcSize, unsi
         zcs->inBuff.filled = 0;
         zcs->dictSize = 0;
         zcs->frameEnded = 1;
-        if (zcs->nextJobID == 0)
+        if (zcs->nextJobID == 0) {
             /* single chunk exception : checksum is calculated directly within worker thread */
             zcs->params.fParams.checksumFlag = 0;
-    }
+    }   }
 
     DEBUGLOG(4, "posting job %u : %u bytes  (end:%u) (note : doneJob = %u=>%u)",
                 zcs->nextJobID,

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -215,7 +215,7 @@ static ZSTD_CCtx* ZSTDMT_getCCtx(ZSTDMT_CCtxPool* pool)
         pool->availCCtx--;
         return pool->cctx[pool->availCCtx];
     }
-    return ZSTD_createCCtx();   /* note : can be NULL, when creation fails ! */
+    return ZSTD_createCCtx_advanced(pool->cMem);   /* note : can be NULL, when creation fails ! */
 }
 
 static void ZSTDMT_releaseCCtx(ZSTDMT_CCtxPool* pool, ZSTD_CCtx* cctx)

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -93,7 +93,7 @@ typedef struct ZSTDMT_bufferPool_s {
 
 static ZSTDMT_bufferPool* ZSTDMT_createBufferPool(unsigned nbThreads, ZSTD_customMem cMem)
 {
-    unsigned const maxNbBuffers = 2*nbThreads + 2;
+    unsigned const maxNbBuffers = 2*nbThreads + 3;
     ZSTDMT_bufferPool* const bufPool = (ZSTDMT_bufferPool*)ZSTD_calloc(
         sizeof(ZSTDMT_bufferPool) + (maxNbBuffers-1) * sizeof(buffer_t), cMem);
     if (bufPool==NULL) return NULL;

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -16,8 +16,8 @@
 
 
 /* Note : This is an internal API.
- *        Some methods are still exposed (ZSTDLIB_API), because for some time,
- *        it used to be the only way to invoke MT compression.
+ *        Some methods are still exposed (ZSTDLIB_API),
+ *        because it used to be the only way to invoke MT compression.
  *        Now, it's recommended to use ZSTD_compress_generic() instead.
  *        These methods will stop being exposed in a future version */
 
@@ -68,7 +68,7 @@ ZSTDLIB_API size_t ZSTDMT_compress_advanced(ZSTDMT_CCtx* mtctx,
                                      const void* src, size_t srcSize,
                                      const ZSTD_CDict* cdict,
                                            ZSTD_parameters const params,
-                                           unsigned overlapRLog);
+                                           unsigned overlapRLog);            /* overlapRLog = 9 - overlapLog */
 
 ZSTDLIB_API size_t ZSTDMT_initCStream_advanced(ZSTDMT_CCtx* mtctx,
                                         const void* dict, size_t dictSize,   /* dict can be released after init, a local copy is preserved within zcs */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -79,7 +79,7 @@ all32: fullbench32 fuzzer32 zstreamtest32
 
 allnothread: fullbench fuzzer paramgrill datagen  decodecorpus
 
-dll: fuzzer-dll zstreamtest-dll 
+dll: fuzzer-dll zstreamtest-dll
 
 zstd:
 	$(MAKE) -C $(PRGDIR) $@
@@ -108,11 +108,11 @@ fullbench-dll: $(PRGDIR)/datagen.c fullbench.c
 	$(MAKE) -C $(ZSTDDIR) libzstd
 	$(CC) $(FLAGS) $^ -o $@$(EXT) -DZSTD_DLL_IMPORT=1 $(ZSTDDIR)/dll/libzstd.dll
 
-fuzzer   : $(ZSTD_FILES) $(ZDICT_FILES) $(PRGDIR)/datagen.c fuzzer.c
-	$(CC)      $(FLAGS) $^ -o $@$(EXT)
-
-fuzzer32 : $(ZSTD_FILES) $(ZDICT_FILES) $(PRGDIR)/datagen.c fuzzer.c
-	$(CC) -m32 $(FLAGS) $^ -o $@$(EXT)
+fuzzer : CPPFLAGS += $(MULTITHREAD_CPP)
+fuzzer : LDFLAGS += $(MULTITHREAD_LD)
+fuzzer32: CFLAGS += -m32
+fuzzer fuzzer32 : $(ZSTD_FILES) $(ZDICT_FILES) $(PRGDIR)/datagen.c fuzzer.c
+	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
 fuzzer-dll : LDFLAGS+= -L$(ZSTDDIR) -lzstd
 fuzzer-dll : $(ZSTDDIR)/common/xxhash.c $(PRGDIR)/datagen.c fuzzer.c

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -136,10 +136,20 @@ static int basicUnitTests(U32 seed, double compressibility)
 
 
     DISPLAYLEVEL(4, "test%3i : compress %u bytes : ", testNb++, (U32)CNBuffSize);
-    CHECKPLUS(r, ZSTD_compress(compressedBuffer, ZSTD_compressBound(CNBuffSize),
-                               CNBuffer, CNBuffSize, 1),
-              cSize=r );
-    DISPLAYLEVEL(4, "OK (%u bytes : %.2f%%)\n", (U32)cSize, (double)cSize/CNBuffSize*100);
+    {   ZSTD_CCtx* cctx = ZSTD_createCCtx();
+        if (cctx==NULL) goto _output_error;
+        CHECKPLUS(r, ZSTD_compressCCtx(cctx,
+                            compressedBuffer, ZSTD_compressBound(CNBuffSize),
+                            CNBuffer, CNBuffSize, 1),
+                  cSize=r );
+        DISPLAYLEVEL(4, "OK (%u bytes : %.2f%%)\n", (U32)cSize, (double)cSize/CNBuffSize*100);
+
+        DISPLAYLEVEL(4, "test%3i : size of cctx for level 1 : ", testNb++);
+        {   size_t const cctxSize = ZSTD_sizeof_CCtx(cctx);
+            DISPLAYLEVEL(4, "%u bytes \n", (U32)cctxSize);
+        }
+        ZSTD_freeCCtx(cctx);
+    }
 
 
     DISPLAYLEVEL(4, "test%3i : ZSTD_getFrameContentSize test : ", testNb++);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -160,7 +160,7 @@ static int FUZ_mallocTests(unsigned seed, double compressibility)
     {   int compressionLevel;
         mallocCounter_t malcount = INIT_MALLOC_COUNTER;
         ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
-        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
+        for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
             ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
             ZSTD_compressCCtx(cctx, outBuffer, outSize, inBuffer, inSize, compressionLevel);
             ZSTD_freeCCtx(cctx);
@@ -173,7 +173,7 @@ static int FUZ_mallocTests(unsigned seed, double compressibility)
     {   int compressionLevel;
         mallocCounter_t malcount = INIT_MALLOC_COUNTER;
         ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
-        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
+        for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
             ZSTD_CCtx* const cstream = ZSTD_createCStream_advanced(cMem);
             ZSTD_outBuffer out = { outBuffer, outSize, 0 };
             ZSTD_inBuffer in = { inBuffer, inSize, 0 };
@@ -186,56 +186,46 @@ static int FUZ_mallocTests(unsigned seed, double compressibility)
             malcount = INIT_MALLOC_COUNTER;
     }   }
 
-    /* advanced API test */
-    {   int compressionLevel;
-        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
-        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
-        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
-            ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
-            ZSTD_outBuffer out = { outBuffer, outSize, 0 };
-            ZSTD_inBuffer in = { inBuffer, inSize, 0 };
-            ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
-            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
-            ZSTD_freeCCtx(cctx);
-            DISPLAYLEVEL(3, "compress_generic,end level %i : ", compressionLevel);
-            FUZ_displayMallocStats(malcount);
-            malcount = INIT_MALLOC_COUNTER;
-    }   }
-
     /* advanced MT API test */
-    {   int compressionLevel;
-        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
-        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
-        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
-            ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
-            ZSTD_outBuffer out = { outBuffer, outSize, 0 };
-            ZSTD_inBuffer in = { inBuffer, inSize, 0 };
-            ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
-            ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbThreads, 2);
-            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
-            ZSTD_freeCCtx(cctx);
-            DISPLAYLEVEL(3, "compress_generic,-T2,end level %i : ", compressionLevel);
-            FUZ_displayMallocStats(malcount);
-            malcount = INIT_MALLOC_COUNTER;
-    }   }
+    {   U32 nbThreads;
+        for (nbThreads=1; nbThreads<=4; nbThreads++) {
+            int compressionLevel;
+            mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+            ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
+            for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
+                ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
+                ZSTD_outBuffer out = { outBuffer, outSize, 0 };
+                ZSTD_inBuffer in = { inBuffer, inSize, 0 };
+                ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
+                ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbThreads, nbThreads);
+                ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+                ZSTD_freeCCtx(cctx);
+                DISPLAYLEVEL(3, "compress_generic,-T%u,end level %i : ",
+                                nbThreads, compressionLevel);
+                FUZ_displayMallocStats(malcount);
+                malcount = INIT_MALLOC_COUNTER;
+    }   }   }
 
     /* advanced MT streaming API test */
-    {   int compressionLevel;
-        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
-        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
-        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
-            ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
-            ZSTD_outBuffer out = { outBuffer, outSize, 0 };
-            ZSTD_inBuffer in = { inBuffer, inSize, 0 };
-            ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
-            ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbThreads, 2);
-            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_continue);
-            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
-            ZSTD_freeCCtx(cctx);
-            DISPLAYLEVEL(3, "compress_generic,-T2,continue level %i : ", compressionLevel);
-            FUZ_displayMallocStats(malcount);
-            malcount = INIT_MALLOC_COUNTER;
-    }   }
+    {   U32 nbThreads;
+        for (nbThreads=1; nbThreads<=4; nbThreads++) {
+            int compressionLevel;
+            mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+            ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
+            for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
+                ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
+                ZSTD_outBuffer out = { outBuffer, outSize, 0 };
+                ZSTD_inBuffer in = { inBuffer, inSize, 0 };
+                ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
+                ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbThreads, nbThreads);
+                ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_continue);
+                ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+                ZSTD_freeCCtx(cctx);
+                DISPLAYLEVEL(3, "compress_generic,-T%u,continue level %i : ",
+                                nbThreads, compressionLevel);
+                FUZ_displayMallocStats(malcount);
+                malcount = INIT_MALLOC_COUNTER;
+    }   }   }
 
     return 0;
 }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -51,14 +51,14 @@ static const U32 nbTestsDefault = 30000;
 /*-************************************
 *  Display Macros
 **************************************/
-#define DISPLAY(...)          fprintf(stderr, __VA_ARGS__)
+#define DISPLAY(...)          fprintf(stdout, __VA_ARGS__)
 #define DISPLAYLEVEL(l, ...)  if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); }
 static U32 g_displayLevel = 2;
 
 #define DISPLAYUPDATE(l, ...) if (g_displayLevel>=l) { \
             if ((FUZ_clockSpan(g_displayClock) > g_refreshRate) || (g_displayLevel>=4)) \
             { g_displayClock = clock(); DISPLAY(__VA_ARGS__); \
-            if (g_displayLevel>=4) fflush(stderr); } }
+            if (g_displayLevel>=4) fflush(stdout); } }
 static const clock_t g_refreshRate = CLOCKS_PER_SEC / 6;
 static clock_t g_displayClock = 0;
 
@@ -97,7 +97,161 @@ static unsigned FUZ_highbit32(U32 v32)
 
 
 /*=============================================
-*   Basic Unit tests
+*   Memory Tests
+=============================================*/
+#if defined(__APPLE__) && defined(__MACH__)
+
+#include <malloc/malloc.h>    /* malloc_size */
+
+typedef struct {
+    unsigned long long totalMalloc;
+    size_t peakMalloc;
+    unsigned nbMalloc;
+    unsigned nbFree;
+} mallocCounter_t;
+
+static const mallocCounter_t INIT_MALLOC_COUNTER = { 0, 0, 0, 0 };
+
+static void* FUZ_mallocDebug(void* counter, size_t size)
+{
+    mallocCounter_t* const mcPtr = (mallocCounter_t*)counter;
+    void* const ptr = malloc(size);
+    if (ptr==NULL) return NULL;
+    mcPtr->totalMalloc += size;
+    mcPtr->peakMalloc += size;
+    mcPtr->nbMalloc += 1;
+    return ptr;
+}
+
+static void FUZ_freeDebug(void* counter, void* address)
+{
+    mallocCounter_t* const mcPtr = (mallocCounter_t*)counter;
+    free(address);
+    mcPtr->nbFree += 1;
+    mcPtr->peakMalloc -= malloc_size(address);  /* OS-X specific */
+}
+
+static void FUZ_displayMallocStats(mallocCounter_t count)
+{
+    DISPLAYLEVEL(3, "peak:%u KB,  nbMallocs:%u, total:%u KB \n",
+        (U32)(count.peakMalloc >> 10),
+        count.nbMalloc,
+        (U32)(count.totalMalloc >> 10));
+}
+
+static int FUZ_mallocTests(unsigned seed, double compressibility)
+{
+    size_t const inSize = 64 MB + 16 MB + 4 MB + 1 MB + 256 KB + 64 KB; /* 85.3 MB */
+    size_t const outSize = ZSTD_compressBound(inSize);
+    void* const inBuffer = malloc(inSize);
+    void* const outBuffer = malloc(outSize);
+
+    /* test only played in verbose mode, as they are long */
+    if (g_displayLevel<3) return 0;
+
+    /* Create compressible noise */
+    if (!inBuffer || !outBuffer) {
+        DISPLAY("Not enough memory, aborting\n");
+        exit(1);
+    }
+    RDG_genBuffer(inBuffer, inSize, compressibility, 0. /*auto*/, seed);
+
+    /* simple compression tests */
+    {   int compressionLevel;
+        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
+        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
+            ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
+            ZSTD_compressCCtx(cctx, outBuffer, outSize, inBuffer, inSize, compressionLevel);
+            ZSTD_freeCCtx(cctx);
+            DISPLAYLEVEL(3, "compressCCtx level %i : ", compressionLevel);
+            FUZ_displayMallocStats(malcount);
+            malcount = INIT_MALLOC_COUNTER;
+    }   }
+
+    /* streaming compression tests */
+    {   int compressionLevel;
+        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
+        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
+            ZSTD_CCtx* const cstream = ZSTD_createCStream_advanced(cMem);
+            ZSTD_outBuffer out = { outBuffer, outSize, 0 };
+            ZSTD_inBuffer in = { inBuffer, inSize, 0 };
+            ZSTD_initCStream(cstream, compressionLevel);
+            ZSTD_compressStream(cstream, &out, &in);
+            ZSTD_endStream(cstream, &out);
+            ZSTD_freeCStream(cstream);
+            DISPLAYLEVEL(3, "compressStream level %i : ", compressionLevel);
+            FUZ_displayMallocStats(malcount);
+            malcount = INIT_MALLOC_COUNTER;
+    }   }
+
+    /* advanced API test */
+    {   int compressionLevel;
+        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
+        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
+            ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
+            ZSTD_outBuffer out = { outBuffer, outSize, 0 };
+            ZSTD_inBuffer in = { inBuffer, inSize, 0 };
+            ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
+            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+            ZSTD_freeCCtx(cctx);
+            DISPLAYLEVEL(3, "compress_generic,end level %i : ", compressionLevel);
+            FUZ_displayMallocStats(malcount);
+            malcount = INIT_MALLOC_COUNTER;
+    }   }
+
+    /* advanced MT API test */
+    {   int compressionLevel;
+        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
+        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
+            ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
+            ZSTD_outBuffer out = { outBuffer, outSize, 0 };
+            ZSTD_inBuffer in = { inBuffer, inSize, 0 };
+            ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
+            ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbThreads, 2);
+            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+            ZSTD_freeCCtx(cctx);
+            DISPLAYLEVEL(3, "compress_generic,-T2,end level %i : ", compressionLevel);
+            FUZ_displayMallocStats(malcount);
+            malcount = INIT_MALLOC_COUNTER;
+    }   }
+
+    /* advanced MT streaming API test */
+    {   int compressionLevel;
+        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
+        for (compressionLevel=1; compressionLevel<=5; compressionLevel++) {
+            ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
+            ZSTD_outBuffer out = { outBuffer, outSize, 0 };
+            ZSTD_inBuffer in = { inBuffer, inSize, 0 };
+            ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel);
+            ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbThreads, 2);
+            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_continue);
+            ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+            ZSTD_freeCCtx(cctx);
+            DISPLAYLEVEL(3, "compress_generic,-T2,continue level %i : ", compressionLevel);
+            FUZ_displayMallocStats(malcount);
+            malcount = INIT_MALLOC_COUNTER;
+    }   }
+
+    return 0;
+}
+
+#else
+
+static int FUZ_mallocTests(unsigned seed, double compressibility)
+{
+    (void)seed; (void)compressibility;
+    return 0;
+}
+
+#endif
+
+/*=============================================
+*   Unit tests
 =============================================*/
 
 #define CHECK_V(var, fn)  size_t const var = fn; if (ZSTD_isError(var)) goto _output_error
@@ -108,7 +262,8 @@ static int basicUnitTests(U32 seed, double compressibility)
 {
     size_t const CNBuffSize = 5 MB;
     void* const CNBuffer = malloc(CNBuffSize);
-    void* const compressedBuffer = malloc(ZSTD_compressBound(CNBuffSize));
+    size_t const compressedBufferSize = ZSTD_compressBound(CNBuffSize);
+    void* const compressedBuffer = malloc(compressedBufferSize);
     void* const decodedBuffer = malloc(CNBuffSize);
     ZSTD_DCtx* dctx = ZSTD_createDCtx();
     int testResult = 0;
@@ -122,6 +277,9 @@ static int basicUnitTests(U32 seed, double compressibility)
         goto _end;
     }
     RDG_genBuffer(CNBuffer, CNBuffSize, compressibility, 0., seed);
+
+    /* memory tests */
+    FUZ_mallocTests(seed, compressibility);
 
     /* Basic tests */
     DISPLAYLEVEL(4, "test%3i : ZSTD_getErrorName : ", testNb++);
@@ -139,7 +297,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     {   ZSTD_CCtx* cctx = ZSTD_createCCtx();
         if (cctx==NULL) goto _output_error;
         CHECKPLUS(r, ZSTD_compressCCtx(cctx,
-                            compressedBuffer, ZSTD_compressBound(CNBuffSize),
+                            compressedBuffer, compressedBufferSize,
                             CNBuffer, CNBuffSize, 1),
                   cSize=r );
         DISPLAYLEVEL(4, "OK (%u bytes : %.2f%%)\n", (U32)cSize, (double)cSize/CNBuffSize*100);
@@ -226,7 +384,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
             DISPLAYLEVEL(4, "test%3i : simple compression test with static CCtx : ", testNb++);
             CHECKPLUS(r, ZSTD_compressCCtx(staticCCtx,
-                            compressedBuffer, ZSTD_compressBound(CNBuffSize),
+                            compressedBuffer, compressedBufferSize,
                             CNBuffer, CNBuffSize, STATIC_CCTX_LEVEL),
                       cSize=r );
             DISPLAYLEVEL(4, "OK (%u bytes : %.2f%%)\n",
@@ -295,7 +453,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         DISPLAYLEVEL(4, "test%3i : compress %u bytes with 2 threads : ", testNb++, (U32)CNBuffSize);
         CHECKPLUS(r, ZSTDMT_compressCCtx(mtctx,
-                                compressedBuffer, ZSTD_compressBound(CNBuffSize),
+                                compressedBuffer, compressedBufferSize,
                                 CNBuffer, CNBuffSize,
                                 1),
                   cSize=r );
@@ -382,7 +540,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         DISPLAYLEVEL(4, "test%3i : compress with flat dictionary : ", testNb++);
         cSize = 0;
-        CHECKPLUS(r, ZSTD_compressEnd(ctxOrig, compressedBuffer, ZSTD_compressBound(CNBuffSize),
+        CHECKPLUS(r, ZSTD_compressEnd(ctxOrig, compressedBuffer, compressedBufferSize,
                                            (const char*)CNBuffer + dictSize, CNBuffSize - dictSize),
                   cSize += r);
         DISPLAYLEVEL(4, "OK (%u bytes : %.2f%%)\n", (U32)cSize, (double)cSize/CNBuffSize*100);
@@ -398,7 +556,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         DISPLAYLEVEL(4, "test%3i : compress with duplicated context : ", testNb++);
         {   size_t const cSizeOrig = cSize;
             cSize = 0;
-            CHECKPLUS(r, ZSTD_compressEnd(ctxDuplicated, compressedBuffer, ZSTD_compressBound(CNBuffSize),
+            CHECKPLUS(r, ZSTD_compressEnd(ctxDuplicated, compressedBuffer, compressedBufferSize,
                                                (const char*)CNBuffer + dictSize, CNBuffSize - dictSize),
                       cSize += r);
             if (cSize != cSizeOrig) goto _output_error;   /* should be identical ==> same size */
@@ -483,7 +641,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         DISPLAYLEVEL(4, "OK : %u \n", dictID);
 
         DISPLAYLEVEL(4, "test%3i : compress with dictionary : ", testNb++);
-        cSize = ZSTD_compress_usingDict(cctx, compressedBuffer, ZSTD_compressBound(CNBuffSize),
+        cSize = ZSTD_compress_usingDict(cctx, compressedBuffer, compressedBufferSize,
                                         CNBuffer, CNBuffSize,
                                         dictBuffer, dictSize, 4);
         if (ZSTD_isError(cSize)) goto _output_error;
@@ -521,7 +679,7 @@ static int basicUnitTests(U32 seed, double compressibility)
                                             1 /* byReference */, ZSTD_dm_auto,
                                             cParams, ZSTD_defaultCMem);
             DISPLAYLEVEL(4, "(size : %u) : ", (U32)ZSTD_sizeof_CDict(cdict));
-            cSize = ZSTD_compress_usingCDict(cctx, compressedBuffer, ZSTD_compressBound(CNBuffSize),
+            cSize = ZSTD_compress_usingCDict(cctx, compressedBuffer, compressedBufferSize,
                                                  CNBuffer, CNBuffSize, cdict);
             ZSTD_freeCDict(cdict);
             if (ZSTD_isError(cSize)) goto _output_error;
@@ -556,7 +714,7 @@ static int basicUnitTests(U32 seed, double compressibility)
                     goto _output_error;
                 }
                 cSize = ZSTD_compress_usingCDict(cctx,
-                                compressedBuffer, ZSTD_compressBound(CNBuffSize),
+                                compressedBuffer, compressedBufferSize,
                                 CNBuffer, CNBuffSize, cdict);
                 if (ZSTD_isError(cSize)) {
                     DISPLAY("ZSTD_compress_usingCDict failed ");
@@ -570,7 +728,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         {   ZSTD_frameParameters const fParams = { 0 /* frameSize */, 1 /* checksum */, 1 /* noDictID*/ };
             ZSTD_compressionParameters const cParams = ZSTD_getCParams(1, CNBuffSize, dictSize);
             ZSTD_CDict* const cdict = ZSTD_createCDict_advanced(dictBuffer, dictSize, 1 /*byRef*/, ZSTD_dm_auto, cParams, ZSTD_defaultCMem);
-            cSize = ZSTD_compress_usingCDict_advanced(cctx, compressedBuffer, ZSTD_compressBound(CNBuffSize),
+            cSize = ZSTD_compress_usingCDict_advanced(cctx, compressedBuffer, compressedBufferSize,
                                                  CNBuffer, CNBuffSize, cdict, fParams);
             ZSTD_freeCDict(cdict);
             if (ZSTD_isError(cSize)) goto _output_error;
@@ -594,7 +752,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         DISPLAYLEVEL(4, "test%3i : ZSTD_compress_advanced, no dictID : ", testNb++);
         {   ZSTD_parameters p = ZSTD_getParams(3, CNBuffSize, dictSize);
             p.fParams.noDictIDFlag = 1;
-            cSize = ZSTD_compress_advanced(cctx, compressedBuffer, ZSTD_compressBound(CNBuffSize),
+            cSize = ZSTD_compress_advanced(cctx, compressedBuffer, compressedBufferSize,
                                            CNBuffer, CNBuffSize,
                                            dictBuffer, dictSize, p);
             if (ZSTD_isError(cSize)) goto _output_error;
@@ -1245,6 +1403,7 @@ int main(int argc, const char** argv)
     U32 mainPause = 0;
     U32 maxDuration = 0;
     int bigTests = 1;
+    U32 memTestsOnly = 0;
     const char* const programName = argv[0];
 
     /* Check command line */
@@ -1255,6 +1414,7 @@ int main(int argc, const char** argv)
         /* Handle commands. Aggregated commands are allowed */
         if (argument[0]=='-') {
 
+            if (!strcmp(argument, "--memtest")) { memTestsOnly=1; continue; }
             if (!strcmp(argument, "--no-big-tests")) { bigTests=0; continue; }
 
             argument++;
@@ -1325,6 +1485,11 @@ int main(int argc, const char** argv)
 
     DISPLAY("Seed = %u\n", seed);
     if (proba!=FUZ_compressibility_default) DISPLAY("Compressibility : %u%%\n", proba);
+
+    if (memTestsOnly) {
+        g_displayLevel=3;
+        return FUZ_mallocTests(seed, ((double)proba) / 100);
+    }
 
     if (nbTests < testNb) nbTests = testNb;
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -158,22 +158,21 @@ static int FUZ_mallocTests(unsigned seed, double compressibility)
 
     /* simple compression tests */
     {   int compressionLevel;
-        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
-        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
         for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
+            mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+            ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
             ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
             ZSTD_compressCCtx(cctx, outBuffer, outSize, inBuffer, inSize, compressionLevel);
             ZSTD_freeCCtx(cctx);
             DISPLAYLEVEL(3, "compressCCtx level %i : ", compressionLevel);
             FUZ_displayMallocStats(malcount);
-            malcount = INIT_MALLOC_COUNTER;
     }   }
 
     /* streaming compression tests */
     {   int compressionLevel;
-        mallocCounter_t malcount = INIT_MALLOC_COUNTER;
-        ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
         for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
+            mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+            ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
             ZSTD_CCtx* const cstream = ZSTD_createCStream_advanced(cMem);
             ZSTD_outBuffer out = { outBuffer, outSize, 0 };
             ZSTD_inBuffer in = { inBuffer, inSize, 0 };
@@ -183,16 +182,15 @@ static int FUZ_mallocTests(unsigned seed, double compressibility)
             ZSTD_freeCStream(cstream);
             DISPLAYLEVEL(3, "compressStream level %i : ", compressionLevel);
             FUZ_displayMallocStats(malcount);
-            malcount = INIT_MALLOC_COUNTER;
     }   }
 
     /* advanced MT API test */
     {   U32 nbThreads;
         for (nbThreads=1; nbThreads<=4; nbThreads++) {
             int compressionLevel;
-            mallocCounter_t malcount = INIT_MALLOC_COUNTER;
-            ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
             for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
+                mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+                ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
                 ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
                 ZSTD_outBuffer out = { outBuffer, outSize, 0 };
                 ZSTD_inBuffer in = { inBuffer, inSize, 0 };
@@ -203,16 +201,15 @@ static int FUZ_mallocTests(unsigned seed, double compressibility)
                 DISPLAYLEVEL(3, "compress_generic,-T%u,end level %i : ",
                                 nbThreads, compressionLevel);
                 FUZ_displayMallocStats(malcount);
-                malcount = INIT_MALLOC_COUNTER;
     }   }   }
 
     /* advanced MT streaming API test */
     {   U32 nbThreads;
         for (nbThreads=1; nbThreads<=4; nbThreads++) {
             int compressionLevel;
-            mallocCounter_t malcount = INIT_MALLOC_COUNTER;
-            ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
             for (compressionLevel=1; compressionLevel<=6; compressionLevel++) {
+                mallocCounter_t malcount = INIT_MALLOC_COUNTER;
+                ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
                 ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
                 ZSTD_outBuffer out = { outBuffer, outSize, 0 };
                 ZSTD_inBuffer in = { inBuffer, inSize, 0 };
@@ -224,7 +221,6 @@ static int FUZ_mallocTests(unsigned seed, double compressibility)
                 DISPLAYLEVEL(3, "compress_generic,-T%u,continue level %i : ",
                                 nbThreads, compressionLevel);
                 FUZ_displayMallocStats(malcount);
-                malcount = INIT_MALLOC_COUNTER;
     }   }   }
 
     return 0;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -118,6 +118,8 @@ static void* FUZ_mallocDebug(void* counter, size_t size)
     mallocCounter_t* const mcPtr = (mallocCounter_t*)counter;
     void* const ptr = malloc(size);
     if (ptr==NULL) return NULL;
+    DISPLAYLEVEL(4, "allocating %u KB => effectively %u KB \n",
+        (U32)(size >> 10), (U32)(malloc_size(ptr) >> 10));  /* OS-X specific */
     mcPtr->totalMalloc += size;
     mcPtr->currentMalloc += size;
     if (mcPtr->currentMalloc > mcPtr->peakMalloc)

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -129,7 +129,7 @@ static void* FUZ_mallocDebug(void* counter, size_t size)
 static void FUZ_freeDebug(void* counter, void* address)
 {
     mallocCounter_t* const mcPtr = (mallocCounter_t*)counter;
-    DISPLAYLEVEL(4, "releasing %u KB \n", (U32)(malloc_size(address) >> 10));
+    DISPLAYLEVEL(4, "freeing %u KB \n", (U32)(malloc_size(address) >> 10));
     mcPtr->nbFree += 1;
     mcPtr->currentMalloc -= malloc_size(address);  /* OS-X specific */
     free(address);

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -7,17 +7,17 @@ die() {
 
 roundTripTest() {
     if [ -n "$3" ]; then
-        local_c="$3"
-        local_p="$2"
+        cLevel="$3"
+        proba="$2"
     else
-        local_c="$2"
-        local_p=""
+        cLevel="$2"
+        proba=""
     fi
 
     rm -f tmp1 tmp2
-    $ECHO "roundTripTest: ./datagen $1 $local_p | $ZSTD -v$local_c | $ZSTD -d"
-    ./datagen $1 $local_p | $MD5SUM > tmp1
-    ./datagen $1 $local_p | $ZSTD --ultra -v$local_c | $ZSTD -d  | $MD5SUM > tmp2
+    $ECHO "roundTripTest: ./datagen $1 $proba | $ZSTD -v$cLevel | $ZSTD -d"
+    ./datagen $1 $proba | $MD5SUM > tmp1
+    ./datagen $1 $proba | $ZSTD --ultra -v$cLevel | $ZSTD -d  | $MD5SUM > tmp2
     $DIFF -q tmp1 tmp2
 }
 
@@ -625,16 +625,15 @@ roundTripTest -g35000000 -P75 10
 roundTripTest -g35000000 -P75 11
 roundTripTest -g35000000 -P75 12
 
-roundTripTest -g18000000 -P80 13
-roundTripTest -g18000000 -P80 14
-roundTripTest -g18000000 -P80 15
-roundTripTest -g18000000 -P80 16
-roundTripTest -g18000000 -P80 17
+roundTripTest -g18000013 -P80 13
+roundTripTest -g18000014 -P80 14
+roundTripTest -g18000015 -P80 15
+roundTripTest -g18000016 -P80 16
+roundTripTest -g18000017 -P80 17
+roundTripTest -g18000018 -P94 18
+roundTripTest -g18000019 -P94 19
 
-roundTripTest -g50000000 -P94 18
-roundTripTest -g50000000 -P94 19
-
-roundTripTest -g99000000 -P99 20
+roundTripTest -g68000020 -P99 20
 roundTripTest -g6000000000 -P99 1
 
 fileRoundTripTest -g4193M -P99 1

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -95,19 +95,6 @@ unsigned int FUZ_rand(unsigned int* seedPtr)
     return rand32 >> 5;
 }
 
-static void* allocFunction(void* opaque, size_t size)
-{
-    void* address = malloc(size);
-    (void)opaque;
-    return address;
-}
-
-static void freeFunction(void* opaque, void* address)
-{
-    (void)opaque;
-    free(address);
-}
-
 
 /*======================================================
 *   Basic Unit tests
@@ -1543,7 +1530,6 @@ int main(int argc, const char** argv)
     int bigTests = (sizeof(size_t) == 8);
     e_api selected_api = simple_api;
     const char* const programName = argv[0];
-    ZSTD_customMem const customMem = { allocFunction, freeFunction, NULL };
     ZSTD_customMem const customNULL = ZSTD_defaultCMem;
 
     /* Check command line */
@@ -1657,10 +1643,7 @@ int main(int argc, const char** argv)
 
     if (testNb==0) {
         result = basicUnitTests(0, ((double)proba) / 100, customNULL);  /* constant seed for predictability */
-        if (!result) {
-            DISPLAYLEVEL(3, "Unit tests using customMem :\n")
-            result = basicUnitTests(0, ((double)proba) / 100, customMem);  /* use custom memory allocation functions */
-    }   }
+    }
 
     if (!result) {
         switch(selected_api)

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1377,13 +1377,12 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest, double 
         /* multi-segments compression test */
         XXH64_reset(&xxhState, 0);
         {   ZSTD_outBuffer outBuff = { cBuffer, cBufferSize, 0 } ;
-            U32 n;
-            for (n=0, cSize=0, totalTestSize=0 ; totalTestSize < maxTestSize ; n++) {
+            for (cSize=0, totalTestSize=0 ; (totalTestSize < maxTestSize) ; ) {
                 /* compress random chunks into randomly sized dst buffers */
                 size_t const randomSrcSize = FUZ_randomLength(&lseed, maxSampleLog);
                 size_t const srcSize = MIN(maxTestSize-totalTestSize, randomSrcSize);
                 size_t const srcStart = FUZ_rand(&lseed) % (srcBufferSize - srcSize);
-                size_t const randomDstSize = FUZ_randomLength(&lseed, maxSampleLog);
+                size_t const randomDstSize = FUZ_randomLength(&lseed, maxSampleLog+1);
                 size_t const dstBuffSize = MIN(cBufferSize - cSize, randomDstSize);
                 ZSTD_EndDirective const flush = (FUZ_rand(&lseed) & 15) ? ZSTD_e_continue : ZSTD_e_flush;
                 ZSTD_inBuffer inBuff = { srcBuffer+srcStart, srcSize, 0 };
@@ -1402,7 +1401,7 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest, double 
             {   size_t remainingToFlush = (size_t)(-1);
                 while (remainingToFlush) {
                     ZSTD_inBuffer inBuff = { NULL, 0, 0 };
-                    size_t const randomDstSize = FUZ_randomLength(&lseed, maxSampleLog);
+                    size_t const randomDstSize = FUZ_randomLength(&lseed, maxSampleLog+1);
                     size_t const adjustedDstSize = MIN(cBufferSize - cSize, randomDstSize);
                     outBuff.size = outBuff.pos + adjustedDstSize;
                     DISPLAYLEVEL(5, "End-flush into dst buffer of size %u \n", (U32)adjustedDstSize);


### PR DESCRIPTION
This patches substantially improves memory usage of `ZSTDMT_*()` API
by making sure resources are allocated "just in time" and released "as soon as possible",
typically directly from within workers.

The new test `fuzzer --memtest` make it possible to measure memory usage of different variants.
For streaming with 2 threads and compression level 1, memory usage drops from ~30 MB to ~18 MB.

More savings are possible by reducing `queueSize` in the thread pool,
so that we have less jobs, hence less buffers, prepared in advanced of workers.

The patch also fixes some issues found during investigation : 
- custom allocator is properly propagated into `ZSTDMT_CCtx*` and child `ZSTD_CCtx*`. Only the thread pool itself now directly calls `stdlib.h`.
- `ZSTDMT_compress_advanced()` (single pass function) correctly generates frame checksum when it's required. Relevant test added in `fuzzer.c`.