### PR TITLE
Bench multiple files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,6 @@ uninstall:
 travis-install:
 	$(MAKE) install PREFIX=~/install_test_dir
 
-.PHONY: gppbuild
-gppbuild: clean
-	g++ -v
-	CC=g++ $(MAKE) -C programs all CFLAGS="-O3 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror"
-
 .PHONY: gcc5build
 gcc5build: clean
 	gcc-5 -v

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ test:
       :
         parallel: true
     - ? |
-        if [[ "$CIRCLE_NODE_INDEX" == "0" ]]                                    ; then make gppbuild     && make clean; fi &&
+        if [[ "$CIRCLE_NODE_INDEX" == "0" ]]                                    ; then make cxxtest      && make clean; fi &&
         if [[ "$CIRCLE_NODE_TOTAL" < "2" ]] || [[ "$CIRCLE_NODE_INDEX" == "1" ]]; then make gcc5build    && make clean; fi
       :
         parallel: true

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -622,7 +622,7 @@ static void BMK_benchFileTable(const char* const * const fileNamesTable, unsigne
 }
 
 
-static void BMK_syntheticTest(int cLevel, int cLevelLast, double compressibility, ZSTD_compressionParameters* compressionParams)
+static void BMK_syntheticTest(int cLevel, int cLevelLast, double compressibility, const ZSTD_compressionParameters* compressionParams)
 {
     char name[20] = {0};
     size_t benchedSize = 10000000;
@@ -643,10 +643,10 @@ static void BMK_syntheticTest(int cLevel, int cLevelLast, double compressibility
 }
 
 
-int BMK_benchFiles(const char** const fileNamesTable, unsigned const nbFiles,
+int BMK_benchFiles(const char** fileNamesTable, unsigned nbFiles,
                    const char* dictFileName,
                    int cLevel, int cLevelLast,
-                   ZSTD_compressionParameters* compressionParams)
+                   const ZSTD_compressionParameters* compressionParams)
 {
     double const compressibility = (double)g_compressibilityDefault / 100;
 

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -17,12 +17,13 @@
 #include "zstd.h"     /* ZSTD_compressionParameters */
 
 int BMK_benchFiles(const char** fileNamesTable, unsigned nbFiles,const char* dictFileName,
-                   int cLevel, int cLevelLast, ZSTD_compressionParameters* compressionParams, int setRealTimePrio);
+                   int cLevel, int cLevelLast, ZSTD_compressionParameters* compressionParams);
 
 /* Set Parameters */
 void BMK_setNbSeconds(unsigned nbLoops);
 void BMK_setBlockSize(size_t blockSize);
 void BMK_setNbThreads(unsigned nbThreads);
+void BMK_setRealTime(unsigned priority);
 void BMK_setNotificationLevel(unsigned level);
 void BMK_setAdditionalParam(int additionalParam);
 void BMK_setDecodeOnlyMode(unsigned decodeFlag);

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -25,6 +25,7 @@ void BMK_setBlockSize(size_t blockSize);
 void BMK_setNbThreads(unsigned nbThreads);
 void BMK_setRealTime(unsigned priority);
 void BMK_setNotificationLevel(unsigned level);
+void BMK_setSeparateFiles(unsigned separate);
 void BMK_setAdditionalParam(int additionalParam);
 void BMK_setDecodeOnlyMode(unsigned decodeFlag);
 void BMK_setLdmFlag(unsigned ldmFlag);

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -16,8 +16,8 @@
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_compressionParameters */
 #include "zstd.h"     /* ZSTD_compressionParameters */
 
-int BMK_benchFiles(const char** fileNamesTable, unsigned nbFiles,const char* dictFileName,
-                   int cLevel, int cLevelLast, ZSTD_compressionParameters* compressionParams);
+int BMK_benchFiles(const char** fileNamesTable, unsigned nbFiles, const char* dictFileName,
+                   int cLevel, int cLevelLast, const ZSTD_compressionParameters* compressionParams);
 
 /* Set Parameters */
 void BMK_setNbSeconds(unsigned nbLoops);

--- a/programs/util.h
+++ b/programs/util.h
@@ -336,7 +336,7 @@ UTIL_STATIC U64 UTIL_getFileSize(const char* infilename)
 }
 
 
-UTIL_STATIC U64 UTIL_getTotalFileSize(const char** fileNamesTable, unsigned nbFiles)
+UTIL_STATIC U64 UTIL_getTotalFileSize(const char* const * const fileNamesTable, unsigned nbFiles)
 {
     U64 total = 0;
     int error = 0;

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -377,6 +377,7 @@ int main(int argCount, const char* argv[])
         lastCommand = 0,
         nbThreads = 1,
         setRealTimePrio = 0,
+        separateFiles = 0,
         ldmFlag = 0;
     unsigned bench_nbSeconds = 3;   /* would be better if this value was synchronized from bench */
     size_t blockSize = 0;
@@ -633,6 +634,12 @@ int main(int argCount, const char* argv[])
                         blockSize = readU32FromChar(&argument);
                         break;
 
+                        /* benchmark files separately (hidden option) */
+                    case 'S':
+                        argument++;
+                        separateFiles = 1;
+                        break;
+
 #endif   /* ZSTD_NOBENCH */
 
                         /* nb of threads (hidden option) */
@@ -751,6 +758,7 @@ int main(int argCount, const char* argv[])
     if (operation==zom_bench) {
 #ifndef ZSTD_NOBENCH
         BMK_setNotificationLevel(g_displayLevel);
+        BMK_setSeparateFiles(separateFiles);
         BMK_setBlockSize(blockSize);
         BMK_setNbThreads(nbThreads);
         BMK_setRealTime(setRealTimePrio);

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -753,6 +753,7 @@ int main(int argCount, const char* argv[])
         BMK_setNotificationLevel(g_displayLevel);
         BMK_setBlockSize(blockSize);
         BMK_setNbThreads(nbThreads);
+        BMK_setRealTime(setRealTimePrio);
         BMK_setNbSeconds(bench_nbSeconds);
         BMK_setLdmFlag(ldmFlag);
         BMK_setLdmMinMatch(g_ldmMinMatch);
@@ -763,7 +764,7 @@ int main(int argCount, const char* argv[])
         if (g_ldmHashEveryLog != LDM_PARAM_DEFAULT) {
             BMK_setLdmHashEveryLog(g_ldmHashEveryLog);
         }
-        BMK_benchFiles(filenameTable, filenameIdx, dictFileName, cLevel, cLevelLast, &compressionParams, setRealTimePrio);
+        BMK_benchFiles(filenameTable, filenameIdx, dictFileName, cLevel, cLevelLast, &compressionParams);
 #endif
         (void)bench_nbSeconds; (void)blockSize; (void)setRealTimePrio;
         goto _end;


### PR DESCRIPTION
Added (hidden) cli command `-S` to benchmark multiple files separately

Currently, when multiple files are provided on command line for benchmark,
all files are joined by default,
which means they are compressed separately but benchmarked together,
providing a single final result.

Benchmarking files separately makes it possible to accurately measure differences for each individual file. This is expected to be useful while tuning optimal parser.