### PR TITLE
Fix CMake build

### DIFF
--- a/build/cmake/programs/CMakeLists.txt
+++ b/build/cmake/programs/CMakeLists.txt
@@ -46,6 +46,12 @@ IF (UNIX)
     ADD_CUSTOM_TARGET(zstdcat.1 ALL ${CMAKE_COMMAND} -E create_symlink zstd.1 zstdcat.1 DEPENDS zstd.1 COMMENT "Creating zstdcat.1 symlink")
     ADD_CUSTOM_TARGET(unzstd.1 ALL ${CMAKE_COMMAND} -E create_symlink zstd.1 unzstd.1 DEPENDS zstd.1 COMMENT "Creating unzstd.1 symlink")
 
+    # Define MAN_INSTALL_DIR if necessary
+    IF (MAN_INSTALL_DIR)
+    ELSE (MAN_INSTALL_DIR)
+      SET(MAN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/share/man/man1)
+    ENDIF (MAN_INSTALL_DIR)
+
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/zstd.1 DESTINATION "${MAN_INSTALL_DIR}")
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/zstdcat.1 DESTINATION "${MAN_INSTALL_DIR}")
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/unzstd.1 DESTINATION "${MAN_INSTALL_DIR}")


### PR DESCRIPTION
`MAN_INSTALL_DIR` was undefined.

Tested with `make cmakebuild`, and saw that the man pages got installed to the right place:

```
-- Installing: /Users/terrelln/install_test_dir/lib/pkgconfig/libzstd.pc
-- Installing: /Users/terrelln/install_test_dir/include/zstd.h
-- Installing: /Users/terrelln/install_test_dir/include/zbuff.h
-- Installing: /Users/terrelln/install_test_dir/include/zdict.h
-- Installing: /Users/terrelln/install_test_dir/include/zstd_errors.h
-- Installing: /Users/terrelln/install_test_dir/lib/libzstd.1.3.4.dylib
-- Installing: /Users/terrelln/install_test_dir/lib/libzstd.dylib
-- Installing: /Users/terrelln/install_test_dir/lib/libzstd.a
-- Installing: /Users/terrelln/install_test_dir/bin/zstd
-- Up-to-date: /Users/terrelln/install_test_dir/bin/zstd
-- Installing: /Users/terrelln/install_test_dir/bin/zstdcat
-- Installing: /Users/terrelln/install_test_dir/bin/unzstd
-- Installing: /Users/terrelln/install_test_dir/share/man/man1/zstd.1
-- Installing: /Users/terrelln/install_test_dir/share/man/man1/zstdcat.1
-- Installing: /Users/terrelln/install_test_dir/share/man/man1/unzstd.1
-- Installing: /Users/terrelln/install_test_dir/bin/zstdmt
-- Installing: /Users/terrelln/install_test_dir/bin/pzstd
-- Installing: /Users/terrelln/install_test_dir/zstd_manual.html
```