### PR TITLE
Fix riscv.

### DIFF
--- a/contrib/pzstd/Makefile
+++ b/contrib/pzstd/Makefile
@@ -50,7 +50,7 @@ GTEST_LIB  = -L googletest/build/googlemock/gtest
 LIBS       =
 
 # Compilation commands
-LD_COMMAND  = $(CXX) $^          $(ALL_LDFLAGS) $(LIBS) -lpthread -o $@
+LD_COMMAND  = $(CXX) $^          $(ALL_LDFLAGS) $(LIBS) -pthread -o $@
 CC_COMMAND  = $(CC)  $(DEPFLAGS) $(ALL_CFLAGS)   -c $<  -o $@
 CXX_COMMAND = $(CXX) $(DEPFLAGS) $(ALL_CXXFLAGS) -c $<  -o $@
 


### PR DESCRIPTION
On riscv64, 4- and 8-byte accesses are atomic, 1- and 2-byte need library support (-latomic).  This is usually automatically added by ``-pthread``, but pzstd said ``-lpthread`` instead.