### PR TITLE
Optimal parser refactoring

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -63,7 +63,7 @@ SET(Headers
         ${LIBRARY_DIR}/common/huf.h
         ${LIBRARY_DIR}/common/mem.h
         ${LIBRARY_DIR}/common/zstd_internal.h
-        ${LIBRARY_DIR}/compress/zstd_compress.h
+        ${LIBRARY_DIR}/compress/zstd_compress_internal.h
         ${LIBRARY_DIR}/compress/zstd_fast.h
         ${LIBRARY_DIR}/compress/zstd_double_fast.h
         ${LIBRARY_DIR}/compress/zstd_lazy.h

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -138,28 +138,40 @@ typedef enum { set_basic, set_rle, set_compressed, set_repeat } symbolEncodingTy
 #define LLFSELog    9
 #define OffFSELog   8
 
-static const U32 LL_bits[MaxLL+1] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                      1, 1, 1, 1, 2, 2, 3, 3, 4, 6, 7, 8, 9,10,11,12,
+static const U32 LL_bits[MaxLL+1] = { 0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0,
+                                      1, 1, 1, 1, 2, 2, 3, 3,
+                                      4, 6, 7, 8, 9,10,11,12,
                                      13,14,15,16 };
-static const S16 LL_defaultNorm[MaxLL+1] = { 4, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1,
-                                             2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 1, 1, 1, 1, 1,
+static const S16 LL_defaultNorm[MaxLL+1] = { 4, 3, 2, 2, 2, 2, 2, 2,
+                                             2, 2, 2, 2, 2, 1, 1, 1,
+                                             2, 2, 2, 2, 2, 2, 2, 2,
+                                             2, 3, 2, 1, 1, 1, 1, 1,
                                             -1,-1,-1,-1 };
 #define LL_DEFAULTNORMLOG 6  /* for static allocation */
 static const U32 LL_defaultNormLog = LL_DEFAULTNORMLOG;
 
-static const U32 ML_bits[MaxML+1] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                      1, 1, 1, 1, 2, 2, 3, 3, 4, 4, 5, 7, 8, 9,10,11,
+static const U32 ML_bits[MaxML+1] = { 0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0,
+                                      1, 1, 1, 1, 2, 2, 3, 3,
+                                      4, 4, 5, 7, 8, 9,10,11,
                                      12,13,14,15,16 };
-static const S16 ML_defaultNorm[MaxML+1] = { 1, 4, 3, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1,
-                                             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                                             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,-1,-1,
+static const S16 ML_defaultNorm[MaxML+1] = { 1, 4, 3, 2, 2, 2, 2, 2,
+                                             2, 1, 1, 1, 1, 1, 1, 1,
+                                             1, 1, 1, 1, 1, 1, 1, 1,
+                                             1, 1, 1, 1, 1, 1, 1, 1,
+                                             1, 1, 1, 1, 1, 1, 1, 1,
+                                             1, 1, 1, 1, 1, 1,-1,-1,
                                             -1,-1,-1,-1,-1 };
 #define ML_DEFAULTNORMLOG 6  /* for static allocation */
 static const U32 ML_defaultNormLog = ML_DEFAULTNORMLOG;
 
-static const S16 OF_defaultNorm[DefaultMaxOff+1] = { 1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1,
-                                                     1, 1, 1, 1, 1, 1, 1, 1,-1,-1,-1,-1,-1 };
+static const S16 OF_defaultNorm[DefaultMaxOff+1] = { 1, 1, 1, 1, 1, 1, 2, 2,
+                                                     2, 1, 1, 1, 1, 1, 1, 1,
+                                                     1, 1, 1, 1, 1, 1, 1, 1,
+                                                    -1,-1,-1,-1,-1 };
 #define OF_DEFAULTNORMLOG 5  /* for static allocation */
 static const U32 OF_defaultNormLog = OF_DEFAULTNORMLOG;
 
@@ -266,8 +278,8 @@ typedef struct {
 } blockProperties_t;
 
 /*! ZSTD_getcBlockSize() :
-*   Provides the size of compressed block from block header `src`
-*   Used by: decompress, fullbench (does not get its definition from here) */
+ *  Provides the size of compressed block from block header `src` */
+/* Used by: decompress, fullbench (does not get its definition from here) */
 size_t ZSTD_getcBlockSize(const void* src, size_t srcSize,
                           blockProperties_t* bpPtr);
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1248,8 +1248,6 @@ static size_t ZSTD_compressLiterals (ZSTD_entropyCTables_t * entropy,
 
 void ZSTD_seqToCodes(const seqStore_t* seqStorePtr)
 {
-    BYTE const LL_deltaCode = 19;
-    BYTE const ML_deltaCode = 36;
     const seqDef* const sequences = seqStorePtr->sequencesStart;
     BYTE* const llCodeTable = seqStorePtr->llCode;
     BYTE* const ofCodeTable = seqStorePtr->ofCode;
@@ -1259,9 +1257,9 @@ void ZSTD_seqToCodes(const seqStore_t* seqStorePtr)
     for (u=0; u<nbSeq; u++) {
         U32 const llv = sequences[u].litLength;
         U32 const mlv = sequences[u].matchLength;
-        llCodeTable[u] = (llv> 63) ? (BYTE)ZSTD_highbit32(llv) + LL_deltaCode : LL_Code[llv];
+        llCodeTable[u] = (BYTE)ZSTD_LLcode(llv);
         ofCodeTable[u] = (BYTE)ZSTD_highbit32(sequences[u].offset);
-        mlCodeTable[u] = (mlv>127) ? (BYTE)ZSTD_highbit32(mlv) + ML_deltaCode : ML_Code[mlv];
+        mlCodeTable[u] = (BYTE)ZSTD_MLcode(mlv);
     }
     if (seqStorePtr->longLengthID==1)
         llCodeTable[seqStorePtr->longLengthPos] = MaxLL;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -26,7 +26,7 @@
 #include "fse.h"
 #define HUF_STATIC_LINKING_ONLY
 #include "huf.h"
-#include "zstd_compress.h"
+#include "zstd_compress_internal.h"
 #include "zstd_fast.h"
 #include "zstd_double_fast.h"
 #include "zstd_lazy.h"

--- a/lib/compress/zstd_compress.h
+++ b/lib/compress/zstd_compress.h
@@ -8,6 +8,9 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
+/* This header contains definitions
+ * that shall only be used by modules from within lib/compress.
+ */
 
 #ifndef ZSTD_COMPRESS_H
 #define ZSTD_COMPRESS_H
@@ -42,6 +45,98 @@ typedef struct ZSTD_prefixDict_s {
     size_t dictSize;
     ZSTD_dictMode_e dictMode;
 } ZSTD_prefixDict;
+
+typedef struct {
+    U32 hufCTable[HUF_CTABLE_SIZE_U32(255)];
+    FSE_CTable offcodeCTable[FSE_CTABLE_SIZE_U32(OffFSELog, MaxOff)];
+    FSE_CTable matchlengthCTable[FSE_CTABLE_SIZE_U32(MLFSELog, MaxML)];
+    FSE_CTable litlengthCTable[FSE_CTABLE_SIZE_U32(LLFSELog, MaxLL)];
+    U32 workspace[HUF_WORKSPACE_SIZE_U32];
+    HUF_repeat hufCTable_repeatMode;
+    FSE_repeat offcode_repeatMode;
+    FSE_repeat matchlength_repeatMode;
+    FSE_repeat litlength_repeatMode;
+} ZSTD_entropyCTables_t;
+
+typedef struct {
+    U32 off;
+    U32 len;
+} ZSTD_match_t;
+
+typedef struct {
+    U32 price;
+    U32 off;
+    U32 mlen;
+    U32 litlen;
+    U32 rep[ZSTD_REP_NUM];
+} ZSTD_optimal_t;
+
+typedef struct {
+    U32* litFreq;
+    U32* litLengthFreq;
+    U32* matchLengthFreq;
+    U32* offCodeFreq;
+    ZSTD_match_t* matchTable;
+    ZSTD_optimal_t* priceTable;
+
+    U32  matchLengthSum;
+    U32  matchSum;
+    U32  litLengthSum;
+    U32  litSum;
+    U32  offCodeSum;
+    U32  log2matchLengthSum;
+    U32  log2matchSum;
+    U32  log2litLengthSum;
+    U32  log2litSum;
+    U32  log2offCodeSum;
+    U32  factor;
+    U32  staticPrices;
+    U32  cachedPrice;
+    U32  cachedLitLength;
+    const BYTE* cachedLiterals;
+} optState_t;
+
+typedef struct {
+    U32 offset;
+    U32 checksum;
+} ldmEntry_t;
+
+typedef struct {
+    ldmEntry_t* hashTable;
+    BYTE* bucketOffsets;    /* Next position in bucket to insert entry */
+    U64 hashPower;          /* Used to compute the rolling hash.
+                             * Depends on ldmParams.minMatchLength */
+} ldmState_t;
+
+typedef struct {
+    U32 enableLdm;          /* 1 if enable long distance matching */
+    U32 hashLog;            /* Log size of hashTable */
+    U32 bucketSizeLog;      /* Log bucket size for collision resolution, at most 8 */
+    U32 minMatchLength;     /* Minimum match length */
+    U32 hashEveryLog;       /* Log number of entries to skip */
+} ldmParams_t;
+
+struct ZSTD_CCtx_params_s {
+    ZSTD_format_e format;
+    ZSTD_compressionParameters cParams;
+    ZSTD_frameParameters fParams;
+
+    int compressionLevel;
+    U32 forceWindow;           /* force back-references to respect limit of
+                                * 1<<wLog, even for dictionary */
+
+    /* Multithreading: used to pass parameters to mtctx */
+    U32 nbThreads;
+    unsigned jobSize;
+    unsigned overlapSizeLog;
+
+    /* Long distance matching parameters */
+    ldmParams_t ldmParams;
+
+    /* For use with createCCtxParams() and freeCCtxParams() only */
+    ZSTD_customMem customMem;
+
+};  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */
 
 struct ZSTD_CCtx_s {
     const BYTE* nextSrc;    /* next block here to continue on current prefix */
@@ -118,9 +213,9 @@ static const BYTE ML_Code[128] = { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11
                                   42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42 };
 
 /*! ZSTD_storeSeq() :
-    Store a sequence (literal length, literals, offset code and match length code) into seqStore_t.
-    `offsetCode` : distance to match, or 0 == repCode.
-    `matchCode` : matchLength - MINMATCH
+ *  Store a sequence (literal length, literals, offset code and match length code) into seqStore_t.
+ *  `offsetCode` : distance to match + 3 (values 1-3 are repCodes).
+ *  `matchCode` : matchLength - MINMATCH
 */
 MEM_STATIC void ZSTD_storeSeq(seqStore_t* seqStorePtr, size_t litLength, const void* literals, U32 offsetCode, size_t matchCode)
 {
@@ -139,6 +234,7 @@ MEM_STATIC void ZSTD_storeSeq(seqStore_t* seqStorePtr, size_t litLength, const v
 
     /* literal Length */
     if (litLength>0xFFFF) {
+        assert(seqStorePtr->longLengthID == 0); /* there can only be a single long length */
         seqStorePtr->longLengthID = 1;
         seqStorePtr->longLengthPos = (U32)(seqStorePtr->sequences - seqStorePtr->sequencesStart);
     }
@@ -149,6 +245,7 @@ MEM_STATIC void ZSTD_storeSeq(seqStore_t* seqStorePtr, size_t litLength, const v
 
     /* match Length */
     if (matchCode>0xFFFF) {
+        assert(seqStorePtr->longLengthID == 0); /* there can only be a single long length */
         seqStorePtr->longLengthID = 2;
         seqStorePtr->longLengthPos = (U32)(seqStorePtr->sequences - seqStorePtr->sequencesStart);
     }
@@ -303,5 +400,48 @@ MEM_STATIC size_t ZSTD_hashPtr(const void* p, U32 hBits, U32 mls)
 #if defined (__cplusplus)
 }
 #endif
+
+
+/* ==============================================================
+ * Private declarations
+ * These prototypes shall only be called from within lib/compress
+ * ============================================================== */
+
+/*! ZSTD_initCStream_internal() :
+ *  Private use only. Init streaming operation.
+ *  expects params to be valid.
+ *  must receive dict, or cdict, or none, but not both.
+ *  @return : 0, or an error code */
+size_t ZSTD_initCStream_internal(ZSTD_CStream* zcs,
+                     const void* dict, size_t dictSize,
+                     const ZSTD_CDict* cdict,
+                     ZSTD_CCtx_params  params, unsigned long long pledgedSrcSize);
+
+/*! ZSTD_compressStream_generic() :
+ *  Private use only. To be called from zstdmt_compress.c in single-thread mode. */
+size_t ZSTD_compressStream_generic(ZSTD_CStream* zcs,
+                                   ZSTD_outBuffer* output,
+                                   ZSTD_inBuffer* input,
+                                   ZSTD_EndDirective const flushMode);
+
+/*! ZSTD_getCParamsFromCDict() :
+ *  as the name implies */
+ZSTD_compressionParameters ZSTD_getCParamsFromCDict(const ZSTD_CDict* cdict);
+
+/* ZSTD_compressBegin_advanced_internal() :
+ * Private use only. To be called from zstdmt_compress.c. */
+size_t ZSTD_compressBegin_advanced_internal(ZSTD_CCtx* cctx,
+                                    const void* dict, size_t dictSize,
+                                    ZSTD_dictMode_e dictMode,
+                                    ZSTD_CCtx_params params,
+                                    unsigned long long pledgedSrcSize);
+
+/* ZSTD_compress_advanced_internal() :
+ * Private use only. To be called from zstdmt_compress.c. */
+size_t ZSTD_compress_advanced_internal(ZSTD_CCtx* cctx,
+                                       void* dst, size_t dstCapacity,
+                                 const void* src, size_t srcSize,
+                                 const void* dict,size_t dictSize,
+                                 ZSTD_CCtx_params params);
 
 #endif /* ZSTD_COMPRESS_H */

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -91,7 +91,7 @@ typedef struct {
     U32  log2offCodeSum;         /* pow2 to compare log2(offreq) to */
     U32  factor;                 /* added to calculate ZSTD_getPrice() (but why?) */
     /* end : updated by ZSTD_setLog2Prices */
-    U32  staticPrices;           /* ? do not update statistics ? */
+    U32  staticPrices;           /* prices follow a static cost structure, statistics are irrelevant */
     U32  cachedPrice;
     U32  cachedLitLength;
     const BYTE* cachedLiterals;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -9,7 +9,7 @@
  */
 
 /* This header contains definitions
- * that shall only be used by modules from within lib/compress.
+ * that shall **only** be used by modules within lib/compress.
  */
 
 #ifndef ZSTD_COMPRESS_H

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -79,18 +79,19 @@ typedef struct {
     ZSTD_match_t* matchTable;
     ZSTD_optimal_t* priceTable;
 
-    U32  matchLengthSum;
-    U32  matchSum;
-    U32  litLengthSum;
-    U32  litSum;
-    U32  offCodeSum;
-    U32  log2matchLengthSum;
-    U32  log2matchSum;
-    U32  log2litLengthSum;
-    U32  log2litSum;
-    U32  log2offCodeSum;
-    U32  factor;
-    U32  staticPrices;
+    U32  litSum;                 /* nb of literals */
+    U32  litLengthSum;           /* nb of litLength codes */
+    U32  matchLengthSum;         /* nb of matchLength codes */
+    U32  matchSum;               /* one argument to calculate `factor` */
+    U32  offCodeSum;             /* nb of offset codes */
+    /* begin updated by ZSTD_setLog2Prices */
+    U32  log2litSum;             /* pow2 to compare log2(litfreq) to */
+    U32  log2litLengthSum;       /* pow2 to compare log2(llfreq) to */
+    U32  log2matchLengthSum;     /* pow2 to compare log2(mlfreq) to */
+    U32  log2offCodeSum;         /* pow2 to compare log2(offreq) to */
+    U32  factor;                 /* added to calculate ZSTD_getPrice() (but why?) */
+    /* end : updated by ZSTD_setLog2Prices */
+    U32  staticPrices;           /* ? do not update statistics ? */
     U32  cachedPrice;
     U32  cachedLitLength;
     const BYTE* cachedLiterals;

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -8,6 +8,7 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
+#include "zstd_compress_internal.h"
 #include "zstd_double_fast.h"
 
 

--- a/lib/compress/zstd_double_fast.h
+++ b/lib/compress/zstd_double_fast.h
@@ -11,11 +11,12 @@
 #ifndef ZSTD_DOUBLE_FAST_H
 #define ZSTD_DOUBLE_FAST_H
 
-#include "zstd_compress.h"
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
+
+#include "mem.h"      /* U32 */
+#include "zstd.h"     /* ZSTD_CCtx, size_t */
 
 void ZSTD_fillDoubleHashTable(ZSTD_CCtx* cctx, const void* end, const U32 mls);
 size_t ZSTD_compressBlock_doubleFast(ZSTD_CCtx* ctx, const void* src, size_t srcSize);

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -8,6 +8,7 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
+#include "zstd_compress_internal.h"
 #include "zstd_fast.h"
 
 

--- a/lib/compress/zstd_fast.h
+++ b/lib/compress/zstd_fast.h
@@ -11,11 +11,12 @@
 #ifndef ZSTD_FAST_H
 #define ZSTD_FAST_H
 
-#include "zstd_compress.h"
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
+
+#include "mem.h"      /* U32 */
+#include "zstd.h"     /* ZSTD_CCtx, size_t */
 
 void ZSTD_fillHashTable(ZSTD_CCtx* zc, const void* end, const U32 mls);
 size_t ZSTD_compressBlock_fast(ZSTD_CCtx* ctx,

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -8,6 +8,7 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
+#include "zstd_compress_internal.h"
 #include "zstd_lazy.h"
 
 

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -11,11 +11,12 @@
 #ifndef ZSTD_LAZY_H
 #define ZSTD_LAZY_H
 
-#include "zstd_compress.h"
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
+
+#include "mem.h"    /* U32 */
+#include "zstd.h"   /* ZSTD_CCtx, size_t */
 
 U32 ZSTD_insertAndFindFirstIndex (ZSTD_CCtx* zc, const BYTE* ip, U32 mls);
 void ZSTD_updateTree(ZSTD_CCtx* zc, const BYTE* const ip, const BYTE* const iend, const U32 nbCompares, const U32 mls);

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -10,11 +10,12 @@
 #ifndef ZSTD_LDM_H
 #define ZSTD_LDM_H
 
-#include "zstd_compress.h"
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
+
+#include "zstd_compress_internal.h"   /* ldmParams_t, U32 */
+#include "zstd.h"   /* ZSTD_CCtx, size_t */
 
 /*-*************************************
 *  Long distance matching

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -8,8 +8,9 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
+#include "zstd_compress_internal.h"
 #include "zstd_opt.h"
-#include "zstd_lazy.h"
+#include "zstd_lazy.h"   /* ZSTD_updateTree, ZSTD_updateTree_extDict */
 
 
 #define ZSTD_LITFREQ_ADD    2

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -100,7 +100,7 @@ static U32 ZSTD_getLiteralPrice(optState_t* optPtr, U32 litLength, const BYTE* l
     U32 price;
 
     if (optPtr->staticPrices)
-        return ZSTD_highbit32((U32)litLength+1) + (litLength*6);  /* 6 bit per literal - no real estimation */
+        return ZSTD_highbit32((U32)litLength+1) + (litLength*6);  /* 6 bit per literal - no statistic used */
 
     if (litLength == 0)
         return optPtr->log2litLengthSum - ZSTD_highbit32(optPtr->litLengthFreq[0]+1);
@@ -414,8 +414,8 @@ FORCE_INLINE_TEMPLATE
 size_t ZSTD_compressBlock_opt_generic(ZSTD_CCtx* ctx,
                                       const void* src, size_t srcSize, const int ultra)
 {
-    seqStore_t* seqStorePtr = &(ctx->seqStore);
-    optState_t* optStatePtr = &(ctx->optState);
+    seqStore_t* const seqStorePtr = &(ctx->seqStore);
+    optState_t* const optStatePtr = &(ctx->optState);
     const BYTE* const istart = (const BYTE*)src;
     const BYTE* ip = istart;
     const BYTE* anchor = istart;
@@ -441,223 +441,223 @@ size_t ZSTD_compressBlock_opt_generic(ZSTD_CCtx* ctx,
 
     /* Match Loop */
     while (ip < ilimit) {
-        U32 cur, match_num, last_pos = 0, litlen, price;
-        U32 u, mlen, best_mlen, best_off, litLength, offset;
+        U32 cur, last_pos = 0;
+        U32 best_mlen, best_off;
+        U32 const initLL = (U32)(ip - anchor);
         memset(opt, 0, sizeof(ZSTD_optimal_t));
-        litlen = (U32)(ip - anchor);
 
         /* check repCode */
-        {   U32 const ll0 = (ip==anchor);
+        {   U32 const ll0 = !initLL;
             U32 const lastR = ZSTD_REP_CHECK + ll0;
             U32 repCode;
             for (repCode = ll0; repCode < lastR; repCode++) {
                 S32 const repOffset = (repCode==ZSTD_REP_MOVE_OPT) ? (rep[0] - 1) : rep[repCode];
                 if ( (repOffset > 0)
-                  && (repOffset < (S32)(ip-prefixStart))  /* only check within current mem segment */
+                  && (repOffset < (S32)(ip-prefixStart))  /* within current mem segment */
                   && (ZSTD_readMINMATCH(ip, minMatch) == ZSTD_readMINMATCH(ip - repOffset, minMatch))) {
                     U32 repLen = (U32)ZSTD_count(ip+minMatch, ip+minMatch-repOffset, iend) + minMatch;
                     if (repLen > sufficient_len) {
                         /* large repMatch => immediate encoding */
                         best_mlen = repLen; best_off = repCode; cur = 0; last_pos = 1;
-                        goto _storeSequence;
+                        goto _shortestPath;
                     }
                     do {
-                        U32 const repPrice = ZSTD_getPrice(optStatePtr, litlen, anchor, repCode - ll0, repLen, ultra);
+                        U32 const repPrice = ZSTD_getPrice(optStatePtr, initLL, anchor, repCode - ll0, repLen, ultra);
                         if (repLen > last_pos || repPrice < opt[repLen].price)
-                            SET_PRICE(repLen, repLen, repCode, litlen, repPrice);   /* note : macro modifies last_pos */
+                            SET_PRICE(repLen, repLen, repCode, initLL, repPrice);   /* note : macro modifies last_pos */
                         repLen--;
                     } while (repLen >= minMatch);
         }   }   }
 
-        match_num = ZSTD_BtGetAllMatches_selectMLS(ctx, ip, iend, maxSearches, mls, matches, minMatch);
+        {   U32 const nb_matches = ZSTD_BtGetAllMatches_selectMLS(ctx, ip, iend, maxSearches, mls, matches, minMatch);
 
-        if (!last_pos /*no repCode*/ && !match_num /*no match*/) { ip++; continue; }
+            if (!last_pos /*no repCode*/ && !nb_matches /*no match*/) { ip++; continue; }
 
-        if (match_num && (matches[match_num-1].len > sufficient_len)) {
-            /* large match => immediate encoding */
-            best_mlen = matches[match_num-1].len;
-            best_off = matches[match_num-1].off;
-            cur = 0;
-            last_pos = 1;
-            goto _storeSequence;
-        }
+            if (nb_matches && (matches[nb_matches-1].len > sufficient_len)) {
+                /* large match => immediate encoding */
+                best_mlen = matches[nb_matches-1].len;
+                best_off = matches[nb_matches-1].off;
+                cur = 0;
+                last_pos = 1;
+                goto _shortestPath;
+            }
 
-        /* set prices for first matches from position == 0 */
-        {   U32 matchNb;
-            for (matchNb = 0; matchNb < match_num; matchNb++) {
-                U32 pos = (matchNb==0) ? (last_pos /*some repCode (assumed cheaper)*/ ? last_pos : minMatch)
-                                       : matches[matchNb-1].len+1;
-                U32 const end = matches[matchNb].len;
-                while (pos <= end) {
-                    U32 const matchPrice = ZSTD_getPrice(optStatePtr, litlen, anchor, matches[matchNb].off-1, pos, ultra);
-                    if (pos > last_pos || matchPrice < opt[pos].price)
-                        SET_PRICE(pos, pos, matches[matchNb].off, litlen, matchPrice);   /* note : macro modifies last_pos */
-                    pos++;
-        }   }   }
+            /* set prices for first matches from position == 0 */
+            {   U32 matchNb;
+                U32 pos = last_pos /*some repCode (assumed cheaper)*/ ? last_pos : minMatch;
+                for (matchNb = 0; matchNb < nb_matches; matchNb++) {
+                    U32 const end = matches[matchNb].len;
+                    while (pos <= end) {
+                        U32 const matchPrice = ZSTD_getPrice(optStatePtr, initLL, anchor, matches[matchNb].off-1, pos, ultra);
+                        if (pos > last_pos || matchPrice < opt[pos].price)
+                            SET_PRICE(pos, pos, matches[matchNb].off, initLL, matchPrice);   /* note : macro modifies last_pos */
+                        pos++;
+        }   }   }   }
 
         if (last_pos < minMatch) { ip++; continue; }
 
         /* initialize opt[0] */
         { U32 i ; for (i=0; i<ZSTD_REP_NUM; i++) opt[0].rep[i] = rep[i]; }
         opt[0].mlen = 1;
-        opt[0].litlen = litlen;
+        opt[0].litlen = initLL;
 
-         /* check further positions */
+        /* check further positions */
         for (cur = 1; cur <= last_pos; cur++) {
-           const BYTE* const inr = ip + cur;
+            const BYTE* const inr = ip + cur;
+            assert(cur < ZSTD_OPT_NUM);
 
-           if (opt[cur-1].mlen == 1) {
-                litlen = opt[cur-1].litlen + 1;
+            /* Fix current position with one literal if cheaper */
+            {   U32 const litlen = (opt[cur-1].mlen == 1) ? opt[cur-1].litlen + 1 : 1;
+                U32 price;
                 if (cur > litlen) {
                     price = opt[cur - litlen].price + ZSTD_getLiteralPrice(optStatePtr, litlen, inr-litlen);
-                } else
+                } else {
                     price = ZSTD_getLiteralPrice(optStatePtr, litlen, anchor);
-           } else {
-                litlen = 1;
-                price = opt[cur - 1].price + ZSTD_getLiteralPrice(optStatePtr, litlen, inr-1);
-           }
-
-           if (cur > last_pos || price <= opt[cur].price)
-                SET_PRICE(cur, 1, 0, litlen, price);  /* note : macro modifies last_pos */
-
-           if (cur == last_pos) break;
-
-           if (inr > ilimit)  /* last match must start at a minimum distance of 8 from oend */
-               continue;
-
-           mlen = opt[cur].mlen;
-           if (opt[cur].off > ZSTD_REP_MOVE_OPT) {
-                opt[cur].rep[2] = opt[cur-mlen].rep[1];
-                opt[cur].rep[1] = opt[cur-mlen].rep[0];
-                opt[cur].rep[0] = opt[cur].off - ZSTD_REP_MOVE_OPT;
-           } else {
-                opt[cur].rep[2] = (opt[cur].off > 1) ? opt[cur-mlen].rep[1] : opt[cur-mlen].rep[2];
-                opt[cur].rep[1] = (opt[cur].off > 0) ? opt[cur-mlen].rep[0] : opt[cur-mlen].rep[1];
-                /* If opt[cur].off == ZSTD_REP_MOVE_OPT, then mlen != 1.
-                 * offset ZSTD_REP_MOVE_OPT is used for the special case
-                 * litLength == 0, where offset 0 means something special.
-                 * mlen == 1 means the previous byte was stored as a literal,
-                 * so they are mutually exclusive.
-                 */
-                assert(!(opt[cur].off == ZSTD_REP_MOVE_OPT && mlen == 1));
-                opt[cur].rep[0] = (opt[cur].off == ZSTD_REP_MOVE_OPT) ? (opt[cur-mlen].rep[0] - 1) : (opt[cur-mlen].rep[opt[cur].off]);
-           }
-
-            best_mlen = minMatch;
-            {   U32 i, last_i = ZSTD_REP_CHECK + (mlen != 1);
-                for (i=(opt[cur].mlen != 1); i<last_i; i++) {  /* check rep */
-                    const S32 repCur = (i==ZSTD_REP_MOVE_OPT) ? (opt[cur].rep[0] - 1) : opt[cur].rep[i];
-                    if ( (repCur > 0) && (repCur < (S32)(inr-prefixStart))
-                       && (ZSTD_readMINMATCH(inr, minMatch) == ZSTD_readMINMATCH(inr - repCur, minMatch))) {
-                       mlen = (U32)ZSTD_count(inr+minMatch, inr+minMatch - repCur, iend) + minMatch;
-
-                       if (mlen > sufficient_len || cur + mlen >= ZSTD_OPT_NUM) {
-                            best_mlen = mlen; best_off = i; last_pos = cur + 1;
-                            goto _storeSequence;
-                       }
-
-                       best_off = i - (opt[cur].mlen != 1);
-                       if (mlen > best_mlen) best_mlen = mlen;
-
-                       do {
-                           if (opt[cur].mlen == 1) {
-                                litlen = opt[cur].litlen;
-                                if (cur > litlen) {
-                                    price = opt[cur - litlen].price + ZSTD_getPrice(optStatePtr, litlen, inr-litlen, best_off, mlen, ultra);
-                                } else
-                                    price = ZSTD_getPrice(optStatePtr, litlen, anchor, best_off, mlen, ultra);
-                            } else {
-                                litlen = 0;
-                                price = opt[cur].price + ZSTD_getPrice(optStatePtr, 0, NULL, best_off, mlen, ultra);
-                            }
-
-                            if (cur + mlen > last_pos || price <= opt[cur + mlen].price)
-                                SET_PRICE(cur + mlen, mlen, i, litlen, price);  /* note : macro modifies last_pos */
-                            mlen--;
-                        } while (mlen >= minMatch);
-            }   }   }
-
-            match_num = ZSTD_BtGetAllMatches_selectMLS(ctx, inr, iend, maxSearches, mls, matches, best_mlen);
-
-            if (match_num > 0 && (matches[match_num-1].len > sufficient_len || cur + matches[match_num-1].len >= ZSTD_OPT_NUM)) {
-                best_mlen = matches[match_num-1].len;
-                best_off = matches[match_num-1].off;
-                last_pos = cur + 1;
-                goto _storeSequence;
+                }
+                if (cur > last_pos || price <= opt[cur].price)
+                    SET_PRICE(cur, 1, 0, litlen, price);  /* note : macro modifies last_pos */
             }
 
-            /* set prices using matches at position = cur */
-            for (u = 0; u < match_num; u++) {
-                mlen = (u>0) ? matches[u-1].len+1 : best_mlen;
-                best_mlen = matches[u].len;
+            if (cur == last_pos) break;
 
-                while (mlen <= best_mlen) {
-                    if (opt[cur].mlen == 1) {
-                        litlen = opt[cur].litlen;
+            /* last match must start at a minimum distance of 8 from oend */
+            if (inr > ilimit) continue;
+
+            /* update repcodes */
+            {   U32 const mlen = opt[cur].mlen;
+                if (opt[cur].off > ZSTD_REP_MOVE_OPT) {
+                    opt[cur].rep[2] = opt[cur-mlen].rep[1];
+                    opt[cur].rep[1] = opt[cur-mlen].rep[0];
+                    opt[cur].rep[0] = opt[cur].off - ZSTD_REP_MOVE_OPT;
+                } else {
+                    opt[cur].rep[2] = (opt[cur].off > 1) ? opt[cur-mlen].rep[1] : opt[cur-mlen].rep[2];
+                    opt[cur].rep[1] = (opt[cur].off > 0) ? opt[cur-mlen].rep[0] : opt[cur-mlen].rep[1];
+                    /* If opt[cur].off == ZSTD_REP_MOVE_OPT, then mlen != 1.
+                     * offset ZSTD_REP_MOVE_OPT is used for the special case
+                     * litLength == 0, where offset 0 means something special.
+                     * mlen == 1 means the previous byte was stored as a literal,
+                     * so they are mutually exclusive.
+                     */
+                    assert(!(opt[cur].off == ZSTD_REP_MOVE_OPT && mlen == 1));
+                    opt[cur].rep[0] = (opt[cur].off == ZSTD_REP_MOVE_OPT) ? (opt[cur-mlen].rep[0] - 1) : (opt[cur-mlen].rep[opt[cur].off]);
+            }   }
+
+            best_mlen = minMatch;
+            {   U32 const ll0 = (opt[cur].mlen != 1);
+                U32 const lastR = ZSTD_REP_CHECK + ll0;
+                U32 repCode4;  /* universal referential */
+                for (repCode4=ll0; repCode4<lastR; repCode4++) {  /* check rep */
+                    const S32 repCur = (repCode4==ZSTD_REP_MOVE_OPT) ? (opt[cur].rep[0] - 1) : opt[cur].rep[repCode4];
+                    if ( (repCur > 0) && (repCur < (S32)(inr-prefixStart))  /* within current mem segment */
+                      && (ZSTD_readMINMATCH(inr, minMatch) == ZSTD_readMINMATCH(inr - repCur, minMatch))) {
+                        U32 matchLength = (U32)ZSTD_count(inr+minMatch, inr+minMatch - repCur, iend) + minMatch;
+                        U32 const repCode3 = repCode4 - ll0;  /* contextual referential, depends on ll0 */
+                        assert(repCode3 < 3);
+
+                        if (matchLength > sufficient_len || cur + matchLength >= ZSTD_OPT_NUM) {
+                            best_mlen = matchLength;
+                            best_off = repCode4;
+                            last_pos = cur + 1;
+                            goto _shortestPath;
+                        }
+
+                        if (matchLength > best_mlen) best_mlen = matchLength;
+
+                        do {
+                            U32 const litlen = ll0 ? 0 : opt[cur].litlen;
+                            U32 price;
+                            if (cur > litlen) {
+                                price = opt[cur - litlen].price + ZSTD_getPrice(optStatePtr, litlen, inr-litlen, repCode3, matchLength, ultra);
+                            } else {
+                                price = ZSTD_getPrice(optStatePtr, litlen, anchor, repCode3, matchLength, ultra);
+                            }
+
+                            if (cur + matchLength > last_pos || price <= opt[cur + matchLength].price)
+                                SET_PRICE(cur + matchLength, matchLength, repCode4, litlen, price);  /* note : macro modifies last_pos */
+                            matchLength--;
+                        } while (matchLength >= minMatch);
+            }   }   }
+
+            {   U32 const nb_matches = ZSTD_BtGetAllMatches_selectMLS(ctx, inr, iend, maxSearches, mls, matches, best_mlen /*largest repLength*/);   /* search for matches larger than repcodes */
+                U32 matchNb;
+
+                if (nb_matches > 0 && (matches[nb_matches-1].len > sufficient_len || cur + matches[nb_matches-1].len >= ZSTD_OPT_NUM)) {
+                    best_mlen = matches[nb_matches-1].len;
+                    best_off = matches[nb_matches-1].off;
+                    last_pos = cur + 1;
+                    goto _shortestPath;
+                }
+
+                /* set prices using matches at position = cur */
+                for (matchNb = 0; matchNb < nb_matches; matchNb++) {
+                    U32 mlen = (matchNb>0) ? matches[matchNb-1].len+1 : best_mlen;
+                    U32 const lastML = matches[matchNb].len;
+
+                    while (mlen <= lastML) {
+                        U32 const litlen = (opt[cur].mlen == 1) ? opt[cur].litlen : 0;
+                        U32 price;
                         if (cur > litlen)
-                            price = opt[cur - litlen].price + ZSTD_getPrice(optStatePtr, litlen, ip+cur-litlen, matches[u].off-1, mlen, ultra);
+                            price = opt[cur - litlen].price + ZSTD_getPrice(optStatePtr, litlen, ip+cur-litlen, matches[matchNb].off-1, mlen, ultra);
                         else
-                            price = ZSTD_getPrice(optStatePtr, litlen, anchor, matches[u].off-1, mlen, ultra);
-                    } else {
-                        litlen = 0;
-                        price = opt[cur].price + ZSTD_getPrice(optStatePtr, 0, NULL, matches[u].off-1, mlen, ultra);
-                    }
+                            price = ZSTD_getPrice(optStatePtr, litlen, anchor, matches[matchNb].off-1, mlen, ultra);
 
-                    if (cur + mlen > last_pos || (price < opt[cur + mlen].price))
-                        SET_PRICE(cur + mlen, mlen, matches[u].off, litlen, price);  /* note : macro modifies last_pos */
+                        if (cur + mlen > last_pos || (price < opt[cur + mlen].price))
+                            SET_PRICE(cur + mlen, mlen, matches[matchNb].off, litlen, price);  /* note : macro modifies last_pos */
 
-                    mlen++;
-        }   }   }
+                        mlen++;
+        }   }   }   }
 
         best_mlen = opt[last_pos].mlen;
         best_off = opt[last_pos].off;
         cur = last_pos - best_mlen;
 
-        /* store sequence */
-_storeSequence:   /* cur, last_pos, best_mlen, best_off have to be set */
+_shortestPath:   /* cur, last_pos, best_mlen, best_off have to be set */
         opt[0].mlen = 1;
 
-        while (1) {
-            mlen = opt[cur].mlen;
-            offset = opt[cur].off;
-            opt[cur].mlen = best_mlen;
-            opt[cur].off = best_off;
-            best_mlen = mlen;
-            best_off = offset;
-            if (mlen > cur) break;
-            cur -= mlen;
-        }
+        /* reverse traversal */
+        {   U32 selected_matchLength = best_mlen;
+            U32 selectedOffset = best_off;
+            U32 pos = cur;
+            while (1) {
+                U32 const mlen = opt[pos].mlen;
+                U32 const off = opt[pos].off;
+                opt[pos].mlen = selected_matchLength;
+                opt[pos].off = selectedOffset;
+                selected_matchLength = mlen;
+                selectedOffset = off;
+                if (mlen > pos) break;
+                pos -= mlen;
+        }   }
 
-        for (u = 0; u <= last_pos;) {
-            u += opt[u].mlen;
-        }
+        /* save sequences */
+        {   U32 pos;
+            for (pos=0; pos < last_pos; ) {
+                U32 const litLength = (U32)(ip - anchor);
+                U32 const mlen = opt[pos].mlen;
+                U32 offset = opt[pos].off;
+                if (mlen == 1) { ip++; pos++; continue; }
+                pos += mlen;
 
-        for (cur=0; cur < last_pos; ) {
-            mlen = opt[cur].mlen;
-            if (mlen == 1) { ip++; cur++; continue; }
-            offset = opt[cur].off;
-            cur += mlen;
-            litLength = (U32)(ip - anchor);
-
-            if (offset > ZSTD_REP_MOVE_OPT) {
-                rep[2] = rep[1];
-                rep[1] = rep[0];
-                rep[0] = offset - ZSTD_REP_MOVE_OPT;
-                offset--;
-            } else {
-                if (offset != 0) {
-                    best_off = (offset==ZSTD_REP_MOVE_OPT) ? (rep[0] - 1) : (rep[offset]);
-                    if (offset != 1) rep[2] = rep[1];
+                /* repcodes update */
+                if (offset > ZSTD_REP_MOVE_OPT) {  /* full offset */
+                    rep[2] = rep[1];
                     rep[1] = rep[0];
-                    rep[0] = best_off;
+                    rep[0] = offset - ZSTD_REP_MOVE_OPT;
+                    offset--;
+                } else {   /* repcode */
+                    if (offset != 0) {
+                        U32 const currentOffset = (offset==ZSTD_REP_MOVE_OPT) ? (rep[0] - 1) : rep[offset];
+                        if (offset != 1) rep[2] = rep[1];
+                        rep[1] = rep[0];
+                        rep[0] = currentOffset;
+                    }
+                    if (litLength==0) offset--;
                 }
-                if (litLength==0) offset--;
-            }
 
-            ZSTD_updatePrice(optStatePtr, litLength, anchor, offset, mlen);
-            ZSTD_storeSeq(seqStorePtr, litLength, anchor, offset, mlen-MINMATCH);
-            anchor = ip = ip + mlen;
-        }
+                ZSTD_updatePrice(optStatePtr, litLength, anchor, offset, mlen);
+                ZSTD_storeSeq(seqStorePtr, litLength, anchor, offset, mlen-MINMATCH);
+                anchor = ip = ip + mlen;
+        }   }
     }   /* for (cur=0; cur < last_pos; ) */
 
     /* Save reps for next block */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -129,8 +129,7 @@ static U32 ZSTD_getLiteralPrice(optState_t* optPtr, U32 litLength, const BYTE* l
     }
 
     /* literal Length */
-    {   BYTE const LL_deltaCode = 19;
-        BYTE const llCode = (litLength>63) ? (BYTE)ZSTD_highbit32(litLength) + LL_deltaCode : LL_Code[litLength];
+    {   U32 const llCode = ZSTD_LLcode(litLength);
         price += LL_bits[llCode] + optPtr->log2litLengthSum - ZSTD_highbit32(optPtr->litLengthFreq[llCode]+1);
     }
 
@@ -151,8 +150,7 @@ FORCE_INLINE_TEMPLATE U32 ZSTD_getPrice(optState_t* optPtr, U32 litLength, const
     if (!ultra && offCode >= 20) price += (offCode-19)*2; /* handicap for long matches, to favor decompression speed */
 
     /* match Length */
-    {   BYTE const ML_deltaCode = 36;
-        BYTE const mlCode = (mlBase>127) ? (BYTE)ZSTD_highbit32(mlBase) + ML_deltaCode : ML_Code[mlBase];
+    {   U32 const mlCode = ZSTD_MLcode(mlBase);
         price += ML_bits[mlCode] + optPtr->log2matchLengthSum - ZSTD_highbit32(optPtr->matchLengthFreq[mlCode]+1);
     }
 
@@ -170,8 +168,7 @@ static void ZSTD_updatePrice(optState_t* optPtr, U32 litLength, const BYTE* lite
         optPtr->litFreq[literals[u]] += ZSTD_LITFREQ_ADD;
 
     /* literal Length */
-    {   const BYTE LL_deltaCode = 19;
-        const BYTE llCode = (litLength>63) ? (BYTE)ZSTD_highbit32(litLength) + LL_deltaCode : LL_Code[litLength];
+    {   const U32 llCode = ZSTD_LLcode(litLength);
         optPtr->litLengthFreq[llCode]++;
         optPtr->litLengthSum++;
     }
@@ -184,8 +181,7 @@ static void ZSTD_updatePrice(optState_t* optPtr, U32 litLength, const BYTE* lite
 
     /* match Length */
     {   U32 const mlBase = matchLength - MINMATCH;
-        const BYTE ML_deltaCode = 36;
-        const BYTE mlCode = (mlBase>127) ? (BYTE)ZSTD_highbit32(mlBase) + ML_deltaCode : ML_Code[mlBase];
+        U32 const mlCode = ZSTD_MLcode(mlBase);
         optPtr->matchLengthFreq[mlCode]++;
         optPtr->matchLengthSum++;
     }

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -25,19 +25,19 @@ static void ZSTD_setLog2Prices(optState_t* optPtr)
     optPtr->log2litLengthSum = ZSTD_highbit32(optPtr->litLengthSum+1);
     optPtr->log2litSum = ZSTD_highbit32(optPtr->litSum+1);
     optPtr->log2offCodeSum = ZSTD_highbit32(optPtr->offCodeSum+1);
-    optPtr->factor = 1 + ((optPtr->litSum>>5) / optPtr->litLengthSum) + ((optPtr->litSum<<1) / (optPtr->litSum + optPtr->matchSum));
+    optPtr->factor = 1 + ((optPtr->litSum>>5) / optPtr->litLengthSum)
+                       + ((optPtr->litSum<<1) / (optPtr->litSum + optPtr->matchSum));
 }
 
 
 static void ZSTD_rescaleFreqs(optState_t* optPtr, const BYTE* src, size_t srcSize)
 {
-    unsigned u;
-
     optPtr->cachedLiterals = NULL;
     optPtr->cachedPrice = optPtr->cachedLitLength = 0;
     optPtr->staticPrices = 0;
 
-    if (optPtr->litLengthSum == 0) {
+    if (optPtr->litLengthSum == 0) {  /* first init */
+        unsigned u;
         if (srcSize <= 1024) optPtr->staticPrices = 1;
 
         assert(optPtr->litFreq!=NULL);
@@ -50,10 +50,10 @@ static void ZSTD_rescaleFreqs(optState_t* optPtr, const BYTE* src, size_t srcSiz
         optPtr->litLengthSum = MaxLL+1;
         optPtr->matchLengthSum = MaxML+1;
         optPtr->offCodeSum = (MaxOff+1);
-        optPtr->matchSum = (ZSTD_LITFREQ_ADD<<Litbits);
+        optPtr->matchSum = (ZSTD_LITFREQ_ADD << Litbits);
 
         for (u=0; u<=MaxLit; u++) {
-            optPtr->litFreq[u] = 1 + (optPtr->litFreq[u]>>ZSTD_FREQ_DIV);
+            optPtr->litFreq[u] = 1 + (optPtr->litFreq[u] >> ZSTD_FREQ_DIV);
             optPtr->litSum += optPtr->litFreq[u];
         }
         for (u=0; u<=MaxLL; u++)
@@ -62,7 +62,10 @@ static void ZSTD_rescaleFreqs(optState_t* optPtr, const BYTE* src, size_t srcSiz
             optPtr->matchLengthFreq[u] = 1;
         for (u=0; u<=MaxOff; u++)
             optPtr->offCodeFreq[u] = 1;
+
     } else {
+
+        unsigned u;
         optPtr->matchLengthSum = 0;
         optPtr->litLengthSum = 0;
         optPtr->offCodeSum = 0;

--- a/lib/compress/zstd_opt.h
+++ b/lib/compress/zstd_opt.h
@@ -11,11 +11,11 @@
 #ifndef ZSTD_OPT_H
 #define ZSTD_OPT_H
 
-#include "zstd_compress.h"
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
+
+#include "zstd.h"   /* ZSTD_CCtx, size_t */
 
 size_t ZSTD_compressBlock_btopt(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
 size_t ZSTD_compressBlock_btultra(ZSTD_CCtx* ctx, const void* src, size_t srcSize);

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -24,7 +24,7 @@
 #include <string.h>      /* memcpy, memset */
 #include "pool.h"        /* threadpool */
 #include "threading.h"   /* mutex */
-#include "zstd_internal.h"  /* MIN, ERROR, ZSTD_*, ZSTD_highbit32 */
+#include "zstd_compress.h"  /* MIN, ERROR, ZSTD_*, ZSTD_highbit32 */
 #include "zstdmt_compress.h"
 
 

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -24,7 +24,7 @@
 #include <string.h>      /* memcpy, memset */
 #include "pool.h"        /* threadpool */
 #include "threading.h"   /* mutex */
-#include "zstd_compress.h"  /* MIN, ERROR, ZSTD_*, ZSTD_highbit32 */
+#include "zstd_compress_internal.h"  /* MIN, ERROR, ZSTD_*, ZSTD_highbit32 */
 #include "zstdmt_compress.h"
 
 


### PR DESCRIPTION
This patch doesn't change functionality nor performance.
Its objective is mostly to rewrite the optimal parser in a way which makes it easier to understand and modify. "Aggressive scoping" is the most relevant rule applied in this patch.

On the noticeable changes : 
- `zstd_compress.h` becomes `zstd_compress_internal.h`, to emphasise that its definitions are strictly internal, meant to be used solely by `/lib/compress` modules.
- Many definitions were moved from `zstd_internal.h` into `zstd_compress_internal.h`. `zstd_internal.h` is reserved for definitions that need to be shared across `/lib` sub-directories, namely `/compress`, `/decompress` and `/dictBuilder`.

The next important change will be the modification of `zstd_opt`'s match finder to transparently manage rep codes, so that it's possible to have a single parser for both single-segment and double-segments memory configuration.