### PR TITLE
[fileio] Improve safety of output file modifications

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -901,10 +901,10 @@ static int FIO_compressFilename_dstFile(cRess_t ress,
         DISPLAYLEVEL(1, "zstd: %s: %s \n", dstFileName, strerror(errno));
         result=1;
     }
-    if (result!=0) {  /* remove operation artefact */
-        if (FIO_remove(dstFileName))
-            EXM_THROW(1, "zstd: %s: %s", dstFileName, strerror(errno));
-    }
+    if ( (result != 0)  /* operation failure */
+      && strcmp(dstFileName, nulmark)      /* special case : don't remove() /dev/null */
+      && strcmp(dstFileName, stdoutmark) ) /* special case : don't remove() stdout */
+        FIO_remove(dstFileName); /* remove compression artefact; note don't do anything special if remove() fails */
     else if ( strcmp(dstFileName, stdoutmark)
            && strcmp(dstFileName, nulmark)
            && stat_result)

--- a/programs/util.h
+++ b/programs/util.h
@@ -246,10 +246,16 @@ UTIL_STATIC void UTIL_waitForNextTick(void)
 #endif
 
 
+UTIL_STATIC int UTIL_isRegularFile(const char* infilename);
+
+
 UTIL_STATIC int UTIL_setFileStat(const char *filename, stat_t *statbuf)
 {
     int res = 0;
     struct utimbuf timebuf;
+
+    if (!UTIL_isRegularFile(filename))
+        return -1;
 
     timebuf.actime = time(NULL);
     timebuf.modtime = statbuf->st_mtime;


### PR DESCRIPTION
* Refuse to set file stat on non-regular file
* Use `FIO_remove()` everywhere to ensure we don't ever remove non-regular files.
* Don't call `FIO_remove()` during compression on `stdout` or `/dev/null` to quiet the message.