### PR TITLE
Added premake4/GENie script to contrib folder

### DIFF
--- a/contrib/premake/premake4.lua
+++ b/contrib/premake/premake4.lua
@@ -1,0 +1,6 @@
+-- Include zstd.lua in your GENie or premake4 file, which exposes a project_zstd function
+dofile('zstd.lua')
+
+solution 'example'
+	configurations { 'Debug', 'Release' }
+	project_zstd('../../lib/')

--- a/contrib/premake/zstd.lua
+++ b/contrib/premake/zstd.lua
@@ -1,0 +1,79 @@
+-- This GENie/premake file copies the behavior of the Makefile in the lib folder.
+-- Basic usage: project_zstd(ZSTD_DIR)
+
+function project_zstd(dir, compression, decompression, deprecated, dictbuilder, legacy)
+	if compression == nil then compression = true end
+	if decompression == nil then decompression = true end
+	if deprecated == nil then deprecated = false end
+	if dictbuilder == nil then dictbuilder = false end
+
+	if legacy == nil then legacy = 0 end
+
+	if compression then
+		dictbuilder = false
+		deprecated = false
+	end
+
+	if decompression then
+		legacy = 0
+		deprecated = false
+	end
+
+	project 'zstd'
+		kind 'StaticLib'
+		language 'C'
+
+		files {
+			dir .. 'zstd.h',
+			dir .. 'common/**.c',
+			dir .. 'common/**.h'
+		}
+
+		if compression then
+			files {
+				dir .. 'compress/**.c',
+				dir .. 'compress/**.h'
+			}
+		end
+
+		if decompression then
+			files {
+				dir .. 'decompress/**.c',
+				dir .. 'decompress/**.h'
+			}
+		end
+
+		if dictbuilder then
+			files {
+				dir .. 'dictBuilder/**.c',
+				dir .. 'dictBuilder/**.h'
+			}
+		end
+
+		if deprecated then
+			files {
+				dir .. 'deprecated/**.c',
+				dir .. 'deprecated/**.h'
+			}
+		end
+
+		if legacy < 8 then
+			files {
+				dir .. 'legacy/zstd_v0' .. (legacy - 7) .. '.*'
+			}
+		else
+			includedirs {
+				dir .. 'legacy'
+			}
+		end
+
+		includedirs {
+			dir,
+			dir .. 'common'
+		}
+
+		defines {
+			'XXH_NAMESPACE=ZSTD_',
+			'ZSTD_LEGACY_SUPPORT=' .. legacy
+		}
+end


### PR DESCRIPTION
This adds support for premake4 and [GENie](https://github.com/bkaradzic/GENie) as earlier mentioned in #1231.

* `zstd.lua`: contains the function for adding the project to a solution.
* `premake4.lua`: example build script which will build the zstd library.

Tested on Windows (GENie) & MacOS (GENie and premake4).