### PR TITLE
Fix build with GCC 3.x.x (3.4.6 tested) on 32-bit x86

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1333,7 +1333,7 @@ static unsigned ZSTD_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanForward64( &r, (U64)val );
             return (unsigned)(r>>3);
-#       elif defined(__GNUC__) && (__GNUC__ >= 3)
+#       elif defined(__GNUC__) && (__GNUC__ >= 3) && (__LONG_MAX__ != 2147483647L)
             return (__builtin_ctzll((U64)val) >> 3);
 #       else
             static const int DeBruijnBytePos[64] = { 0, 0, 0, 0, 0, 1, 1, 2,
@@ -1367,7 +1367,7 @@ static unsigned ZSTD_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanReverse64( &r, val );
             return (unsigned)(r>>3);
-#       elif defined(__GNUC__) && (__GNUC__ >= 3)
+#       elif defined(__GNUC__) && (__GNUC__ >= 3) && (__LONG_MAX__ != 2147483647L)
             return (__builtin_clzll(val) >> 3);
 #       else
             unsigned r;


### PR DESCRIPTION
It seems that old versions of GCC fail with an Internal Compiler Error when they try to generate the code for __builtin_ctzll() in 32-bit mode. We can simply avoid emitting this intrinsic in 32-bit code - since that branch should be eliminated in any case after inlining and optimising.