### PR TITLE
fix benchmark issue when measuring decoding speed only

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -260,7 +260,11 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
     }   }   }
 
     /* warmimg up memory */
-    RDG_genBuffer(compressedBuffer, maxCompressedSize, 0.10, 0.50, 1);
+    if (g_decodeOnly) {
+        memcpy(compressedBuffer, srcBuffer, loadedCompressedSize);
+    } else {
+        RDG_genBuffer(compressedBuffer, maxCompressedSize, 0.10, 0.50, 1);
+    }
 
     /* Bench */
     {   U64 fastestC = (U64)(-1LL), fastestD = (U64)(-1LL);
@@ -373,9 +377,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                             ratioAccuracy, ratio,
                             cSpeedAccuracy, compressionSpeed );
                 }
-            } else {   /* g_decodeOnly */
-                memcpy(compressedBuffer, srcBuffer, loadedCompressedSize);
-            }
+            }  /* if (!g_decodeOnly) */
 
 #if 0       /* disable decompression test */
             dCompleted=1;

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -573,7 +573,8 @@ int main(int argCount, const char* argv[])
                          /* Decoding */
                     case 'd':
 #ifndef ZSTD_NOBENCH
-                            if (operation==zom_bench) { BMK_setDecodeOnlyMode(1); argument++; break; }  /* benchmark decode (hidden option) */
+                            BMK_setDecodeOnlyMode(1);
+                            if (operation==zom_bench) { argument++; break; }  /* benchmark decode (hidden option) */
 #endif
                             operation=zom_decompress; argument++; break;
 


### PR DESCRIPTION
zstd bench module can focus on decompression speed _only_.

This is useful when trying to measure decompression speed
on some large input data compressed using a high level,
as compression time becomes problematic (too long).

This mode is triggered by command : `zstd -b -d`

Problem was : in such a mode,
measured decoding speed was > 10% slower
than in nominal mode (compression + decompression).

The reason for such difference wasn't clear, and still isn't.
Nonetheless, this patch fixes the issue.
Moving the `memcpy()` operation sooner in the pipeline fixed it.

I can still measure small differences, but they are in the < 2% range,
so it's much more tolerable.

also : it doesn't matter anymore in which order are selected
commands `-b` and `-d`.
This combination always triggers bench_decodeOnly mode.