### PR TITLE
ZSTD_btlazy2: Support Searching the Dictionary Context In-Place

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1236,7 +1236,7 @@ static size_t ZSTD_resetCCtx_usingCDict(ZSTD_CCtx* cctx,
         32 KB, /* ZSTD_greedy */
         32 KB, /* ZSTD_lazy */
         32 KB, /* ZSTD_lazy2 */
-        256 KB, /* ZSTD_btlazy2 */
+        32 KB, /* ZSTD_btlazy2 */
         256 KB, /* ZSTD_btopt */
         256 KB /* ZSTD_btultra */
     };
@@ -1244,7 +1244,7 @@ static size_t ZSTD_resetCCtx_usingCDict(ZSTD_CCtx* cctx,
                           || pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN )
                         && !params.forceWindow /* dictMatchState isn't correctly
                                                 * handled in _enforceMaxDist */
-                        && cdict->cParams.strategy <= ZSTD_lazy2
+                        && cdict->cParams.strategy <= ZSTD_btlazy2
                         && ZSTD_equivalentCParams(cctx->appliedParams.cParams,
                                                   cdict->cParams);
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -356,7 +356,7 @@ static size_t ZSTD_DUBT_findBestMatch (
 
 
 /** ZSTD_BtFindBestMatch() : Tree updater, providing best match */
-static size_t ZSTD_BtFindBestMatch (
+FORCE_INLINE_TEMPLATE size_t ZSTD_BtFindBestMatch (
                         ZSTD_matchState_t* ms, ZSTD_compressionParameters const* cParams,
                         const BYTE* const ip, const BYTE* const iLimit,
                         size_t* offsetPtr,


### PR DESCRIPTION
Continuing the work of #1169 (and #1151 and #1117), this PR allows the `ZSTD_btlazy2` to perform searches against an external, immutable dictionary context.

