### PR TITLE
removed constants from `zstd.h`

### DIFF
--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -486,7 +486,7 @@ ZSTD_CStream* ZSTD_initStaticCStream(void* workspace, size_t workspaceSize);    
 <pre><b>typedef void* (*ZSTD_allocFunction) (void* opaque, size_t size);
 typedef void  (*ZSTD_freeFunction) (void* opaque, void* address);
 typedef struct { ZSTD_allocFunction customAlloc; ZSTD_freeFunction customFree; void* opaque; } ZSTD_customMem;
-static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< this constant defers to stdlib's functions */<b>
+#define ZSTD_defaultCMem ((ZSTD_customMem){ NULL, NULL, NULL})   </b>/**< this defers memory management to stdlib's functions */<b>
 </b><p>  These prototypes make it possible to pass your own allocation/free functions.
   ZSTD_customMem is provided at creation time, using ZSTD_create*_advanced() variants listed below.
   All allocation/free operations will be completed using these custom variants instead of regular <stdlib.h> ones.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -408,10 +408,12 @@ ZSTDLIB_API size_t ZSTD_DStreamOutSize(void);   /*!< recommended size for output
 #define ZSTD_FRAMEHEADERSIZE_PREFIX 5   /* minimum input size to know frame header size */
 #define ZSTD_FRAMEHEADERSIZE_MIN    6
 #define ZSTD_FRAMEHEADERSIZE_MAX   18   /* for static allocation */
-static const size_t ZSTD_frameHeaderSize_prefix = ZSTD_FRAMEHEADERSIZE_PREFIX;
-static const size_t ZSTD_frameHeaderSize_min = ZSTD_FRAMEHEADERSIZE_MIN;
-static const size_t ZSTD_frameHeaderSize_max = ZSTD_FRAMEHEADERSIZE_MAX;
-static const size_t ZSTD_skippableHeaderSize = 8;  /* magic number + skippable frame length */
+
+#define ZSTD_frameHeaderSize_prefix ZSTD_FRAMEHEADERSIZE_PREFIX
+#define ZSTD_frameHeaderSize_min    ZSTD_FRAMEHEADERSIZE_MIN
+#define ZSTD_frameHeaderSize_max    ZSTD_FRAMEHEADERSIZE_MAX
+#define ZSTD_skippableHeaderSize    8
+
 
 
 /*--- Advanced types ---*/
@@ -600,7 +602,7 @@ ZSTDLIB_API const ZSTD_DDict* ZSTD_initStaticDDict(
 typedef void* (*ZSTD_allocFunction) (void* opaque, size_t size);
 typedef void  (*ZSTD_freeFunction) (void* opaque, void* address);
 typedef struct { ZSTD_allocFunction customAlloc; ZSTD_freeFunction customFree; void* opaque; } ZSTD_customMem;
-static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  /**< this constant defers to stdlib's functions */
+#define ZSTD_defaultCMem ((ZSTD_customMem){ NULL, NULL, NULL})   /**< this defers memory management to stdlib's functions */
 
 ZSTDLIB_API ZSTD_CCtx*    ZSTD_createCCtx_advanced(ZSTD_customMem customMem);
 ZSTDLIB_API ZSTD_CStream* ZSTD_createCStream_advanced(ZSTD_customMem customMem);


### PR DESCRIPTION
Some constants were defined as `static const` within `zstd.h`, experimental section (`ZSTD_STATIC_LINKING_ONLY`).

Problem is, some compilers complain when those constants are not used by the user program,
typically when combined with `-Wunused-const-variable` on `gcc` :
https://trac.torproject.org/projects/tor/ticket/26272

Reverted to `#define`, which do not trigger such warning.

Note : as a consequence, some constants are now `#define` under 2 different names,
in an attempt to preserve availability of both names,
in order to not break potential source code depending on the `static const` name.