### PR TITLE
Make sure that make check runs on OpenBSD.

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -69,6 +69,7 @@ UNAME=$(uname)
 case "$UNAME" in
   Darwin) MD5SUM="md5 -r" ;;
   FreeBSD) MD5SUM="gmd5sum" ;;
+  OpenBSD) MD5SUM="md5" ;;
   *) MD5SUM="md5sum" ;;
 esac
 
@@ -258,7 +259,7 @@ rm ./*.tmp ./*.zstd
 $ECHO "frame concatenation tests completed"
 
 
-if [ "$isWindows" = false ] && [ "$UNAME" != 'SunOS' ] ; then
+if [ "$isWindows" = false ] && [ "$UNAME" != 'SunOS' ] && [ "$UNAME" != "OpenBSD" ] ; then
 $ECHO "\n**** flush write error test **** "
 
 $ECHO "$ECHO foo | $ZSTD > /dev/full"


### PR DESCRIPTION
OpenBSD uses md5 instead of md5sum, and has no device called full.

With this patch, make check runs until issue #1088. With the assumption made
in the issue, make check runs succesfully.