### PR TITLE
FIO_addFInfo: Fully initialize output 'total' struct

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1963,6 +1963,7 @@ static void displayInfo(const char* inFileName, const fileInfo_t* info, int disp
 static fileInfo_t FIO_addFInfo(fileInfo_t fi1, fileInfo_t fi2)
 {
     fileInfo_t total;
+    memset(&total, 0, sizeof(total));
     total.numActualFrames = fi1.numActualFrames + fi2.numActualFrames;
     total.numSkippableFrames = fi1.numSkippableFrames + fi2.numSkippableFrames;
     total.compressedSize = fi1.compressedSize + fi2.compressedSize;


### PR DESCRIPTION
Silence a Coverity warning about 'windowSize' being uninitialized.
(Yes, nothing that calls this routine actually uses the windowSize
value.  Still, appeasing Coverity is pretty harmless in this case.)