### PR TITLE
Thread Pool resize

### DIFF
--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -188,7 +188,6 @@ size_t POOL_sizeof(POOL_ctx *ctx) {
 /* note : only works if no job is running ! */
 static POOL_ctx* POOL_resize_internal(POOL_ctx* ctx, size_t numThreads)
 {
-    if (ctx->numThreadsBusy > 0) return NULL;
     if (numThreads <= ctx->threadCapacity) {
         ctx->threadLimit = numThreads;
         return ctx;

--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -91,12 +91,13 @@ static void* POOL_thread(void* opaque) {
             job.function(job.opaque);
 
             /* If the intended queue size was 0, signal after finishing job */
+            ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+            ctx->numThreadsBusy--;
             if (ctx->queueSize == 1) {
-                ZSTD_pthread_mutex_lock(&ctx->queueMutex);
-                ctx->numThreadsBusy--;
-                ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
                 ZSTD_pthread_cond_signal(&ctx->queuePushCond);
-        }   }
+            }
+            ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
+        }
     }  /* for (;;) */
     assert(0); /* Unreachable */
 }

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -40,14 +40,14 @@ void POOL_free(POOL_ctx* ctx);
 
 /*! POOL_resize() :
  *  Expands or shrinks pool's number of threads.
- *  This is more efficient than releasing and creating a new context.
- * @return : a new pool context on success, NULL on failure
- *    note : new pool context might have same address as original one, but it's not guaranteed.
- *           consider starting context as consumed, only rely on returned one.
- *    note 2 : only numThreads can be resized, queueSize is unchanged.
- *    note 3 : `numThreads` must be at least 1
+ *  This is more efficient than releasing + creating a new context,
+ *  since it tries to preserve and re-use existing threads.
+ * `numThreads` must be at least 1.
+ * @return : 0 when resize was successful,
+ *           !0 (typically 1) if there is an error.
+ *    note : only numThreads can be resized, queueSize remains unchanged.
  */
-POOL_ctx* POOL_resize(POOL_ctx* ctx, size_t numThreads);
+int POOL_resize(POOL_ctx* ctx, size_t numThreads);
 
 /*! POOL_sizeof() :
  * @return threadpool memory usage

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -45,6 +45,7 @@ void POOL_free(POOL_ctx* ctx);
  *    note : new pool context might have same address as original one, but it's not guaranteed.
  *           consider starting context as consumed, only rely on returned one.
  *    note 2 : only numThreads can be resized, queueSize is unchanged.
+ *    note 3 : `numThreads` must be at least 1
  */
 POOL_ctx* POOL_resize(POOL_ctx* ctx, size_t numThreads);
 

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -30,40 +30,39 @@ typedef struct POOL_ctx_s POOL_ctx;
 */
 POOL_ctx* POOL_create(size_t numThreads, size_t queueSize);
 
-POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize, ZSTD_customMem customMem);
+POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize,
+                               ZSTD_customMem customMem);
 
 /*! POOL_free() :
-    Free a thread pool returned by POOL_create().
-*/
+ *  Free a thread pool returned by POOL_create().
+ */
 void POOL_free(POOL_ctx* ctx);
 
 /*! POOL_sizeof() :
-    return memory usage of pool returned by POOL_create().
-*/
+ * @return threadpool memory usage
+ *  note : compatible with NULL (returns 0 in this case)
+ */
 size_t POOL_sizeof(POOL_ctx* ctx);
 
 /*! POOL_function :
-    The function type that can be added to a thread pool.
-*/
+ *  The function type that can be added to a thread pool.
+ */
 typedef void (*POOL_function)(void*);
-/*! POOL_add_function :
-    The function type for a generic thread pool add function.
-*/
-typedef void (*POOL_add_function)(void*, POOL_function, void*);
 
 /*! POOL_add() :
-    Add the job `function(opaque)` to the thread pool. `ctx` must be valid.
-    Possibly blocks until there is room in the queue.
-    Note : The function may be executed asynchronously, so `opaque` must live until the function has been completed.
-*/
+ *  Add the job `function(opaque)` to the thread pool. `ctx` must be valid.
+ *  Possibly blocks until there is room in the queue.
+ *  Note : The function may be executed asynchronously,
+ *         therefore, `opaque` must live until function has been completed.
+ */
 void POOL_add(POOL_ctx* ctx, POOL_function function, void* opaque);
 
 
 /*! POOL_tryAdd() :
-    Add the job `function(opaque)` to the thread pool if a worker is available.
-    return immediately otherwise.
-   @return : 1 if successful, 0 if not.
-*/
+ *  Add the job `function(opaque)` to thread pool _if_ a worker is available.
+ *  Returns immediately even if not (does not block).
+ * @return : 1 if successful, 0 if not.
+ */
 int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque);
 
 

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -38,6 +38,16 @@ POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize,
  */
 void POOL_free(POOL_ctx* ctx);
 
+/*! POOL_resize() :
+ *  Expands or shrinks pool's number of threads.
+ *  This is more efficient than releasing and creating a new context.
+ * @return : a new pool context on success, NULL on failure
+ *    note : new pool context might have same address as original one, but it's not guaranteed.
+ *           consider starting context as consumed, only rely on returned one.
+ *    note 2 : only numThreads can be resized, queueSize is unchanged.
+ */
+POOL_ctx* POOL_resize(POOL_ctx* ctx, size_t numThreads);
+
 /*! POOL_sizeof() :
  * @return threadpool memory usage
  *  note : compatible with NULL (returns 0 in this case)

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3645,13 +3645,9 @@ size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
         }
         if (params.nbWorkers > 0) {
             /* mt context creation */
-            if (cctx->mtctx == NULL || (params.nbWorkers != ZSTDMT_getNbWorkers(cctx->mtctx))) {
+            if (cctx->mtctx == NULL) {
                 DEBUGLOG(4, "ZSTD_compress_generic: creating new mtctx for nbWorkers=%u",
                             params.nbWorkers);
-                if (cctx->mtctx != NULL)
-                    DEBUGLOG(4, "ZSTD_compress_generic: previous nbWorkers was %u",
-                                ZSTDMT_getNbWorkers(cctx->mtctx));
-                ZSTDMT_freeCCtx(cctx->mtctx);
                 cctx->mtctx = ZSTDMT_createCCtx_advanced(params.nbWorkers, cctx->customMem);
                 if (cctx->mtctx == NULL) return ERROR(memory_allocation);
             }

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1280,7 +1280,7 @@ size_t ZSTDMT_initCStream_internal(
 
     /* init */
     if (params.nbWorkers != mtctx->params.nbWorkers)
-        ZSTDMT_resize(mtctx, params.nbWorkers);
+        CHECK_F( ZSTDMT_resize(mtctx, params.nbWorkers) );
 
     if (params.jobSize == 0) {
         params.jobSize = 1U << ZSTDMT_computeTargetJobLog(params);

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1018,8 +1018,7 @@ static ZSTD_CCtx_params ZSTDMT_initJobCCtxParams(ZSTD_CCtx_params const params)
  * @return : error code if fails, 0 on success */
 static size_t ZSTDMT_resize(ZSTDMT_CCtx* mtctx, unsigned nbWorkers)
 {
-    mtctx->factory = POOL_resize(mtctx->factory, nbWorkers);
-    if (mtctx->factory == NULL) return ERROR(memory_allocation);
+    if (POOL_resize(mtctx->factory, nbWorkers)) return ERROR(memory_allocation);
     CHECK_F( ZSTDMT_expandJobsTable(mtctx, nbWorkers) );
     mtctx->bufPool = ZSTDMT_expandBufferPool(mtctx->bufPool, nbWorkers);
     if (mtctx->bufPool == NULL) return ERROR(memory_allocation);

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -126,11 +126,6 @@ size_t ZSTDMT_CCtxParam_setNbWorkers(ZSTD_CCtx_params* params, unsigned nbWorker
  *  New parameters will be applied to next compression job. */
 void ZSTDMT_updateCParams_whileCompressing(ZSTDMT_CCtx* mtctx, const ZSTD_CCtx_params* cctxParams);
 
-/* ZSTDMT_getNbWorkers():
- * @return nb threads currently active in mtctx.
- * mtctx must be valid */
-unsigned ZSTDMT_getNbWorkers(const ZSTDMT_CCtx* mtctx);
-
 /* ZSTDMT_getFrameProgression():
  * tells how much data has been consumed (input) and produced (output) for current frame.
  * able to count progression inside worker threads.

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1108,15 +1108,11 @@ size_t ZSTD_execSequence(BYTE* op,
             return sequenceLength;
         }
         /* span extDict & currentPrefixSegment */
-        DEBUGLOG(2, "ZSTD_execSequence: found a 2-segments match")
         {   size_t const length1 = dictEnd - match;
-            DEBUGLOG(2, "first part (extDict) is %zu bytes long", length1);
             memmove(oLitEnd, match, length1);
             op = oLitEnd + length1;
             sequence.matchLength -= length1;
-            DEBUGLOG(2, "second part (prefix) is %zu bytes long", sequence.matchLength);
             match = prefixStart;
-            DEBUGLOG(2, "first byte of 2nd part : %02X", *prefixStart);
             if (op > oend_w || sequence.matchLength < MINMATCH) {
               U32 i;
               for (i = 0; i < sequence.matchLength; ++i) op[i] = match[i];

--- a/tests/poolTests.c
+++ b/tests/poolTests.c
@@ -121,8 +121,7 @@ static int testThreadReduction_internal(POOL_ctx* ctx, poolTest_t test)
     ZSTD_pthread_mutex_unlock(&test.mut);
     time4threads = UTIL_clockSpanNano(startTime);
 
-    ctx = POOL_resize(ctx, 2/*nbThreads*/);
-    ASSERT_TRUE(ctx);
+    ASSERT_EQ( POOL_resize(ctx, 2/*nbThreads*/) , 0 );
     test.val = 0;
     startTime = UTIL_getTime();
     {   int i;
@@ -142,7 +141,7 @@ static int testThreadReduction_internal(POOL_ctx* ctx, poolTest_t test)
 static int testThreadReduction(void) {
     int result;
     poolTest_t test;
-    POOL_ctx* ctx = POOL_create(4 /*nbThreads*/, 2 /*queueSize*/);
+    POOL_ctx* const ctx = POOL_create(4 /*nbThreads*/, 2 /*queueSize*/);
 
     ASSERT_TRUE(ctx);
 
@@ -179,7 +178,7 @@ static int testAbruptEnding_internal(abruptEndCanary_t test)
 {
     int const nbWaits = 16;
 
-    POOL_ctx* ctx = POOL_create(3 /*numThreads*/, nbWaits /*queueSize*/);
+    POOL_ctx* const ctx = POOL_create(3 /*numThreads*/, nbWaits /*queueSize*/);
     ASSERT_TRUE(ctx);
     test.val = 0;
 
@@ -187,7 +186,7 @@ static int testAbruptEnding_internal(abruptEndCanary_t test)
         for (i=0; i<nbWaits; i++)
             POOL_add(ctx, &waitIncFn, &test);  /* all jobs pushed into queue */
     }
-    ctx = POOL_resize(ctx, 1 /*numThreads*/);   /* downsize numThreads, to try to break end condition */
+    ASSERT_EQ( POOL_resize(ctx, 1 /*numThreads*/) , 0 );   /* downsize numThreads, to try to break end condition */
 
     POOL_free(ctx);  /* must finish all jobs in queue before giving back control */
     ASSERT_EQ(test.val, nbWaits);

--- a/tests/poolTests.c
+++ b/tests/poolTests.c
@@ -15,11 +15,11 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#define ASSERT_TRUE(p)                                                         \
-  do {                                                                         \
-    if (!(p)) {                                                                \
-      return 1;                                                                \
-    }                                                                          \
+#define ASSERT_TRUE(p)                                                       \
+  do {                                                                       \
+    if (!(p)) {                                                              \
+      return 1;                                                              \
+    }                                                                        \
   } while (0)
 #define ASSERT_FALSE(p) ASSERT_TRUE(!(p))
 #define ASSERT_EQ(lhs, rhs) ASSERT_TRUE((lhs) == (rhs))
@@ -32,10 +32,10 @@ struct data {
 
 void fn(void *opaque) {
   struct data *data = (struct data *)opaque;
-  pthread_mutex_lock(&data->mutex);
+  ZSTD_pthread_mutex_lock(&data->mutex);
   data->data[data->i] = data->i;
   ++data->i;
-  pthread_mutex_unlock(&data->mutex);
+  ZSTD_pthread_mutex_unlock(&data->mutex);
 }
 
 int testOrder(size_t numThreads, size_t queueSize) {
@@ -43,24 +43,25 @@ int testOrder(size_t numThreads, size_t queueSize) {
   POOL_ctx *ctx = POOL_create(numThreads, queueSize);
   ASSERT_TRUE(ctx);
   data.i = 0;
-  pthread_mutex_init(&data.mutex, NULL);
-  {
-    size_t i;
+  ZSTD_pthread_mutex_init(&data.mutex, NULL);
+  { size_t i;
     for (i = 0; i < 16; ++i) {
       POOL_add(ctx, &fn, &data);
     }
   }
   POOL_free(ctx);
   ASSERT_EQ(16, data.i);
-  {
-    size_t i;
+  { size_t i;
     for (i = 0; i < data.i; ++i) {
       ASSERT_EQ(i, data.data[i]);
     }
   }
-  pthread_mutex_destroy(&data.mutex);
+  ZSTD_pthread_mutex_destroy(&data.mutex);
   return 0;
 }
+
+
+/* --- test deadlocks --- */
 
 void waitFn(void *opaque) {
   (void)opaque;
@@ -72,8 +73,7 @@ int testWait(size_t numThreads, size_t queueSize) {
   struct data data;
   POOL_ctx *ctx = POOL_create(numThreads, queueSize);
   ASSERT_TRUE(ctx);
-  {
-    size_t i;
+  { size_t i;
     for (i = 0; i < 16; ++i) {
         POOL_add(ctx, &waitFn, &data);
     }
@@ -82,25 +82,115 @@ int testWait(size_t numThreads, size_t queueSize) {
   return 0;
 }
 
+
+/* --- test POOL_resize() --- */
+
+typedef struct {
+    ZSTD_pthread_mutex_t mut;
+    int val;
+    int max;
+    ZSTD_pthread_cond_t cond;
+} test_t;
+
+void waitLongFn(void *opaque) {
+  test_t* test = (test_t*) opaque;
+  UTIL_sleepMilli(10);
+  ZSTD_pthread_mutex_lock(&test->mut);
+  test->val = test->val + 1;
+  if (test->val == test->max)
+    ZSTD_pthread_cond_signal(&test->cond);
+  ZSTD_pthread_mutex_unlock(&test->mut);
+}
+
+static int testThreadReduction_internal(POOL_ctx* ctx, test_t test)
+{
+    int const nbWaits = 16;
+    UTIL_time_t startTime, time4threads, time2threads;
+
+    test.val = 0;
+    test.max = nbWaits;
+
+    startTime = UTIL_getTime();
+    {   int i;
+        for (i=0; i<nbWaits; i++)
+            POOL_add(ctx, &waitLongFn, &test);
+    }
+    ZSTD_pthread_mutex_lock(&test.mut);
+    ZSTD_pthread_cond_wait(&test.cond, &test.mut);
+    ASSERT_TRUE(test.val == nbWaits);
+    ZSTD_pthread_mutex_unlock(&test.mut);
+    time4threads = UTIL_clockSpanNano(startTime);
+
+    ctx = POOL_resize(ctx, 2/*nbThreads*/);
+    ASSERT_TRUE(ctx);
+    test.val = 0;
+    startTime = UTIL_getTime();
+    {   int i;
+        for (i=0; i<nbWaits; i++)
+            POOL_add(ctx, &waitLongFn, &test);
+    }
+    ZSTD_pthread_mutex_lock(&test.mut);
+    ZSTD_pthread_cond_wait(&test.cond, &test.mut);
+    ASSERT_TRUE(test.val == nbWaits);
+    ZSTD_pthread_mutex_unlock(&test.mut);
+    time2threads = UTIL_clockSpanNano(startTime);
+
+    if (time4threads >= time2threads) return 1;   /* check 4 threads were effectively faster than 2 */
+    return 0;
+}
+
+static int testThreadReduction(void) {
+    int result;
+    test_t test;
+    POOL_ctx* ctx = POOL_create(4 /*nbThreads*/, 2 /*queueSize*/);
+
+    ASSERT_TRUE(ctx);
+
+    memset(&test, 0, sizeof(test));
+    ASSERT_FALSE( ZSTD_pthread_mutex_init(&test.mut, NULL) );
+    ASSERT_FALSE( ZSTD_pthread_cond_init(&test.cond, NULL) );
+
+    result = testThreadReduction_internal(ctx, test);
+
+    ZSTD_pthread_mutex_destroy(&test.mut);
+    ZSTD_pthread_cond_destroy(&test.cond);
+    POOL_free(ctx);
+    return result;
+}
+
+
+/* --- test launcher --- */
+
 int main(int argc, const char **argv) {
   size_t numThreads;
+  (void)argc;
+  (void)argv;
+
+  if (POOL_create(0, 1)) {   /* should not be possible */
+    printf("FAIL: should not create POOL with 0 threads\n");
+    return 1;
+  }
+
   for (numThreads = 1; numThreads <= 4; ++numThreads) {
     size_t queueSize;
     for (queueSize = 0; queueSize <= 2; ++queueSize) {
+      printf("queueSize==%u, numThreads=%u \n",
+            (unsigned)queueSize, (unsigned)numThreads);
       if (testOrder(numThreads, queueSize)) {
         printf("FAIL: testOrder\n");
         return 1;
       }
+      printf("SUCCESS: testOrder\n");
       if (testWait(numThreads, queueSize)) {
         printf("FAIL: testWait\n");
         return 1;
       }
+      printf("SUCCESS: testWait\n");
     }
   }
-  printf("PASS: testOrder\n");
-  (void)argc;
-  (void)argv;
-  return (POOL_create(0, 1)) ? printf("FAIL: testInvalid\n"), 1
-                             : printf("PASS: testInvalid\n"), 0;
+
+  if (testThreadReduction()) return 1;
+  printf("PASS: all POOL tests\n");
+
   return 0;
 }

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1643,13 +1643,13 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest, double 
             DISPLAYLEVEL(5, "Creating new context \n");
             ZSTD_freeCCtx(zc);
             zc = ZSTD_createCCtx();
-            CHECK(zc==NULL, "ZSTD_createCCtx allocation error");
-            resetAllowed=0;
+            CHECK(zc == NULL, "ZSTD_createCCtx allocation error");
+            resetAllowed = 0;
         }
         if ((FUZ_rand(&lseed) & 0xFF) == 132) {
             ZSTD_freeDStream(zd);
             zd = ZSTD_createDStream();
-            CHECK(zd==NULL, "ZSTD_createDStream allocation error");
+            CHECK(zd == NULL, "ZSTD_createDStream allocation error");
             ZSTD_initDStream_usingDict(zd, NULL, 0);  /* ensure at least one init */
         }
 


### PR DESCRIPTION
This patch makes `POOL_ctx` resizable.
Up to now, when number of threads was changed, it was only possible to `free` and then `create` a new `POOL_ctx`.

This capability, combined with a few more resizable structures inside `ZSTDMT`, dramatically reduces the number of threads created in situation where the number of requested threads frequently changes,
which is the case with `zstreamtest --newapi`.

The expected benefits are :
- thread sanitizer : this test max out pretty quickly when the nb of threads created becomes large. It stops on reaching a limit. The limit should now be a lesser problem.
- less flaky qemu ARM test : we regularly have random crashes when testing ARM with qemu, but specifically during test of `zstreamtest --newapi`. This behavior is suspected related to the high number of created and destroyed threads during this test. This patch reducing the number of thread creation / destruction, it's expected to have a positive impact on qemu ARM test, making them more stable.

As a reference point, running ~3000 tests with `zstreamtest --newapi` used to create ~2000 threads, it now only creates ~50 threads, a 40x reduction.
The test continues creating threads even with this patch because, on top of regularly changing the nb of threads, it also free / create CCtx randomly. In order to reduce the nb of created threads even more, it would be enough to reduce the probability to free / create CCtx.