### PR TITLE
re-enable arm64 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,7 @@ matrix:
     - env: Cmd='make valgrindinstall && make -C tests clean valgrindTest'
 
     - env: Cmd='make arminstall && make armfuzz'
-
-# Following test is disabled, as there is a bug in Travis' ld
-# preventing aarch64 compilation to complete.
-# > collect2: error: ld terminated with signal 11 [Segmentation fault], core dumped
-# to be re-enabled in a few commit, as it's possible that a random code change circumvent the ld bug
-#    - env: Cmd='make arminstall && make aarch64fuzz'
+    - env: Cmd='make arminstall && make aarch64fuzz'
 
     - env: Cmd='make ppcinstall && make ppcfuzz'
     - env: Cmd='make ppcinstall && make ppc64fuzz'


### PR DESCRIPTION
arm64 tests have been failing recently
due to some strange bug in `ld` after travis CI updated `ld` version for arm64.

Just attempting to re-enable arm64 tests, see if they work correctly again