### PR TITLE
targetLength for lazy strategy

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3037,16 +3037,16 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
 },
 {   /* for srcSize <= 16 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 14, 12, 12,  1,  7,  6, ZSTD_fast    },  /* level  0 - not used */
-    { 14, 14, 14,  1,  6,  6, ZSTD_fast    },  /* level  1 */
-    { 14, 14, 14,  1,  4,  6, ZSTD_fast    },  /* level  2 */
-    { 14, 14, 14,  1,  4,  6, ZSTD_dfast   },  /* level  3.*/
-    { 14, 14, 14,  4,  4,  6, ZSTD_greedy  },  /* level  4.*/
-    { 14, 14, 14,  3,  4, 16, ZSTD_lazy    },  /* level  5.*/
-    { 14, 14, 14,  4,  4, 20, ZSTD_lazy2   },  /* level  6 */
-    { 14, 14, 14,  5,  4, 24, ZSTD_lazy2   },  /* level  7 */
-    { 14, 14, 14,  6,  4, 32, ZSTD_lazy2   },  /* level  8.*/
-    { 14, 15, 14,  6,  4, 48, ZSTD_btlazy2 },  /* level  9.*/
+    { 14, 12, 12,  1,  7, 16, ZSTD_fast    },  /* level  0 - not used */
+    { 14, 14, 14,  1,  6, 16, ZSTD_fast    },  /* level  1 */
+    { 14, 14, 14,  1,  4, 16, ZSTD_fast    },  /* level  2 */
+    { 14, 14, 14,  1,  4, 16, ZSTD_dfast   },  /* level  3.*/
+    { 14, 14, 14,  4,  4, 16, ZSTD_greedy  },  /* level  4.*/
+    { 14, 14, 14,  3,  4, 20, ZSTD_lazy    },  /* level  5.*/
+    { 14, 14, 14,  4,  4, 24, ZSTD_lazy2   },  /* level  6 */
+    { 14, 14, 14,  5,  4, 32, ZSTD_lazy2   },  /* level  7 */
+    { 14, 14, 14,  6,  4, 48, ZSTD_lazy2   },  /* level  8.*/
+    { 14, 15, 14,  4,  4, 64, ZSTD_btlazy2 },  /* level  9.*/
     { 14, 15, 14,  3,  3,  6, ZSTD_btopt   },  /* level 10.*/
     { 14, 15, 14,  6,  3,  8, ZSTD_btopt   },  /* level 11.*/
     { 14, 15, 14,  6,  3, 16, ZSTD_btopt   },  /* level 12.*/
@@ -3056,7 +3056,7 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 14, 15, 15,  6,  3, 96, ZSTD_btopt   },  /* level 16.*/
     { 14, 15, 15,  6,  3,128, ZSTD_btopt   },  /* level 17.*/
     { 14, 15, 15,  6,  3,256, ZSTD_btopt   },  /* level 18.*/
-    { 14, 15, 15,  7,  3,256, ZSTD_btopt   },  /* level 19.*/
+    { 14, 15, 15,  6,  3,256, ZSTD_btultra },  /* level 19.*/
     { 14, 15, 15,  8,  3,256, ZSTD_btultra },  /* level 20.*/
     { 14, 15, 15,  9,  3,256, ZSTD_btultra },  /* level 21.*/
     { 14, 15, 15, 10,  3,256, ZSTD_btultra },  /* level 22.*/

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2965,17 +2965,17 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 20, 16, 17,  1,  5, 16, ZSTD_dfast   },  /* level  3 */
     { 20, 17, 18,  1,  5, 16, ZSTD_dfast   },  /* level  4 */
     { 20, 17, 18,  2,  5, 16, ZSTD_greedy  },  /* level  5 */
-    { 21, 17, 19,  2,  5, 20, ZSTD_lazy    },  /* level  6 */
-    { 21, 18, 19,  3,  5, 24, ZSTD_lazy    },  /* level  7 */
-    { 21, 18, 20,  3,  5, 32, ZSTD_lazy2   },  /* level  8 */
-    { 21, 19, 20,  3,  5, 40, ZSTD_lazy2   },  /* level  9 */
-    { 21, 19, 21,  4,  5, 48, ZSTD_lazy2   },  /* level 10 */
-    { 22, 20, 22,  4,  5, 64, ZSTD_lazy2   },  /* level 11 */
-    { 22, 20, 22,  5,  5, 80, ZSTD_lazy2   },  /* level 12 */
-    { 22, 21, 22,  5,  5, 96, ZSTD_lazy2   },  /* level 13 */
-    { 22, 21, 22,  6,  5,112, ZSTD_lazy2   },  /* level 14 */
-    { 22, 21, 22,  4,  5,128, ZSTD_btlazy2 },  /* level 15 */
-    { 22, 21, 22,  4,  5, 48, ZSTD_btopt   },  /* level 16 */
+    { 21, 18, 19,  2,  5, 32, ZSTD_lazy    },  /* level  6 */
+    { 21, 19, 19,  3,  5, 32, ZSTD_lazy    },  /* level  7 */
+    { 21, 19, 20,  3,  5, 24, ZSTD_lazy2   },  /* level  8 */
+    { 21, 20, 20,  3,  5, 40, ZSTD_lazy2   },  /* level  9 */
+    { 22, 20, 21,  4,  5, 64, ZSTD_lazy2   },  /* level 10 */
+    { 22, 20, 21,  5,  5, 96, ZSTD_lazy2   },  /* level 11 */
+    { 22, 21, 22,  5,  5,160, ZSTD_lazy2   },  /* level 12 */
+    { 22, 22, 22,  5,  5,192, ZSTD_lazy2   },  /* level 13 */
+    { 22, 22, 22,  6,  5,192, ZSTD_lazy2   },  /* level 14 */
+    { 22, 22, 22,  4,  5,192, ZSTD_btlazy2 },  /* level 15 */
+    { 22, 22, 22,  4,  5, 48, ZSTD_btopt   },  /* level 16 */
     { 23, 22, 22,  4,  4, 48, ZSTD_btopt   },  /* level 17 */
     { 23, 22, 22,  5,  3, 64, ZSTD_btopt   },  /* level 18 */
     { 23, 23, 22,  7,  3,128, ZSTD_btopt   },  /* level 19 */
@@ -2986,19 +2986,19 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
 {   /* for srcSize <= 256 KB */
     /* W,  C,  H,  S,  L,  T, strat */
     {  0,  0,  0,  0,  0,  0, ZSTD_fast    },  /* level  0 - not used */
-    { 18, 13, 14,  1,  6,  8, ZSTD_fast    },  /* level  1 */
-    { 18, 14, 13,  1,  5,  8, ZSTD_dfast   },  /* level  2 */
-    { 18, 16, 15,  1,  5,  8, ZSTD_dfast   },  /* level  3 */
-    { 18, 15, 17,  1,  5,  8, ZSTD_greedy  },  /* level  4.*/
-    { 18, 16, 17,  4,  5,  8, ZSTD_greedy  },  /* level  5.*/
-    { 18, 16, 17,  3,  5,  8, ZSTD_lazy    },  /* level  6.*/
-    { 18, 17, 17,  4,  4,  8, ZSTD_lazy    },  /* level  7 */
-    { 18, 17, 17,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
-    { 18, 17, 17,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 18, 17, 17,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
-    { 18, 18, 17,  6,  4,  8, ZSTD_lazy2   },  /* level 11.*/
-    { 18, 18, 17,  7,  4,  8, ZSTD_lazy2   },  /* level 12.*/
-    { 18, 19, 17,  6,  4,  8, ZSTD_btlazy2 },  /* level 13 */
+    { 18, 13, 14,  1,  6, 16, ZSTD_fast    },  /* level  1 */
+    { 18, 14, 13,  1,  5, 16, ZSTD_dfast   },  /* level  2 */
+    { 18, 16, 15,  1,  5, 16, ZSTD_dfast   },  /* level  3 */
+    { 18, 15, 17,  1,  5, 16, ZSTD_greedy  },  /* level  4.*/
+    { 18, 16, 17,  4,  5, 16, ZSTD_greedy  },  /* level  5.*/
+    { 18, 16, 17,  3,  5, 20, ZSTD_lazy    },  /* level  6.*/
+    { 18, 17, 17,  4,  4, 24, ZSTD_lazy    },  /* level  7 */
+    { 18, 17, 17,  4,  4, 28, ZSTD_lazy2   },  /* level  8 */
+    { 18, 17, 17,  5,  4, 32, ZSTD_lazy2   },  /* level  9 */
+    { 18, 17, 17,  6,  4, 40, ZSTD_lazy2   },  /* level 10 */
+    { 18, 18, 17,  6,  4, 48, ZSTD_lazy2   },  /* level 11.*/
+    { 18, 18, 17,  7,  4, 56, ZSTD_lazy2   },  /* level 12.*/
+    { 18, 19, 17,  6,  4, 64, ZSTD_btlazy2 },  /* level 13 */
     { 18, 18, 18,  4,  4, 16, ZSTD_btopt   },  /* level 14.*/
     { 18, 18, 18,  4,  3, 16, ZSTD_btopt   },  /* level 15.*/
     { 18, 19, 18,  6,  3, 32, ZSTD_btopt   },  /* level 16.*/

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3015,22 +3015,22 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 17, 12, 13,  1,  6, 16, ZSTD_fast    },  /* level  1 */
     { 17, 13, 16,  1,  5, 16, ZSTD_fast    },  /* level  2 */
     { 17, 16, 16,  2,  5, 16, ZSTD_dfast   },  /* level  3 */
-    { 17, 13, 15,  3,  4, 16, ZSTD_greedy  },  /* level  4 */
-    { 17, 15, 17,  4,  4, 16, ZSTD_greedy  },  /* level  5 */
+    { 17, 14, 16,  2,  4, 16, ZSTD_greedy  },  /* level  4 */
+    { 17, 15, 16,  4,  4, 16, ZSTD_greedy  },  /* level  5 */
     { 17, 16, 17,  3,  4, 20, ZSTD_lazy    },  /* level  6 */
-    { 17, 15, 17,  4,  4, 24, ZSTD_lazy2   },  /* level  7 */
+    { 17, 16, 17,  3,  4, 28, ZSTD_lazy2   },  /* level  7 */
     { 17, 17, 17,  4,  4, 28, ZSTD_lazy2   },  /* level  8 */
     { 17, 17, 17,  5,  4, 32, ZSTD_lazy2   },  /* level  9 */
     { 17, 17, 17,  6,  4, 40, ZSTD_lazy2   },  /* level 10 */
     { 17, 17, 17,  7,  4, 48, ZSTD_lazy2   },  /* level 11 */
     { 17, 17, 17,  8,  4, 56, ZSTD_lazy2   },  /* level 12 */
-    { 17, 18, 17,  6,  4, 64, ZSTD_btlazy2 },  /* level 13.*/
+    { 17, 17, 17,  7,  4, 96, ZSTD_btlazy2 },  /* level 13.*/
     { 17, 17, 17,  7,  3,  8, ZSTD_btopt   },  /* level 14.*/
     { 17, 17, 17,  7,  3, 16, ZSTD_btopt   },  /* level 15.*/
     { 17, 18, 17,  7,  3, 32, ZSTD_btopt   },  /* level 16.*/
     { 17, 18, 17,  7,  3, 64, ZSTD_btopt   },  /* level 17.*/
     { 17, 18, 17,  7,  3,256, ZSTD_btopt   },  /* level 18.*/
-    { 17, 18, 17,  8,  3,256, ZSTD_btopt   },  /* level 19.*/
+    { 17, 18, 17,  7,  3,256, ZSTD_btultra },  /* level 19.*/
     { 17, 18, 17,  9,  3,256, ZSTD_btultra },  /* level 20.*/
     { 17, 18, 17, 10,  3,256, ZSTD_btultra },  /* level 21.*/
     { 17, 18, 17, 11,  3,512, ZSTD_btultra },  /* level 22.*/
@@ -3042,11 +3042,11 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 14, 14, 14,  1,  4,  6, ZSTD_fast    },  /* level  2 */
     { 14, 14, 14,  1,  4,  6, ZSTD_dfast   },  /* level  3.*/
     { 14, 14, 14,  4,  4,  6, ZSTD_greedy  },  /* level  4.*/
-    { 14, 14, 14,  3,  4,  6, ZSTD_lazy    },  /* level  5.*/
-    { 14, 14, 14,  4,  4,  6, ZSTD_lazy2   },  /* level  6 */
-    { 14, 14, 14,  5,  4,  6, ZSTD_lazy2   },  /* level  7 */
-    { 14, 14, 14,  6,  4,  6, ZSTD_lazy2   },  /* level  8.*/
-    { 14, 15, 14,  6,  4,  6, ZSTD_btlazy2 },  /* level  9.*/
+    { 14, 14, 14,  3,  4, 16, ZSTD_lazy    },  /* level  5.*/
+    { 14, 14, 14,  4,  4, 20, ZSTD_lazy2   },  /* level  6 */
+    { 14, 14, 14,  5,  4, 24, ZSTD_lazy2   },  /* level  7 */
+    { 14, 14, 14,  6,  4, 32, ZSTD_lazy2   },  /* level  8.*/
+    { 14, 15, 14,  6,  4, 48, ZSTD_btlazy2 },  /* level  9.*/
     { 14, 15, 14,  3,  3,  6, ZSTD_btopt   },  /* level 10.*/
     { 14, 15, 14,  6,  3,  8, ZSTD_btopt   },  /* level 11.*/
     { 14, 15, 14,  6,  3, 16, ZSTD_btopt   },  /* level 12.*/

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2965,16 +2965,16 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 20, 16, 17,  1,  5, 16, ZSTD_dfast   },  /* level  3 */
     { 20, 17, 18,  1,  5, 16, ZSTD_dfast   },  /* level  4 */
     { 20, 17, 18,  2,  5, 16, ZSTD_greedy  },  /* level  5 */
-    { 21, 17, 19,  2,  5, 16, ZSTD_lazy    },  /* level  6 */
-    { 21, 18, 19,  3,  5, 16, ZSTD_lazy    },  /* level  7 */
-    { 21, 18, 20,  3,  5, 16, ZSTD_lazy2   },  /* level  8 */
-    { 21, 19, 20,  3,  5, 16, ZSTD_lazy2   },  /* level  9 */
-    { 21, 19, 21,  4,  5, 16, ZSTD_lazy2   },  /* level 10 */
-    { 22, 20, 22,  4,  5, 16, ZSTD_lazy2   },  /* level 11 */
-    { 22, 20, 22,  5,  5, 16, ZSTD_lazy2   },  /* level 12 */
-    { 22, 21, 22,  5,  5, 16, ZSTD_lazy2   },  /* level 13 */
-    { 22, 21, 22,  6,  5, 16, ZSTD_lazy2   },  /* level 14 */
-    { 22, 21, 22,  4,  5, 16, ZSTD_btlazy2 },  /* level 15 */
+    { 21, 17, 19,  2,  5, 20, ZSTD_lazy    },  /* level  6 */
+    { 21, 18, 19,  3,  5, 24, ZSTD_lazy    },  /* level  7 */
+    { 21, 18, 20,  3,  5, 32, ZSTD_lazy2   },  /* level  8 */
+    { 21, 19, 20,  3,  5, 40, ZSTD_lazy2   },  /* level  9 */
+    { 21, 19, 21,  4,  5, 48, ZSTD_lazy2   },  /* level 10 */
+    { 22, 20, 22,  4,  5, 64, ZSTD_lazy2   },  /* level 11 */
+    { 22, 20, 22,  5,  5, 80, ZSTD_lazy2   },  /* level 12 */
+    { 22, 21, 22,  5,  5, 96, ZSTD_lazy2   },  /* level 13 */
+    { 22, 21, 22,  6,  5,112, ZSTD_lazy2   },  /* level 14 */
+    { 22, 21, 22,  4,  5,128, ZSTD_btlazy2 },  /* level 15 */
     { 22, 21, 22,  4,  5, 48, ZSTD_btopt   },  /* level 16 */
     { 23, 22, 22,  4,  4, 48, ZSTD_btopt   },  /* level 17 */
     { 23, 22, 22,  5,  3, 64, ZSTD_btopt   },  /* level 18 */

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2985,12 +2985,12 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
 },
 {   /* for srcSize <= 256 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    {  0,  0,  0,  0,  0,  0, ZSTD_fast    },  /* level  0 - not used */
-    { 18, 13, 14,  1,  6, 16, ZSTD_fast    },  /* level  1 */
-    { 18, 14, 13,  1,  5, 16, ZSTD_dfast   },  /* level  2 */
+    { 18, 12, 12,  1,  6, 16, ZSTD_fast    },  /* level  0 - not used */
+    { 18, 13, 13,  1,  6, 16, ZSTD_fast    },  /* level  1 */
+    { 18, 14, 15,  1,  5, 16, ZSTD_fast    },  /* level  2 */
     { 18, 16, 15,  1,  5, 16, ZSTD_dfast   },  /* level  3 */
-    { 18, 15, 17,  1,  5, 16, ZSTD_greedy  },  /* level  4.*/
-    { 18, 16, 17,  4,  5, 16, ZSTD_greedy  },  /* level  5.*/
+    { 18, 16, 17,  1,  4, 16, ZSTD_dfast   },  /* level  4.*/
+    { 18, 16, 17,  2,  5, 16, ZSTD_greedy  },  /* level  5.*/
     { 18, 16, 17,  3,  5, 20, ZSTD_lazy    },  /* level  6.*/
     { 18, 17, 17,  4,  4, 24, ZSTD_lazy    },  /* level  7 */
     { 18, 17, 17,  4,  4, 28, ZSTD_lazy2   },  /* level  8 */
@@ -2998,33 +2998,33 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 18, 17, 17,  6,  4, 40, ZSTD_lazy2   },  /* level 10 */
     { 18, 18, 17,  6,  4, 48, ZSTD_lazy2   },  /* level 11.*/
     { 18, 18, 17,  7,  4, 56, ZSTD_lazy2   },  /* level 12.*/
-    { 18, 19, 17,  6,  4, 64, ZSTD_btlazy2 },  /* level 13 */
-    { 18, 18, 18,  4,  4, 16, ZSTD_btopt   },  /* level 14.*/
-    { 18, 18, 18,  4,  3, 16, ZSTD_btopt   },  /* level 15.*/
-    { 18, 19, 18,  6,  3, 32, ZSTD_btopt   },  /* level 16.*/
+    { 18, 18, 18,  5,  4, 64, ZSTD_btlazy2 },  /* level 13 */
+    { 18, 18, 18,  4,  4, 24, ZSTD_btopt   },  /* level 14.*/
+    { 18, 18, 18,  5,  3, 40, ZSTD_btopt   },  /* level 15.*/
+    { 18, 19, 18,  6,  3, 48, ZSTD_btopt   },  /* level 16.*/
     { 18, 19, 18,  8,  3, 64, ZSTD_btopt   },  /* level 17.*/
     { 18, 19, 18,  9,  3,128, ZSTD_btopt   },  /* level 18.*/
-    { 18, 19, 18, 10,  3,256, ZSTD_btopt   },  /* level 19.*/
-    { 18, 19, 18, 11,  3,512, ZSTD_btultra },  /* level 20.*/
-    { 18, 19, 18, 12,  3,512, ZSTD_btultra },  /* level 21.*/
+    { 18, 19, 18,  9,  3,128, ZSTD_btultra },  /* level 19.*/
+    { 18, 19, 18, 10,  3,256, ZSTD_btultra },  /* level 20.*/
+    { 18, 19, 18, 11,  3,512, ZSTD_btultra },  /* level 21.*/
     { 18, 19, 18, 13,  3,512, ZSTD_btultra },  /* level 22.*/
 },
 {   /* for srcSize <= 128 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 17, 12, 12,  1,  7,  8, ZSTD_fast    },  /* level  0 - not used */
-    { 17, 12, 13,  1,  6,  8, ZSTD_fast    },  /* level  1 */
-    { 17, 13, 16,  1,  5,  8, ZSTD_fast    },  /* level  2 */
-    { 17, 16, 16,  2,  5,  8, ZSTD_dfast   },  /* level  3 */
-    { 17, 13, 15,  3,  4,  8, ZSTD_greedy  },  /* level  4 */
-    { 17, 15, 17,  4,  4,  8, ZSTD_greedy  },  /* level  5 */
-    { 17, 16, 17,  3,  4,  8, ZSTD_lazy    },  /* level  6 */
-    { 17, 15, 17,  4,  4,  8, ZSTD_lazy2   },  /* level  7 */
-    { 17, 17, 17,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
-    { 17, 17, 17,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 17, 17, 17,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
-    { 17, 17, 17,  7,  4,  8, ZSTD_lazy2   },  /* level 11 */
-    { 17, 17, 17,  8,  4,  8, ZSTD_lazy2   },  /* level 12 */
-    { 17, 18, 17,  6,  4,  8, ZSTD_btlazy2 },  /* level 13.*/
+    { 17, 12, 12,  1,  6, 16, ZSTD_fast    },  /* level  0 - not used */
+    { 17, 12, 13,  1,  6, 16, ZSTD_fast    },  /* level  1 */
+    { 17, 13, 16,  1,  5, 16, ZSTD_fast    },  /* level  2 */
+    { 17, 16, 16,  2,  5, 16, ZSTD_dfast   },  /* level  3 */
+    { 17, 13, 15,  3,  4, 16, ZSTD_greedy  },  /* level  4 */
+    { 17, 15, 17,  4,  4, 16, ZSTD_greedy  },  /* level  5 */
+    { 17, 16, 17,  3,  4, 20, ZSTD_lazy    },  /* level  6 */
+    { 17, 15, 17,  4,  4, 24, ZSTD_lazy2   },  /* level  7 */
+    { 17, 17, 17,  4,  4, 28, ZSTD_lazy2   },  /* level  8 */
+    { 17, 17, 17,  5,  4, 32, ZSTD_lazy2   },  /* level  9 */
+    { 17, 17, 17,  6,  4, 40, ZSTD_lazy2   },  /* level 10 */
+    { 17, 17, 17,  7,  4, 48, ZSTD_lazy2   },  /* level 11 */
+    { 17, 17, 17,  8,  4, 56, ZSTD_lazy2   },  /* level 12 */
+    { 17, 18, 17,  6,  4, 64, ZSTD_btlazy2 },  /* level 13.*/
     { 17, 17, 17,  7,  3,  8, ZSTD_btopt   },  /* level 14.*/
     { 17, 17, 17,  7,  3, 16, ZSTD_btopt   },  /* level 15.*/
     { 17, 18, 17,  7,  3, 32, ZSTD_btopt   },  /* level 16.*/

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -482,10 +482,10 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
                 size_t const mlRep = ZSTD_count(ip+4, ip+4-offset_1, iend) + 4;
                 int const gain2 = (int)(mlRep * 3);
                 int const gain1 = (int)(matchLength*3 - ZSTD_highbit32((U32)offset+1) + 1);
-                if ((mlRep >= 4) & (gain2 > gain1))
+                if ((mlRep >= 4) & (gain2 > gain1)) {
                     matchLength = mlRep, offset = 0, start = ip;
                     if (matchLength > targetLength) break;
-            }
+            }   }
             {   size_t offset2=99999999;
                 size_t const ml2 = searchMax(ctx, ip, iend, &offset2, maxSearches, mls);
                 int const gain2 = (int)(ml2*4 - ZSTD_highbit32((U32)offset2+1));   /* raw approx */
@@ -503,10 +503,10 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
                     size_t const ml2 = ZSTD_count(ip+4, ip+4-offset_1, iend) + 4;
                     int const gain2 = (int)(ml2 * 4);
                     int const gain1 = (int)(matchLength*4 - ZSTD_highbit32((U32)offset+1) + 1);
-                    if ((ml2 >= 4) & (gain2 > gain1))
+                    if ((ml2 >= 4) & (gain2 > gain1)) {
                         matchLength = ml2, offset = 0, start = ip;
                         if (matchLength > targetLength) break;
-                }
+                }   }
                 {   size_t offset2=99999999;
                     size_t const ml2 = searchMax(ctx, ip, iend, &offset2, maxSearches, mls);
                     int const gain2 = (int)(ml2*4 - ZSTD_highbit32((U32)offset2+1));   /* raw approx */

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -428,7 +428,7 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
     const BYTE* anchor = istart;
     const BYTE* const iend = istart + srcSize;
     const BYTE* const ilimit = iend - 8;
-    const BYTE* const base = ctx->base + ctx->dictLimit;
+    const BYTE* const prefix = ctx->base + ctx->dictLimit;
 
     U32 const maxSearches = 1 << ctx->appliedParams.cParams.searchLog;
     U32 const mls = ctx->appliedParams.cParams.searchLength;
@@ -440,9 +440,9 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
     U32 offset_1 = seqStorePtr->rep[0], offset_2 = seqStorePtr->rep[1], savedOffset=0;
 
     /* init */
-    ip += (ip==base);
+    ip += (ip == ctx->base);
     ctx->nextToUpdate3 = ctx->nextToUpdate;
-    {   U32 const maxRep = (U32)(ip-base);
+    {   U32 const maxRep = (U32)(ip-prefix);
         if (offset_2 > maxRep) savedOffset = offset_2, offset_2 = 0;
         if (offset_1 > maxRep) savedOffset = offset_1, offset_1 = 0;
     }
@@ -457,7 +457,7 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
         if ((offset_1>0) & (MEM_read32(ip+1) == MEM_read32(ip+1 - offset_1))) {
             /* repcode : we take it */
             matchLength = ZSTD_count(ip+1+4, ip+1+4-offset_1, iend) + 4;
-            if (depth==0) goto _storeSequence;
+            if (depth==0) goto _storeSequence;  /* greedy favors repcode, for speed */
         }
 
         /* first search (depth 0) */
@@ -467,7 +467,7 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
                 matchLength = ml2, start = ip, offset=offsetFound;
         }
 
-        if (matchLength < 4) {
+        if (matchLength < 4) {  /* no match found */
             ip += ((ip-anchor) >> g_searchStrength) + 1;   /* jump faster over incompressible sections */
             continue;
         }
@@ -480,14 +480,14 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
                 size_t const mlRep = ZSTD_count(ip+4, ip+4-offset_1, iend) + 4;
                 int const gain2 = (int)(mlRep * 3);
                 int const gain1 = (int)(matchLength*3 - ZSTD_highbit32((U32)offset+1) + 1);
-                if ((mlRep >= 4) && (gain2 > gain1))
+                if ((mlRep >= 4) & (gain2 > gain1))
                     matchLength = mlRep, offset = 0, start = ip;
             }
             {   size_t offset2=99999999;
                 size_t const ml2 = searchMax(ctx, ip, iend, &offset2, maxSearches, mls);
                 int const gain2 = (int)(ml2*4 - ZSTD_highbit32((U32)offset2+1));   /* raw approx */
                 int const gain1 = (int)(matchLength*4 - ZSTD_highbit32((U32)offset+1) + 4);
-                if ((ml2 >= 4) && (gain2 > gain1)) {
+                if ((ml2 >= 4) & (gain2 > gain1)) {
                     matchLength = ml2, offset = offset2, start = ip;
                     continue;   /* search a better one */
             }   }
@@ -499,18 +499,18 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
                     size_t const ml2 = ZSTD_count(ip+4, ip+4-offset_1, iend) + 4;
                     int const gain2 = (int)(ml2 * 4);
                     int const gain1 = (int)(matchLength*4 - ZSTD_highbit32((U32)offset+1) + 1);
-                    if ((ml2 >= 4) && (gain2 > gain1))
+                    if ((ml2 >= 4) & (gain2 > gain1))
                         matchLength = ml2, offset = 0, start = ip;
                 }
                 {   size_t offset2=99999999;
                     size_t const ml2 = searchMax(ctx, ip, iend, &offset2, maxSearches, mls);
                     int const gain2 = (int)(ml2*4 - ZSTD_highbit32((U32)offset2+1));   /* raw approx */
                     int const gain1 = (int)(matchLength*4 - ZSTD_highbit32((U32)offset+1) + 7);
-                    if ((ml2 >= 4) && (gain2 > gain1)) {
+                    if ((ml2 >= 4) & (gain2 > gain1)) {
                         matchLength = ml2, offset = offset2, start = ip;
                         continue;
             }   }   }
-            break;  /* nothing found : store previous solution */
+            break;  /* no better found : store last selected solution */
         }
 
         /* NOTE:
@@ -520,7 +520,7 @@ size_t ZSTD_compressBlock_lazy_generic(ZSTD_CCtx* ctx,
          */
         /* catch up */
         if (offset) {
-            while ( ((start > anchor) & (start - (offset-ZSTD_REP_MOVE) > base))
+            while ( ((start > anchor) & (start - (offset-ZSTD_REP_MOVE) > prefix))
                  && (start[-1] == (start-(offset-ZSTD_REP_MOVE))[-1]) )  /* only search for offset within prefix */
                 { start--; matchLength++; }
             offset_2 = offset_1; offset_1 = (U32)(offset - ZSTD_REP_MOVE);

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -22,10 +22,10 @@ U32 ZSTD_insertAndFindFirstIndex (ZSTD_CCtx* zc, const BYTE* ip, U32 mls);
 void ZSTD_updateTree(ZSTD_CCtx* zc, const BYTE* const ip, const BYTE* const iend, const U32 nbCompares, const U32 mls);
 void ZSTD_updateTree_extDict(ZSTD_CCtx* zc, const BYTE* const ip, const BYTE* const iend, const U32 nbCompares, const U32 mls);
 
-size_t ZSTD_compressBlock_btlazy2(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
-size_t ZSTD_compressBlock_lazy2(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
-size_t ZSTD_compressBlock_lazy(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
 size_t ZSTD_compressBlock_greedy(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
+size_t ZSTD_compressBlock_lazy(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
+size_t ZSTD_compressBlock_lazy2(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
+size_t ZSTD_compressBlock_btlazy2(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
 
 size_t ZSTD_compressBlock_greedy_extDict(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
 size_t ZSTD_compressBlock_lazy_extDict(ZSTD_CCtx* ctx, const void* src, size_t srcSize);


### PR DESCRIPTION
This patch adds support for `targetLength` parameter for "lazy" strategies (`zstd_lazy.c`).

The impact is moderate, because lazy strategies already skip a lot of positions by design (in contrast with optimal, which may only skip when it reaches `targetLength`). For lazy strategy, `targetLength` parameter triggers skip a bit more often, mostly when the value of `targetLength` is small enough.

All compression level tables have been updated to use the new parameter.

The impact is not earth shattering. Mostly, it translates into a different position in the speed / compression curb. Levels 6-9 are where the impact is most visible, but even then, it remains a relatively small improvement.
