### PR TITLE
Fix windowSize check at getFrameHeader

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -344,7 +344,11 @@ size_t ZSTD_getFrameHeader(ZSTD_frameHeader* zfhPtr, const void* src, size_t src
             case 2 : frameContentSize = MEM_readLE32(ip+pos); break;
             case 3 : frameContentSize = MEM_readLE64(ip+pos); break;
         }
-        if (singleSegment) windowSize = frameContentSize;
+        if (singleSegment) {
+            if (frameContentSize > ZSTD_MAXWINDOWSIZE_DEFAULT)
+                return ERROR(frameParameter_windowTooLarge);
+            windowSize = frameContentSize;
+        }
 
         zfhPtr->frameType = ZSTD_frame;
         zfhPtr->frameContentSize = frameContentSize;


### PR DESCRIPTION
In the case that singleSegment: 1, fcsId: 3 and frameContentSize is
larger than UINT_MAX, getFrameHeader fail to check windowSize, results
in an assertion fail at ZSTD_highbit32(U32): Assertion `val != 0'.

This case was found by using libFuzzer: `tests/fuzz/simple_decompress`

----

## Steps to reproduce

- decompress.c : `clang  -g -lzstd  decompress.c -o decompress`
```c
#include <stdlib.h>
#include "zstd.h"

int main()
{
    ZSTD_DCtx *dctx = NULL;
    void* rBuf = NULL;
    size_t bufSize = 0;

    // crash-b1288541e13ad9854c48cede2b08b63ecb8e31d6
    char src[] =
        "\x28\xB5\x2F\xFD"
        "\xE4" // fhdByte(singleSegment: 1, fcsId: 3)
        "\x00\x00\x00\x00\x00\xA0\x00\x00" // frameContentSize: 175921860444160
        "\x00\x00\x00"
        "\x00\x00\x00\x00\x00\x00\xCD\x00\x00\x21\x21\x21\x21\x21\x21\x00"
        "\x00\x89\x00\x00\x00\x00\x00\x89\x89\x89\x89\x28\xB5\x2F\x89\x89"
        "\x04\x2F\x89\x89\x04";

    size_t const size = sizeof(src);
    size_t const neededBufSize = (size_t) 256 << 10;

    dctx = ZSTD_createDCtx();
    rBuf = malloc(neededBufSize);

    ZSTD_decompressDCtx(dctx, rBuf, neededBufSize, src, size);

    free(rBuf);
    ZSTD_freeDCtx(dctx);

    return 0;
}
```

- output : libzstd compiled with `-DZSTD_DEBUG=6`
```
$ ./decompress 
decompress/zstd_decompress.c: ZSTD_decompressBlock_internal 
decompress/zstd_decompress.c: ZSTD_decodeLiteralsBlock : 2 
decompress/zstd_decompress.c: ZSTD_decodeSeqHeaders 
decompress: ./common/zstd_internal.h:276: U32 ZSTD_highbit32(U32): Assertion `val != 0' failed.
Aborted (core dumped)
````

----

### libFuzzer Output

- `$ ./simple_decompress CORPUS_simple_decompress/`
  - just start with empty corpus and no dictionary
  - It may take 30 minutes or more to find this case
```
...
#3172560        REDUCE cov: 552 ft: 2021 corp: 592/165Kb exec/s: 13443 rss: 137Mb L: 41/3523 MS: 1 EraseBytes-
simple_decompress: ../../lib/common/zstd_internal.h:276: U32 ZSTD_highbit32(U32): Assertion `val != 0' failed.
==10170== ERROR: libFuzzer: deadly signal
    #0 0x4dd8a9 in __sanitizer_print_stack_trace (/home/eiichi/git/zstd/tests/fuzz/simple_decompress+0x4dd8a9)
    #1 0x652701 in fuzzer::Fuzzer::CrashCallback() /home/eiichi/git/Fuzzer/./FuzzerLoop.cpp:196:5
    #2 0x6526cd in fuzzer::Fuzzer::StaticCrashSignalCallback() /home/eiichi/git/Fuzzer/./FuzzerLoop.cpp:175:6
    #3 0x7fda01c162bf  (/lib64/libpthread.so.0+0x122bf)
    #4 0x7fda0124669a in __GI_raise (/lib64/libc.so.6+0x3669a)
    #5 0x7fda0124849f in __GI_abort (/lib64/libc.so.6+0x3849f)
    #6 0x7fda0123ed59 in __assert_fail_base (/lib64/libc.so.6+0x2ed59)
    #7 0x7fda0123edd1 in __GI___assert_fail (/lib64/libc.so.6+0x2edd1)
    #8 0x54e0d6 in ZSTD_highbit32 /home/eiichi/git/zstd/tests/fuzz/../../lib/common/zstd_internal.h:276:5
    #9 0x54e0d6 in ZSTD_decodeSequenceLong /home/eiichi/git/zstd/tests/fuzz/../../lib/decompress/zstd_decompress.c:1184
    #10 0x5305db in ZSTD_decompressSequencesLong /home/eiichi/git/zstd/tests/fuzz/../../lib/decompress/zstd_decompress.c:1318:32
    #11 0x5305db in ZSTD_decompressBlock_internal /home/eiichi/git/zstd/tests/fuzz/../../lib/decompress/zstd_decompress.c:1377
    #12 0x54327b in ZSTD_decompressFrame /home/eiichi/git/zstd/tests/fuzz/../../lib/decompress/zstd_decompress.c:1514:27
    #13 0x54327b in ZSTD_decompressMultiFrame /home/eiichi/git/zstd/tests/fuzz/../../lib/decompress/zstd_decompress.c:1619
    #14 0x543e11 in ZSTD_decompress_usingDict /home/eiichi/git/zstd/tests/fuzz/../../lib/decompress/zstd_decompress.c:1638:12
    #15 0x543e11 in ZSTD_decompressDCtx /home/eiichi/git/zstd/tests/fuzz/../../lib/decompress/zstd_decompress.c:1644
    #16 0x648c4e in LLVMFuzzerTestOneInput /home/eiichi/git/zstd/tests/fuzz/simple_decompress.c:40:5
    #17 0x65368b in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/eiichi/git/Fuzzer/./FuzzerLoop.cpp:495:13
    #18 0x653128 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*) /home/eiichi/git/Fuzzer/./FuzzerLoop.cpp:424:3
    #19 0x6543a6 in fuzzer::Fuzzer::MutateAndTestOne() /home/eiichi/git/Fuzzer/./FuzzerLoop.cpp:619:9
    #20 0x6545b7 in fuzzer::Fuzzer::Loop() /home/eiichi/git/Fuzzer/./FuzzerLoop.cpp:662:5
    #21 0x64d668 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/eiichi/git/Fuzzer/./FuzzerDriver.cpp:751:6
    #22 0x648d90 in main /home/eiichi/git/Fuzzer/./FuzzerMain.cpp:20:10
    #23 0x7fda01230509 in __libc_start_main (/lib64/libc.so.6+0x20509)
    #24 0x41c579 in _start (/home/eiichi/git/zstd/tests/fuzz/simple_decompress+0x41c579)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 1 ChangeByte-; base unit: 333f88a3453793f2eb726b5bb3cd559354a6ba7a
0x28,0xb5,0x2f,0xfd,0xe4,0x0,0x0,0x0,0x0,0x0,0xa0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xcd,0x0,0x0,0x21,0x21,0x21,0x21,0x21,0x21,0x0,0x0,0x89,0x0,0x0,0x0,0x0,0x0,0x89,0x89,0x89,0x89,0x28,0xb5,0x2f,0x89,0x89,0x4,0x2f,0x89,0x89,0x4,
(\xb5/\xfd\xe4\x00\x00\x00\x00\x00\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xcd\x00\x00!!!!!!\x00\x00\x89\x00\x00\x00\x00\x00\x89\x89\x89\x89(\xb5/\x89\x89\x04/\x89\x89\x04
artifact_prefix='./'; Test unit written to ./crash-b1288541e13ad9854c48cede2b08b63ecb8e31d6
Base64: KLUv/eQAAAAAAKAAAAAAAAAAAAAAAM0AACEhISEhIQAAiQAAAAAAiYmJiSi1L4mJBC+JiQQ=
```