### PR TITLE
2 separate issues found when running zstd's tests on OpenBSD

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -548,16 +548,16 @@ $ZSTD --format=xz -V || LZMAMODE=0
 if [ $LZMAMODE -eq 1 ]; then
     $ECHO "xz support detected"
     XZEXE=1
-    xz -V && lzma -V || XZEXE=0
+    xz -Q -V && lzma -Q -V || XZEXE=0
     if [ $XZEXE -eq 1 ]; then
         $ECHO "Testing zstd xz and lzma support"
         ./datagen > tmp
         $ZSTD --format=lzma -f tmp
         $ZSTD --format=xz -f tmp
-        xz -t -v tmp.xz
-        xz -t -v tmp.lzma
-        xz -f -k tmp
-        lzma -f -k --lzma1 tmp
+        xz -Q -t -v tmp.xz
+        xz -Q -t -v tmp.lzma
+        xz -Q -f -k tmp
+        lzma -Q -f -k --lzma1 tmp
         $ZSTD -d -f -v tmp.xz
         $ZSTD -d -f -v tmp.lzma
         rm tmp*
@@ -569,13 +569,13 @@ if [ $LZMAMODE -eq 1 ]; then
         $ECHO "Testing xz and lzma symlinks"
         ./datagen > tmp
         ./xz tmp
-        xz -d tmp.xz
+        xz -Q -d tmp.xz
         ./lzma tmp
-        lzma -d tmp.lzma
+        lzma -Q -d tmp.lzma
         $ECHO "Testing unxz and unlzma symlinks"
-        xz tmp
+        xz -Q tmp
         ./xz -d tmp.xz
-        lzma tmp
+        lzma -Q tmp
         ./lzma -d tmp.lzma
         rm xz unxz lzma unlzma
         rm tmp*

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -48,6 +48,8 @@ fileRoundTripTest() {
     $DIFF -q tmp.md5.1 tmp.md5.2
 }
 
+UNAME=$(uname)
+
 isTerminal=false
 if [ -t 0 ] && [ -t 1 ]
 then
@@ -56,7 +58,10 @@ fi
 
 isWindows=false
 INTOVOID="/dev/null"
-DEVDEVICE="/dev/random"
+case "$UNAME" in
+  OpenBSD) DEVDEVICE="/dev/zero" ;;
+  *) DEVDEVICE="/dev/random" ;;
+esac
 case "$OS" in
   Windows*)
     isWindows=true
@@ -65,7 +70,6 @@ case "$OS" in
     ;;
 esac
 
-UNAME=$(uname)
 case "$UNAME" in
   Darwin) MD5SUM="md5 -r" ;;
   FreeBSD) MD5SUM="gmd5sum" ;;


### PR DESCRIPTION
1.) OpenBSD is unable to write to /dev/zero

#1124 fixes an issue with GNU/Hurd being unable to write to /dev/zero. Implemented fix is writing to /dev/random instead.

On OpenBSD a regular user is unable to write to /dev/random because of permissions set on this device. Result is failing a regression test.

Proposed solution should work for all platforms.

2.) xz/lzma warning causes test to fail
    
OpenBSD's port building infrastructure is able to build in a privilege separated mode. It uses a privilege drop model. Regression tests fail in this mode as xz/lzma is unable to set file group and errors out with:
    
```
xz: tmp.xz: Cannot set the file group: Operation not permitted
gmake[1]: *** [Makefile:307: zstd-playTests] Error 2
```

Actually it is not a xz/lzma error but a warning causing zstd's regression test to fail. Proposed fix is to have xz/lzma not set the exit status to 2 even if a condition worth a warning was detected (-Q flag).