### PR TITLE
Small fixes to fuzz.py

### DIFF
--- a/tests/fuzz/fuzz.py
+++ b/tests/fuzz/fuzz.py
@@ -265,7 +265,7 @@ def build_parser(args):
         '--disable-fuzzing-mode',
         dest='fuzzing_mode',
         action='store_false',
-        help='Do not define FUZZING_BUILD_MORE_UNSAFE_FOR_PRODUCTION')
+        help='Do not define FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION')
     parser.add_argument(
         '--enable-stateful-fuzzing',
         dest='stateful_fuzzing',
@@ -399,7 +399,7 @@ def build(args):
         cppflags += ['-DSTATEFUL_FUZZING']
 
     if args.fuzzing_mode:
-        cppflags += ['-DFUZZING_BUILD_MORE_UNSAFE_FOR_PRODUCTION']
+        cppflags += ['-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION']
 
     if args.lib_fuzzing_engine == 'libregression.a':
         targets = ['libregression.a'] + targets
@@ -750,11 +750,10 @@ def zip_cmd(args):
     for target in args.TARGET:
         # Zip the seed_corpus
         seed_corpus = abs_join(CORPORA_DIR, "{}_seed_corpus".format(target))
-        seeds = [abs_join(seed_corpus, f) for f in os.listdir(seed_corpus)]
         zip_file = "{}.zip".format(seed_corpus)
-        cmd = ["zip", "-q", "-j", "-9", zip_file]
-        print(' '.join(cmd + [abs_join(seed_corpus, '*')]))
-        subprocess.check_call(cmd + seeds)
+        cmd = ["zip", "-r", "-q", "-j", "-9", zip_file, "."]
+        print(' '.join(cmd))
+        subprocess.check_call(cmd, cwd=seed_corpus)
 
 
 def list_cmd(args):

--- a/tests/fuzz/fuzz.py
+++ b/tests/fuzz/fuzz.py
@@ -248,7 +248,7 @@ def build_parser(args):
         dest='debug',
         type=int,
         default=1,
-        help='Set ZSTD_DEBUG (default: 1)')
+        help='Set ZSTD_DEBUG and BIT_DEBUG (default: 1)')
     parser.add_argument(
         '--force-memory-access',
         dest='memory_access',
@@ -356,6 +356,7 @@ def build(args):
 
     cppflags += [
         '-DZSTD_DEBUG={}'.format(args.debug),
+        '-DBIT_DEBUG={}'.format(args.debug),
         '-DMEM_FORCE_MEMORY_ACCESS={}'.format(args.memory_access),
         '-DFUZZ_RNG_SEED_SIZE={}'.format(args.fuzz_rng_seed_size),
     ]

--- a/tests/fuzz/fuzz.py
+++ b/tests/fuzz/fuzz.py
@@ -147,15 +147,18 @@ def compiler_version(cc, cxx):
     """
     cc_version_bytes = subprocess.check_output([cc, "--version"])
     cxx_version_bytes = subprocess.check_output([cxx, "--version"])
-    if cc_version_bytes.startswith(b'clang'):
-        assert(cxx_version_bytes.startswith(b'clang'))
+    compiler = None
+    version = None
+    if b'clang' in cc_version_bytes:
+        assert(b'clang' in cxx_version_bytes)
         compiler = 'clang'
-    if cc_version_bytes.startswith(b'gcc'):
-        assert(cxx_version_bytes.startswith(b'g++'))
+    elif b'gcc' in cc_version_bytes:
+        assert(b'gcc' in cxx_version_bytes)
         compiler = 'gcc'
-    version_regex = b'([0-9])+\.([0-9])+\.([0-9])+'
-    version_match = re.search(version_regex, cc_version_bytes)
-    version = tuple(int(version_match.group(i)) for i in range(1, 4))
+    if compiler is not None:
+        version_regex = b'([0-9])+\.([0-9])+\.([0-9])+'
+        version_match = re.search(version_regex, cc_version_bytes)
+        version = tuple(int(version_match.group(i)) for i in range(1, 4))
     return compiler, version
 
 

--- a/tests/fuzz/regression_driver.c
+++ b/tests/fuzz/regression_driver.c
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 
 int main(int argc, char const **argv) {
-  size_t const kMaxFileSize = (size_t)1 << 20;
+  size_t const kMaxFileSize = (size_t)1 << 27;
   int const kFollowLinks = 1;
   char *fileNamesBuf = NULL;
   char const **files = argv + 1;


### PR DESCRIPTION
* Fix a typo.
* Make `zip` work for larger corpora, tested it by updating the regression test corpora.
* Define `BIT_DEBUG` in addition to `ZSTD_DEBUG`.
* Increase the maximum allowed file size to 128 MB.