### PR TITLE
Optimal parser part 2 : Merge normal and _extDict parsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ check: shortest
 
 .PHONY: test shortest
 test shortest:
-	$(MAKE) -C $(PRGDIR) allVariants
+	$(MAKE) -C $(PRGDIR) allVariants MOREFLAGS="-g -DZSTD_DEBUG=1"
 	$(MAKE) -C $(TESTDIR) $@
 
 .PHONY: examples

--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -123,20 +123,26 @@ MEM_STATIC void MEM_write64(void* memPtr, U64 value) { *(U64*)memPtr = value; }
 /* currently only defined for gcc and icc */
 #if defined(_MSC_VER) || (defined(__INTEL_COMPILER) && defined(WIN32))
     __pragma( pack(push, 1) )
-    typedef union { U16 u16; U32 u32; U64 u64; size_t st; } unalign;
+    typedef struct { U16 v; } unalign16;
+    typedef struct { U32 v; } unalign32;
+    typedef struct { U64 v; } unalign64;
+    typedef struct { size_t v; } unalignArch;
     __pragma( pack(pop) )
 #else
-    typedef union { U16 u16; U32 u32; U64 u64; size_t st; } __attribute__((packed)) unalign;
+    typedef struct { U16 v; } __attribute__((packed)) unalign16;
+    typedef struct { U32 v; } __attribute__((packed)) unalign32;
+    typedef struct { U64 v; } __attribute__((packed)) unalign64;
+    typedef struct { size_t v; } __attribute__((packed)) unalignArch;
 #endif
 
-MEM_STATIC U16 MEM_read16(const void* ptr) { return ((const unalign*)ptr)->u16; }
-MEM_STATIC U32 MEM_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
-MEM_STATIC U64 MEM_read64(const void* ptr) { return ((const unalign*)ptr)->u64; }
-MEM_STATIC size_t MEM_readST(const void* ptr) { return ((const unalign*)ptr)->st; }
+MEM_STATIC U16 MEM_read16(const void* ptr) { return ((const unalign16*)ptr)->v; }
+MEM_STATIC U32 MEM_read32(const void* ptr) { return ((const unalign32*)ptr)->v; }
+MEM_STATIC U64 MEM_read64(const void* ptr) { return ((const unalign64*)ptr)->v; }
+MEM_STATIC size_t MEM_readST(const void* ptr) { return ((const unalignArch*)ptr)->v; }
 
-MEM_STATIC void MEM_write16(void* memPtr, U16 value) { ((unalign*)memPtr)->u16 = value; }
-MEM_STATIC void MEM_write32(void* memPtr, U32 value) { ((unalign*)memPtr)->u32 = value; }
-MEM_STATIC void MEM_write64(void* memPtr, U64 value) { ((unalign*)memPtr)->u64 = value; }
+MEM_STATIC void MEM_write16(void* memPtr, U16 value) { ((unalign16*)memPtr)->v = value; }
+MEM_STATIC void MEM_write32(void* memPtr, U32 value) { ((unalign32*)memPtr)->v = value; }
+MEM_STATIC void MEM_write64(void* memPtr, U64 value) { ((unalign64*)memPtr)->v = value; }
 
 #else
 

--- a/lib/common/zstd_common.c
+++ b/lib/common/zstd_common.c
@@ -31,20 +31,26 @@ const char* ZSTD_versionString(void) { return ZSTD_VERSION_STRING; }
 *  ZSTD Error Management
 ******************************************/
 /*! ZSTD_isError() :
-*   tells if a return value is an error code */
+ *  tells if a return value is an error code */
 unsigned ZSTD_isError(size_t code) { return ERR_isError(code); }
 
 /*! ZSTD_getErrorName() :
-*   provides error code string from function result (useful for debugging) */
+ *  provides error code string from function result (useful for debugging) */
 const char* ZSTD_getErrorName(size_t code) { return ERR_getErrorName(code); }
 
 /*! ZSTD_getError() :
-*   convert a `size_t` function result into a proper ZSTD_errorCode enum */
+ *  convert a `size_t` function result into a proper ZSTD_errorCode enum */
 ZSTD_ErrorCode ZSTD_getErrorCode(size_t code) { return ERR_getErrorCode(code); }
 
 /*! ZSTD_getErrorString() :
-*   provides error code string from enum */
+ *  provides error code string from enum */
 const char* ZSTD_getErrorString(ZSTD_ErrorCode code) { return ERR_getErrorString(code); }
+
+/*! g_debuglog_enable :
+ *  turn on/off debug traces (global switch) */
+#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 2)
+int g_debuglog_enable = 1;
+#endif
 
 
 /*=**************************************************************

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -54,6 +54,7 @@ extern "C" {
 
 #if defined(ZSTD_DEBUG) && (ZSTD_DEBUG>=2)
 #  include <stdio.h>
+extern int g_debuglog_enable;
 /* recommended values for ZSTD_DEBUG display levels :
  * 1 : no display, enables assert() only
  * 2 : reserved for currently active debugging path
@@ -61,11 +62,11 @@ extern "C" {
  * 4 : events once per frame
  * 5 : events once per block
  * 6 : events once per sequence (*very* verbose) */
-#  define DEBUGLOG(l, ...) {                         \
-                if (l<=ZSTD_DEBUG) {                 \
-                    fprintf(stderr, __FILE__ ": ");  \
-                    fprintf(stderr, __VA_ARGS__);    \
-                    fprintf(stderr, " \n");          \
+#  define DEBUGLOG(l, ...) {                                 \
+                if ((g_debuglog_enable) & (l<=ZSTD_DEBUG)) { \
+                    fprintf(stderr, __FILE__ ": ");          \
+                    fprintf(stderr, __VA_ARGS__);            \
+                    fprintf(stderr, " \n");                  \
             }   }
 #else
 #  define DEBUGLOG(l, ...)      {}    /* disabled */
@@ -89,9 +90,7 @@ extern "C" {
 #define ZSTD_OPT_NUM    (1<<12)
 
 #define ZSTD_REP_NUM      3                 /* number of repcodes */
-#define ZSTD_REP_CHECK    (ZSTD_REP_NUM)    /* number of repcodes to check by the optimal parser */
 #define ZSTD_REP_MOVE     (ZSTD_REP_NUM-1)
-#define ZSTD_REP_MOVE_OPT (ZSTD_REP_NUM)
 static const U32 repStartValue[ZSTD_REP_NUM] = { 1, 4, 8 };
 
 #define KB *(1 <<10)

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -62,6 +62,10 @@ extern int g_debuglog_enable;
  * 4 : events once per frame
  * 5 : events once per block
  * 6 : events once per sequence (*very* verbose) */
+#  define RAWLOG(l, ...) {                                 \
+                if ((g_debuglog_enable) & (l<=ZSTD_DEBUG)) { \
+                    fprintf(stderr, __VA_ARGS__);            \
+            }   }
 #  define DEBUGLOG(l, ...) {                                 \
                 if ((g_debuglog_enable) & (l<=ZSTD_DEBUG)) { \
                     fprintf(stderr, __FILE__ ": ");          \
@@ -69,7 +73,8 @@ extern int g_debuglog_enable;
                     fprintf(stderr, " \n");                  \
             }   }
 #else
-#  define DEBUGLOG(l, ...)      {}    /* disabled */
+#  define RAWLOG(l, ...)      {}    /* disabled */
+#  define DEBUGLOG(l, ...)    {}    /* disabled */
 #endif
 
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -142,17 +142,17 @@ const seqStore_t* ZSTD_getSeqStore(const ZSTD_CCtx* ctx) { return &(ctx->seqStor
 #define ZSTD_CLEVEL_CUSTOM 999
 
 static ZSTD_compressionParameters ZSTD_getCParamsFromCCtxParams(
-        ZSTD_CCtx_params params, U64 srcSizeHint, size_t dictSize)
+        ZSTD_CCtx_params CCtxParams, U64 srcSizeHint, size_t dictSize)
 {
-    return (params.compressionLevel == ZSTD_CLEVEL_CUSTOM ?
-                    params.cParams :
-                    ZSTD_getCParams(params.compressionLevel, srcSizeHint, dictSize));
+    return (CCtxParams.compressionLevel == ZSTD_CLEVEL_CUSTOM) ?
+                CCtxParams.cParams :
+                ZSTD_getCParams(CCtxParams.compressionLevel, srcSizeHint, dictSize);
 }
 
-static void ZSTD_cLevelToCCtxParams_srcSize(ZSTD_CCtx_params* params, U64 srcSize)
+static void ZSTD_cLevelToCCtxParams_srcSize(ZSTD_CCtx_params* CCtxParams, U64 srcSize)
 {
-    params->cParams = ZSTD_getCParamsFromCCtxParams(*params, srcSize, 0);
-    params->compressionLevel = ZSTD_CLEVEL_CUSTOM;
+    CCtxParams->cParams = ZSTD_getCParamsFromCCtxParams(*CCtxParams, srcSize, 0);
+    CCtxParams->compressionLevel = ZSTD_CLEVEL_CUSTOM;
 }
 
 static void ZSTD_cLevelToCParams(ZSTD_CCtx* cctx)
@@ -161,9 +161,9 @@ static void ZSTD_cLevelToCParams(ZSTD_CCtx* cctx)
             &cctx->requestedParams, cctx->pledgedSrcSizePlusOne-1);
 }
 
-static void ZSTD_cLevelToCCtxParams(ZSTD_CCtx_params* params)
+static void ZSTD_cLevelToCCtxParams(ZSTD_CCtx_params* CCtxParams)
 {
-    ZSTD_cLevelToCCtxParams_srcSize(params, 0);
+    ZSTD_cLevelToCCtxParams_srcSize(CCtxParams, 0);
 }
 
 static ZSTD_CCtx_params ZSTD_makeCCtxParamsFromCParams(
@@ -314,148 +314,157 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned v
 }
 
 size_t ZSTD_CCtxParam_setParameter(
-        ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned value)
+        ZSTD_CCtx_params* CCtxParams, ZSTD_cParameter param, unsigned value)
 {
     switch(param)
     {
     case ZSTD_p_format :
         if (value > (unsigned)ZSTD_f_zstd1_magicless)
             return ERROR(parameter_unsupported);
-        params->format = (ZSTD_format_e)value;
-        return 0;
+        CCtxParams->format = (ZSTD_format_e)value;
+        return (size_t)CCtxParams->format;
 
     case ZSTD_p_compressionLevel :
         if ((int)value > ZSTD_maxCLevel()) value = ZSTD_maxCLevel();
-        if (value == 0) return 0;
-        params->compressionLevel = value;
-        return 0;
+        if (value)  /* 0 : does not change current level */
+            CCtxParams->compressionLevel = value;
+        return CCtxParams->compressionLevel;
 
     case ZSTD_p_windowLog :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_WINDOWLOG_MIN, ZSTD_WINDOWLOG_MAX);
-        ZSTD_cLevelToCCtxParams(params);
-        params->cParams.windowLog = value;
-        return 0;
+        if (value) {  /* 0 : does not change current windowLog */
+            CLAMPCHECK(value, ZSTD_WINDOWLOG_MIN, ZSTD_WINDOWLOG_MAX);
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.windowLog = value;
+        }
+        return CCtxParams->cParams.windowLog;
 
     case ZSTD_p_hashLog :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_HASHLOG_MIN, ZSTD_HASHLOG_MAX);
-        ZSTD_cLevelToCCtxParams(params);
-        params->cParams.hashLog = value;
-        return 0;
+        if (value) { /* 0 : does not change current hashLog */
+            CLAMPCHECK(value, ZSTD_HASHLOG_MIN, ZSTD_HASHLOG_MAX);
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.hashLog = value;
+        }
+        return CCtxParams->cParams.hashLog;
 
     case ZSTD_p_chainLog :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_CHAINLOG_MIN, ZSTD_CHAINLOG_MAX);
-        ZSTD_cLevelToCCtxParams(params);
-        params->cParams.chainLog = value;
-        return 0;
+        if (value) { /* 0 : does not change current chainLog */
+            CLAMPCHECK(value, ZSTD_CHAINLOG_MIN, ZSTD_CHAINLOG_MAX);
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.chainLog = value;
+        }
+        return CCtxParams->cParams.chainLog;
 
     case ZSTD_p_searchLog :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_SEARCHLOG_MIN, ZSTD_SEARCHLOG_MAX);
-        ZSTD_cLevelToCCtxParams(params);
-        params->cParams.searchLog = value;
-        return 0;
+        if (value) { /* 0 : does not change current searchLog */
+            CLAMPCHECK(value, ZSTD_SEARCHLOG_MIN, ZSTD_SEARCHLOG_MAX);
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.searchLog = value;
+        }
+        return value;
 
     case ZSTD_p_minMatch :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_SEARCHLENGTH_MIN, ZSTD_SEARCHLENGTH_MAX);
-        ZSTD_cLevelToCCtxParams(params);
-        params->cParams.searchLength = value;
-        return 0;
+        if (value) { /* 0 : does not change current minMatch length */
+            CLAMPCHECK(value, ZSTD_SEARCHLENGTH_MIN, ZSTD_SEARCHLENGTH_MAX);
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.searchLength = value;
+        }
+        return CCtxParams->cParams.searchLength;
 
     case ZSTD_p_targetLength :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_TARGETLENGTH_MIN, ZSTD_TARGETLENGTH_MAX);
-        ZSTD_cLevelToCCtxParams(params);
-        params->cParams.targetLength = value;
-        return 0;
+        if (value) { /* 0 : does not change current sufficient_len */
+            CLAMPCHECK(value, ZSTD_TARGETLENGTH_MIN, ZSTD_TARGETLENGTH_MAX);
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.targetLength = value;
+        }
+        return CCtxParams->cParams.targetLength;
 
     case ZSTD_p_compressionStrategy :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, (unsigned)ZSTD_fast, (unsigned)ZSTD_btultra);
-        ZSTD_cLevelToCCtxParams(params);
-        params->cParams.strategy = (ZSTD_strategy)value;
-        return 0;
+        if (value) { /* 0 : does not change currentstrategy */
+            CLAMPCHECK(value, (unsigned)ZSTD_fast, (unsigned)ZSTD_btultra);
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.strategy = (ZSTD_strategy)value;
+        }
+        return (size_t)CCtxParams->cParams.strategy;
 
     case ZSTD_p_contentSizeFlag :
         /* Content size written in frame header _when known_ (default:1) */
         DEBUGLOG(4, "set content size flag = %u", (value>0));
-        params->fParams.contentSizeFlag = value > 0;
-        return 0;
+        CCtxParams->fParams.contentSizeFlag = value > 0;
+        return CCtxParams->fParams.contentSizeFlag;
 
     case ZSTD_p_checksumFlag :
         /* A 32-bits content checksum will be calculated and written at end of frame (default:0) */
-        params->fParams.checksumFlag = value > 0;
-        return 0;
+        CCtxParams->fParams.checksumFlag = value > 0;
+        return CCtxParams->fParams.checksumFlag;
 
     case ZSTD_p_dictIDFlag : /* When applicable, dictionary's dictID is provided in frame header (default:1) */
         DEBUGLOG(4, "set dictIDFlag = %u", (value>0));
-        params->fParams.noDictIDFlag = (value == 0);
-        return 0;
+        CCtxParams->fParams.noDictIDFlag = (value == 0);
+        return !CCtxParams->fParams.noDictIDFlag;
 
     case ZSTD_p_forceMaxWindow :
-        params->forceWindow = value > 0;
-        return 0;
+        CCtxParams->forceWindow = (value > 0);
+        return CCtxParams->forceWindow;
 
     case ZSTD_p_nbThreads :
-        if (value == 0) return 0;
+        if (value == 0) return CCtxParams->nbThreads;
 #ifndef ZSTD_MULTITHREAD
         if (value > 1) return ERROR(parameter_unsupported);
-        return 0;
+        return 1;
 #else
-        return ZSTDMT_initializeCCtxParameters(params, value);
+        return ZSTDMT_CCtxParam_setNbThreads(CCtxParams, value);
 #endif
 
     case ZSTD_p_jobSize :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
-        if (params->nbThreads <= 1) return ERROR(parameter_unsupported);
-        return ZSTDMT_CCtxParam_setMTCtxParameter(params, ZSTDMT_p_sectionSize, value);
+        if (CCtxParams->nbThreads <= 1) return ERROR(parameter_unsupported);
+        return ZSTDMT_CCtxParam_setMTCtxParameter(CCtxParams, ZSTDMT_p_sectionSize, value);
 #endif
 
     case ZSTD_p_overlapSizeLog :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
-        if (params->nbThreads <= 1) return ERROR(parameter_unsupported);
-        return ZSTDMT_CCtxParam_setMTCtxParameter(params, ZSTDMT_p_overlapSectionLog, value);
+        if (CCtxParams->nbThreads <= 1) return ERROR(parameter_unsupported);
+        return ZSTDMT_CCtxParam_setMTCtxParameter(CCtxParams, ZSTDMT_p_overlapSectionLog, value);
 #endif
 
     case ZSTD_p_enableLongDistanceMatching :
         if (value != 0) {
-            ZSTD_cLevelToCCtxParams(params);
-            params->cParams.windowLog = ZSTD_LDM_DEFAULT_WINDOW_LOG;
+            ZSTD_cLevelToCCtxParams(CCtxParams);
+            CCtxParams->cParams.windowLog = ZSTD_LDM_DEFAULT_WINDOW_LOG;
         }
-        return ZSTD_ldm_initializeParameters(&params->ldmParams, value);
+        return ZSTD_ldm_initializeParameters(&CCtxParams->ldmParams, value);
 
     case ZSTD_p_ldmHashLog :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_HASHLOG_MIN, ZSTD_HASHLOG_MAX);
-        params->ldmParams.hashLog = value;
-        return 0;
+        if (value) { /* 0 : does not change current ldmHashLog */
+            CLAMPCHECK(value, ZSTD_HASHLOG_MIN, ZSTD_HASHLOG_MAX);
+            CCtxParams->ldmParams.hashLog = value;
+        }
+        return CCtxParams->ldmParams.hashLog;
 
     case ZSTD_p_ldmMinMatch :
-        if (value == 0) return 0;
-        CLAMPCHECK(value, ZSTD_LDM_MINMATCH_MIN, ZSTD_LDM_MINMATCH_MAX);
-        params->ldmParams.minMatchLength = value;
-        return 0;
+        if (value) { /* 0 : does not change current ldmMinMatch */
+            CLAMPCHECK(value, ZSTD_LDM_MINMATCH_MIN, ZSTD_LDM_MINMATCH_MAX);
+            CCtxParams->ldmParams.minMatchLength = value;
+        }
+        return CCtxParams->ldmParams.minMatchLength;
 
     case ZSTD_p_ldmBucketSizeLog :
         if (value > ZSTD_LDM_BUCKETSIZELOG_MAX) {
             return ERROR(parameter_outOfBound);
         }
-        params->ldmParams.bucketSizeLog = value;
-        return 0;
+        CCtxParams->ldmParams.bucketSizeLog = value;
+        return value;
 
     case ZSTD_p_ldmHashEveryLog :
         if (value > ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN) {
             return ERROR(parameter_outOfBound);
         }
-        params->ldmParams.hashEveryLog = value;
-        return 0;
+        CCtxParams->ldmParams.hashEveryLog = value;
+        return value;
 
     default: return ERROR(parameter_unsupported);
     }
@@ -768,12 +777,26 @@ static U32 ZSTD_equivalentLdmParams(ldmParams_t ldmParams1,
             ldmParams1.hashEveryLog == ldmParams2.hashEveryLog);
 }
 
+typedef enum { ZSTDb_not_buffered, ZSTDb_buffered } ZSTD_buffered_policy_e;
+
+/* ZSTD_equivalentBuffPolicy() :
+ * check internal buffers exist for streaming if buffPol == ZSTDb_buffered .
+ * Note : they are assumed to be correctly sized if ZSTD_equivalentCParams()==1 */
+static U32 ZSTD_equivalentBuffPolicy(size_t bufferSize, ZSTD_buffered_policy_e buffPol)
+{
+    if ((buffPol == ZSTDb_buffered) & (!bufferSize)) return 0;
+    return 1;
+}
+
 /** Equivalence for resetCCtx purposes */
 static U32 ZSTD_equivalentParams(ZSTD_CCtx_params params1,
-                                 ZSTD_CCtx_params params2)
+                                 ZSTD_CCtx_params params2,
+                                 size_t buffSize1,
+                                 ZSTD_buffered_policy_e buffPol2)
 {
     return ZSTD_equivalentCParams(params1.cParams, params2.cParams) &&
-           ZSTD_equivalentLdmParams(params1.ldmParams, params2.ldmParams);
+           ZSTD_equivalentLdmParams(params1.ldmParams, params2.ldmParams) &&
+           ZSTD_equivalentBuffPolicy(buffSize1, buffPol2);
 }
 
 /*! ZSTD_continueCCtx() :
@@ -802,7 +825,6 @@ static size_t ZSTD_continueCCtx(ZSTD_CCtx* cctx, ZSTD_CCtx_params params, U64 pl
 }
 
 typedef enum { ZSTDcrp_continue, ZSTDcrp_noMemset } ZSTD_compResetPolicy_e;
-typedef enum { ZSTDb_not_buffered, ZSTDb_buffered } ZSTD_buffered_policy_e;
 
 /*! ZSTD_resetCCtx_internal() :
     note : `params` are assumed fully validated at this stage */
@@ -815,8 +837,8 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
     assert(!ZSTD_isError(ZSTD_checkCParams(params.cParams)));
 
     if (crp == ZSTDcrp_continue) {
-        if (ZSTD_equivalentParams(params, zc->appliedParams)) {
-            DEBUGLOG(4, "ZSTD_equivalentParams()==1");
+        if (ZSTD_equivalentParams(params, zc->appliedParams, zc->inBuffSize, zbuff)) {
+            DEBUGLOG(4, "ZSTD_equivalentParams()==1 -> continue mode");
             assert(!(params.ldmParams.enableLdm &&
                      params.ldmParams.hashEveryLog == ZSTD_LDM_HASHEVERYLOG_NOTSET));
             zc->entropy->hufCTable_repeatMode = HUF_repeat_none;
@@ -825,6 +847,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
             zc->entropy->litlength_repeatMode = FSE_repeat_none;
             return ZSTD_continueCCtx(zc, params, pledgedSrcSize);
     }   }
+    DEBUGLOG(4, "ZSTD_equivalentParams()==0 -> reset CCtx");
 
     if (params.ldmParams.enableLdm) {
         /* Adjust long distance matching parameters */
@@ -863,11 +886,15 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
                 : 0;
             size_t const neededSpace = entropySpace + optSpace + ldmSpace +
                                        tableSpace + tokenSpace + bufferSpace;
+            DEBUGLOG(4, "Need %uKB workspace, including %uKB for tables",
+                        (U32)(neededSpace>>10), (U32)(tableSpace>>10));
+            DEBUGLOG(4, "chainSize: %u - hSize: %u - h3Size: %u",
+                        (U32)chainSize, (U32)hSize, (U32)h3Size);
 
             if (zc->workSpaceSize < neededSpace) {  /* too small : resize */
-                DEBUGLOG(5, "Need to update workSpaceSize from %uK to %uK \n",
-                            (unsigned)zc->workSpaceSize>>10,
-                            (unsigned)neededSpace>>10);
+                DEBUGLOG(4, "Need to update workSpaceSize from %uK to %uK",
+                            (unsigned)(zc->workSpaceSize>>10),
+                            (unsigned)(neededSpace>>10));
                 /* static cctx : no resize, error out */
                 if (zc->staticSize) return ERROR(memory_allocation);
 
@@ -916,7 +943,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 
         /* opt parser space */
         if ((params.cParams.strategy == ZSTD_btopt) || (params.cParams.strategy == ZSTD_btultra)) {
-            DEBUGLOG(5, "reserving optimal parser space");
+            DEBUGLOG(4, "reserving optimal parser space");
             assert(((size_t)ptr & 3) == 0);  /* ensure ptr is properly aligned */
             zc->optState.litFreq = (U32*)ptr;
             zc->optState.litLengthFreq = zc->optState.litFreq + (1<<Litbits);
@@ -940,6 +967,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
         }
 
         /* table Space */
+        DEBUGLOG(4, "reset table : %u", crp!=ZSTDcrp_noMemset);
         if (crp!=ZSTDcrp_noMemset) memset(ptr, 0, tableSpace);   /* reset tables only */
         assert(((size_t)ptr & 3) == 0);  /* ensure ptr is properly aligned */
         zc->hashTable = (U32*)(ptr);
@@ -1753,7 +1781,6 @@ static size_t ZSTD_writeFrameHeader(void* dst, size_t dstCapacity,
                 !params.fParams.noDictIDFlag, dictID,  dictIDSizeCode);
 
     if (params.format == ZSTD_f_zstd1) {
-        DEBUGLOG(4, "writing zstd magic number");
         MEM_writeLE32(dst, ZSTD_MAGICNUMBER);
         pos = 4;
     }
@@ -1787,8 +1814,7 @@ static size_t ZSTD_compressContinue_internal (ZSTD_CCtx* cctx,
     const BYTE* const ip = (const BYTE*) src;
     size_t fhSize = 0;
 
-    DEBUGLOG(5, "ZSTD_compressContinue_internal");
-    DEBUGLOG(5, "stage: %u", cctx->stage);
+    DEBUGLOG(5, "ZSTD_compressContinue_internal, stage: %u", cctx->stage);
     if (cctx->stage==ZSTDcs_created) return ERROR(stage_wrong);   /* missing init (ZSTD_compressBegin) */
 
     if (frame && (cctx->stage==ZSTDcs_init)) {
@@ -2017,7 +2043,7 @@ static size_t ZSTD_compress_insertDictionary(ZSTD_CCtx* cctx,
                                        const void* dict, size_t dictSize,
                                              ZSTD_dictMode_e dictMode)
 {
-    DEBUGLOG(5, "ZSTD_compress_insertDictionary");
+    DEBUGLOG(4, "ZSTD_compress_insertDictionary (dictSize=%u)", (U32)dictSize);
     if ((dict==NULL) || (dictSize<=8)) return 0;
 
     /* dict restricted modes */
@@ -2026,7 +2052,7 @@ static size_t ZSTD_compress_insertDictionary(ZSTD_CCtx* cctx,
 
     if (MEM_readLE32(dict) != ZSTD_MAGIC_DICTIONARY) {
         if (dictMode == ZSTD_dm_auto) {
-            DEBUGLOG(5, "raw content dictionary detected");
+            DEBUGLOG(4, "raw content dictionary detected");
             return ZSTD_loadDictionaryContent(cctx, dict, dictSize);
         }
         if (dictMode == ZSTD_dm_fullDict)
@@ -2097,6 +2123,7 @@ size_t ZSTD_compressBegin_usingDict(ZSTD_CCtx* cctx, const void* dict, size_t di
     ZSTD_parameters const params = ZSTD_getParams(compressionLevel, 0, dictSize);
     ZSTD_CCtx_params const cctxParams =
             ZSTD_assignParamsToCCtxParams(cctx->requestedParams, params);
+    DEBUGLOG(4, "ZSTD_compressBegin_usingDict");
     return ZSTD_compressBegin_internal(cctx, dict, dictSize, ZSTD_dm_auto, NULL,
                                        cctxParams, ZSTD_CONTENTSIZE_UNKNOWN, ZSTDb_not_buffered);
 }
@@ -2179,6 +2206,7 @@ static size_t ZSTD_compress_internal (ZSTD_CCtx* cctx,
 {
     ZSTD_CCtx_params const cctxParams =
             ZSTD_assignParamsToCCtxParams(cctx->requestedParams, params);
+    DEBUGLOG(4, "ZSTD_compress_internal");
     return ZSTD_compress_advanced_internal(cctx,
                                           dst, dstCapacity,
                                           src, srcSize,
@@ -2192,6 +2220,7 @@ size_t ZSTD_compress_advanced (ZSTD_CCtx* ctx,
                          const void* dict,size_t dictSize,
                                ZSTD_parameters params)
 {
+    DEBUGLOG(4, "ZSTD_compress_advanced");
     CHECK_F(ZSTD_checkCParams(params.cParams));
     return ZSTD_compress_internal(ctx, dst, dstCapacity, src, srcSize, dict, dictSize, params);
 }
@@ -2204,6 +2233,7 @@ size_t ZSTD_compress_advanced_internal(
         const void* dict,size_t dictSize,
         ZSTD_CCtx_params params)
 {
+    DEBUGLOG(4, "ZSTD_compress_advanced_internal");
     CHECK_F( ZSTD_compressBegin_internal(cctx, dict, dictSize, ZSTD_dm_auto, NULL,
                                          params, srcSize, ZSTDb_not_buffered) );
     return ZSTD_compressEnd(cctx, dst, dstCapacity, src, srcSize);
@@ -2214,6 +2244,8 @@ size_t ZSTD_compress_usingDict(ZSTD_CCtx* ctx, void* dst, size_t dstCapacity, co
 {
     ZSTD_parameters params = ZSTD_getParams(compressionLevel, srcSize ? srcSize : 1, dict ? dictSize : 0);
     params.fParams.contentSizeFlag = 1;
+    DEBUGLOG(4, "ZSTD_compress_usingDict (level=%i, srcSize=%u, dictSize=%u)",
+                compressionLevel, (U32)srcSize, (U32)dictSize);
     return ZSTD_compress_internal(ctx, dst, dstCapacity, src, srcSize, dict, dictSize, params);
 }
 
@@ -2270,7 +2302,7 @@ static size_t ZSTD_initCDict_internal(
                     ZSTD_dictMode_e dictMode,
                     ZSTD_compressionParameters cParams)
 {
-    DEBUGLOG(5, "ZSTD_initCDict_internal, mode %u", (U32)dictMode);
+    DEBUGLOG(4, "ZSTD_initCDict_internal, mode %u", (U32)dictMode);
     if ((dictLoadMethod == ZSTD_dlm_byRef) || (!dictBuffer) || (!dictSize)) {
         cdict->dictBuffer = NULL;
         cdict->dictContent = dictBuffer;
@@ -2409,11 +2441,11 @@ size_t ZSTD_compressBegin_usingCDict_advanced(
     ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict,
     ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize)
 {
+    DEBUGLOG(4, "ZSTD_compressBegin_usingCDict_advanced");
     if (cdict==NULL) return ERROR(dictionary_wrong);
     {   ZSTD_CCtx_params params = cctx->requestedParams;
         params.cParams = ZSTD_getCParamsFromCDict(cdict);
         params.fParams = fParams;
-        DEBUGLOG(4, "ZSTD_compressBegin_usingCDict_advanced");
         return ZSTD_compressBegin_internal(cctx,
                                            NULL, 0, ZSTD_dm_auto,
                                            cdict,
@@ -2811,16 +2843,17 @@ size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
 
     /* transparent initialization stage */
     if (cctx->streamStage == zcss_init) {
-        ZSTD_prefixDict const prefixDict = cctx->prefixDict;
         ZSTD_CCtx_params params = cctx->requestedParams;
-        if (endOp == ZSTD_e_end) cctx->pledgedSrcSizePlusOne = input->size + 1;
-        params.cParams = ZSTD_getCParamsFromCCtxParams(
-                cctx->requestedParams, cctx->pledgedSrcSizePlusOne-1, 0 /*dictSize*/);
+        ZSTD_prefixDict const prefixDict = cctx->prefixDict;
         memset(&cctx->prefixDict, 0, sizeof(cctx->prefixDict));  /* single usage */
         assert(prefixDict.dict==NULL || cctx->cdict==NULL);   /* only one can be set */
         DEBUGLOG(4, "ZSTD_compress_generic : transparent init stage");
+        if (endOp == ZSTD_e_end) cctx->pledgedSrcSizePlusOne = input->size + 1;  /* auto-fix pledgedSrcSize */
+        params.cParams = ZSTD_getCParamsFromCCtxParams(
+                cctx->requestedParams, cctx->pledgedSrcSizePlusOne-1, 0 /*dictSize*/);
 
 #ifdef ZSTD_MULTITHREAD
+        if ((cctx->pledgedSrcSizePlusOne-1) <= ZSTDMT_JOBSIZE_MIN) params.nbThreads = 1; /* do not invoke multi-threading when src size is too small */
         if (params.nbThreads > 1) {
             if (cctx->mtctx == NULL || cctx->appliedParams.nbThreads != params.nbThreads) {
                 ZSTDMT_freeCCtx(cctx->mtctx);
@@ -2897,8 +2930,7 @@ size_t ZSTD_endStream(ZSTD_CStream* zcs, ZSTD_outBuffer* output)
     {   size_t const lastBlockSize = zcs->frameEnded ? 0 : ZSTD_BLOCKHEADERSIZE;
         size_t const checksumSize = zcs->frameEnded ? 0 : zcs->appliedParams.fParams.checksumFlag * 4;
         size_t const toFlush = zcs->outBuffContentSize - zcs->outBuffFlushedSize + lastBlockSize + checksumSize;
-        DEBUGLOG(5, "ZSTD_endStream : remaining to flush : %u",
-                (unsigned)toFlush);
+        DEBUGLOG(4, "ZSTD_endStream : remaining to flush : %u", (U32)toFlush);
         return toFlush;
     }
 }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -43,17 +43,6 @@ size_t ZSTD_compressBound(size_t srcSize) {
 
 
 /*-*************************************
-*  Sequence storage
-***************************************/
-static void ZSTD_resetSeqStore(seqStore_t* ssPtr)
-{
-    ssPtr->lit = ssPtr->litStart;
-    ssPtr->sequences = ssPtr->sequencesStart;
-    ssPtr->longLengthID = 0;
-}
-
-
-/*-*************************************
 *  Context memory management
 ***************************************/
 struct ZSTD_CDict_s {
@@ -1604,6 +1593,13 @@ static void ZSTD_storeLastLiterals(seqStore_t* seqStorePtr,
 {
     memcpy(seqStorePtr->lit, anchor, lastLLSize);
     seqStorePtr->lit += lastLLSize;
+}
+
+static void ZSTD_resetSeqStore(seqStore_t* ssPtr)
+{
+    ssPtr->lit = ssPtr->litStart;
+    ssPtr->sequences = ssPtr->sequencesStart;
+    ssPtr->longLengthID = 0;
 }
 
 static size_t ZSTD_compressBlock_internal(ZSTD_CCtx* zc, void* dst, size_t dstCapacity, const void* src, size_t srcSize)

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1386,7 +1386,7 @@ size_t ZSTD_encodeSequences(
             U32  const llBits = LL_bits[llCode];
             U32  const ofBits = ofCode;
             U32  const mlBits = ML_bits[mlCode];
-            DEBUGLOG(6, "encoding: litlen:%u - matchlen:%u - offCode:%u",
+            DEBUGLOG(6, "encoding: litlen:%2u - matchlen:%2u - offCode:%7u",
                         sequences[n].litLength,
                         sequences[n].matchLength + MINMATCH,
                         sequences[n].offset);                               /* 32b*/  /* 64b*/

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -233,13 +233,14 @@ MEM_STATIC U32 ZSTD_MLcode(U32 mlBase)
 */
 MEM_STATIC void ZSTD_storeSeq(seqStore_t* seqStorePtr, size_t litLength, const void* literals, U32 offsetCode, size_t mlBase)
 {
-#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 6)
+#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 2)
     static const BYTE* g_start = NULL;
-    U32 const pos = (U32)((const BYTE*)literals - g_start);
     if (g_start==NULL) g_start = (const BYTE*)literals;  /* note : index only works for compression within a single segment */
-    if ((pos > 0) && (pos < 1000000000))
-        DEBUGLOG(6, "Cpos %6u :%5u literals & match %3u bytes at distance %6u",
+    {   U32 const pos = (U32)((const BYTE*)literals - g_start);
+        g_debuglog_enable = ((pos >= 1622540) & (pos < 1622575));
+        DEBUGLOG(2, "Cpos%7u :%3u literals, match%3u bytes at distance%7u",
                pos, (U32)litLength, (U32)mlBase+MINMATCH, (U32)offsetCode);
+    }
 #endif
     /* copy Literals */
     assert(seqStorePtr->lit + litLength <= seqStorePtr->litStart + 128 KB);

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -237,8 +237,8 @@ MEM_STATIC void ZSTD_storeSeq(seqStore_t* seqStorePtr, size_t litLength, const v
     static const BYTE* g_start = NULL;
     if (g_start==NULL) g_start = (const BYTE*)literals;  /* note : index only works for compression within a single segment */
     {   U32 const pos = (U32)((const BYTE*)literals - g_start);
-        g_debuglog_enable = ((pos >= 1622540) & (pos < 1622575));
-        DEBUGLOG(2, "Cpos%7u :%3u literals, match%3u bytes at distance%7u",
+        g_debuglog_enable = ((pos >= 3670500) & (pos < 3673800));
+        DEBUGLOG(2, "Cpos%7u :%3u literals, match%3u bytes at dist.code%7u",
                pos, (U32)litLength, (U32)mlBase+MINMATCH, (U32)offsetCode);
     }
 #endif

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -237,7 +237,6 @@ MEM_STATIC void ZSTD_storeSeq(seqStore_t* seqStorePtr, size_t litLength, const v
     static const BYTE* g_start = NULL;
     if (g_start==NULL) g_start = (const BYTE*)literals;  /* note : index only works for compression within a single segment */
     {   U32 const pos = (U32)((const BYTE*)literals - g_start);
-        g_debuglog_enable = ((pos >= 3670500) & (pos < 3673800));
         DEBUGLOG(6, "Cpos%7u :%3u literals, match%3u bytes at dist.code%7u",
                pos, (U32)litLength, (U32)mlBase+MINMATCH, (U32)offsetCode);
     }

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -233,12 +233,12 @@ MEM_STATIC U32 ZSTD_MLcode(U32 mlBase)
 */
 MEM_STATIC void ZSTD_storeSeq(seqStore_t* seqStorePtr, size_t litLength, const void* literals, U32 offsetCode, size_t mlBase)
 {
-#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 2)
+#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 6)
     static const BYTE* g_start = NULL;
     if (g_start==NULL) g_start = (const BYTE*)literals;  /* note : index only works for compression within a single segment */
     {   U32 const pos = (U32)((const BYTE*)literals - g_start);
         g_debuglog_enable = ((pos >= 3670500) & (pos < 3673800));
-        DEBUGLOG(2, "Cpos%7u :%3u literals, match%3u bytes at dist.code%7u",
+        DEBUGLOG(6, "Cpos%7u :%3u literals, match%3u bytes at dist.code%7u",
                pos, (U32)litLength, (U32)mlBase+MINMATCH, (U32)offsetCode);
     }
 #endif

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -50,12 +50,6 @@ static U32 ZSTD_insertBt1(ZSTD_CCtx* zc, const BYTE* const ip, const U32 mls, co
     predictedLarge += (predictedLarge>0);
 #endif /* ZSTD_C_PREDICT */
 
-#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 2)
-    g_debuglog_enable = (current <=  8530000);
-#endif
-#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 8)
-    g_debuglog_enable = (current ==  5202593);
-#endif
     DEBUGLOG(8, "ZSTD_insertBt1 (%u)", current);
 
     assert(ip <= iend-8);   /* required for h calculation */
@@ -64,12 +58,6 @@ static U32 ZSTD_insertBt1(ZSTD_CCtx* zc, const BYTE* const ip, const U32 mls, co
     while (nbCompares-- && (matchIndex > windowLow)) {
         U32* const nextPtr = bt + 2*(matchIndex & btMask);
         size_t matchLength = MIN(commonLengthSmaller, commonLengthLarger);   /* guaranteed minimum nb of common bytes */
-
-#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 8)
-        if (current ==  5189477) g_debuglog_enable = 1;
-#endif
-        DEBUGLOG(8, "index%8u evaluated during insertion of %u (presumed min matchLength:%3u) ",
-                    matchIndex, current, (U32)matchLength);
 
 #ifdef ZSTD_C_PREDICT   /* note : can create issues when hlog small <= 11 */
         const U32* predictPtr = bt + 2*((matchIndex-1) & btMask);   /* written this way, as bt is a roll buffer */
@@ -91,33 +79,18 @@ static U32 ZSTD_insertBt1(ZSTD_CCtx* zc, const BYTE* const ip, const U32 mls, co
             continue;
         }
 #endif
+
         if ((!extDict) || (matchIndex+matchLength >= dictLimit)) {
+            assert(matchIndex+matchLength >= dictLimit);   /* might be wrong if extDict is incorrectly set to 0 */
             match = base + matchIndex;
-#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG>=2)
-            {   size_t const controlSize = ZSTD_count(ip, match, iend);
-                if (controlSize < matchLength) {
-                    DEBUGLOG(2, "Warning !! => matchIndex %u while inserting %u within prefix is smaller than minimum expectation (%u<%u) !",
-                                matchIndex, current, (U32)controlSize, (U32)matchLength);
-            }   }
-#endif
             if (match[matchLength] == ip[matchLength])
                 matchLength += ZSTD_count(ip+matchLength+1, match+matchLength+1, iend) +1;
         } else {
             match = dictBase + matchIndex;
-#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG>=2)
-            {   size_t const controlSize = ZSTD_count_2segments(ip, match, iend, dictEnd, prefixStart);
-                if (controlSize < matchLength) {
-                    DEBUGLOG(2, "Warning !! => matchIndex %u while inserting %u into _extDict is smaller than minimum expectation (%u<%u) !",
-                                matchIndex, current, (U32)controlSize, (U32)matchLength);
-            }   }
-#endif
             matchLength += ZSTD_count_2segments(ip+matchLength, match+matchLength, iend, dictEnd, prefixStart);
             if (matchIndex+matchLength >= dictLimit)
                 match = base + matchIndex;   /* to prepare for next usage of match[matchLength] */
         }
-
-        DEBUGLOG(8, "matchIndex%8u has %u bytes in common with %u ",
-                    matchIndex, (U32)matchLength, current);
 
         if (matchLength > bestLength) {
             bestLength = matchLength;
@@ -126,24 +99,18 @@ static U32 ZSTD_insertBt1(ZSTD_CCtx* zc, const BYTE* const ip, const U32 mls, co
         }
 
         if (ip+matchLength == iend) {   /* equal : no way to know if inf or sup */
-            DEBUGLOG(8, "index %u has equal value at length %u as src : cannot determine > or <",
-                        matchIndex, (U32)matchLength);
             break;   /* drop , to guarantee consistency ; miss a bit of compression, but other solutions can corrupt tree */
         }
 
         if (match[matchLength] < ip[matchLength]) {  /* necessarily within buffer */
-            /* match+1 is smaller than current */
-            DEBUGLOG(8, "matchIndex%8u is smaller than %u (%u < %u)",
-                        matchIndex, current, match[matchLength], ip[matchLength]);
+            /* match is smaller than current */
             *smallerPtr = matchIndex;             /* update smaller idx */
             commonLengthSmaller = matchLength;    /* all smaller will now have at least this guaranteed common length */
             if (matchIndex <= btLow) { smallerPtr=&dummy32; break; }   /* beyond tree size, stop searching */
-            smallerPtr = nextPtr+1;               /* new "smaller" => larger of match */
-            matchIndex = nextPtr[1];              /* new matchIndex larger than previous (closer to current) */
+            smallerPtr = nextPtr+1;               /* new "candidate" => larger than match, which was smaller than target */
+            matchIndex = nextPtr[1];              /* new matchIndex, larger than previous and closer to current */
         } else {
             /* match is larger than current */
-            DEBUGLOG(8, "matchIndex%8u is larger than %u (%u < %u)",
-                        matchIndex, current, match[matchLength], ip[matchLength]);
             *largerPtr = matchIndex;
             commonLengthLarger = matchLength;
             if (matchIndex <= btLow) { largerPtr=&dummy32; break; }   /* beyond tree size, stop searching */

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -146,14 +146,14 @@ void ZSTD_updateTree(ZSTD_CCtx* zc,
                 const BYTE* const ip, const BYTE* const iend,
                 const U32 nbCompares, const U32 mls)
 {
-    return ZSTD_updateTree_internal(zc, ip, iend, nbCompares, mls, 0 /*extDict*/);
+    ZSTD_updateTree_internal(zc, ip, iend, nbCompares, mls, 0 /*extDict*/);
 }
 
 void ZSTD_updateTree_extDict(ZSTD_CCtx* zc,
                 const BYTE* const ip, const BYTE* const iend,
                 const U32 nbCompares, const U32 mls)
 {
-    return ZSTD_updateTree_internal(zc, ip, iend, nbCompares, mls, 1 /*extDict*/);
+    ZSTD_updateTree_internal(zc, ip, iend, nbCompares, mls, 1 /*extDict*/);
 }
 
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -264,14 +264,10 @@ static U32 ZSTD_insertBtAndGetAllMatches (
     size_t bestLength = minMatchLen-1;
 
 #if defined(ZSTD_DEBUG) && (ZSTD_DEBUG >= 8)
-    static const BYTE* g_start = NULL;
-    if (g_start==NULL) g_start = base;  /* note : index only works for compression within a single segment */
-    {   U32 const pos = (U32)(ip - g_start);
-        g_debuglog_enable = (pos==3673728);
-    }
-    if (current == 8793162) g_debuglog_enable = 1;
+    g_debuglog_enable = (current ==  5202593);
+    //g_debuglog_enable = (current ==  8845622);
+    //if (current == 12193408) g_debuglog_enable = 1;
 #endif
-
 
     /* check repCode */
 #if 0
@@ -293,7 +289,7 @@ static U32 ZSTD_insertBtAndGetAllMatches (
                     matches[mnum].len = (U32)repLen;
                     mnum++;
                     if ( (repLen > ZSTD_OPT_NUM)
-                      || (ip+repLen == iLimit) ) {  /* best possible */
+                       | (ip+repLen == iLimit) ) {  /* best possible */
                         return mnum;
         }   }   }   }
     } else {   /* extDict */
@@ -320,7 +316,7 @@ static U32 ZSTD_insertBtAndGetAllMatches (
                     matches[mnum].len = (U32)repLen;
                     mnum++;
                     if ( (repLen > ZSTD_OPT_NUM)
-                      || (ip+repLen == iLimit) ) {  /* best possible */
+                       | (ip+repLen == iLimit) ) {  /* best possible */
                         return mnum;
         }   }   }   }
     }
@@ -352,10 +348,10 @@ static U32 ZSTD_insertBtAndGetAllMatches (
                 assert(mnum==0);  /* no prior solution */
                 matches[0].off = (current - matchIndex3) + ZSTD_REP_MOVE;
                 matches[0].len = (U32)mlen;
-                mnum=1;
+                mnum = 1;
                 if ( (mlen > ZSTD_OPT_NUM)
-                  || (ip+mlen == iLimit) ) {  /* best possible */
-                    return mnum;
+                   | (ip+mlen == iLimit) ) {  /* best possible */
+                    return 1;
     }   }   }   }
 #endif
 
@@ -373,6 +369,13 @@ static U32 ZSTD_insertBtAndGetAllMatches (
 #endif
         if ((!extDict) || (matchIndex+matchLength >= dictLimit)) {
             match = base + matchIndex;
+#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG>=2)
+            {   size_t const controlSize = ZSTD_count(ip, match, iLimit);
+                if (controlSize < matchLength) {
+                    DEBUGLOG(2, "Warning !! => matchIndex %u while searching %u within prefix is smaller than minimum expectation (%u<%u) !",
+                                matchIndex, current, (U32)controlSize, (U32)matchLength);
+            }   }
+#endif
             if (match[matchLength] == ip[matchLength]) {
                 matchLength += ZSTD_count(ip+matchLength+1, match+matchLength+1, iLimit) +1;
             }
@@ -388,9 +391,16 @@ static U32 ZSTD_insertBtAndGetAllMatches (
 #endif
         } else {
             match = dictBase + matchIndex;
+#if defined(ZSTD_DEBUG) && (ZSTD_DEBUG>=2)
+            {   size_t const controlSize = ZSTD_count_2segments(ip, match, iLimit, dictEnd, prefixStart);
+                if (controlSize < matchLength) {
+                    DEBUGLOG(2, "Warning !! => matchIndex %u while searching %u into _extDict is smaller than minimum expectation (%u<%u) !",
+                                matchIndex, current, (U32)controlSize, (U32)matchLength);
+            }   }
+#endif
             matchLength += ZSTD_count_2segments(ip+matchLength, match+matchLength, iLimit, dictEnd, prefixStart);
             if (matchIndex+matchLength >= dictLimit)
-                match = base + matchIndex;   /* to prepare for next usage of match[matchLength] */
+                match = base + matchIndex;   /* prepare for match[matchLength] */
 #if defined(ZSTD_DEBUG) && (ZSTD_DEBUG>=8)
             if (matchIndex + 8 < dictLimit)
             {   int i;
@@ -431,7 +441,7 @@ static U32 ZSTD_insertBtAndGetAllMatches (
                         matchIndex, match[matchLength], ip[matchLength], (U32)matchLength);
             {   int i;
                 RAWLOG(8, "index %u: ", matchIndex);
-                for (i=0; i<27; i++) RAWLOG(7," %02X ", match[i]);
+                for (i=0; i<18; i++) RAWLOG(7," %02X ", match[i]);
                 RAWLOG(8, " \n");
             }
 #endif
@@ -445,7 +455,7 @@ static U32 ZSTD_insertBtAndGetAllMatches (
             {   int i;
                 const BYTE* const match2 = (matchIndex < dictLimit) ? dictBase + matchIndex : base + matchIndex;
                 RAWLOG(8, "index %u: ", matchIndex);
-                for (i=0; i<27; i++) RAWLOG(7," %02X ", match2[i]);
+                for (i=0; i<18; i++) RAWLOG(7," %02X ", match2[i]);
                 RAWLOG(8, " \n");
             }
 #endif
@@ -455,7 +465,7 @@ static U32 ZSTD_insertBtAndGetAllMatches (
                         matchIndex, match[matchLength], ip[matchLength], (U32)matchLength);
             {   int i;
                 RAWLOG(8, "index %u: ", matchIndex);
-                for (i=0; i<27; i++) RAWLOG(7," %02X ", match[i]);
+                for (i=0; i<18; i++) RAWLOG(7," %02X ", match[i]);
                 RAWLOG(8, " \n");
             }
 #endif
@@ -469,7 +479,7 @@ static U32 ZSTD_insertBtAndGetAllMatches (
             {   int i;
                 const BYTE* const match2 = (matchIndex < dictLimit) ? dictBase + matchIndex : base + matchIndex;
                 RAWLOG(8, "index %u: ", matchIndex);
-                for (i=0; i<27; i++) RAWLOG(7," %02X ", match2[i]);
+                for (i=0; i<18; i++) RAWLOG(7," %02X ", match2[i]);
                 RAWLOG(8, " \n");
             }
 #endif

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -271,7 +271,6 @@ FORCE_INLINE_TEMPLATE
             U32 const repOffset = (repCode==ZSTD_REP_NUM) ? (rep[0] - 1) : rep[repCode];
             U32 const repIndex = current - repOffset;
             U32 repLen = 0;
-            assert(repOffset <= current);
             assert(current >= dictLimit);
             if (!extDict /*static*/ || (repIndex>=dictLimit)) {
                 if ( (repOffset-1 /* intentional overflow, discards 0 and -1 */ < current-dictLimit)  /* within current mem segment */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -312,8 +312,6 @@ FORCE_INLINE_TEMPLATE
 
             /* save best solution */
             if (mlen >= mls /* == 3 > bestLength */) {
-                DEBUGLOG(8, "current %u : found short match of size%3u at distance%7u",
-                            current, (U32)mlen, current - matchIndex3);
                 bestLength = mlen;
                 assert(current > matchIndex3);
                 assert(mnum==0);  /* no prior solution */
@@ -511,15 +509,11 @@ size_t ZSTD_compressBlock_opt_generic(ZSTD_CCtx* ctx,
                     U32 const offset = matches[matchNb].off;
                     U32 const end = matches[matchNb].len;
                     repcodes_t const repHistory = ZSTD_updateRep(rep, offset, ll0);
-                    DEBUGLOG(7, "match %u: starting reps=%u,%u,%u ==> %u,%u,%u",
-                                matchNb, rep[0], rep[1], rep[2], repHistory.rep[0], repHistory.rep[1], repHistory.rep[2])
                     while (pos <= end) {
                         U32 const matchPrice = ZSTD_getPrice(optStatePtr, litlen, anchor, offset, pos, ultra);
                         if (pos > last_pos || matchPrice < opt[pos].price) {
                             DEBUGLOG(7, "rPos:%u => set initial price : %u",
                                         pos, matchPrice);
-                            DEBUGLOG(7, "transferring rep:%u,%u,%u",
-                                        repHistory.rep[0], repHistory.rep[1], repHistory.rep[2]);
                             SET_PRICE(pos, pos, offset, litlen, matchPrice, repHistory);   /* note : macro modifies last_pos */
                         }
                         pos++;
@@ -542,8 +536,6 @@ size_t ZSTD_compressBlock_opt_generic(ZSTD_CCtx* ctx,
                 if (price <= opt[cur].price) {
                     DEBUGLOG(7, "rPos:%u : better price (%u<%u) using literal",
                                 cur, price, opt[cur].price);
-                    DEBUGLOG(7, "transferring rep:%u,%u,%u",
-                                opt[cur-1].rep[0], opt[cur-1].rep[1], opt[cur-1].rep[2]);
                     SET_PRICE(cur, 1/*mlen*/, 0/*offset*/, litlen, price, opt[cur-1].rep);
             }   }
 
@@ -601,8 +593,6 @@ size_t ZSTD_compressBlock_opt_generic(ZSTD_CCtx* ctx,
         best_mlen = opt[last_pos].mlen;
         best_off = opt[last_pos].off;
         cur = last_pos - best_mlen;
-        DEBUGLOG(7, "Preparing path selection : last_pos:%u, cur:%u, best_mlen:%u",
-                    last_pos, cur, best_mlen);
 
 _shortestPath:   /* cur, last_pos, best_mlen, best_off have to be set */
         assert(opt[0].mlen == 1);
@@ -650,8 +640,6 @@ _shortestPath:   /* cur, last_pos, best_mlen, best_off have to be set */
 
                 ZSTD_updatePrice(optStatePtr, llen, anchor, offset, mlen);
                 ZSTD_storeSeq(seqStorePtr, llen, anchor, offset, mlen-MINMATCH);
-                DEBUGLOG(7, "seq: ll:%u,ml:%u,off:%u - rep:%u,%u,%u",
-                            llen, mlen, offset, rep[0], rep[1], rep[2]);
                 anchor = ip;
         }   }
     }   /* for (cur=0; cur < last_pos; ) */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -231,7 +231,7 @@ static U32 ZSTD_insertAndFindFirstIndexHash3 (ZSTD_CCtx* zc, const BYTE* ip)
 /*-*************************************
 *  Binary Tree search
 ***************************************/
-//FORCE_INLINE_TEMPLATE
+FORCE_INLINE_TEMPLATE
 U32 ZSTD_insertBtAndGetAllMatches (
                         ZSTD_CCtx* zc,
                         const BYTE* const ip, const BYTE* const iLimit, const int extDict,

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -112,6 +112,9 @@ ZSTDLIB_API size_t ZSTDMT_compressStream_generic(ZSTDMT_CCtx* mtctx,
 
 size_t ZSTDMT_CCtxParam_setMTCtxParameter(ZSTD_CCtx_params* params, ZSTDMT_parameter parameter, unsigned value);
 
+/* ZSTDMT_CCtxParam_setNbThreads()
+ * Set nbThreads, and clamp it correctly,
+ * but also reset jobSize and overlapLog */ 
 size_t ZSTDMT_CCtxParam_setNbThreads(ZSTD_CCtx_params* params, unsigned nbThreads);
 
 /*! ZSTDMT_initCStream_internal() :

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -60,8 +60,8 @@ ZSTDLIB_API size_t ZSTDMT_endStream(ZSTDMT_CCtx* mtctx, ZSTD_outBuffer* output);
 
 /* ===   Advanced functions and parameters  === */
 
-#ifndef ZSTDMT_SECTION_SIZE_MIN
-#  define ZSTDMT_SECTION_SIZE_MIN (1U << 20)   /* 1 MB - Minimum size of each compression job */
+#ifndef ZSTDMT_JOBSIZE_MIN
+#  define ZSTDMT_JOBSIZE_MIN (1U << 20)   /* 1 MB - Minimum size of each compression job */
 #endif
 
 ZSTDLIB_API size_t ZSTDMT_compress_advanced(ZSTDMT_CCtx* mtctx,
@@ -112,7 +112,7 @@ ZSTDLIB_API size_t ZSTDMT_compressStream_generic(ZSTDMT_CCtx* mtctx,
 
 size_t ZSTDMT_CCtxParam_setMTCtxParameter(ZSTD_CCtx_params* params, ZSTDMT_parameter parameter, unsigned value);
 
-size_t ZSTDMT_initializeCCtxParameters(ZSTD_CCtx_params* params, unsigned nbThreads);
+size_t ZSTDMT_CCtxParam_setNbThreads(ZSTD_CCtx_params* params, unsigned nbThreads);
 
 /*! ZSTDMT_initCStream_internal() :
  *  Private use only. Init streaming operation.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1059,7 +1059,8 @@ typedef enum {
 /*! ZSTD_CCtx_setParameter() :
  *  Set one compression parameter, selected by enum ZSTD_cParameter.
  *  Note : when `value` is an enum, cast it to unsigned for proper type checking.
- *  @result : 0, or an error code (which can be tested with ZSTD_isError()). */
+ *  @result : informational value (typically, the one being set, possibly corrected),
+ *            or an error code (which can be tested with ZSTD_isError()). */
 ZSTDLIB_API size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned value);
 
 /*! ZSTD_CCtx_setPledgedSrcSize() :

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -416,10 +416,12 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                             DISPLAY("(sample %u, block %u, pos %u) \n", segNb, bNb, pos);
                             if (u>5) {
                                 int n;
+                                DISPLAY("origin: ");
                                 for (n=-5; n<0; n++) DISPLAY("%02X ", ((const BYTE*)srcBuffer)[u+n]);
                                 DISPLAY(" :%02X:  ", ((const BYTE*)srcBuffer)[u]);
                                 for (n=1; n<3; n++) DISPLAY("%02X ", ((const BYTE*)srcBuffer)[u+n]);
                                 DISPLAY(" \n");
+                                DISPLAY("decode: ");
                                 for (n=-5; n<0; n++) DISPLAY("%02X ", ((const BYTE*)resultBuffer)[u+n]);
                                 DISPLAY(" :%02X:  ", ((const BYTE*)resultBuffer)[u]);
                                 for (n=1; n<3; n++) DISPLAY("%02X ", ((const BYTE*)resultBuffer)[u+n]);

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -473,6 +473,7 @@ static int basicUnitTests(U32 seed, double compressibility, ZSTD_customMem custo
     DISPLAYLEVEL(3, "test%3i : digested dictionary : ", testNb++);
     {   ZSTD_CDict* const cdict = ZSTD_createCDict(dictionary.start, dictionary.filled, 1 /*byRef*/ );
         size_t const initError = ZSTD_initCStream_usingCDict(zc, cdict);
+        DISPLAYLEVEL(5, "ZSTD_initCStream_usingCDict result : %u ", (U32)initError);
         if (ZSTD_isError(initError)) goto _output_error;
         cSize = 0;
         outBuff.dst = compressedBuffer;
@@ -481,10 +482,13 @@ static int basicUnitTests(U32 seed, double compressibility, ZSTD_customMem custo
         inBuff.src = CNBuffer;
         inBuff.size = CNBufferSize;
         inBuff.pos = 0;
+        DISPLAYLEVEL(5, "- starting ZSTD_compressStream ");
         CHECK_Z( ZSTD_compressStream(zc, &outBuff, &inBuff) );
         if (inBuff.pos != inBuff.size) goto _output_error;   /* entire input should be consumed */
-        { size_t const r = ZSTD_endStream(zc, &outBuff);
-          if (r != 0) goto _output_error; }  /* error, or some data not flushed */
+        {   size_t const r = ZSTD_endStream(zc, &outBuff);
+            DISPLAYLEVEL(5, "- ZSTD_endStream result : %u ", (U32)r);
+            if (r != 0) goto _output_error;  /* error, or some data not flushed */
+        }
         cSize = outBuff.pos;
         ZSTD_freeCDict(cdict);
         DISPLAYLEVEL(3, "OK (%u bytes : %.2f%%)\n", (U32)cSize, (double)cSize/CNBufferSize*100);


### PR DESCRIPTION
There is now a single optimal parser for both normal and _extDict modes.

The enabler was to isolate _extDict specificities into the match finder.

The new parser code is highly simplified compared to earlier versions.
This should help reviews, and future modifications.

This new version does not compress identically compared with `dev` nor `v1.3.1`,
but it's within the same range. Speed is about the same. Compression ratio is similar, though exact compressed size vary.

```
calgary.tar : -b19 :  903756 (v1.3.1) ==>  903635 (patch)
enwik7      : -b19 : 2830032 (v1.3.1) ==> 2830756 (patch)
```

The difference is likely because search used to stop immediately after repcode when finding `sufficient_len`, while it will continue searching now. Searching more is supposed to be better, or so I believed, but we have here the proof it's not always the case. This is likely because statistics are only roughly evaluated, hence parsing decisions are based on flawed data.

The next modification will attempt to keep the table clean after each match insertion.
Currently, it's not, and rely on the mechanical study at each position to fix left over.
This prevent ability to skip positions, and flexible insertions.
Both capabilities are important to consider writing faster variants.