### PR TITLE
Added zstdcli-style format for compression parameters in paramgrill

### DIFF
--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -996,12 +996,13 @@ int main(int argc, const char** argv)
                 if (longCommandWArg(&argument, "searchLength=") || longCommandWArg(&argument, "slen=")) { g_params.searchLength = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
                 if (longCommandWArg(&argument, "targetLength=") || longCommandWArg(&argument, "tlen=")) { g_params.targetLength = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
                 if (longCommandWArg(&argument, "strategy=") || longCommandWArg(&argument, "strat=")) { g_params.strategy = (ZSTD_strategy)(readU32FromChar(&argument)); if (argument[0]==',') { argument++; continue; } else break; }
+                if (longCommandWArg(&argument, "level=") || longCommandWArg(&argument, "lvl=")) { g_params = ZSTD_getCParams(readU32FromChar(&argument), g_blockSize, 0); if (argument[0]==',') { argument++; continue; } else break; }
                 DISPLAY("invalid compression parameter \n");
                 return 1;
             }
 
             if (argument[0] != 0) {
-                DISPLAY("invvalid --zstd= format\n");
+                DISPLAY("invalid --zstd= format\n");
                 return 1; /* check the end of string */
             }
             break;

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -952,6 +952,7 @@ static int usage_advanced(void)
     DISPLAY( " -i#    : iteration loops [1-9](default : %i) \n", NBLOOPS);
     DISPLAY( " -O#    : find Optimized parameters for # MB/s compression speed (default : 0) \n");
     DISPLAY( " -S     : Single run \n");
+    DISPLAY( " --zstd : Single run, parameter selection same as zstdcli \n");
     DISPLAY( " -P#    : generated sample compressibility (default : %.1f%%) \n", COMPRESSIBILITY_DEFAULT * 100);
     return 0;
 }

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -889,6 +889,7 @@ int optimizeForSize(const char* inFileName, U32 targetSpeed)
 
         /* end summary */
         BMK_printWinner(stdout, 99, winner.result, winner.params, benchedSize);
+        BMK_translateAdvancedParams(winner.params);
         DISPLAY("grillParams size - optimizer completed \n");
 
         /* clean up*/
@@ -1005,7 +1006,6 @@ int main(int argc, const char** argv)
                 DISPLAY("invalid --zstd= format\n");
                 return 1; /* check the end of string */
             }
-            break;
             //if not return, success
         } else if (argument[0]=='-') {
             argument++;
@@ -1114,7 +1114,12 @@ int main(int argc, const char** argv)
     }
 
     if (filenamesStart==0) {
-        result = benchSample();
+        if (optimizer) {
+            DISPLAY("Optimizer Expects File")
+            return 1;
+        } else {
+            result = benchSample();
+        }
     } else {
         if (optimizer) {
             result = optimizeForSize(input_filename, targetSpeed);

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -177,6 +177,35 @@ BMK_benchParam(BMK_result_t* resultPtr,
     resultPtr->cSpeed = 0.;
     resultPtr->dSpeed = 0.;
 
+    /* parse arg, wip */
+    if (longCommandWArg(&argument, "--zstd=")) { if (!parseCompressionParameters(argument, &compressionParams)) CLEAN_RETURN(badusage(programName)); continue; }
+
+/*
+static unsigned parseCompressionParameters(const char* stringPtr, ZSTD_compressionParameters* params)
+{
+    for ( ; ;) {
+        if (longCommandWArg(&stringPtr, "windowLog=") || longCommandWArg(&stringPtr, "wlog=")) { params->windowLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "chainLog=") || longCommandWArg(&stringPtr, "clog=")) { params->chainLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "hashLog=") || longCommandWArg(&stringPtr, "hlog=")) { params->hashLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "searchLog=") || longCommandWArg(&stringPtr, "slog=")) { params->searchLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "searchLength=") || longCommandWArg(&stringPtr, "slen=")) { params->searchLength = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "targetLength=") || longCommandWArg(&stringPtr, "tlen=")) { params->targetLength = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "strategy=") || longCommandWArg(&stringPtr, "strat=")) { params->strategy = (ZSTD_strategy)(readU32FromChar(&stringPtr)); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "overlapLog=") || longCommandWArg(&stringPtr, "ovlog=")) { g_overlapLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmHashLog=") || longCommandWArg(&stringPtr, "ldmhlog=")) { g_ldmHashLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmSearchLength=") || longCommandWArg(&stringPtr, "ldmslen=")) { g_ldmMinMatch = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmBucketSizeLog=") || longCommandWArg(&stringPtr, "ldmblog=")) { g_ldmBucketSizeLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmHashEveryLog=") || longCommandWArg(&stringPtr, "ldmhevery=")) { g_ldmHashEveryLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        DISPLAYLEVEL(4, "invalid compression parameter \n");
+        return 0;
+    }
+
+    DISPLAYLEVEL(4, "windowLog=%d, chainLog=%d, hashLog=%d, searchLog=%d \n", params->windowLog, params->chainLog, params->hashLog, params->searchLog);
+    DISPLAYLEVEL(4, "searchLength=%d, targetLength=%d, strategy=%d \n", params->searchLength, params->targetLength, params->strategy);
+    if (stringPtr[0] != 0) return 0; /* check the end of string */
+    return 1;
+}
+*/
     /* Memory allocation & restrictions */
     snprintf(name, 30, "Sw%02uc%02uh%02us%02ul%1ut%03uS%1u", Wlog, Clog, Hlog, Slog, Slength, Tlength, strat);
     if (!compressedBuffer || !resultBuffer || !blockTable) {

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -1000,7 +1000,10 @@ int main(int argc, const char** argv)
                 return 1;
             }
 
-            if (argument[0] != 0) return 1; /* check the end of string */
+            if (argument[0] != 0) {
+                DISPLAY("invvalid --zstd= format\n");
+                return 1; /* check the end of string */
+            }
             break;
             //if not return, success
         } else if (argument[0]=='-') {

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -1116,7 +1116,7 @@ int main(int argc, const char** argv)
 
     if (filenamesStart==0) {
         if (optimizer) {
-            DISPLAY("Optimizer Expects File")
+            DISPLAY("Optimizer Expects File\n");
             return 1;
         } else {
             result = benchSample();


### PR DESCRIPTION
Previous: paramgrill -Sw23c23h22s06l3t048S6
Added: paramgrill --zstd=windowLog=23,chainLog=23,hashLog=22,searchLog=6,searchLength=3,targetLength=48,strategy=6
Should behave equivalently to old command (which still exists)

Test Plan:
Ran above commands, produced same result.