### PR TITLE
Visual Studio 2017 build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ A Meson project is provided within `contrib/meson`.
 
 Going into `build` directory, you will find additional possibilities:
 - Projects for Visual Studio 2005, 2008 and 2010.
-  + VS2010 project is compatible with VS2012, VS2013 and VS2015.
-- Automated build scripts for Visual compiler by @KrzysFR , in `build/VS_scripts`,
+  + VS2010 project is compatible with VS2012, VS2013, VS2015 and VS2017.
+- Automated build scripts for Visual compiler by [@KrzysFR](https://github.com/KrzysFR) and [@HaydnTrigg](https://github.com/HaydnTrigg) , in `build/VS_scripts`,
   which will build `zstd` cli and `libzstd` library without any need to open Visual Studio solution.
 
 

--- a/build/VS_scripts/build.VS2017Community.cmd
+++ b/build/VS_scripts/build.VS2017Community.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2017Community Win32 Release v141
+
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2017Community x64 Release v141

--- a/build/VS_scripts/build.VS2017Enterprise.cmd
+++ b/build/VS_scripts/build.VS2017Enterprise.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2017Enterprise Win32 Release v141
+
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2017Enterprise x64 Release v141

--- a/build/VS_scripts/build.VS2017Professional.cmd
+++ b/build/VS_scripts/build.VS2017Professional.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2017Professional Win32 Release v141
+
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2017Professional x64 Release v141

--- a/build/VS_scripts/build.generic.cmd
+++ b/build/VS_scripts/build.generic.cmd
@@ -31,7 +31,9 @@ EXIT /B 1
 SET msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 IF %msbuild_version% == VS2013 SET msbuild="%programfiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2015 SET msbuild="%programfiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
-rem TODO: Visual Studio "15" (vNext) will use MSBuild 15.0 ?
+IF %msbuild_version% == VS2017Community SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
+IF %msbuild_version% == VS2017Professional SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
+IF %msbuild_version% == VS2017Enterprise SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
 
 SET project="%~p0\..\VS2010\zstd.sln"
 


### PR DESCRIPTION
These scripts allow building through Visual Studio 2017 and separate VS installations for Community, Professional, and Enterprise