### PR TITLE
Error code on no forward progress

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -66,6 +66,9 @@ static UTIL_time_t g_displayClock = UTIL_TIME_INITIALIZER;
             if (g_displayLevel>=4) fflush(stderr); } }
 
 
+/*-*******************************************************
+*  Compile time test
+*********************************************************/
 #undef MIN
 #undef MAX
 void FUZ_bug976(void)
@@ -73,6 +76,7 @@ void FUZ_bug976(void)
     assert(ZSTD_HASHLOG_MAX < 31);
     assert(ZSTD_CHAINLOG_MAX < 31);
 }
+
 
 /*-*******************************************************
 *  Internal functions


### PR DESCRIPTION
Streaming decoders, such as `ZSTD_decompressStream()` or `ZSTD_decompress_generic()`,
may end up making no forward progress,
(aka no byte read from input __and__ no byte written to output),
due to unusual parameters conditions,
such as providing an output buffer already full.

In such case, the caller may be caught in an infinite loop,
calling the streaming decompression function again and again,
without making any progress.

This version detects such situation, and generates an error instead :
`ZSTD_error_dstSize_tooSmall` when output buffer is full,
`ZSTD_error_srcSize_wrong` when input buffer is empty.

The detection tolerates a number of attempts before triggering an error,
controlled by `ZSTD_NO_FORWARD_PROGRESS_MAX` macro constant,
which is set to 16 by default, and can be re-defined at compilation time.
This behavior tolerates potentially existing implementations
where such cases happen sporadically, like once or twice,
which is not dangerous (only infinite loops are),
without generating an error, hence without breaking these implementations.

added: corresponding test case.