### PR TITLE
Added --format=zstd

### DIFF
--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -164,7 +164,8 @@ the last one takes effect.
 * `--format=FORMAT`:
     compress and decompress in other formats. If compiled with
     support, zstd can compress to or decompress from other compression algorithm
-    formats. Possibly available options are `gzip`, `xz`, `lzma`, and `lz4`.
+    formats. Possibly available options are `zstd`, `gzip`, `xz`, `lzma`, and `lz4`.
+    If no such format is provided, `zstd` is the default.
 * `-h`/`-H`, `--help`:
     display help/long help and exit
 * `-V`, `--version`:

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -145,6 +145,7 @@ static int usage_advanced(const char* programName)
 #ifdef UTIL_HAS_CREATEFILELIST
     DISPLAY( " -r     : operate recursively on directories \n");
 #endif
+    DISPLAY( "--format=zstd : compress files to the .zstd format \n");
 #ifdef ZSTD_GZCOMPRESS
     DISPLAY( "--format=gzip : compress files to the .gz format \n");
 #endif
@@ -500,6 +501,7 @@ int main(int argCount, const char* argv[])
                     if (!strcmp(argument, "--rm")) { FIO_setRemoveSrcFile(1); continue; }
                     if (!strcmp(argument, "--priority=rt")) { setRealTimePrio = 1; continue; }
                     if (!strcmp(argument, "--single-thread")) { nbWorkers = 0; singleThread = 1; continue; }
+                    if (!strcmp(argument, "--format=zstd")) { suffix = ZSTD_EXTENSION; FIO_setCompressionType(FIO_zstdCompression); continue; }
 #ifdef ZSTD_GZCOMPRESS
                     if (!strcmp(argument, "--format=gzip")) { suffix = GZ_EXTENSION; FIO_setCompressionType(FIO_gzipCompression); continue; }
 #endif

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -145,7 +145,7 @@ static int usage_advanced(const char* programName)
 #ifdef UTIL_HAS_CREATEFILELIST
     DISPLAY( " -r     : operate recursively on directories \n");
 #endif
-    DISPLAY( "--format=zstd : compress files to the .zstd format \n");
+    DISPLAY( "--format=zstd : compress files to the .zstd format (default) \n");
 #ifdef ZSTD_GZCOMPRESS
     DISPLAY( "--format=gzip : compress files to the .gz format \n");
 #endif

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -485,6 +485,11 @@ $ZSTD -bi0 --fast tmp1
 $ECHO "with recursive and quiet modes"
 $ZSTD -rqi1b1e2 tmp1
 
+$ECHO "\n===>  zstd compatibility tests "
+
+./datagen > tmp
+$ZSTD --format=zstd tmp 2> tmplog
+grep "zst" tmplog > $INTOVOID || die "--format=zstd not supported"
 
 $ECHO "\n===>  gzip compatibility tests "
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -488,8 +488,9 @@ $ZSTD -rqi1b1e2 tmp1
 $ECHO "\n===>  zstd compatibility tests "
 
 ./datagen > tmp
-$ZSTD --format=zstd tmp 2> tmplog
-grep "zst" tmplog > $INTOVOID || die "--format=zstd not supported"
+rm -f tmp.zst
+$ZSTD --format=zstd -f tmp
+test -f tmp.zst
 
 $ECHO "\n===>  gzip compatibility tests "
 
@@ -527,6 +528,12 @@ else
     $ECHO "gzip mode not supported"
 fi
 
+if [ $GZIPMODE -eq 1 ]; then
+    ./datagen > tmp
+    rm -f tmp.zst
+    $ZSTD --format=gzip --format=zstd -f tmp 
+    test -f tmp.zst
+fi
 
 $ECHO "\n===>  xz compatibility tests "
 


### PR DESCRIPTION
for scripts

Test Plan:
Ran with new flag over an old flag
gclu-mbp:programs gclu$ ./zstd --rm --format=gzip --format=zstd blah.txt
blah.txt             :183.33%   (    12 =>     22 bytes, blah.txt.zst)         
gclu-mbp:programs gclu$ ./zstd -d --rm --format=gzip --format=zstd blah.txt.zst
blah.txt.zst        : 12 bytes
Overrides previous format flags (and doesn't give error)