### PR TITLE
Guard uses of __builtin_clz and __builtin_clzll

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -175,7 +175,7 @@ MEM_STATIC unsigned BIT_highbit32 (register U32 val)
         unsigned long r=0;
         _BitScanReverse ( &r, val );
         return (unsigned) r;
-#   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* Use GCC Intrinsic */
+#   elif defined(__GNUC__) && (__GNUC__ >= 3) && __has_builtin(__builtin_clz)   /* Use GCC Intrinsic */
         return 31 - __builtin_clz (val);
 #   else   /* Software version */
         static const unsigned DeBruijnClz[32] = { 0,  9,  1, 10, 13, 21,  2, 29,

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -327,7 +327,7 @@ MEM_STATIC U32 ZSTD_highbit32(U32 val)
         unsigned long r=0;
         _BitScanReverse(&r, val);
         return (unsigned)r;
-#   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* GCC Intrinsic */
+#   elif defined(__GNUC__) && (__GNUC__ >= 3) && __has_builtin(__builtin_clz)   /* GCC Intrinsic */
         return 31 - __builtin_clz(val);
 #   else   /* Software version */
         static const int DeBruijnClz[32] = { 0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30, 8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31 };

--- a/lib/compress/zstd_compress.h
+++ b/lib/compress/zstd_compress.h
@@ -203,7 +203,7 @@ static unsigned ZSTD_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanReverse64( &r, val );
             return (unsigned)(r>>3);
-#       elif defined(__GNUC__) && (__GNUC__ >= 4)
+#       elif defined(__GNUC__) && (__GNUC__ >= 4) && __has_builtin(__builtin_clzll)
             return (__builtin_clzll(val) >> 3);
 #       else
             unsigned r;
@@ -218,7 +218,7 @@ static unsigned ZSTD_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanReverse( &r, (unsigned long)val );
             return (unsigned)(r>>3);
-#       elif defined(__GNUC__) && (__GNUC__ >= 3)
+#       elif defined(__GNUC__) && (__GNUC__ >= 3) && __has_builtin(__builtin_clz)
             return (__builtin_clz((U32)val) >> 3);
 #       else
             unsigned r;

--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -135,7 +135,7 @@ static unsigned ZDICT_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanReverse64( &r, val );
             return (unsigned)(r>>3);
-#       elif defined(__GNUC__) && (__GNUC__ >= 3)
+#       elif defined(__GNUC__) && (__GNUC__ >= 3) && __has_builtin(__builtin_clzll)
             return (__builtin_clzll(val) >> 3);
 #       else
             unsigned r;
@@ -150,7 +150,7 @@ static unsigned ZDICT_NbCommonBytes (register size_t val)
             unsigned long r = 0;
             _BitScanReverse( &r, (unsigned long)val );
             return (unsigned)(r>>3);
-#       elif defined(__GNUC__) && (__GNUC__ >= 3)
+#       elif defined(__GNUC__) && (__GNUC__ >= 3) && __has_builtin(__builtin_clz)
             return (__builtin_clz((U32)val) >> 3);
 #       else
             unsigned r;


### PR DESCRIPTION
Prevents undefined reference to `__clzdi2' on FreeBSD sparc64 compiled with gcc 4.2

Fallback to the software implementation by making the preprocessor guard better