### PR TITLE
New (tiny) feature - print summary stats even when --quiet is enabled

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -83,6 +83,8 @@
 #define DISPLAYLEVEL(l, ...) { if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); } }
 static int g_displayLevel = 2;   /* 0 : no display;  1: errors;  2: + result + interaction + warnings;  3: + progression;  4: + information */
 void FIO_setNotificationLevel(unsigned level) { g_displayLevel=level; }
+static int g_displaySummary = 0; /* 0 : no summary; 1: show summary */
+void FIO_setDisplaySummary(unsigned summary) { g_displaySummary=summary; }
 
 static const U64 g_refreshRate = SEC_TO_MICRO / 6;
 static UTIL_time_t g_displayClock = UTIL_TIME_INITIALIZER;
@@ -875,6 +877,14 @@ FIO_compressFilename_internal(cRess_t ress,
         (unsigned long long)readsize, (unsigned long long) compressedfilesize,
          dstFileName);
 
+    if ( g_displaySummary == 1 ) {
+      DISPLAYLEVEL(1,"%-20s :%6.2f%%   (%6llu => %6llu bytes, %s) \n",
+        srcFileName,
+        (double)compressedfilesize / (readsize+(!readsize)/*avoid div by zero*/) * 100,
+        (unsigned long long)readsize, (unsigned long long) compressedfilesize,
+         dstFileName);
+    }
+    
     return 0;
 }
 

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -49,6 +49,7 @@ typedef enum { FIO_zstdCompression, FIO_gzipCompression, FIO_xzCompression, FIO_
 void FIO_setCompressionType(FIO_compressionType_t compressionType);
 void FIO_overwriteMode(void);
 void FIO_setNotificationLevel(unsigned level);
+void FIO_setDisplaySummary(unsigned summary);
 void FIO_setSparseWrite(unsigned sparse);  /**< 0: no sparse; 1: disable on stdout; 2: always enabled */
 void FIO_setDictIDFlag(unsigned dictIDFlag);
 void FIO_setChecksumFlag(unsigned checksumFlag);

--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -179,6 +179,10 @@ verbose mode
 suppress warnings, interactivity, and notifications\. specify twice to suppress errors too\.
 .
 .TP
+\fB\-\-sum\fR
+print a summary even when quiet mode is enabled\.
+.
+.TP
 \fB\-C\fR, \fB\-\-[no\-]check\fR
 add integrity check computed from uncompressed data (default: enabled)
 .

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -70,6 +70,7 @@
 #define GB *(1U<<30)
 
 #define DISPLAY_LEVEL_DEFAULT 2
+#define DISPLAY_SUMMARY_DEFAULT 0
 
 static const char*    g_defaultDictName = "dictionary";
 static const unsigned g_defaultMaxDictSize = 110 KB;
@@ -91,6 +92,7 @@ static U32 g_ldmBucketSizeLog = LDM_PARAM_DEFAULT;
 #define DISPLAY(...)         fprintf(g_displayOut, __VA_ARGS__)
 #define DISPLAYLEVEL(l, ...) { if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); } }
 static int g_displayLevel = DISPLAY_LEVEL_DEFAULT;   /* 0 : no display,  1: errors,  2 : + result + interaction + warnings,  3 : + progression,  4 : + information */
+static int g_displaySummary = DISPLAY_SUMMARY_DEFAULT; /* 0 : no summary, 1: show summary */
 static FILE* g_displayOut;
 
 
@@ -129,6 +131,7 @@ static int usage_advanced(const char* programName)
     DISPLAY( " -V     : display Version number and exit \n");
     DISPLAY( " -v     : verbose mode; specify multiple times to increase verbosity\n");
     DISPLAY( " -q     : suppress warnings; specify twice to suppress errors too\n");
+    DISPLAY( " --sum  : print summary on completion even when -q is set\n");
     DISPLAY( " -c     : force write to standard output, even if it is the console\n");
     DISPLAY( " -l     : print information about zstd compressed files \n");
 #ifndef ZSTD_NOCOMPRESS
@@ -485,6 +488,7 @@ int main(int argCount, const char* argv[])
                     if (!strcmp(argument, "--help")) { g_displayOut=stdout; CLEAN_RETURN(usage_advanced(programName)); }
                     if (!strcmp(argument, "--verbose")) { g_displayLevel++; continue; }
                     if (!strcmp(argument, "--quiet")) { g_displayLevel--; continue; }
+		    if (!strcmp(argument, "--sum")) { g_displaySummary=1; continue; }
                     if (!strcmp(argument, "--stdout")) { forceStdout=1; outFileName=stdoutmark; g_displayLevel-=(g_displayLevel==2); continue; }
                     if (!strcmp(argument, "--ultra")) { ultra=1; continue; }
                     if (!strcmp(argument, "--check")) { FIO_setChecksumFlag(2); continue; }
@@ -878,6 +882,8 @@ int main(int argCount, const char* argv[])
 
     /* IO Stream/File */
     FIO_setNotificationLevel(g_displayLevel);
+    FIO_setDisplaySummary(g_displaySummary);
+
     if (operation==zom_compress) {
 #ifndef ZSTD_NOCOMPRESS
         FIO_setNbWorkers(nbWorkers);


### PR DESCRIPTION
The title kind of says it all - I wanted zstd to print out the compression summary upon completion even when quiet mode is enabled.

I'm not great at coding, so if this pull request is bad please consider it a feature request instead and just send my code to /dev/null. I figured it'd be a more genuine way to ask  :-)
