### PR TITLE
meson: fix build

### DIFF
--- a/contrib/meson/meson.build
+++ b/contrib/meson/meson.build
@@ -2,14 +2,39 @@ project('zstd', 'c', license: 'BSD')
 
 libm = meson.get_compiler('c').find_library('m', required: true)
 
-lib_dir = join_paths(meson.source_root(), '..', '..', 'lib')
+lib_dir = join_paths('..', '..', 'lib')
 common_dir = join_paths(lib_dir, 'common')
 compress_dir = join_paths(lib_dir, 'compress')
 decompress_dir = join_paths(lib_dir, 'decompress')
 dictbuilder_dir = join_paths(lib_dir, 'dictBuilder')
 deprecated_dir = join_paths(lib_dir, 'deprecated')
 
-libzstd_srcs = [join_paths(common_dir, 'entropy_common.c'), join_paths(common_dir, 'fse_decompress.c'), join_paths(common_dir, 'threading.c'), join_paths(common_dir, 'pool.c'), join_paths(common_dir, 'zstd_common.c'), join_paths(common_dir, 'error_private.c'), join_paths(common_dir, 'xxhash.c'), join_paths(compress_dir, 'fse_compress.c'), join_paths(compress_dir, 'huf_compress.c'), join_paths(compress_dir, 'zstd_compress.c'), join_paths(compress_dir, 'zstdmt_compress.c'), join_paths(decompress_dir, 'huf_decompress.c'), join_paths(decompress_dir, 'zstd_decompress.c'), join_paths(dictbuilder_dir, 'cover.c'), join_paths(dictbuilder_dir, 'divsufsort.c'), join_paths(dictbuilder_dir, 'zdict.c'), join_paths(deprecated_dir, 'zbuff_common.c'), join_paths(deprecated_dir, 'zbuff_compress.c'), join_paths(deprecated_dir, 'zbuff_decompress.c')]
+libzstd_srcs = [
+    join_paths(common_dir, 'entropy_common.c'),
+    join_paths(common_dir, 'fse_decompress.c'),
+    join_paths(common_dir, 'threading.c'),
+    join_paths(common_dir, 'pool.c'),
+    join_paths(common_dir, 'zstd_common.c'),
+    join_paths(common_dir, 'error_private.c'),
+    join_paths(common_dir, 'xxhash.c'),
+    join_paths(compress_dir, 'fse_compress.c'),
+    join_paths(compress_dir, 'huf_compress.c'),
+    join_paths(compress_dir, 'zstd_compress.c'),
+    join_paths(compress_dir, 'zstd_fast.c'),
+    join_paths(compress_dir, 'zstd_double_fast.c'),
+    join_paths(compress_dir, 'zstd_lazy.c'),
+    join_paths(compress_dir, 'zstd_opt.c'),
+    join_paths(compress_dir, 'zstd_ldm.c'),
+    join_paths(compress_dir, 'zstdmt_compress.c'),
+    join_paths(decompress_dir, 'huf_decompress.c'),
+    join_paths(decompress_dir, 'zstd_decompress.c'),
+    join_paths(dictbuilder_dir, 'cover.c'),
+    join_paths(dictbuilder_dir, 'divsufsort.c'),
+    join_paths(dictbuilder_dir, 'zdict.c'),
+    join_paths(deprecated_dir, 'zbuff_common.c'),
+    join_paths(deprecated_dir, 'zbuff_compress.c'),
+    join_paths(deprecated_dir, 'zbuff_decompress.c')
+]
 
 libzstd_includes = [include_directories(common_dir, dictbuilder_dir, compress_dir, lib_dir)]
 
@@ -19,7 +44,15 @@ if get_option('legacy_support')
 
     legacy_dir = join_paths(lib_dir, 'legacy')
     libzstd_includes += [include_directories(legacy_dir)]
-    libzstd_srcs += [join_paths(legacy_dir, 'zstd_v01.c'), join_paths(legacy_dir, 'zstd_v02.c'), join_paths(legacy_dir, 'zstd_v03.c'), join_paths(legacy_dir, 'zstd_v04.c'), join_paths(legacy_dir, 'zstd_v05.c'), join_paths(legacy_dir, 'zstd_v06.c'), join_paths(legacy_dir, 'zstd_v07.c')]
+    libzstd_srcs += [
+        join_paths(legacy_dir, 'zstd_v01.c'),
+        join_paths(legacy_dir, 'zstd_v02.c'),
+        join_paths(legacy_dir, 'zstd_v03.c'),
+        join_paths(legacy_dir, 'zstd_v04.c'),
+        join_paths(legacy_dir, 'zstd_v05.c'),
+        join_paths(legacy_dir, 'zstd_v06.c'),
+        join_paths(legacy_dir, 'zstd_v07.c')
+    ]
 else
     libzstd_cflags = []
 endif
@@ -39,16 +72,20 @@ libzstd = library('zstd',
                   dependencies: libzstd_deps,
                   install: true)
 
-programs_dir = join_paths(meson.source_root(), '..', '..', 'programs')
+programs_dir = join_paths('..', '..', 'programs')
 
 zstd = executable('zstd',
-                  join_paths(programs_dir, 'bench.c'), join_paths(programs_dir, 'datagen.c'), join_paths(programs_dir, 'dibio.c'), join_paths(programs_dir, 'fileio.c'), join_paths(programs_dir, 'zstdcli.c'),
+                  join_paths(programs_dir, 'bench.c'),
+                  join_paths(programs_dir, 'datagen.c'),
+                  join_paths(programs_dir, 'dibio.c'),
+                  join_paths(programs_dir, 'fileio.c'),
+                  join_paths(programs_dir, 'zstdcli.c'),
                   include_directories: libzstd_includes,
                   c_args: ['-DZSTD_NODICT', '-DZSTD_NOBENCH'],
                   link_with: libzstd,
                   install: true)
 
-tests_dir = join_paths(meson.source_root(), '..', '..', 'tests')
+tests_dir = join_paths('..', '..', 'tests')
 datagen_c = join_paths(programs_dir, 'datagen.c')
 test_includes = libzstd_includes + [include_directories(programs_dir)]
 


### PR DESCRIPTION
fix use of absolute paths which are deprecated to build failure in meson, also missing some sources
that got split

also move source files each to their own line so future diffs are clearer.