### PR TITLE
Generic Visual Studio 2017 build script

### DIFF
--- a/build/VS_scripts/build.VS2017.cmd
+++ b/build/VS_scripts/build.VS2017.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2017 Win32 Release v141
+
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2017 x64 Release v141

--- a/build/VS_scripts/build.generic.cmd
+++ b/build/VS_scripts/build.generic.cmd
@@ -38,9 +38,9 @@ IF %msbuild_version% == VS2017Community SET msbuild="%msbuild_vs2017community%
 IF %msbuild_version% == VS2017Professional SET msbuild=%msbuild_vs2017professional%
 IF %msbuild_version% == VS2017Enterprise SET msbuild=%msbuild_vs2017enterprise%
 IF %msbuild_version% == VS2017 (
-	IF EXIST %msbuild_vs2017enterprise% SET msbuild=%msbuild_vs2017enterprise%
-	IF EXIST %msbuild_vs2017professional% SET msbuild=%msbuild_vs2017professional%
 	IF EXIST %msbuild_vs2017community% SET msbuild=%msbuild_vs2017community%
+	IF EXIST %msbuild_vs2017professional% SET msbuild=%msbuild_vs2017professional%
+	IF EXIST %msbuild_vs2017enterprise% SET msbuild=%msbuild_vs2017enterprise%
 )
 
 SET project="%~p0\..\VS2010\zstd.sln"

--- a/build/VS_scripts/build.generic.cmd
+++ b/build/VS_scripts/build.generic.cmd
@@ -19,10 +19,10 @@ GOTO build
 :display_help
 
 echo Syntax: build.generic.cmd msbuild_version msbuild_platform msbuild_configuration msbuild_toolset
-echo   msbuild_version:          VS installed version (VS2012, VS2013, VS2015, ...)
+echo   msbuild_version:          VS installed version (VS2012, VS2013, VS2015, VS2017, ...)
 echo   msbuild_platform:         Platform (x64 or Win32)
 echo   msbuild_configuration:    VS configuration (Release or Debug)
-echo   msbuild_toolset:          Platform Toolset (v100, v110, v120, v140)
+echo   msbuild_toolset:          Platform Toolset (v100, v110, v120, v140, v141)
 
 EXIT /B 1
 
@@ -34,17 +34,13 @@ SET msbuild_vs2017professional="%programfiles(x86)%\Microsoft Visual Studio\2017
 SET msbuild_vs2017enterprise="%programfiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2013 SET msbuild="%programfiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2015 SET msbuild="%programfiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
-IF %msbuild_version% == VS2017Community SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
-IF %msbuild_version% == VS2017Professional SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
-IF %msbuild_version% == VS2017Enterprise SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
-if exist %msbuild_vs2017enterprise% (
-    IF %msbuild_version% == VS2017 SET msbuild=%msbuild_vs2017enterprise%
-)
-if exist %msbuild_vs2017professional% (
-    IF %msbuild_version% == VS2017 SET msbuild=%msbuild_vs2017professional%
-)
-if exist %msbuild_vs2017community% (
-    IF %msbuild_version% == VS2017 SET msbuild=%msbuild_vs2017community%
+IF %msbuild_version% == VS2017Community SET msbuild="%msbuild_vs2017community%
+IF %msbuild_version% == VS2017Professional SET msbuild=%msbuild_vs2017professional%
+IF %msbuild_version% == VS2017Enterprise SET msbuild=%msbuild_vs2017enterprise%
+IF %msbuild_version% == VS2017 (
+	IF EXIST %msbuild_vs2017enterprise% SET msbuild=%msbuild_vs2017enterprise%
+	IF EXIST %msbuild_vs2017professional% SET msbuild=%msbuild_vs2017professional%
+	IF EXIST %msbuild_vs2017community% SET msbuild=%msbuild_vs2017community%
 )
 
 SET project="%~p0\..\VS2010\zstd.sln"

--- a/build/VS_scripts/build.generic.cmd
+++ b/build/VS_scripts/build.generic.cmd
@@ -29,11 +29,23 @@ EXIT /B 1
 :build
 
 SET msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+SET msbuild_vs2017community="%programfiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
+SET msbuild_vs2017professional="%programfiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
+SET msbuild_vs2017enterprise="%programfiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2013 SET msbuild="%programfiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2015 SET msbuild="%programfiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2017Community SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2017Professional SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
 IF %msbuild_version% == VS2017Enterprise SET msbuild="%programfiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
+if exist %msbuild_vs2017enterprise% (
+    IF %msbuild_version% == VS2017 SET msbuild=%msbuild_vs2017enterprise%
+)
+if exist %msbuild_vs2017professional% (
+    IF %msbuild_version% == VS2017 SET msbuild=%msbuild_vs2017professional%
+)
+if exist %msbuild_vs2017community% (
+    IF %msbuild_version% == VS2017 SET msbuild=%msbuild_vs2017community%
+)
 
 SET project="%~p0\..\VS2010\zstd.sln"
 


### PR DESCRIPTION
This new build script automatically selects the installed Visual Studio 2017 implementation to use in order of Enterprise, Professional, and Community. This should be easier for people to reference without needing to specify which specific version of Visual Studio to use.

If a specific version is required, I have left the `build.VS2017Community` `build.VS2017Enterprise` and `build.VS2017Professional` build scripts so they can still be referenced.

There are now four `msbuild_version` options for 2017 `VS2017Community` `VS2017Professional` `VS2017Enterprise` and `VS2017` which automatically chooses the version to use.