### PR TITLE
Fixed unsafe string copy and concat in `fileio.c`.

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1011,8 +1011,8 @@ int FIO_compressMultipleFilenames(const char** inFileNamesTable, unsigned nbFile
                 if (!dstFileName) {
                     EXM_THROW(30, "zstd: %s", strerror(errno));
             }   }
-            strcpy(dstFileName, inFileNamesTable[u]);
-            strcat(dstFileName, suffix);
+            strncpy(dstFileName, inFileNamesTable[u], ifnSize+1 /* Include null */);
+            strncat(dstFileName, suffix, suffixSize);
             missed_files += FIO_compressFilename_dstFile(ress, dstFileName, inFileNamesTable[u], compressionLevel);
     }   }
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -26,6 +26,7 @@ invalidDictionaries
 checkTag
 zcat
 zstdcat
+tm
 
 # Tmp test directory
 zstdtest


### PR DESCRIPTION
Per warnings from flawfinder: "Does not check for buffer overflows when
copying to destination [MS-banned] (CWE-120). Consider using snprintf,
strcpy_s, or strlcpy (warning: strncpy easily misused).".

To reproduce warning:
./flawfinder.py ./programs/fileio.c

Replaced called to strcpy and strcat in `fileio.c` to calls with a
specified size (`strncpy` and `strncat`).

Tested the changes on OSX, Linux, Windows.
On OSX + Linux, changes were tested with ASAN. The following flags were
used: 'check_initialization_order=1:strict_init_order=1:detect_odr_violation=1:detect_stack_use_after_return=1'
All test suites were run (`make test`).

On Windows, building was done with visual studio and `fuzzer.c` binary was executed.

Also: added gitigignore entry for test byproduct `tm`.