### PR TITLE
Unknown Suffix Error

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1754,16 +1754,17 @@ int FIO_decompressMultipleFilenames(const char** srcNamesTable, unsigned nbFiles
                     && strcmp(suffixPtr, ZSTD_EXTENSION)
                     && strcmp(suffixPtr, LZMA_EXTENSION)
                     && strcmp(suffixPtr, LZ4_EXTENSION)) ) {
-                char suffixlist[50] = ZSTD_EXTENSION;
-                #ifdef ZSTD_GZCOMPRESS
-                    strcat(suffixlist, "/" GZ_EXTENSION);
+                const char* suffixlist = ZSTD_EXTENSION
+                #ifdef ZSTD_GZCOMPRESS 
+                    "/" GZ_EXTENSION
                 #endif
                 #ifdef ZSTD_LZMACOMPRESS
-                    strcat(suffixlist, "/" XZ_EXTENSION "/" LZMA_EXTENSION);
+                    "/" XZ_EXTENSION "/" LZMA_EXTENSION
                 #endif
                 #ifdef ZSTD_LZ4COMPRESS
-                    strcat(suffixlist, "/" LZ4_EXTENSION);
+                    "/" LZ4_EXTENSION
                 #endif
+                ;
                 DISPLAYLEVEL(1, "zstd: %s: unknown suffix (%s expected) -- ignored \n",
                              srcFileName, suffixlist);
                 skippedFiles++;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1754,8 +1754,18 @@ int FIO_decompressMultipleFilenames(const char** srcNamesTable, unsigned nbFiles
                     && strcmp(suffixPtr, ZSTD_EXTENSION)
                     && strcmp(suffixPtr, LZMA_EXTENSION)
                     && strcmp(suffixPtr, LZ4_EXTENSION)) ) {
-                DISPLAYLEVEL(1, "zstd: %s: unknown suffix (%s/%s/%s/%s/%s expected) -- ignored \n",
-                             srcFileName, GZ_EXTENSION, XZ_EXTENSION, ZSTD_EXTENSION, LZMA_EXTENSION, LZ4_EXTENSION);
+                char suffixlist[50] = ZSTD_EXTENSION;
+                #ifdef ZSTD_GZCOMPRESS
+                    strcat(suffixlist, "/" GZ_EXTENSION);
+                #endif
+                #ifdef ZSTD_LZMACOMPRESS
+                    strcat(suffixlist, "/" XZ_EXTENSION "/" LZMA_EXTENSION);
+                #endif
+                #ifdef ZSTD_LZ4COMPRESS
+                    strcat(suffixlist, "/" LZ4_EXTENSION);
+                #endif
+                DISPLAYLEVEL(1, "zstd: %s: unknown suffix (%s expected) -- ignored \n",
+                             srcFileName, suffixlist);
                 skippedFiles++;
                 continue;
             } else {

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -622,7 +622,7 @@ fi
 
 $ECHO "\n===> suffix list test"
 
-$ZSTD -d tmp.abc 2> tmplg || echo 
+! $ZSTD -d tmp.abc 2> tmplg
 
 if [ $GZIPMODE -ne 1 ]; then 
     grep ".gz" tmplg > $INTOVOID && die "Unsupported suffix listed"

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -620,6 +620,23 @@ else
     $ECHO "lz4 mode not supported"
 fi
 
+$ECHO "\n===> suffix list test"
+
+$ZSTD -d tmp.abc 2> tmplg || echo 
+
+if [ $GZIPMODE -ne 1 ]; then 
+    grep ".gz" tmplg > $INTOVOID && die "Unsupported suffix listed"
+fi
+
+if [ $LZMAMODE -ne 1 ]; then 
+    grep ".lzma" tmplg > $INTOVOID && die "Unsupported suffix listed"
+    grep ".xz" tmplg > $INTOVOID && die "Unsupported suffix listed"
+fi
+
+if [ $LZ4MODE -ne 1 ]; then
+    grep ".lz4" tmplg > $INTOVOID && die "Unsupported suffix listed"
+fi
+
 $ECHO "\n===>  zstd round-trip tests "
 
 roundTripTest


### PR DESCRIPTION
Changed so only compiled formats are printed in list of supported extensions

Test Plan: Compiled w/o support for lzma/xz/lz4, did in fact print out the right thing.

zstd -d blah.abc
zstd: blah.abc: unknown suffix (.zst/.gz expected) -- ignored