### PR TITLE
fix dctx initialization within ZSTD_decompress in stack mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,18 @@ matrix:
     - env: Cmd='make clang38install && CC=clang-3.8 make clean msan-fuzztest'
     - env: Cmd='make clang38install && CC=clang-3.8 make clean tsan-test-zstream'
 
+    - env: Cmd='make -C tests test-fuzzer-stackmode'
+
     - env: Cmd='make valgrindinstall && make -C tests clean valgrindTest'
 
     - env: Cmd='make arminstall && make armfuzz'
+
 # Following test is disabled, as there is a bug in Travis' ld
 # preventing aarch64 compilation to complete.
 # > collect2: error: ld terminated with signal 11 [Segmentation fault], core dumped
 # to be re-enabled in a few commit, as it's possible that a random code change circumvent the ld bug
 #    - env: Cmd='make arminstall && make aarch64fuzz'
+
     - env: Cmd='make ppcinstall && make ppcfuzz'
     - env: Cmd='make ppcinstall && make ppc64fuzz'
     - env: Cmd='make -j uasanregressiontest && make clean && make -j msanregressiontest'
@@ -35,6 +39,7 @@ matrix:
     - env: Cmd='make lz4install && make -C tests test-lz4'
 
     - env: Cmd='bash tests/libzstd_partial_builds.sh'
+
     # tag-specific test
     - if: tag =~ ^v[0-9]\.[0-9]
       env: Cmd='make -C tests checkTag && tests/checkTag $TRAVIS_BRANCH'

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -192,6 +192,8 @@ static void ZSTD_initDCtx_internal(ZSTD_DCtx* dctx)
     dctx->inBuffSize  = 0;
     dctx->outBuffSize = 0;
     dctx->streamStage = zdss_init;
+    dctx->legacyContext = NULL;
+    dctx->previousLegacyVersion = 0;
     dctx->bmi2 = ZSTD_cpuid_bmi2(ZSTD_cpuid());
 }
 
@@ -215,8 +217,6 @@ ZSTD_DCtx* ZSTD_createDCtx_advanced(ZSTD_customMem customMem)
     {   ZSTD_DCtx* const dctx = (ZSTD_DCtx*)ZSTD_malloc(sizeof(*dctx), customMem);
         if (!dctx) return NULL;
         dctx->customMem = customMem;
-        dctx->legacyContext = NULL;
-        dctx->previousLegacyVersion = 0;
         ZSTD_initDCtx_internal(dctx);
         return dctx;
     }
@@ -1996,6 +1996,7 @@ size_t ZSTD_decompress(void* dst, size_t dstCapacity, const void* src, size_t sr
     return regenSize;
 #else   /* stack mode */
     ZSTD_DCtx dctx;
+    ZSTD_initDCtx_internal(&dctx);
     return ZSTD_decompressDCtx(&dctx, dst, dstCapacity, src, srcSize);
 #endif
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -360,6 +360,9 @@ test-fullbench32: fullbench32 datagen
 test-fuzzer: fuzzer
 	$(QEMU_SYS) ./fuzzer -v $(FUZZERTEST) $(FUZZER_FLAGS)
 
+test-fuzzer-stackmode: MOREFLAGS += -DZSTD_HEAPMODE=0
+test-fuzzer-stackmode: test-fuzzer
+
 test-fuzzer32: fuzzer32
 	$(QEMU_SYS) ./fuzzer32 -v $(FUZZERTEST) $(FUZZER_FLAGS)
 


### PR DESCRIPTION
when `ZSTD_HEAPMODE=0` (which is not default).

Also : added an associated test (`test-fuzzer-stackmode`)
run on travis CI

fix #1186