### PR TITLE
minor: control numeric argument overflow

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -108,6 +108,8 @@ $ECHO "test : --fast aka negative compression levels"
 $ZSTD --fast -f tmp  # == -1
 $ZSTD --fast=3 -f tmp  # == -3
 $ZSTD --fast=200000 -f tmp  # == no compression
+$ECHO "test : too large numeric argument"
+$ZSTD --fast=9999999999 -f tmp  && die "should have refused numeric value"
 $ECHO "test : compress to stdout"
 $ZSTD tmp -c > tmpCompressed
 $ZSTD tmp --stdout > tmpCompressed       # long command format


### PR DESCRIPTION
backported from `paramgrill`
`exit()` when numeric argument overflows (>= 4GB)
added associated test case