### PR TITLE
fix typo in programs/zstd.{1,1.md}

### DIFF
--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -119,7 +119,7 @@ Compress using \fB#\fR threads (default: 1)\. If \fB#\fR is 0, attempt to detect
 use \fBfile\fR as Dictionary to compress or decompress FILE(s)
 .
 .TP
-\fB\-\-nodictID\fR
+\fB\-\-no\-dictID\fR
 do not store dictionary ID within frame header (dictionary compression)\. The decoder will have to rely on implicit knowledge about which dictionary to use, it won\'t be able to check if it\'s correct\.
 .
 .TP

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -136,7 +136,7 @@ the last one takes effect.
     Single-thread mode also features lower memory usage.
 * `-D file`:
     use `file` as Dictionary to compress or decompress FILE(s)
-* `--nodictID`:
+* `--no-dictID`:
     do not store dictionary ID within frame header (dictionary compression).
     The decoder will have to rely on implicit knowledge about which dictionary to use,
     it won't be able to check if it's correct.


### PR DESCRIPTION
s/nodictID/no-dictID/g