### PR TITLE
Expose reference external sequence API

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -213,12 +213,6 @@ MEM_STATIC void ZSTD_wildcopy_e(void* dst, const void* src, void* dstEnd)   /* s
 /*-*******************************************
 *  Private declarations
 *********************************************/
-typedef struct rawSeq_s {
-    U32 offset;
-    U32 litLength;
-    U32 matchLength;
-} rawSeq;
-
 typedef struct seqDef_s {
     U32 offset;
     U16 litLength;


### PR DESCRIPTION
* Expose the reference external sequences API for zstdmt.
  Allows external sequences of any length, which get split when necessary.
* Reset the LDM window when the context is reset.
* Store the maximum number of LDM sequences.
* Sequence generation now returns the number of last literals.
* Fix sequence generation to not throw out the last literals when blocks of
  more than 1 MB are encountered.