### PR TITLE
Fix minor fuzz test failures

### DIFF
--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -295,7 +295,7 @@ size_t ZSTD_compressBlock_ldm_generic(ZSTD_CCtx* cctx,
     const U32   lowestIndex = cctx->dictLimit;
     const BYTE* const lowest = base + lowestIndex;
     const BYTE* const iend = istart + srcSize;
-    const BYTE* const ilimit = iend - ldmParams.minMatchLength;
+    const BYTE* const ilimit = iend - MAX(ldmParams.minMatchLength, HASH_READ_SIZE);
 
     const ZSTD_blockCompressor blockCompressor =
         ZSTD_selectBlockCompressor(cctx->appliedParams.cParams.strategy, 0);
@@ -499,7 +499,7 @@ static size_t ZSTD_compressBlock_ldm_extDict_generic(
     const BYTE* const lowPrefixPtr = base + dictLimit;
     const BYTE* const dictEnd = dictBase + dictLimit;
     const BYTE* const iend = istart + srcSize;
-    const BYTE* const ilimit = iend - ldmParams.minMatchLength;
+    const BYTE* const ilimit = iend - MAX(ldmParams.minMatchLength, HASH_READ_SIZE);
 
     const ZSTD_blockCompressor blockCompressor =
         ZSTD_selectBlockCompressor(ctx->appliedParams.cParams.strategy, 1);

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1372,8 +1372,9 @@ static size_t ZSTD_decompressBlock_internal(ZSTD_DCtx* dctx,
      * conservative.
      */
     ZSTD_longOffset_e const isLongOffset = (ZSTD_longOffset_e)(MEM_32bits() && (!frame || dctx->fParams.windowSize > (1ULL << STREAM_ACCUMULATOR_MIN)));
-    /* We don't expect window sizes this big. */
-    assert(!frame || dctx->fParams.windowSize <= (1ULL << STREAM_ACCUMULATOR_MIN_64));
+    /* windowSize could be any value at this point, since it is only validated
+     * in the streaming API.
+     */
     DEBUGLOG(5, "ZSTD_decompressBlock_internal");
 
     if (srcSize >= ZSTD_BLOCKSIZE_MAX) return ERROR(srcSize_wrong);


### PR DESCRIPTION
* Fix bad window size assert during decompression
* Fix buffer overflow in the long distance matcher when LDM min match < 8 (default is 64)