### PR TITLE
Update API documentation related to memory management capabilities

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2416,7 +2416,6 @@ ZSTD_CDict* ZSTD_initStaticCDict(void* workspace, size_t workspaceSize,
                             + cctxSize;
     ZSTD_CDict* const cdict = (ZSTD_CDict*) workspace;
     void* ptr;
-    DEBUGLOG(4, "(size_t)workspace & 7 : %u", (U32)(size_t)workspace & 7);
     if ((size_t)workspace & 7) return NULL;  /* 8-aligned */
     DEBUGLOG(4, "(workspaceSize < neededSize) : (%u < %u) => %u",
         (U32)workspaceSize, (U32)neededSize, (U32)(workspaceSize < neededSize));


### PR DESCRIPTION
This patch doesn't change the code,
its only purpose is to update `zstd.h` API documentation
by regrouping all functions related to memory management together.

This section of the API now lists, in order :
- `ZSTD_sizeof_*()` 
- `ZSTD_estimate*Size*()`
- `ZSTD_initStatic*()`, which needs `ZSTD_estimate*Size*()` to correctly set size of buffers
- `ZSTD_create*_advanced()`, because related to `ZSTD_customMem`

This order feels like a natural progression in complexity.