### PR TITLE
Add splitLimit to COVER

### DIFF
--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -565,13 +565,15 @@ static int COVER_ctx_init(COVER_ctx_t *ctx, const void *samplesBuffer,
   /* Split samples into testing and training sets */
   unsigned nbTrainSamples = splitPoint < 1.0 ? (unsigned)((double)nbSamples * splitPoint) : nbSamples;
   size_t trainingSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes, nbTrainSamples) : totalSamplesSize;
+  unsigned nbTestSamples;
+  size_t testSamplesSize;
   /* recalculate number of training samples if size is greater than splitLimit */
   if (trainingSamplesSize > splitLimit) {
     nbTrainSamples = COVER_computeNewNbSamples(samplesSizes, nbSamples, splitLimit);
     trainingSamplesSize = COVER_sum(samplesSizes, nbTrainSamples);
   }
-  unsigned nbTestSamples = splitPoint < 1.0 ? nbSamples - nbTrainSamples : nbTrainSamples;
-  size_t testSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes + nbTrainSamples, nbTestSamples) : trainingSamplesSize;
+  nbTestSamples = splitPoint < 1.0 ? nbSamples - nbTrainSamples : nbTrainSamples;
+  testSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes + nbTrainSamples, nbTestSamples) : trainingSamplesSize;
   /* Checks */
   if (totalSamplesSize < MAX(d, sizeof(U64)) ||
       totalSamplesSize >= (size_t)COVER_MAX_SAMPLES_SIZE) {

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -941,7 +941,7 @@ static void COVER_tryParameters(void *opaque) {
     /* Local variables */
     size_t dstCapacity;
     size_t i;
-    unsigned maxNbSamples = parameters.splitPoint < 1.0 ? ctx->nbSamples : ctx->nbTestSamples;
+    const size_t maxNbSamples = parameters.splitPoint < 1.0 ? ctx->nbSamples : ctx->nbTestSamples;
     /* Allocate dst with enough space to compress the maximum sized sample */
     {
       size_t maxSampleSize = 0;

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -501,6 +501,10 @@ static int COVER_checkParameters(ZDICT_cover_params_t parameters,
   if (parameters.splitPoint <= 0 || parameters.splitPoint > 1){
     return 0;
   }
+  /* 0 < splitLimit */
+  if (parameters.splitLimit == 0){
+    return 0;
+  }
   return 1;
 }
 
@@ -530,6 +534,23 @@ static void COVER_ctx_destroy(COVER_ctx_t *ctx) {
 }
 
 /**
+ * Recalculate number of training samples given splitLimit
+ */
+static unsigned COVER_computeNewNbSamples(const size_t *sampleSizes,
+                                        unsigned nbSamples, size_t splitLimit) {
+  unsigned i = 0;
+  size_t totalSize = 0;
+  for (i = 0; i < nbSamples; i++) {
+    totalSize += sampleSizes[i];
+    /* If adding this sample will exceed splitLimit, return index of this sample */
+    if (totalSize > splitLimit) {
+      break;
+    }
+  }
+  return i;
+}
+
+/**
  * Prepare a context for dictionary building.
  * The context is only dependent on the parameter `d` and can used multiple
  * times.
@@ -538,14 +559,19 @@ static void COVER_ctx_destroy(COVER_ctx_t *ctx) {
  */
 static int COVER_ctx_init(COVER_ctx_t *ctx, const void *samplesBuffer,
                           const size_t *samplesSizes, unsigned nbSamples,
-                          unsigned d, double splitPoint) {
+                          unsigned d, double splitPoint, size_t splitLimit) {
   const BYTE *const samples = (const BYTE *)samplesBuffer;
   const size_t totalSamplesSize = COVER_sum(samplesSizes, nbSamples);
   /* Split samples into testing and training sets */
-  const unsigned nbTrainSamples = splitPoint < 1.0 ? (unsigned)((double)nbSamples * splitPoint) : nbSamples;
-  const unsigned nbTestSamples = splitPoint < 1.0 ? nbSamples - nbTrainSamples : nbSamples;
-  const size_t trainingSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes, nbTrainSamples) : totalSamplesSize;
-  const size_t testSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes + nbTrainSamples, nbTestSamples) : totalSamplesSize;
+  unsigned nbTrainSamples = splitPoint < 1.0 ? (unsigned)((double)nbSamples * splitPoint) : nbSamples;
+  size_t trainingSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes, nbTrainSamples) : totalSamplesSize;
+  /* recalculate number of training samples if size is greater than splitLimit */
+  if (trainingSamplesSize > splitLimit) {
+    nbTrainSamples = COVER_computeNewNbSamples(samplesSizes, nbSamples, splitLimit);
+    trainingSamplesSize = COVER_sum(samplesSizes, nbTrainSamples);
+  }
+  unsigned nbTestSamples = splitPoint < 1.0 ? nbSamples - nbTrainSamples : nbTrainSamples;
+  size_t testSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes + nbTrainSamples, nbTestSamples) : trainingSamplesSize;
   /* Checks */
   if (totalSamplesSize < MAX(d, sizeof(U64)) ||
       totalSamplesSize >= (size_t)COVER_MAX_SAMPLES_SIZE) {
@@ -692,6 +718,7 @@ ZDICTLIB_API size_t ZDICT_trainFromBuffer_cover(
   COVER_ctx_t ctx;
   COVER_map_t activeDmers;
   parameters.splitPoint = 1.0;
+  parameters.splitLimit = 512 * dictBufferCapacity;
   /* Initialize global data */
   g_displayLevel = parameters.zParams.notificationLevel;
   /* Checks */
@@ -710,7 +737,7 @@ ZDICTLIB_API size_t ZDICT_trainFromBuffer_cover(
   }
   /* Initialize context and activeDmers */
   if (!COVER_ctx_init(&ctx, samplesBuffer, samplesSizes, nbSamples,
-                      parameters.d, parameters.splitPoint)) {
+                      parameters.d, parameters.splitPoint, parameters.splitLimit)) {
     return ERROR(GENERIC);
   }
   if (!COVER_map_init(&activeDmers, parameters.k - parameters.d + 1)) {
@@ -912,11 +939,12 @@ static void COVER_tryParameters(void *opaque) {
     /* Local variables */
     size_t dstCapacity;
     size_t i;
+    unsigned maxNbSamples = parameters.splitPoint < 1.0 ? ctx->nbSamples : ctx->nbTestSamples;
     /* Allocate dst with enough space to compress the maximum sized sample */
     {
       size_t maxSampleSize = 0;
       i = parameters.splitPoint < 1.0 ? ctx->nbTrainSamples : 0;
-      for (; i < ctx->nbSamples; ++i) {
+      for (; i < maxNbSamples; ++i) {
         maxSampleSize = MAX(ctx->samplesSizes[i], maxSampleSize);
       }
       dstCapacity = ZSTD_compressBound(maxSampleSize);
@@ -932,7 +960,7 @@ static void COVER_tryParameters(void *opaque) {
     /* Compress each sample and sum their sizes (or error) */
     totalCompressedSize = dictBufferCapacity;
     i = parameters.splitPoint < 1.0 ? ctx->nbTrainSamples : 0;
-    for (; i < ctx->nbSamples; ++i) {
+    for (; i < maxNbSamples; ++i) {
       const size_t size = ZSTD_compress_usingCDict(
           cctx, dst, dstCapacity, ctx->samples + ctx->offsets[i],
           ctx->samplesSizes[i], cdict);
@@ -971,6 +999,8 @@ ZDICTLIB_API size_t ZDICT_optimizeTrainFromBuffer_cover(
   const unsigned nbThreads = parameters->nbThreads;
   const double splitPoint =
       parameters->splitPoint <= 0.0 ? DEFAULT_SPLITPOINT : parameters->splitPoint;
+  const size_t splitLimit =
+      parameters->splitLimit == 0 ? (512 * dictBufferCapacity) : parameters->splitLimit;
   const unsigned kMinD = parameters->d == 0 ? 6 : parameters->d;
   const unsigned kMaxD = parameters->d == 0 ? 8 : parameters->d;
   const unsigned kMinK = parameters->k == 0 ? 50 : parameters->k;
@@ -988,7 +1018,7 @@ ZDICTLIB_API size_t ZDICT_optimizeTrainFromBuffer_cover(
   POOL_ctx *pool = NULL;
 
   /* Checks */
-  if (splitPoint <= 0 || splitPoint > 1) {
+  if (splitPoint <= 0 || splitPoint > 1 || splitLimit == 0) {
     LOCALDISPLAYLEVEL(displayLevel, 1, "Incorrect parameters\n");
     return ERROR(GENERIC);
   }
@@ -1022,7 +1052,7 @@ ZDICTLIB_API size_t ZDICT_optimizeTrainFromBuffer_cover(
     /* Initialize the context for this value of d */
     COVER_ctx_t ctx;
     LOCALDISPLAYLEVEL(displayLevel, 3, "d=%u\n", d);
-    if (!COVER_ctx_init(&ctx, samplesBuffer, samplesSizes, nbSamples, d, splitPoint)) {
+    if (!COVER_ctx_init(&ctx, samplesBuffer, samplesSizes, nbSamples, d, splitPoint, splitLimit)) {
       LOCALDISPLAYLEVEL(displayLevel, 1, "Failed to initialize context\n");
       COVER_best_destroy(&best);
       POOL_free(pool);
@@ -1048,6 +1078,7 @@ ZDICTLIB_API size_t ZDICT_optimizeTrainFromBuffer_cover(
       data->parameters.k = k;
       data->parameters.d = d;
       data->parameters.splitPoint = splitPoint;
+      data->parameters.splitLimit = splitLimit;
       data->parameters.steps = kSteps;
       data->parameters.zParams.notificationLevel = g_displayLevel;
       /* Check the parameters */

--- a/lib/dictBuilder/zdict.h
+++ b/lib/dictBuilder/zdict.h
@@ -86,8 +86,8 @@ typedef struct {
     unsigned d;                  /* dmer size : constraint: 0 < d <= k : Reasonable range [6, 16] */
     unsigned steps;              /* Number of steps : Only used for optimization : 0 means default (32) : Higher means more parameters checked */
     unsigned nbThreads;          /* Number of threads : constraint: 0 < nbThreads : 1 means single-threaded : Only used for optimization : Ignored if ZSTD_MULTITHREAD is not defined */
-    size_t splitLimit;         /* Maximum number of bytes used for training: 0 means default(512*maxDictSize); minimum of splitLimit and splitPoint used for training */
     double splitPoint;           /* Percentage of samples used for training: the first nbSamples * splitPoint samples will be used to training, the last nbSamples * (1 - splitPoint) samples will be used for testing, 0 means default (1.0), 1.0 when all samples are used for both training and testing */
+    size_t splitLimit;           /* Maximum number of bytes used for training: 0 means default (512 * maxDictSize); minimum of splitLimit and splitPoint used for training */
     ZDICT_params_t zParams;
 } ZDICT_cover_params_t;
 

--- a/lib/dictBuilder/zdict.h
+++ b/lib/dictBuilder/zdict.h
@@ -86,6 +86,7 @@ typedef struct {
     unsigned d;                  /* dmer size : constraint: 0 < d <= k : Reasonable range [6, 16] */
     unsigned steps;              /* Number of steps : Only used for optimization : 0 means default (32) : Higher means more parameters checked */
     unsigned nbThreads;          /* Number of threads : constraint: 0 < nbThreads : 1 means single-threaded : Only used for optimization : Ignored if ZSTD_MULTITHREAD is not defined */
+    size_t splitLimit;         /* Maximum number of bytes used for training: 0 means default(512*maxDictSize); minimum of splitLimit and splitPoint used for training */
     double splitPoint;           /* Percentage of samples used for training: the first nbSamples * splitPoint samples will be used to training, the last nbSamples * (1 - splitPoint) samples will be used for testing, 0 means default (1.0), 1.0 when all samples are used for both training and testing */
     ZDICT_params_t zParams;
 } ZDICT_cover_params_t;

--- a/programs/README.md
+++ b/programs/README.md
@@ -150,7 +150,7 @@ Advanced arguments :
 
 Dictionary builder :
 --train ## : create a dictionary from a training set of files
---train-cover[=k=#,d=#,steps=#,split=#] : use the cover algorithm with optional args
+--train-cover[=k=#,d=#,steps=#,split=#,limit=#] : use the cover algorithm with optional args
 --train-legacy[=s=#] : use the legacy algorithm with selectivity (default: 9)
  -o file : `file` is dictionary name (default: dictionary)
 --maxdict=# : limit dictionary to specified size (default: 112640)

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -324,7 +324,7 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
                                                            coverParams);
             if (!ZDICT_isError(dictSize)) {
                 unsigned splitPercentage = (unsigned)(coverParams->splitPoint * 100);
-                DISPLAYLEVEL(2, "k=%u\nd=%u\nsteps=%u\nsplit=%u\n", coverParams->k, coverParams->d, coverParams->steps, splitPercentage);
+                DISPLAYLEVEL(2, "k=%u\nd=%u\nsteps=%u\nsplit=%u\nlimit=%lu\n", coverParams->k, coverParams->d, coverParams->steps, splitPercentage, coverParams->splitLimit);
             }
         } else {
             dictSize = ZDICT_trainFromBuffer_cover(dictBuffer, maxDictSize, srcBuffer,

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -324,7 +324,7 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
                                                            coverParams);
             if (!ZDICT_isError(dictSize)) {
                 unsigned splitPercentage = (unsigned)(coverParams->splitPoint * 100);
-                DISPLAYLEVEL(2, "k=%u\nd=%u\nsteps=%u\nsplit=%u\nlimit=%lu\n", coverParams->k, coverParams->d, coverParams->steps, splitPercentage, coverParams->splitLimit);
+                DISPLAYLEVEL(2, "k=%u\nd=%u\nsteps=%u\nsplit=%u\nlimit=%u\n", coverParams->k, coverParams->d, coverParams->steps, splitPercentage, (unsigned)coverParams->splitLimit);
             }
         } else {
             dictSize = ZDICT_trainFromBuffer_cover(dictBuffer, maxDictSize, srcBuffer,

--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -218,8 +218,10 @@ A dictionary ID is a locally unique ID that a decoder can use to verify it is us
 .
 .TP
 \fB\-\-train\-cover[=k#,d=#,steps=#,split=#]\fR
-Select parameters for the default dictionary builder algorithm named cover\. If \fId\fR is not specified, then it tries \fId\fR = 6 and \fId\fR = 8\. If \fIk\fR is not specified, then it tries \fIsteps\fR values in the range [50, 2000]\. If \fIsteps\fR is not specified, then the default value of 40 is used\. If \fIsplit\fR is not specified or \fIsplit\fR <= 0, then the default value of 100 is used\. If \fIsplit\fR is 100, all input samples are used for both training and testing
-to find optimal _d_ and _k_ to build dictionary.Requires that \fId\fR <= \fIk\fR\.
+Select parameters for the default dictionary builder algorithm named cover\. If \fId\fR is not specified, then it tries \fId\fR = 6 and \fId\fR = 8\. If \fIk\fR is not specified, then it tries \fIsteps\fR values in the range [50, 2000]\.
+If \fIsteps\fR is not specified, then the default value of 40 is used\. If \fIsplit\fR is not specified or \fIsplit\fR <= 0, then the default value of 100 is used\. If \fIsplit\fR is 100, the same input samples are used for both training and testing
+to find optimal _d_ and _k_ to build dictionary. If \fIlimit\fR is not specified or \fIlimit\fR == 0, then the default value of 512 * maxDictSize is used. If training sample size exceeds \fIlimit\fR, the first i samples summing up to
+\fIlimit\fR are used for training and the rest are used for testing (when \fIsplit\fR is not 100) or the same first i samples are used for testing (when \fIsplit\fR is 100). Requires that \fId\fR <= \fIk\fR\.
 .
 .IP
 Selects segments of size \fIk\fR with highest score to put in the dictionary\. The score of a segment is computed by the sum of the frequencies of all the subsegments of size \fId\fR\. Generally \fId\fR should be in the range [6, 8], occasionally up to 16, but the algorithm will run faster with d <= \fI8\fR\. Good values for \fIk\fR vary widely based on the input data, but a safe range is [2 * \fId\fR, 2000]\. Supports multithreading if \fBzstd\fR is compiled with threading support\.

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -223,12 +223,13 @@ Compression of small files similar to the sample set will be greatly improved.
     This compares favorably to 4 bytes default.
     However, it's up to the dictionary manager to not assign twice the same ID to
     2 different dictionaries.
-* `--train-cover[=k#,d=#,steps=#,split=#]`:
+* `--train-cover[=k#,d=#,steps=#,split=#,limit=#]`:
     Select parameters for the default dictionary builder algorithm named cover.
     If _d_ is not specified, then it tries _d_ = 6 and _d_ = 8.
     If _k_ is not specified, then it tries _steps_ values in the range [50, 2000].
     If _steps_ is not specified, then the default value of 40 is used.
     If _split_ is not specified or split <= 0, then the default value of 100 is used.
+    If _limit_ is not specified or limit == 0, then the default value of 512 * maxDictSize is used.
     Requires that _d_ <= _k_.
 
     Selects segments of size _k_ with highest score to put in the dictionary.
@@ -238,8 +239,11 @@ Compression of small files similar to the sample set will be greatly improved.
     algorithm will run faster with d <= _8_.
     Good values for _k_ vary widely based on the input data, but a safe range is
     [2 * _d_, 2000].
-    If _split_ is 100, all input samples are used for both training and testing
+    If _split_ is 100, the same input samples are used for both training and testing
     to find optimal _d_ and _k_ to build dictionary.
+    If training sample size exceeds _limit_, the first i samples summing up to
+    _limit_ are used for training and the rest are used for testing (when _split_ is not 100)
+    or the same first i samples are used for testing (when _split_ is 100)
     Supports multithreading if `zstd` is compiled with threading support.
 
     Examples:
@@ -252,7 +256,7 @@ Compression of small files similar to the sample set will be greatly improved.
 
     `zstd --train-cover=k=50 FILEs`
 
-    `zstd --train-cover=k=50,split=60 FILEs`
+    `zstd --train-cover=k=50,split=60,limit=524288 FILEs`
 
 * `--train-legacy[=selectivity=#]`:
     Use legacy dictionary builder algorithm with the given dictionary

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -292,7 +292,7 @@ static unsigned parseCoverParameters(const char* stringPtr, ZDICT_cover_params_t
         return 0;
     }
     if (stringPtr[0] != 0) return 0;
-    DISPLAYLEVEL(4, "cover: k=%u\nd=%u\nsteps=%u\nsplit=%u\nlimit=%lu\n", params->k, params->d, params->steps, (unsigned)(params->splitPoint * 100), params->splitLimit);
+    DISPLAYLEVEL(4, "cover: k=%u\nd=%u\nsteps=%u\nsplit=%u\nlimit=%u\n", params->k, params->d, params->steps, (unsigned)(params->splitPoint * 100), (unsigned)params->splitLimit);
     return 1;
 }
 

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -171,7 +171,7 @@ static int usage_advanced(const char* programName)
     DISPLAY( "\n");
     DISPLAY( "Dictionary builder : \n");
     DISPLAY( "--train ## : create a dictionary from a training set of files \n");
-    DISPLAY( "--train-cover[=k=#,d=#,steps=#,split=#] : use the cover algorithm with optional args\n");
+    DISPLAY( "--train-cover[=k=#,d=#,steps=#,split=#, limit=#] : use the cover algorithm with optional args\n");
     DISPLAY( "--train-legacy[=s=#] : use the legacy algorithm with selectivity (default: %u)\n", g_defaultSelectivityLevel);
     DISPLAY( " -o file : `file` is dictionary name (default: %s) \n", g_defaultDictName);
     DISPLAY( "--maxdict=# : limit dictionary to specified size (default: %u) \n", g_defaultMaxDictSize);
@@ -283,6 +283,7 @@ static unsigned parseCoverParameters(const char* stringPtr, ZDICT_cover_params_t
         if (longCommandWArg(&stringPtr, "k=")) { params->k = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "d=")) { params->d = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "steps=")) { params->steps = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "limit=")) { params->splitLimit = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "split=")) {
           unsigned splitPercentage = readU32FromChar(&stringPtr);
           params->splitPoint = (double)splitPercentage / 100.0;
@@ -291,7 +292,7 @@ static unsigned parseCoverParameters(const char* stringPtr, ZDICT_cover_params_t
         return 0;
     }
     if (stringPtr[0] != 0) return 0;
-    DISPLAYLEVEL(4, "cover: k=%u\nd=%u\nsteps=%u\nsplit=%u\n", params->k, params->d, params->steps, (unsigned)(params->splitPoint * 100));
+    DISPLAYLEVEL(4, "cover: k=%u\nd=%u\nsteps=%u\nsplit=%u\nlimit=%lu\n", params->k, params->d, params->steps, (unsigned)(params->splitPoint * 100), params->splitLimit);
     return 1;
 }
 

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -171,7 +171,7 @@ static int usage_advanced(const char* programName)
     DISPLAY( "\n");
     DISPLAY( "Dictionary builder : \n");
     DISPLAY( "--train ## : create a dictionary from a training set of files \n");
-    DISPLAY( "--train-cover[=k=#,d=#,steps=#,split=#, limit=#] : use the cover algorithm with optional args\n");
+    DISPLAY( "--train-cover[=k=#,d=#,steps=#,split=#,limit=#] : use the cover algorithm with optional args\n");
     DISPLAY( "--train-legacy[=s=#] : use the legacy algorithm with selectivity (default: %u)\n", g_defaultSelectivityLevel);
     DISPLAY( " -o file : `file` is dictionary name (default: %s) \n", g_defaultDictName);
     DISPLAY( "--maxdict=# : limit dictionary to specified size (default: %u) \n", g_defaultMaxDictSize);

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -418,7 +418,7 @@ $ECHO "\n===>  cover dictionary builder : advanced options "
 TESTFILE=../programs/zstdcli.c
 ./datagen > tmpDict
 $ECHO "- Create first dictionary"
-$ZSTD --train-cover=k=46,d=8,split=80 *.c ../programs/*.c -o tmpDict
+$ZSTD --train-cover=k=46,d=8,split=80,limit=524288 *.c ../programs/*.c -o tmpDict
 cp $TESTFILE tmp
 $ZSTD -f tmp -D tmpDict
 $ZSTD -d tmp.zst -D tmpDict -fo result


### PR DESCRIPTION
- Size of all training samples cannot exceed splitLimit.
- If splitPoint is 1.0, the same training samples are used for testing
- Otherwise, use remaining samples for testing, which may be more than (1-splitPoint) * 100% of all samples if number of training samples is updated so that total training size is below splitLimit.