### PR TITLE
Increase threshold detection of poorly compressible data

### DIFF
--- a/lib/compress/huf_compress.c
+++ b/lib/compress/huf_compress.c
@@ -670,7 +670,7 @@ static size_t HUF_compress_internal (
     /* Scan input and build symbol stats */
     {   CHECK_V_F(largest, HIST_count_wksp (table->count, &maxSymbolValue, (const BYTE*)src, srcSize, table->count) );
         if (largest == srcSize) { *ostart = ((const BYTE*)src)[0]; return 1; }   /* single symbol, rle */
-        if (largest <= (srcSize >> 7)+1) return 0;   /* heuristic : probably not compressible enough */
+        if (largest <= (srcSize >> 7)+4) return 0;   /* heuristic : probably not compressible enough */
     }
 
     /* Check validity of previous table */


### PR DESCRIPTION
for huffman compression.

It's a minor but impactful change.
When data is not compressible, it's not worth spending cpu time trying to compress it just to discard the result afterwards.

The heuristics `largest <= (srcSize >> 7)` works relatively well, but mostly for "large enough" data.

When data is small (for example ~1KB, typical for network packets), there are natural irregularity in a random source, which guarantee that the most frequent symbol will be `> (srcSize >> 8)`, to the point of being fairly close to current threshold.

Actually, measurements show that, for a small `srcSize`, a majority of distributions satisfy the condition. As a consequence, huffman compression is uselessly attempted. 
Any compression triggers a fixed cost, in the form of creating a huffman table, which itself requires sorting symbols by frequency, which is very costly for a random source.

Long story short : the new heuristics cut through a majority of this bad cases, saving substantial cpu:

```
./zstd -b -B1300 noiseFile
before : 85 MB/s, HUF_sort ~45% of cpu
after : 230 MB/s, HUF_sort ~4% of cpu
```