### PR TITLE
fixed decoding bogus lz4 frame

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1487,7 +1487,7 @@ static unsigned long long FIO_decompressLz4Frame(dRess_t* ress,
             if (LZ4F_isError(nextToLoad)) {
                 DISPLAYLEVEL(1, "zstd: %s: lz4 decompression error : %s \n",
                                 srcFileName, LZ4F_getErrorName(nextToLoad));
-                decodingError = 1; break;
+                decodingError = 1; nextToLoad = 0; break;
             }
             pos += remaining;
 
@@ -1495,7 +1495,7 @@ static unsigned long long FIO_decompressLz4Frame(dRess_t* ress,
             if (decodedBytes) {
                 if (fwrite(ress->dstBuffer, 1, decodedBytes, ress->dstFile) != decodedBytes) {
                     DISPLAYLEVEL(1, "zstd: %s \n", strerror(errno));
-                    decodingError = 1; break;
+                    decodingError = 1; nextToLoad = 0; break;
                 }
                 filesize += decodedBytes;
                 DISPLAYUPDATE(2, "\rDecompressed : %u MB  ", (unsigned)(filesize>>20));


### PR DESCRIPTION
`FIO_decompressLz4Frame()` would keep presenting bogus data 
after an `LZ4F_decompress()` decoding error
resulting in a `NULL` pointer dereference
when associated with older `liblz4` version (< v1.8.1.2).

This fixes it, by exiting the outer loop  too.

Note: I would have liked to add a test case featuring the bug with `liblz4` v1.8.0,
but I was unable to generate one with existing tools
(beyond copy / pasting the reference file in the repository, which would be too heavy weight).