### PR TITLE
Allow Invoking `zstd --list` When `stdin` is not a `tty`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 matrix:
   include:
     # Ubuntu 14.04
-    - env: Cmd='make gcc6install && CC=gcc-6 make -j all && make clean && CC=gcc-6 make clean uasan-test-zstd'
+    - env: Cmd='make gcc6install && CC=gcc-6 make -j all && make clean && CC=gcc-6 make clean uasan-test-zstd </dev/null' # also test when stdin is not a tty
     - env: Cmd='make gcc6install libc6install && CC=gcc-6 make clean uasan-test-zstd32'
     - env: Cmd='make gcc7install && CC=gcc-7 make clean uasan-test-zstd'
     - env: Cmd='make clang38install && CC=clang-3.8 make clean msan-test-zstd'

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2017,21 +2017,25 @@ static int FIO_listFile(fileInfo_t* total, const char* inFileName, int displayLe
 }
 
 int FIO_listMultipleFiles(unsigned numFiles, const char** filenameTable, int displayLevel){
-
-    if (!IS_CONSOLE(stdin)) {
-        DISPLAYOUT("zstd: --list does not support reading from standard input\n");
-        return 1;
+    unsigned u;
+    for (u=0; u<numFiles;u++) {
+        if (!strcmp (filenameTable[u], stdinmark)) {
+            DISPLAYOUT("zstd: --list does not support reading from standard input\n");
+            return 1;
+        }
     }
 
     if (numFiles == 0) {
+        if (!IS_CONSOLE(stdin)) {
+            DISPLAYOUT("zstd: --list does not support reading from standard input\n");
+        }
         DISPLAYOUT("No files given\n");
-        return 0;
+        return 1;
     }
     if (displayLevel <= 2) {
         DISPLAYOUT("Frames  Skips  Compressed  Uncompressed  Ratio  Check  Filename\n");
     }
     {   int error = 0;
-        unsigned u;
         fileInfo_t total;
         memset(&total, 0, sizeof(total));
         total.usesCheck = 1;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -731,8 +731,14 @@ $ECHO "\n===>  zstd --list/-l error detection tests "
 ! $ZSTD -lv tmp1*
 ! $ZSTD --list -v tmp2 tmp12.zst
 
-$ECHO "\n===>  zstd --list/-l exits 1 when stdin is piped in"
-! echo "piped STDIN" | $ZSTD --list
+$ECHO "\n===>  zstd --list/-l errors when presented with stdin / no files"
+! $ZSTD -l
+! $ZSTD -l -
+! $ZSTD -l < tmp1.zst
+! $ZSTD -l - < tmp1.zst
+! $ZSTD -l - tmp1.zst
+! $ZSTD -l - tmp1.zst < tmp1.zst
+$ZSTD -l tmp1.zst < tmp1.zst # but doesn't error just because stdin is not a tty
 
 $ECHO "\n===>  zstd --list/-l test with null files "
 ./datagen -g0 > tmp5


### PR DESCRIPTION
Also now returns an error when no inputs are given.

New proposed behavior:

```
felix@odin:~/prog/zstd (list-stdin-check)$ ./zstd -l; echo $?
No files given
1
felix@odin:~/prog/zstd (list-stdin-check)$ ./zstd -l Makefile.zst; echo $?
Frames  Skips  Compressed  Uncompressed  Ratio  Check  Filename
     1      0     3.08 KB      10.92 KB  3.544  XXH64  Makefile.zst
0
felix@odin:~/prog/zstd (list-stdin-check)$ ./zstd -l <Makefile.zst; echo $?
zstd: --list does not support reading from standard input
No files given
1
felix@odin:~/prog/zstd (list-stdin-check)$ ./zstd -l Makefile.zst <Makefile.zst; echo $?
Frames  Skips  Compressed  Uncompressed  Ratio  Check  Filename
     1      0     3.08 KB      10.92 KB  3.544  XXH64  Makefile.zst
0
felix@odin:~/prog/zstd (list-stdin-check)$
```