### PR TITLE
zstd: fix crash when not overwriting existing files

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -951,10 +951,14 @@ int FIO_compressMultipleFilenames(const char** inFileNamesTable, unsigned nbFile
     if (outFileName != NULL) {
         unsigned u;
         ress.dstFile = FIO_openDstFile(outFileName);
-        for (u=0; u<nbFiles; u++)
-            missed_files += FIO_compressFilename_srcFile(ress, outFileName, inFileNamesTable[u], compressionLevel);
-        if (fclose(ress.dstFile))
-            EXM_THROW(29, "Write error : cannot properly close stdout");
+        if (ress.dstFile==NULL) {  /* could not open outFileName */
+            missed_files = nbFiles;
+        } else {
+            for (u=0; u<nbFiles; u++)
+                missed_files += FIO_compressFilename_srcFile(ress, outFileName, inFileNamesTable[u], compressionLevel);
+            if (fclose(ress.dstFile))
+                EXM_THROW(29, "Write error : cannot properly close stdout");
+        }
     } else {
         unsigned u;
         for (u=0; u<nbFiles; u++) {


### PR DESCRIPTION
This fixes the following crash:
  $ touch exists
  $ programs/zstd -r examples/ -o exists
  zstd: exists already exists; not overwritten
  Segmentation fault (core dumped)

* programs/fileio.c (FIO_compressMultipleFilenames):
Handle the case where we're not overwriting the destination.

Reported at https://bugzilla.redhat.com/1530049