### PR TITLE
Remove non-ASCII characters in header file comments

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -417,7 +417,7 @@ MEM_STATIC size_t BIT_readBitsFast(BIT_DStream_t* bitD, U32 nbBits)
  *  Refill `bitD` from buffer previously set in BIT_initDStream() .
  *  This function is safe, it guarantees it will not read beyond src buffer.
  * @return : status of `BIT_DStream_t` internal register.
- *           when status == BIT_DStream_unfinished, internal register is filled with at least 25 or 57 bits */
+ *           when status == BIT_DStream_unfinished, internal register is filled with at least 25 or 57 bits */
 MEM_STATIC BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD)
 {
     if (bitD->bitsConsumed > (sizeof(bitD->bitContainer)*8))  /* overflow detected, like end of stream */

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -70,7 +70,7 @@ extern "C" {
 ***************************************************************/
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__)) /* UNIX-like OS */ \
    || defined(__midipix__) || defined(__VMS))
-#  if (defined(__APPLE__) && defined(__MACH__)) || defined(__SVR4) || defined(_AIX) || defined(__hpux) /* POSIX.1–2001 (SUSv3) conformant */ \
+#  if (defined(__APPLE__) && defined(__MACH__)) || defined(__SVR4) || defined(_AIX) || defined(__hpux) /* POSIX.1-2001 (SUSv3) conformant */ \
      || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  /* BSD distros */
 #    define PLATFORM_POSIX_VERSION 200112L
 #  else


### PR DESCRIPTION
Currently there's a couple of UTF-8 characters in two header files, an en-dash & a non-breaking space. I guess they come out of copy-paste from elsewhere since I didn't see a reason for them otherwise. Without a UTF-8 BOM if the system codepage doesn't include the character this can lead to compile warnings in visual studio at least. I think this change is preferable to adding a BOM and potential headaches from that.

If this change isn't desired then feel free to reject the PR, though I'd like to fix the issue another way if possible.