### PR TITLE
Improves UX for --list command's lack of support for pipes

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2031,9 +2031,10 @@ static int FIO_listFile(fileInfo_t* total, const char* inFileName, int displayLe
 }
 
 int FIO_listMultipleFiles(unsigned numFiles, const char** filenameTable, int displayLevel){
-    if (!isatty(0))
-        DISPLAYOUT("zstd --list does not support reading from standard input\n");
+    if (!isatty(0)) {
+        DISPLAYOUT("zstd: --list does not support reading from standard input\n");
         return 1;
+    }
 
     if (numFiles == 0) {
         DISPLAYOUT("No files given\n");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -61,6 +61,7 @@
 #if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(_WIN32) ||     \
     defined(__CYGWIN__)
 #include <io.h> /* _isatty */
+#include <sys/stat.h>
 #define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))
 #elif defined(_POSIX_C_SOURCE) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE) || (defined(__APPLE__) && defined(__MACH__)) || \
       defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  /* https://sourceforge.net/p/predef/wiki/OperatingSystems/ */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -57,20 +57,10 @@
 #  include <lz4.h>
 #endif
 
-// Multi-OS support for determining if terminal is tty
-#if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(_WIN32) ||     \
-    defined(__CYGWIN__)
-#include <io.h> /* _isatty */
-#include <sys/stat.h>
-#define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))
-#elif defined(_POSIX_C_SOURCE) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE) || (defined(__APPLE__) && defined(__MACH__)) || \
-      defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  /* https://sourceforge.net/p/predef/wiki/OperatingSystems/ */
-#include <unistd.h> /* isatty */
-#define IS_CONSOLE(stdStream) isatty(fileno(stdStream))
-#else
-#define IS_CONSOLE(stdStream) 0
+#if defined (_MSC_VER)
+#  include <sys/stat.h>
+#  include <io.h>
 #endif
-
 
 /*-*************************************
 *  Constants

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -31,6 +31,11 @@
 #include <string.h>     /* strcmp, strlen */
 #include <errno.h>      /* errno */
 
+#if defined (_MSC_VER)
+#  include <sys/stat.h>
+#  include <io.h>
+#endif
+
 #include "mem.h"
 #include "fileio.h"
 #include "util.h"
@@ -57,10 +62,6 @@
 #  include <lz4.h>
 #endif
 
-#if defined (_MSC_VER)
-#  include <sys/stat.h>
-#  include <io.h>
-#endif
 
 /*-*************************************
 *  Constants

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -27,7 +27,6 @@
 #include "platform.h"   /* Large Files support, SET_BINARY_MODE */
 #include "util.h"       /* UTIL_getFileSize, UTIL_isRegularFile */
 #include <stdio.h>      /* fprintf, fopen, fread, _fileno, stdin, stdout */
-#include <unistd.h>     /* isatty */
 #include <stdlib.h>     /* malloc, free */
 #include <string.h>     /* strcmp, strlen */
 #include <errno.h>      /* errno */
@@ -35,6 +34,8 @@
 #if defined (_MSC_VER)
 #  include <sys/stat.h>
 #  include <io.h>
+#else
+#  include <unistd.h>     /* isatty */
 #endif
 
 #include "mem.h"
@@ -2031,10 +2032,14 @@ static int FIO_listFile(fileInfo_t* total, const char* inFileName, int displayLe
 }
 
 int FIO_listMultipleFiles(unsigned numFiles, const char** filenameTable, int displayLevel){
+    // isatty comes from the header unistd.h
+    // windows has no equilivant
+    #if !defined(_MSC_VER)
     if (!isatty(0)) {
         DISPLAYOUT("zstd: --list does not support reading from standard input\n");
         return 1;
     }
+    #endif
 
     if (numFiles == 0) {
         DISPLAYOUT("No files given\n");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -27,6 +27,7 @@
 #include "platform.h"   /* Large Files support, SET_BINARY_MODE */
 #include "util.h"       /* UTIL_getFileSize, UTIL_isRegularFile */
 #include <stdio.h>      /* fprintf, fopen, fread, _fileno, stdin, stdout */
+#include <unistd.h>     /* isatty */
 #include <stdlib.h>     /* malloc, free */
 #include <string.h>     /* strcmp, strlen */
 #include <errno.h>      /* errno */
@@ -2030,6 +2031,10 @@ static int FIO_listFile(fileInfo_t* total, const char* inFileName, int displayLe
 }
 
 int FIO_listMultipleFiles(unsigned numFiles, const char** filenameTable, int displayLevel){
+    if (!isatty(0))
+        DISPLAYOUT("zstd --list does not support reading from standard input\n");
+        return 1;
+
     if (numFiles == 0) {
         DISPLAYOUT("No files given\n");
         return 0;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -729,6 +729,9 @@ $ECHO "\n===>  zstd --list/-l error detection tests "
 ! $ZSTD -lv tmp1*
 ! $ZSTD --list -v tmp2 tmp12.zst
 
+$ECHO "\n===>  zstd --list/-l exits 1 when stdin is piped in"
+! echo "piped STDIN" | $ZSTD --list
+
 $ECHO "\n===>  zstd --list/-l test with null files "
 ./datagen -g0 > tmp5
 $ZSTD tmp5


### PR DESCRIPTION
`--list` does not support piped input
This commit checks if the STDIN is not from a terminal and exits 1 
with a well formatted error message 

the output of this command may still be piped to another program


**examples of the code change below**
```
zstd [dev] :> ./zstd --list # exits 0

zstd [dev] :> echo "awdaw" | ./zstd --list
zstd --list does not support reading from standard input # exits 1

zstd [dev] :> ./zstd --list | echo # exits 0
```
 I don't believe this type of code is usually tested.  Please inform me if i am incorrect and I will add tests.

closes task `T29991838` @Cyan4973 
