### PR TITLE
Add reference to Ruby FFI bindings

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,7 @@ here is a list of known bindings and their authors :
 | __Swift__    | Anatoli Peredera    | https://github.com/omniprog/SwiftZSTD |
 | __Go__       | Vianney Tran        | https://github.com/DataDog/zstd       |
 | __Ruby__     | SpringMT            | https://github.com/SpringMT/zstd-ruby |
+| __Ruby__ (FFI) | Michael Sievers   | https://github.com/msievers/zstandard-ruby |
 | __D__        | Masahiro Nakagawa   | https://code.dlang.org/packages/zstd  |
 | __Ada__      | John Marino         | https://github.com/jrmarino/zstd-ada  |
 | __Lua__      | Soojin Nam          | https://github.com/sjnam/lua-resty-zstd


### PR DESCRIPTION
This PR adds a link to the [FFI based ruby bindings for zstd](https://github.com/msievers/zstandard-ruby). The differences to the already mentioned ruby bindings provided by SpringMT are

* the FFI bindings do not ship with a zstd implementation, but use the version which is installed on the system
* tested to work with zstd 0.6.0 - 1.3.3
* work with both major Ruby implementations MRI (CRuby) and JRuby (Java)