### PR TITLE
fileio and bench : ZSTD_NEWAPI as the only code path

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -37,8 +37,7 @@ endif
 
 CPPFLAGS+= -I$(ZSTDDIR) -I$(ZSTDDIR)/common -I$(ZSTDDIR)/compress \
            -I$(ZSTDDIR)/dictBuilder \
-           -DXXH_NAMESPACE=ZSTD_ \
-           -DZSTD_NEWAPI
+           -DXXH_NAMESPACE=ZSTD_
 CFLAGS  ?= -O3
 DEBUGFLAGS+=-Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
             -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement \

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -203,10 +203,6 @@ static U32 g_blockSize = 0;
 void FIO_setBlockSize(unsigned blockSize) {
     if (blockSize && g_nbThreads==1)
         DISPLAYLEVEL(2, "Setting block size is useless in single-thread mode \n");
-#ifdef ZSTD_MULTITHREAD
-    if (blockSize-1 < ZSTDMT_SECTION_SIZE_MIN-1)   /* intentional underflow */
-        DISPLAYLEVEL(2, "Note : minimum block size is %u KB \n", (ZSTDMT_SECTION_SIZE_MIN>>10));
-#endif
     g_blockSize = blockSize;
 }
 #define FIO_OVERLAP_LOG_NOTSET 9999


### PR DESCRIPTION
removed the other 2 code paths (single thread, and ZSTDMT ones)
keeping only the new advanced API, for easier code coverage.

It shall also fix identified issue with Visual Studio
which doesn't have ZSTD_NEWAPI defined.