### PR TITLE
tests: use /dev/zero instead of /dev/random on all systems except GNU/Hurd

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -59,8 +59,8 @@ fi
 isWindows=false
 INTOVOID="/dev/null"
 case "$UNAME" in
-  OpenBSD) DEVDEVICE="/dev/zero" ;;
-  *) DEVDEVICE="/dev/random" ;;
+  GNU) DEVDEVICE="/dev/random" ;;
+  *) DEVDEVICE="/dev/zero" ;;
 esac
 case "$OS" in
   Windows*)


### PR DESCRIPTION
https://github.com/facebook/zstd/pull/1124 broke the test suite
on Linux.  Looks like GNU/Hurd is the only operating system where
/dev/random is available for writing by unprivileged processes.

https://github.com/facebook/zstd/pull/1222 reverted the change
introduced by https://github.com/facebook/zstd/pull/1124 for OpenBSD
only, other operating systems need that change to be reverted, too.

Fixes: 2dde9d5abaad ("Write to /dev/random for test")
Complements: 276988f7948d ("OpenBSD is unable to write to /dev/zero")