### PR TITLE
fix : ZSTD_compress_generic(,,,ZSTD_e_end) automatically sets pledgedSrcSize

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2814,6 +2814,7 @@ size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
     if (cctx->streamStage == zcss_init) {
         ZSTD_prefixDict const prefixDict = cctx->prefixDict;
         ZSTD_CCtx_params params = cctx->requestedParams;
+        if (endOp == ZSTD_e_end) cctx->pledgedSrcSizePlusOne = input->size + 1;
         params.cParams = ZSTD_getCParamsFromCCtxParams(
                 cctx->requestedParams, cctx->pledgedSrcSizePlusOne-1, 0 /*dictSize*/);
         memset(&cctx->prefixDict, 0, sizeof(cctx->prefixDict));  /* single usage */

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -286,7 +286,6 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                     U32 nbLoops = 0;
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_nbThreads, g_nbThreads);
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_compressionLevel, cLevel);
-                    //ZSTD_CCtx_setPledgedSrcSize(ctx, blockTable[0].srcSize);  /* estimation, only to help cLevel conversion before applying advanced compression parameters */
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_enableLongDistanceMatching, g_ldmFlag);
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmMinMatch, g_ldmMinMatch);
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmHashLog, g_ldmHashLog);

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -286,6 +286,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                     U32 nbLoops = 0;
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_nbThreads, g_nbThreads);
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_compressionLevel, cLevel);
+                    //ZSTD_CCtx_setPledgedSrcSize(ctx, blockTable[0].srcSize);  /* estimation, only to help cLevel conversion before applying advanced compression parameters */
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_enableLongDistanceMatching, g_ldmFlag);
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmMinMatch, g_ldmMinMatch);
                     ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmHashLog, g_ldmHashLog);
@@ -305,6 +306,14 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                     do {
                         U32 blockNb;
                         for (blockNb=0; blockNb<nbBlocks; blockNb++) {
+#if 0   /* direct compression function, for occasional comparison */
+                            ZSTD_parameters const params = ZSTD_getParams(cLevel, blockTable[blockNb].srcSize, dictBufferSize);
+                            blockTable[blockNb].cSize = ZSTD_compress_advanced(ctx,
+                                                            blockTable[blockNb].cPtr, blockTable[blockNb].cRoom,
+                                                            blockTable[blockNb].srcPtr, blockTable[blockNb].srcSize,
+                                                            dictBuffer, dictBufferSize,
+                                                            params);
+#else
                             size_t moreToFlush = 1;
                             ZSTD_outBuffer out;
                             ZSTD_inBuffer in;
@@ -322,6 +331,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                                                 ZSTD_getErrorName(moreToFlush));
                             }
                             blockTable[blockNb].cSize = out.pos;
+#endif
                         }
                         nbLoops++;
                     } while (UTIL_clockSpanMicro(clockStart) < clockLoop);


### PR DESCRIPTION
as per documentation, on `ZSTD_setPledgedSrcSize()` :
> If all data is provided and consumed in a single round,
> this value (pledgedSrcSize) is overriden by srcSize instead.

This wasn't applied before compression level is transformed into compression parameters.
As a consequence, small input missed compression parameters adaptation.

It works fine now : compression was compared with `ZSTD_compress_advanced()`,
results were the same.