### PR TITLE
Allow skippable frames of any size

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -525,7 +525,7 @@ static int basicUnitTests(U32 seed, double compressibility)
             off += r;
             if (i == segs/2) {
                 /* insert skippable frame */
-                const U32 skipLen = 128 KB;
+                const U32 skipLen = 129 KB;
                 MEM_writeLE32((BYTE*)compressedBuffer + off, ZSTD_MAGIC_SKIPPABLE_START);
                 MEM_writeLE32((BYTE*)compressedBuffer + off + 4, skipLen);
                 off += skipLen + ZSTD_skippableHeaderSize;

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -213,7 +213,7 @@ static int basicUnitTests(U32 seed, double compressibility, ZSTD_customMem custo
 {
     size_t const CNBufferSize = COMPRESSIBLE_NOISE_LENGTH;
     void* CNBuffer = malloc(CNBufferSize);
-    size_t const skippableFrameSize = 11;
+    size_t const skippableFrameSize = 200 KB;
     size_t const compressedBufferSize = (8 + skippableFrameSize) + ZSTD_compressBound(COMPRESSIBLE_NOISE_LENGTH);
     void* compressedBuffer = malloc(compressedBufferSize);
     size_t const decodedBufferSize = CNBufferSize;


### PR DESCRIPTION
Previously we were only able to decode skippable frames that are smaller than `zds->inBuffSize`.

Fixes #904.