### PR TITLE
Don't `size -= 1` in ZSTD_adjustCParams()

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -651,7 +651,7 @@ ZSTD_compressionParameters ZSTD_adjustCParams_internal(ZSTD_compressionParameter
 
     if (dictSize && (srcSize+1<2) /* srcSize unknown */ )
         srcSize = minSrcSize;  /* presumed small when there is a dictionary */
-    else
+    else if (srcSize == 0)
         srcSize -= 1;  /* unknown 0 => -1ULL : presumed large */
 
     /* resize windowLog if input is small enough, to use less memory */


### PR DESCRIPTION
* The window size could end up too small if the source size is 2^n + 1.
* Reproducing test case will be added to the corpus once this PR is merged.

Credit to OSS-Fuzz