### PR TITLE
gcc-8 travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - env: Cmd='make gcc6install libc6install
              && make clean && CC=gcc-6 make -j uasan-test-zstd32'
     - env: Cmd='make gcc7install && make clean && CC=gcc-7 make -j uasan-test-zstd'
-    - env: Cmd='make gcc8install && CC=gcc-8 CFLAGS=-Werror make -j all'
+    - env: Cmd='make gcc8install && CC=gcc-8 CFLAGS="-Werror -O3" make -j all'
     - env: Cmd='make clang38install && CC=clang-3.8 make clean msan-test-zstd'
 
     - env: Cmd='make gcc6install && CC=gcc-6 make clean uasan-fuzztest'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - env: Cmd='make gcc6install libc6install
              && make clean && CC=gcc-6 make -j uasan-test-zstd32'
     - env: Cmd='make gcc7install && make clean && CC=gcc-7 make -j uasan-test-zstd'
+    - env: Cmd='make gcc8install && CC=gcc-8 CFLAGS=-Werror make -j all'
     - env: Cmd='make clang38install && CC=clang-3.8 make clean msan-test-zstd'
 
     - env: Cmd='make gcc6install && CC=gcc-6 make clean uasan-fuzztest'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ matrix:
     # Ubuntu 14.04
     - env: Cmd='make test'
 
-    - env: Cmd='make gcc6install && CC=gcc-6 make -j all
-             && make clean && CC=gcc-6 make clean uasan-test-zstd </dev/null' # also test when stdin is not a tty
-    - env: Cmd='make gcc6install libc6install && CC=gcc-6 make clean uasan-test-zstd32'
-    - env: Cmd='make gcc7install && CC=gcc-7 make clean uasan-test-zstd'
+    - env: Cmd='make gcc6install && CC=gcc-6 CFLAGS=-Werror make -j all
+             && make clean && CC=gcc-6 make -j uasan-test-zstd </dev/null'   # test when stdin is not a tty
+    - env: Cmd='make gcc6install libc6install
+             && make clean && CC=gcc-6 make -j uasan-test-zstd32'
+    - env: Cmd='make gcc7install && make clean && CC=gcc-7 make -j uasan-test-zstd'
     - env: Cmd='make clang38install && CC=clang-3.8 make clean msan-test-zstd'
 
     - env: Cmd='make gcc6install && CC=gcc-6 make clean uasan-fuzztest'

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,9 @@ gcc6install: apt-add-repo
 gcc7install: apt-add-repo
 	APT_PACKAGES="libc6-dev-i386 gcc-multilib gcc-7 gcc-7-multilib" $(MAKE) apt-install
 
+gcc8install: apt-add-repo
+	APT_PACKAGES="libc6-dev-i386 gcc-multilib gcc-8 gcc-8-multilib" $(MAKE) apt-install
+
 gpp6install: apt-add-repo
 	APT_PACKAGES="libc6-dev-i386 g++-multilib gcc-6 g++-6 g++-6-multilib" $(MAKE) apt-install
 


### PR DESCRIPTION
Added gcc-8 tests, ensure warnings break tests

note : currently break, due to existing issues that were not flagged
to be fixed in a separate PR