### PR TITLE
add build macro NO_PREFETCH

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -88,15 +88,20 @@
   #endif
 #endif
 
-/* prefetch */
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  /* _mm_prefetch() is not defined outside of x86/x64 */
-#  include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
-#  define PREFETCH(ptr)   _mm_prefetch((const char*)ptr, _MM_HINT_T0)
-#elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
-#  define PREFETCH(ptr)   __builtin_prefetch(ptr, 0, 0)
-#else
+/* prefetch
+ * can be disabled, by declaring NO_PREFETCH macro */
+#if defined(NO_PREFETCH)
 #  define PREFETCH(ptr)   /* disabled */
-#endif
+#else
+#  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  /* _mm_prefetch() is not defined outside of x86/x64 */
+#    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
+#    define PREFETCH(ptr)   _mm_prefetch((const char*)ptr, _MM_HINT_T0)
+#  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
+#    define PREFETCH(ptr)   __builtin_prefetch(ptr, 0, 0)
+#  else
+#    define PREFETCH(ptr)   /* disabled */
+#  endif
+#endif  /* NO_PREFETCH */
 
 /* disable warnings */
 #ifdef _MSC_VER    /* Visual Studio */


### PR DESCRIPTION
prevent usage of prefetch intrinsic commands
which are not supported by `c2rust`
(see https://github.com/immunant/c2rust/issues/13)