### PR TITLE
LDM manages its own window round buffer

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -136,6 +136,7 @@ typedef struct {
 } ldmEntry_t;
 
 typedef struct {
+    ZSTD_window_t window;   /* State for the window round buffer management */
     ldmEntry_t* hashTable;
     BYTE* bucketOffsets;    /* Next position in bucket to insert entry */
     U64 hashPower;          /* Used to compute the rolling hash.
@@ -148,6 +149,7 @@ typedef struct {
     U32 bucketSizeLog;      /* Log bucket size for collision resolution, at most 8 */
     U32 minMatchLength;     /* Minimum match length */
     U32 hashEveryLog;       /* Log number of entries to skip */
+    U32 windowLog;          /* Window log for the LDM */
 } ldmParams_t;
 
 struct ZSTD_CCtx_params_s {

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -29,13 +29,15 @@ extern "C" {
  *
  * Generates the sequences using the long distance match finder.
  * The sequences completely parse a prefix of the source, but leave off the last
- * literals. Returns the number of sequences generated into `sequences`.
+ * literals. Returns the number of sequences generated into `sequences`. The
+ * user must have called ZSTD_window_update() for all of the input they have,
+ * even if they pass it to ZSTD_ldm_generateSequences() in chunks.
  *
  * NOTE: The source may be any size, assuming it doesn't overflow the hash table
  * indices, and the output sequences table is large enough..
  */
 size_t ZSTD_ldm_generateSequences(
-        ldmState_t* ldms, rawSeq* sequences, ZSTD_matchState_t const* ms,
+        ldmState_t* ldms, rawSeq* sequences,
         ldmParams_t const* params, void const* src, size_t srcSize,
         int const extDict);
 


### PR DESCRIPTION
* Give the LDM its own `windowLog` parameter, which can't yet be set to anything other than the `ZSTD_CCtx`'s window log.
* Give the LDM its own round buffer management, separate from the `ZSTD_CCtx`'s.