### PR TITLE
examples/Makefile assumes GNU make.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -22,7 +22,7 @@ all: simple_compression simple_decompression \
 	multiple_streaming_compression streaming_memory_usage
 
 $(LIB) :
-	make -C ../lib libzstd.a
+	$(MAKE) -C ../lib libzstd.a
 
 simple_compression : simple_compression.c $(LIB)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $^ $(LDFLAGS) -o $@


### PR DESCRIPTION
This fixes a building issue on systems that default to a different
flavour of make (as is the case with OpenBSD).