### PR TITLE
Set repcodes for empty ZSTD_CDict

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2540,6 +2540,8 @@ static size_t ZSTD_initCDict_internal(
     }
     cdict->dictContentSize = dictSize;
 
+    /* Reset the state to no dictionary */
+    ZSTD_reset_compressedBlockState(&cdict->cBlockState);
     {
         void* const end = ZSTD_reset_matchState(
                 &cdict->matchState,
@@ -2548,6 +2550,9 @@ static size_t ZSTD_initCDict_internal(
         assert(end == (char*)cdict->workspace + cdict->workspaceSize);
         (void)end;
     }
+    /* (Maybe) load the dictionary
+     * Skips loading the dictionary if it is <= 8 bytes.
+     */
     {
         ZSTD_CCtx_params params;
         memset(&params, 0, sizeof(params));


### PR DESCRIPTION
When the dictionary is <= 8 bytes, no data is loaded from the dictionary.
In this case the repcodes weren't set, because they were inserted after the
size check. Fix this problem in general by first setting the cdict state to
a clean state of an empty dictionary, then filling the state from there.