### PR TITLE
Check tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
 
     - env: Cmd='make lz4install && make -C tests test-lz4'
 
+    # tag-specific test
+    - if: tag =~ ^v[0-9]\.[0-9]
+      env: Cmd='make -C tests checkTag && tests/checkTag $TRAVIS_BRANCH'
+
 git:
   depth: 1
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -23,6 +23,7 @@ decodecorpus
 pool
 poolTests
 invalidDictionaries
+checkTag
 
 # Tmp test directory
 zstdtest

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -236,8 +236,12 @@ endif
 poolTests : poolTests.c $(ZSTDDIR)/common/pool.c $(ZSTDDIR)/common/threading.c $(ZSTDDIR)/common/zstd_common.c $(ZSTDDIR)/common/error_private.c
 	$(CC) $(FLAGS) $(MULTITHREAD) $^ -o $@$(EXT)
 
+.PHONY: versionsTest
 versionsTest: clean
 	$(PYTHON) test-zstd-versions.py
+
+checkTag: checkTag.c $(ZSTDDIR)/zstd.h
+	$(CC) $(FLAGS) $< -o $@$(EXT)
 
 clean:
 	$(MAKE) -C $(ZSTDDIR) clean
@@ -251,7 +255,7 @@ clean:
         zstreamtest$(EXT) zstreamtest32$(EXT) \
         datagen$(EXT) paramgrill$(EXT) roundTripCrash$(EXT) longmatch$(EXT) \
         symbols$(EXT) invalidDictionaries$(EXT) legacy$(EXT) poolTests$(EXT) \
-        decodecorpus$(EXT)
+        decodecorpus$(EXT) checkTag$(EXT)
 	@echo Cleaning completed
 
 

--- a/tests/checkTag.c
+++ b/tests/checkTag.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+/* checkTag : validation tool for libzstd
+ * command :
+ * $ ./checkTag tag
+ * checkTag validates tags of following format : v[0-9].[0-9].[0-9]{any}
+ * The tag is then compared to zstd version number.
+ * They are compatible if first 3 digits are identical.
+ * Anything beyond that is free, and doesn't impact validation.
+ * Example : tag v1.8.1.2 is compatible with version 1.8.1
+ * When tag and version are not compatible, program exits with error code 1.
+ * When they are compatible, it exists with a code 0.
+ * checkTag is intended to be used in automated testing environment.
+ */
+
+#include <stdio.h>   /* printf */
+#include <string.h>  /* strlen, strncmp */
+#include "zstd.h"    /* ZSTD_VERSION_STRING */
+
+
+/*  validate() :
+ * @return 1 if tag is compatible, 0 if not.
+ */
+static int validate(const char* const tag)
+{
+    size_t const tagLength = strlen(tag);
+    size_t const verLength = strlen(ZSTD_VERSION_STRING);
+
+    if (tagLength < 2) return 0;
+    if (tag[0] != 'v') return 0;
+    if (tagLength <= verLength) return 0;
+
+    if (strncmp(ZSTD_VERSION_STRING, tag+1, verLength)) return 0;
+
+    return 1;
+}
+
+int main(int argc, const char** argv)
+{
+    const char* const exeName = argv[0];
+    const char* const tag = argv[1];
+    if (argc!=2) {
+        printf("incorrect usage : %s tag \n", exeName);
+        return 2;
+    }
+
+    printf("Version : %s \n", ZSTD_VERSION_STRING);
+    printf("Tag     : %s \n", tag);
+
+    if (validate(tag)) {
+        printf("OK : tag is compatible with zstd version \n");
+        return 0;
+    }
+
+    printf("!! error : tag and versions are not compatible !! \n");
+    return 1;
+}


### PR DESCRIPTION
Added the `tests/checkTag` utility
which validates that provided tag is compatible with current libzstd version.

`checkTag` is launched automatically at each tag creation.

The objective is to reduce risks of tag-version mismatch.

_How to test_ : 
`checkTag` can be tested manually,
but the automatic trigger on TravisCI requires creation of a tag.
Fork the repository, and create a new tag from the fork.
Beware of the branch restrictions specified in `.travis.yml` : it might be necessary to remove them first, or create the tag from an authorised branch (`dev` or `master`).