### PR TITLE
Fix broken assertion

### DIFF
--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1029,7 +1029,7 @@ static size_t ZSTDMT_computeTargetJobLog(ZSTD_CCtx_params const params)
 {
     if (params.ldmParams.enableLdm)
         return MAX(21, params.cParams.chainLog + 4);
-    return params.cParams.windowLog + 2;
+    return MAX(20, params.cParams.windowLog + 2);
 }
 
 static size_t ZSTDMT_computeOverlapLog(ZSTD_CCtx_params const params)


### PR DESCRIPTION
The `avgJobSize` must not be lower than 256 KB for single-pass mode.
In `zstd.h` we say the minimum value for `ZSTD_p_jobSize` is 1 MB,
so ensure that we always pick a size >= 1 MB.

Found by libFuzzer fuzzer tests with large input limits.

This bug has been around for a while, but only shows up when the
`windowLog` is very small, like in fuzzer tests, so I don't expect it to be
found in practice.