### PR TITLE
Refactored bench.c

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1322,8 +1322,7 @@ static size_t ZSTD_resetCCtx_usingCDict(ZSTD_CCtx* cctx,
         }
 
         /* copy dictionary offsets */
-        {
-            ZSTD_matchState_t const* srcMatchState = &cdict->matchState;
+        {   ZSTD_matchState_t const* srcMatchState = &cdict->matchState;
             ZSTD_matchState_t* dstMatchState = &cctx->blockState.matchState;
             dstMatchState->window       = srcMatchState->window;
             dstMatchState->nextToUpdate = srcMatchState->nextToUpdate;

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -311,7 +311,7 @@ BMK_runOutcome_t BMK_benchFunction(
             size_t blockCount,
             const void* const * srcBlockBuffers, const size_t* srcBlockSizes,
             void* const * dstBlockBuffers, const size_t* dstBlockCapacities,
-            size_t* blockResult,
+            size_t* blockResults,
             unsigned nbLoops)
 {
     size_t dstSize = 0;
@@ -350,7 +350,7 @@ BMK_runOutcome_t BMK_benchFunction(
                         blockNb, (U32)dstBlockCapacities[blockNb], ZSTD_getErrorName(res));
                 } else if (loopNb == 0) {
                     dstSize += res;
-                    if (blockResult != NULL) blockResult[blockNb] = res;
+                    if (blockResults != NULL) blockResults[blockNb] = res;
                     dstSize += res;
             }   }
         }  /* for (loopNb = 0; loopNb < nbLoops; loopNb++) */

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -507,7 +507,7 @@ BMK_benchResult_t BMK_extract_benchResult(BMK_benchOutcome_t outcome)
     return outcome.internal_never_use_directly;
 }
 
-static BMK_benchOutcome_t BMK_benchOutcome_error()
+static BMK_benchOutcome_t BMK_benchOutcome_error(void)
 {
     BMK_benchOutcome_t b;
     memset(&b, 0, sizeof(b));
@@ -765,7 +765,7 @@ static BMK_benchOutcome_t BMK_benchMemAdvancedNoAlloc(
 BMK_benchOutcome_t BMK_benchMemAdvanced(const void* srcBuffer, size_t srcSize,
                         void* dstBuffer, size_t dstCapacity,
                         const size_t* fileSizes, unsigned nbFiles,
-                        const int cLevel, const ZSTD_compressionParameters* comprParams,
+                        int cLevel, const ZSTD_compressionParameters* comprParams,
                         const void* dictBuffer, size_t dictBufferSize,
                         int displayLevel, const char* displayName, const BMK_advancedParams_t* adv)
 

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -667,7 +667,7 @@ static BMK_benchOutcome_t BMK_benchMemAdvancedNoAlloc(
                     DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f),%6.*f MB/s\r",
                             marks[markNb], displayName, (U32)srcSize, (U32)cSize,
                             ratioAccuracy, ratio,
-                            benchResult.cSpeed < (10 MB) ? 2 : 1, (double)benchResult.cSpeed / (1 MB));
+                            benchResult.cSpeed < (10 MB) ? 2 : 1, (double)benchResult.cSpeed / MB_UNIT);
                 }
             }
 
@@ -695,7 +695,7 @@ static BMK_benchOutcome_t BMK_benchMemAdvancedNoAlloc(
                     DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f),%6.*f MB/s ,%6.1f MB/s \r",
                             marks[markNb], displayName, (U32)srcSize, (U32)benchResult.cSize,
                             ratioAccuracy, ratio,
-                            benchResult.cSpeed < (10 MB) ? 2 : 1, (double)benchResult.cSpeed / (1 MB),
+                            benchResult.cSpeed < (10 MB) ? 2 : 1, (double)benchResult.cSpeed / MB_UNIT,
                             (double)benchResult.dSpeed / (1 MB));
                 }
             }
@@ -742,8 +742,8 @@ static BMK_benchOutcome_t BMK_benchMemAdvancedNoAlloc(
         }   /* CRC Checking */
 
         if (displayLevel == 1) {   /* hidden display mode -q, used by python speed benchmark */
-            double const cSpeed = (double)benchResult.cSpeed / (1 MB);
-            double const dSpeed = (double)benchResult.dSpeed / (1 MB);
+            double const cSpeed = (double)benchResult.cSpeed / MB_UNIT;
+            double const dSpeed = (double)benchResult.dSpeed / MB_UNIT;
             if (adv->additionalParam) {
                 DISPLAY("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s (param=%d)\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName, adv->additionalParam);
             } else {

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -124,8 +124,8 @@ static UTIL_time_t g_displayClock = UTIL_TIME_INITIALIZER;
 *  Benchmark Parameters
 ***************************************/
 
-BMK_advancedParams_t BMK_initAdvancedParams(void) { 
-    BMK_advancedParams_t res = { 
+BMK_advancedParams_t BMK_initAdvancedParams(void) {
+    BMK_advancedParams_t res = {
         BMK_both, /* mode */
         BMK_timeMode, /* loopMode */
         BMK_TIMETEST_DEFAULT_S, /* nbSeconds */
@@ -133,7 +133,7 @@ BMK_advancedParams_t BMK_initAdvancedParams(void) {
         0, /* nbWorkers */
         0, /* realTime */
         0, /* additionalParam */
-        0, /* ldmFlag */ 
+        0, /* ldmFlag */
         0, /* ldmMinMatch */
         0, /* ldmHashLog */
         0, /* ldmBuckSizeLog */
@@ -168,8 +168,8 @@ struct  BMK_timeState_t{
 #define MIN(a,b)    ((a) < (b) ? (a) : (b))
 #define MAX(a,b)    ((a) > (b) ? (a) : (b))
 
-static void BMK_initCCtx(ZSTD_CCtx* ctx, 
-    const void* dictBuffer, size_t dictBufferSize, int cLevel, 
+static void BMK_initCCtx(ZSTD_CCtx* ctx,
+    const void* dictBuffer, size_t dictBufferSize, int cLevel,
     const ZSTD_compressionParameters* comprParams, const BMK_advancedParams_t* adv) {
     ZSTD_CCtx_reset(ctx);
     ZSTD_CCtx_resetParameters(ctx);
@@ -195,7 +195,7 @@ static void BMK_initCCtx(ZSTD_CCtx* ctx,
 }
 
 
-static void BMK_initDCtx(ZSTD_DCtx* dctx, 
+static void BMK_initDCtx(ZSTD_DCtx* dctx,
     const void* dictBuffer, size_t dictBufferSize) {
     ZSTD_DCtx_reset(dctx);
     ZSTD_DCtx_loadDictionary(dctx, dictBuffer, dictBufferSize);
@@ -230,8 +230,8 @@ static size_t local_initDCtx(void* payload) {
 
 /* additional argument is just the context */
 static size_t local_defaultCompress(
-    const void* srcBuffer, size_t srcSize, 
-    void* dstBuffer, size_t dstSize, 
+    const void* srcBuffer, size_t srcSize,
+    void* dstBuffer, size_t dstSize,
     void* addArgs) {
     size_t moreToFlush = 1;
     ZSTD_CCtx* ctx = (ZSTD_CCtx*)addArgs;
@@ -257,8 +257,8 @@ static size_t local_defaultCompress(
 
 /* additional argument is just the context */
 static size_t local_defaultDecompress(
-    const void* srcBuffer, size_t srcSize, 
-    void* dstBuffer, size_t dstSize, 
+    const void* srcBuffer, size_t srcSize,
+    void* dstBuffer, size_t dstSize,
     void* addArgs) {
     size_t moreToFlush = 1;
     ZSTD_DCtx* dctx = (ZSTD_DCtx*)addArgs;
@@ -294,7 +294,7 @@ BMK_customReturn_t BMK_benchFunction(
     BMK_initFn_t initFn, void* initPayload,
     size_t blockCount,
     const void* const * const srcBlockBuffers, const size_t* srcBlockSizes,
-    void* const * const dstBlockBuffers, const size_t* dstBlockCapacities, size_t* blockResult, 
+    void* const * const dstBlockBuffers, const size_t* dstBlockCapacities, size_t* blockResult,
     unsigned nbLoops) {
     size_t dstSize = 0;
     U64 totalTime;
@@ -312,15 +312,15 @@ BMK_customReturn_t BMK_benchFunction(
             memset(dstBlockBuffers[i], 0xE5, dstBlockCapacities[i]);  /* warm up and erase result buffer */
         }
 #if 0
-        /* based on testing these seem to lower accuracy of multiple calls of 1 nbLoops vs 1 call of multiple nbLoops 
-         * (Makes former slower)   
+        /* based on testing these seem to lower accuracy of multiple calls of 1 nbLoops vs 1 call of multiple nbLoops
+         * (Makes former slower)
          */
         UTIL_sleepMilli(5);  /* give processor time to other processes */
         UTIL_waitForNextTick();
 #endif
     }
 
-    {      
+    {
         unsigned i, j;
         clockStart = UTIL_getTime();
         if(initFn != NULL) { initFn(initPayload); }
@@ -335,7 +335,7 @@ BMK_customReturn_t BMK_benchFunction(
                     if(blockResult != NULL) {
                         blockResult[j] = res;
                     }
-                } 
+                }
             }
         }
         totalTime = UTIL_clockSpanNano(clockStart);
@@ -345,27 +345,27 @@ BMK_customReturn_t BMK_benchFunction(
     retval.result.nanoSecPerRun = totalTime / nbLoops;
     retval.result.sumOfReturn = dstSize;
     return retval;
-} 
+}
 
 #define MINUSABLETIME 500000000ULL /* 0.5 seconds in ns */
 
-void BMK_resetTimeState(BMK_timedFnState_t* r, unsigned nbSeconds) {
+void BMK_resetTimedFnState(BMK_timedFnState_t* r, unsigned nbSeconds) {
     r->nbLoops = 1;
     r->timeRemaining = (U64)nbSeconds * TIMELOOP_NANOSEC;
     r->coolTime = UTIL_getTime();
     r->fastestTime = (U64)(-1LL);
 }
 
-BMK_timedFnState_t* BMK_createTimeState(unsigned nbSeconds) {
+BMK_timedFnState_t* BMK_createTimedFnState(unsigned nbSeconds) {
     BMK_timedFnState_t* r = (BMK_timedFnState_t*)malloc(sizeof(struct BMK_timeState_t));
     if(r == NULL) {
         return r;
     }
-    BMK_resetTimeState(r, nbSeconds);
+    BMK_resetTimedFnState(r, nbSeconds);
     return r;
 }
 
-void BMK_freeTimeState(BMK_timedFnState_t* state) {
+void BMK_freeTimedFnState(BMK_timedFnState_t* state) {
     free(state);
 }
 
@@ -376,7 +376,7 @@ BMK_customTimedReturn_t BMK_benchFunctionTimed(
     BMK_initFn_t initFn, void* initPayload,
     size_t blockCount,
     const void* const* const srcBlockBuffers, const size_t* srcBlockSizes,
-    void * const * const dstBlockBuffers, const size_t * dstBlockCapacities, size_t* blockResults) 
+    void * const * const dstBlockBuffers, const size_t * dstBlockCapacities, size_t* blockResults)
 {
     U64 fastest = cont->fastestTime;
     int completed = 0;
@@ -402,7 +402,7 @@ BMK_customTimedReturn_t BMK_benchFunctionTimed(
         {   U64 const loopDuration = r.result.result.nanoSecPerRun * cont->nbLoops;
             r.completed = (cont->timeRemaining <= loopDuration);
             cont->timeRemaining -= loopDuration;
-            if (loopDuration > (TIMELOOP_NANOSEC / 100)) { 
+            if (loopDuration > (TIMELOOP_NANOSEC / 100)) {
                 fastest = MIN(fastest, r.result.result.nanoSecPerRun);
                 if(loopDuration >= MINUSABLETIME) {
                     r.result.result.nanoSecPerRun = fastest;
@@ -427,7 +427,7 @@ BMK_customTimedReturn_t BMK_benchFunctionTimed(
 /* benchMem with no allocation */
 static BMK_return_t BMK_benchMemAdvancedNoAlloc(
     const void ** const srcPtrs, size_t* const srcSizes,
-    void** const cPtrs, size_t* const cCapacities, size_t* const cSizes, 
+    void** const cPtrs, size_t* const cCapacities, size_t* const cSizes,
     void** const resPtrs, size_t* const resSizes,
     void** resultBufferPtr, void* compressedBuffer,
     const size_t maxCompressedSize,
@@ -438,7 +438,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
     const int cLevel, const ZSTD_compressionParameters* comprParams,
     const void* dictBuffer, size_t dictBufferSize,
     ZSTD_CCtx* ctx, ZSTD_DCtx* dctx,
-    int displayLevel, const char* displayName, const BMK_advancedParams_t* adv) 
+    int displayLevel, const char* displayName, const BMK_advancedParams_t* adv)
 {
     size_t const blockSize = ((adv->blockSize>=32 && (adv->mode != BMK_decodeOnly)) ? adv->blockSize : srcSize) + (!srcSize); /* avoid div by 0 */
     BMK_return_t results = { { 0, 0, 0, 0 }, 0 } ;
@@ -447,7 +447,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
     double ratio = 0.;
     U32 nbBlocks;
 
-    if(!ctx || !dctx) 
+    if(!ctx || !dctx)
         EXM_THROW(31, BMK_return_t, "error: passed in null context");
 
     /* init */
@@ -466,16 +466,16 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
             free(*resultBufferPtr);
             *resultBufferPtr = malloc(decodedSize);
             if (!(*resultBufferPtr)) {
-                EXM_THROW(33, BMK_return_t, "not enough memory"); 
+                EXM_THROW(33, BMK_return_t, "not enough memory");
             }
             if (totalDSize64 > decodedSize) {
-                free(*resultBufferPtr); 
+                free(*resultBufferPtr);
                 EXM_THROW(32, BMK_return_t, "original size is too large");   /* size_t overflow */
             }
             cSize = srcSize;
             srcSize = decodedSize;
             ratio = (double)srcSize / (double)cSize;
-        }   
+        }
     }
 
     /* Init data blocks  */
@@ -499,8 +499,8 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                 cPtr += cCapacities[nbBlocks];
                 resPtr += thisBlockSize;
                 remaining -= thisBlockSize;
-            }   
-        }   
+            }
+        }
     }
 
     /* warmimg up memory */
@@ -511,7 +511,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
     }
 
     /* Bench */
-    {   
+    {
         U64 const crcOrig = (adv->mode == BMK_decodeOnly) ? 0 : XXH64(srcBuffer, srcSize, 0);
 #       define NB_MARKS 4
         const char* const marks[NB_MARKS] = { " |", " /", " =",  "\\" };
@@ -545,7 +545,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                     intermediateResultDecompress.completed = 0;
                 }
                 while(!(intermediateResultCompress.completed && intermediateResultDecompress.completed)) {
-                    if(!intermediateResultCompress.completed) { 
+                    if(!intermediateResultCompress.completed) {
                         intermediateResultCompress = BMK_benchFunctionTimed(timeStateCompress, &local_defaultCompress, (void*)ctx, &local_initCCtx, (void*)&cctxprep,
                         nbBlocks, srcPtrs, srcSizes, cPtrs, cCapacities, cSizes);
                         if(intermediateResultCompress.result.error) {
@@ -553,7 +553,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                             return results;
                         }
                         ratio = (double)(srcSize / intermediateResultCompress.result.result.sumOfReturn);
-                        {   
+                        {
                             int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
                             results.result.cSpeed = (srcSize * TIMELOOP_NANOSEC / intermediateResultCompress.result.result.nanoSecPerRun);
                             cSize = intermediateResultCompress.result.result.sumOfReturn;
@@ -574,8 +574,8 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                             results.error = intermediateResultDecompress.result.error;
                             return results;
                         }
-      
-                        {   
+
+                        {
                             int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
                             results.result.dSpeed = (srcSize * TIMELOOP_NANOSEC/ intermediateResultDecompress.result.result.nanoSecPerRun);
                             markNb = (markNb+1) % NB_MARKS;
@@ -592,7 +592,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                 if(adv->mode != BMK_decodeOnly) {
 
                     BMK_customReturn_t compressionResults = BMK_benchFunction(&local_defaultCompress, (void*)ctx, &local_initCCtx, (void*)&cctxprep,
-                        nbBlocks, srcPtrs, srcSizes, cPtrs, cCapacities, cSizes, adv->nbSeconds); 
+                        nbBlocks, srcPtrs, srcSizes, cPtrs, cCapacities, cSizes, adv->nbSeconds);
                     if(compressionResults.error) {
                         results.error = compressionResults.error;
                         return results;
@@ -605,7 +605,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                     }
 
                     results.result.cSize = compressionResults.result.sumOfReturn;
-                    {   
+                    {
                         int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
                         cSize = compressionResults.result.sumOfReturn;
                         results.result.cSize = cSize;
@@ -621,7 +621,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                     BMK_customReturn_t decompressionResults = BMK_benchFunction(
                         &local_defaultDecompress, (void*)(dctx),
                         &local_initDCtx, (void*)&dctxprep, nbBlocks,
-                        (const void* const*)cPtrs, cSizes, resPtrs, resSizes, NULL, 
+                        (const void* const*)cPtrs, cSizes, resPtrs, resSizes, NULL,
                         adv->nbSeconds);
                     if(decompressionResults.error) {
                         results.error = decompressionResults.error;
@@ -634,7 +634,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                         results.result.dSpeed = srcSize * TIMELOOP_NANOSEC / decompressionResults.result.nanoSecPerRun;
                     }
 
-                    {   
+                    {
                         int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
                         markNb = (markNb+1) % NB_MARKS;
                         DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f),%6.*f MB/s ,%6.1f MB/s \r",
@@ -683,9 +683,9 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
                     }
                     if (u==srcSize-1) {  /* should never happen */
                         DISPLAY("no difference detected\n");
-                    }   
+                    }
                 }
-            }   
+            }
         }   /* CRC Checking */
 
     if (displayLevel == 1) {   /* hidden display mode -q, used by python speed benchmark */
@@ -705,7 +705,7 @@ static BMK_return_t BMK_benchMemAdvancedNoAlloc(
 }
 
 BMK_return_t BMK_benchMemAdvanced(const void* srcBuffer, size_t srcSize,
-                        void* dstBuffer, size_t dstCapacity, 
+                        void* dstBuffer, size_t dstCapacity,
                         const size_t* fileSizes, unsigned nbFiles,
                         const int cLevel, const ZSTD_compressionParameters* comprParams,
                         const void* dictBuffer, size_t dictBufferSize,
@@ -727,8 +727,8 @@ BMK_return_t BMK_benchMemAdvanced(const void* srcBuffer, size_t srcSize,
     void ** const resPtrs = (void**)malloc(maxNbBlocks * sizeof(void*));
     size_t* const resSizes = (size_t*)malloc(maxNbBlocks * sizeof(size_t));
 
-    BMK_timedFnState_t* timeStateCompress = BMK_createTimeState(adv->nbSeconds);
-    BMK_timedFnState_t* timeStateDecompress = BMK_createTimeState(adv->nbSeconds);
+    BMK_timedFnState_t* timeStateCompress = BMK_createTimedFnState(adv->nbSeconds);
+    BMK_timedFnState_t* timeStateDecompress = BMK_createTimedFnState(adv->nbSeconds);
 
     ZSTD_CCtx* ctx = ZSTD_createCCtx();
     ZSTD_DCtx* dctx = ZSTD_createDCtx();
@@ -744,8 +744,8 @@ BMK_return_t BMK_benchMemAdvanced(const void* srcBuffer, size_t srcSize,
 
     void* resultBuffer = srcSize ? malloc(srcSize) : NULL;
 
-    int allocationincomplete = !srcPtrs || !srcSizes || !cPtrs || 
-        !cSizes || !cCapacities || !resPtrs || !resSizes || 
+    int allocationincomplete = !srcPtrs || !srcSizes || !cPtrs ||
+        !cSizes || !cCapacities || !resPtrs || !resSizes ||
         !timeStateCompress || !timeStateDecompress || !compressedBuffer || !resultBuffer;
 
 
@@ -756,20 +756,20 @@ BMK_return_t BMK_benchMemAdvanced(const void* srcBuffer, size_t srcSize,
             srcBuffer, srcSize, fileSizes, nbFiles, cLevel, comprParams,
             dictBuffer, dictBufferSize, ctx, dctx, displayLevel, displayName, adv);
     }
-    
+
     /* clean up */
-    BMK_freeTimeState(timeStateCompress);
-    BMK_freeTimeState(timeStateDecompress);
-    
+    BMK_freeTimedFnState(timeStateCompress);
+    BMK_freeTimedFnState(timeStateDecompress);
+
     ZSTD_freeCCtx(ctx);
     ZSTD_freeDCtx(dctx);
 
     free(internalDstBuffer);
     free(resultBuffer);
 
-    free((void*)srcPtrs); 
-    free(srcSizes); 
-    free(cPtrs); 
+    free((void*)srcPtrs);
+    free(srcSizes);
+    free(cPtrs);
     free(cSizes);
     free(cCapacities);
     free(resPtrs);
@@ -778,9 +778,9 @@ BMK_return_t BMK_benchMemAdvanced(const void* srcBuffer, size_t srcSize,
     if(allocationincomplete) {
         EXM_THROW(31, BMK_return_t, "allocation error : not enough memory");
     }
-    
+
     if(parametersConflict) {
-        EXM_THROW(32, BMK_return_t, "Conflicting input results");   
+        EXM_THROW(32, BMK_return_t, "Conflicting input results");
     }
     return results;
 }
@@ -840,11 +840,11 @@ static BMK_return_t BMK_benchCLevel(const void* srcBuffer, size_t benchedSize,
     if (displayLevel == 1 && !adv->additionalParam)
         DISPLAY("bench %s %s: input %u bytes, %u seconds, %u KB blocks\n", ZSTD_VERSION_STRING, ZSTD_GIT_COMMIT_STRING, (U32)benchedSize, adv->nbSeconds, (U32)(adv->blockSize>>10));
 
-    res = BMK_benchMemAdvanced(srcBuffer, benchedSize, 
-                NULL, 0, 
-                fileSizes, nbFiles, 
-                cLevel, comprParams, 
-                dictBuffer, dictBufferSize, 
+    res = BMK_benchMemAdvanced(srcBuffer, benchedSize,
+                NULL, 0,
+                fileSizes, nbFiles,
+                cLevel, comprParams,
+                dictBuffer, dictBufferSize,
                 displayLevel, displayName, adv);
 
     return res;
@@ -855,7 +855,7 @@ static BMK_return_t BMK_benchCLevel(const void* srcBuffer, size_t benchedSize,
  *  Loads `buffer` with content of files listed within `fileNamesTable`.
  *  At most, fills `buffer` entirely. */
 static int BMK_loadFiles(void* buffer, size_t bufferSize,
-                          size_t* fileSizes, const char* const * const fileNamesTable, 
+                          size_t* fileSizes, const char* const * const fileNamesTable,
                           unsigned nbFiles, int displayLevel)
 {
     size_t pos = 0, totalSize = 0;
@@ -890,8 +890,8 @@ static int BMK_loadFiles(void* buffer, size_t bufferSize,
 }
 
 BMK_return_t BMK_benchFilesAdvanced(const char* const * const fileNamesTable, unsigned const nbFiles,
-                               const char* const dictFileName, int const cLevel, 
-                               const ZSTD_compressionParameters* const compressionParams, 
+                               const char* const dictFileName, int const cLevel,
+                               const ZSTD_compressionParameters* const compressionParams,
                                int displayLevel, const BMK_advancedParams_t * const adv)
 {
     void* srcBuffer = NULL;
@@ -960,13 +960,13 @@ BMK_return_t BMK_benchFilesAdvanced(const char* const * const fileNamesTable, un
     {
         char mfName[20] = {0};
         snprintf (mfName, sizeof(mfName), " %u files", nbFiles);
-        {   
+        {
             const char* const displayName = (nbFiles > 1) ? mfName : fileNamesTable[0];
-            res = BMK_benchCLevel(srcBuffer, benchedSize, 
-                            fileSizes, nbFiles, 
+            res = BMK_benchCLevel(srcBuffer, benchedSize,
+                            fileSizes, nbFiles,
                             cLevel, compressionParams,
-                            dictBuffer, dictBufferSize, 
-                            displayLevel, displayName, 
+                            dictBuffer, dictBufferSize,
+                            displayLevel, displayName,
                             adv);
     }   }
 
@@ -1000,10 +1000,10 @@ BMK_return_t BMK_syntheticTest(int cLevel, double compressibility,
 
     /* Bench */
     snprintf (name, sizeof(name), "Synthetic %2u%%", (unsigned)(compressibility*100));
-    res = BMK_benchCLevel(srcBuffer, benchedSize, 
-                    &benchedSize, 1, 
-                    cLevel, compressionParams, 
-                    NULL, 0, 
+    res = BMK_benchCLevel(srcBuffer, benchedSize,
+                    &benchedSize, 1,
+                    cLevel, compressionParams,
+                    NULL, 0,
                     displayLevel, name, adv);
 
     /* clean up */
@@ -1013,8 +1013,8 @@ BMK_return_t BMK_syntheticTest(int cLevel, double compressibility,
 }
 
 BMK_return_t BMK_benchFiles(const char* const * const fileNamesTable, unsigned const nbFiles,
-                   const char* const dictFileName, 
-                   int const cLevel, const ZSTD_compressionParameters* const compressionParams, 
+                   const char* const dictFileName,
+                   int const cLevel, const ZSTD_compressionParameters* const compressionParams,
                    int displayLevel) {
     const BMK_advancedParams_t adv = BMK_initAdvancedParams();
     return BMK_benchFilesAdvanced(fileNamesTable, nbFiles, dictFileName, cLevel, compressionParams, displayLevel, &adv);

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -216,6 +216,7 @@ int BMK_isSuccessful_runOutcome(BMK_runOutcome_t outcome);
 BMK_runTime_t BMK_extract_runTime(BMK_runOutcome_t outcome);
 
 
+
 typedef size_t (*BMK_benchFn_t)(const void* src, size_t srcSize, void* dst, size_t dstCapacity, void* customPayload);
 typedef size_t (*BMK_initFn_t)(void* initPayload);
 
@@ -263,21 +264,6 @@ BMK_timedFnState_t* BMK_createTimedFnState(unsigned nbSeconds);
 void BMK_resetTimedFnState(BMK_timedFnState_t* timedFnState, unsigned nbSeconds);
 void BMK_freeTimedFnState(BMK_timedFnState_t* state);
 
-/* define timedFnOutcome */
-VARIANT_ERROR_RESULT(BMK_runTime_t, BMK_timedFnOutcome_t);
-
-/* check first if the return structure represents an error or a valid result */
-int BMK_isSuccessful_timedFnOutcome(BMK_timedFnOutcome_t outcome);
-
-/* extract intermediate results from variant type.
- * note : this function will abort() program execution if result is not valid.
- *        check result validity first, by using BMK_isSuccessful_timedFnOutcome() */
-BMK_runTime_t BMK_extract_timedFnResult(BMK_timedFnOutcome_t outcome);
-
-/* Tells if nb of seconds set in timedFnState for all runs is spent.
- * note : this function will return 1 if BMK_benchFunctionTimed() has actually errored. */
-int BMK_isCompleted_timedFnOutcome(BMK_timedFnOutcome_t outcome);
-
 
 /* BMK_benchFunctionTimed() :
  * Similar to BMK_benchFunction(),
@@ -286,16 +272,23 @@ int BMK_isCompleted_timedFnOutcome(BMK_timedFnOutcome_t outcome);
  * Most arguments are the same as BMK_benchFunction()
  * Usage - initialize a timedFnState, selecting a total nbSeconds allocated for _all_ benchmarks run
  *         call BMK_benchFunctionTimed() repetitively, collecting intermediate results (each run is supposed to last about 1 seconds)
- *         Check if time budget is spent using BMK_isCompleted_timedFnOutcome()
+ *         Check if time budget is spent using BMK_isCompleted_runOutcome()
  */
-BMK_timedFnOutcome_t BMK_benchFunctionTimed(
-            BMK_timedFnState_t* timedFnState,
-            BMK_benchFn_t benchFn, void* benchPayload,
-            BMK_initFn_t initFn, void* initPayload,
-            size_t blockCount,
-            const void *const * srcBlockBuffers, const size_t* srcBlockSizes,
-            void *const * dstBlockBuffers, const size_t* dstBlockCapacities,
-            size_t* blockResults);
+BMK_runOutcome_t BMK_benchFunctionTimed(
+                    BMK_timedFnState_t* timedFnState,
+                    BMK_benchFn_t benchFn, void* benchPayload,
+                    BMK_initFn_t initFn, void* initPayload,
+                    size_t blockCount,
+                    const void *const * srcBlockBuffers, const size_t* srcBlockSizes,
+                    void *const * dstBlockBuffers, const size_t* dstBlockCapacities,
+                    size_t* blockResults);
+
+
+/* Tells if total nb of benchmark runs has exceeded amount of time set in timedFnState
+ */
+int BMK_isCompleted_runOutcome(BMK_runOutcome_t outcome);
+
+
 
 #endif   /* BENCH_H_121279284357 */
 

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -144,7 +144,7 @@ BMK_benchOutcome_t BMK_benchFilesAdvanced(
 BMK_benchOutcome_t BMK_syntheticTest(
                               int cLevel, double compressibility,
                               const ZSTD_compressionParameters* compressionParams,
-                              int displayLevel, const BMK_advancedParams_t * const adv);
+                              int displayLevel, const BMK_advancedParams_t* adv);
 
 
 

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -529,7 +529,7 @@ static size_t benchMem(U32 benchNb,
         }
 
         {   BMK_runTime_t const result = BMK_extract_runTime(outcome);
-            DISPLAY("%2u#%-25.25s:%7.1f MB/s (%7u) \n", benchNb, benchName, (double)srcSize / result.nanoSecPerRun * 1000000000 / 1000000, (unsigned)result.sumOfReturn );
+            DISPLAY("%2u#%-25.25s:%7.1f MB/s (%7u) \n", benchNb, benchName, (double)srcSize * 1000000000 / result.nanoSecPerRun / MB_UNIT, (unsigned)result.sumOfReturn );
     }   }
 
 _cleanOut:

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -520,7 +520,7 @@ static size_t benchMem(U32 benchNb,
         bestResult.nanoSecPerRun = (unsigned long long)(-1LL);
         for (;;) {
             void* const dstBuffv = dstBuff;
-            BMK_timedFnOutcome_t const bOutcome =
+            BMK_runOutcome_t const bOutcome =
                     BMK_benchFunctionTimed( tfs,
                             benchFunction, buff2,
                             NULL, NULL,   /* initFn */
@@ -529,13 +529,13 @@ static size_t benchMem(U32 benchNb,
                             &dstBuffv, &dstBuffSize,
                             NULL);
 
-            if (!BMK_isSuccessful_timedFnOutcome(bOutcome)) {
+            if (!BMK_isSuccessful_runOutcome(bOutcome)) {
                 DISPLAY("ERROR benchmarking function ! ! \n");
                 errorcode = 1;
                 goto _cleanOut;
             }
 
-            {   BMK_runTime_t const newResult = BMK_extract_timedFnResult(bOutcome);
+            {   BMK_runTime_t const newResult = BMK_extract_runTime(bOutcome);
                 if (newResult.nanoSecPerRun < bestResult.nanoSecPerRun )
                     bestResult.nanoSecPerRun = newResult.nanoSecPerRun;
                 DISPLAY("\r%2u#%-29.29s:%8.1f MB/s  (%8u) ",
@@ -544,7 +544,7 @@ static size_t benchMem(U32 benchNb,
                         (unsigned)newResult.sumOfReturn );
             }
 
-            if ( BMK_isCompleted_timedFnOutcome(bOutcome) ) break;
+            if ( BMK_isCompleted_runOutcome(bOutcome) ) break;
     }   }
     DISPLAY("\n");
 

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -290,7 +290,7 @@ size_t local_ZSTD_compressContinue(const void* src, size_t srcSize, void* dst, s
 size_t local_ZSTD_compressContinue_extDict(const void* src, size_t srcSize, void* dst, size_t dstCapacity, void* buff2)
 {
     BYTE firstBlockBuf[FIRST_BLOCK_SIZE];
-    
+
     ZSTD_parameters p;
     ZSTD_frameParameters f = {1 , 0, 0};
     p.fParams = f;
@@ -333,14 +333,16 @@ size_t local_ZSTD_decompressContinue(const void* src, size_t srcSize, void* dst,
 /*_*******************************************************
 *  Bench functions
 *********************************************************/
-static size_t benchMem(const void* src, size_t srcSize, U32 benchNb, int cLevel, ZSTD_compressionParameters* cparams)
+static size_t benchMem(U32 benchNb,
+                       const void* src, size_t srcSize,
+                       int cLevel, ZSTD_compressionParameters cparams)
 {
     BYTE*  dstBuff;
     size_t dstBuffSize = ZSTD_compressBound(srcSize);
-    void*  buff2, *buff1;
+    void*  buff1;
+    void*  buff2;
     const char* benchName;
     BMK_benchFn_t benchFunction;
-    BMK_customReturn_t r;
     int errorcode = 0;
 
     /* Selection */
@@ -405,44 +407,44 @@ static size_t benchMem(const void* src, size_t srcSize, U32 benchNb, int cLevel,
     if (g_cstream==NULL) g_cstream = ZSTD_createCStream();
     if (g_dstream==NULL) g_dstream = ZSTD_createDStream();
 
-    /* DISPLAY("params: cLevel %d, wlog %d hlog %d clog %d slog %d slen %d tlen %d strat %d \n"
-        , cLevel, cparams->windowLog, cparams->hashLog, cparams->chainLog, cparams->searchLog, 
-          cparams->searchLength, cparams->targetLength, cparams->strategy);*/
+    /* DISPLAY("params: cLevel %d, wlog %d hlog %d clog %d slog %d slen %d tlen %d strat %d \n",
+          cLevel, cparams->windowLog, cparams->hashLog, cparams->chainLog, cparams->searchLog,
+          cparams->searchLength, cparams->targetLength, cparams->strategy); */
 
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_compressionLevel, cLevel);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_windowLog, cparams->windowLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_hashLog, cparams->hashLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_chainLog, cparams->chainLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_searchLog, cparams->searchLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_minMatch, cparams->searchLength);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_targetLength, cparams->targetLength);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_compressionStrategy, cparams->strategy);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_windowLog, cparams.windowLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_hashLog, cparams.hashLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_chainLog, cparams.chainLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_searchLog, cparams.searchLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_minMatch, cparams.searchLength);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_targetLength, cparams.targetLength);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_compressionStrategy, cparams.strategy);
 
 
     ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_compressionLevel, cLevel);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_windowLog, cparams->windowLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_hashLog, cparams->hashLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_chainLog, cparams->chainLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_searchLog, cparams->searchLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_minMatch, cparams->searchLength);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_targetLength, cparams->targetLength);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_compressionStrategy, cparams->strategy);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_windowLog, cparams.windowLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_hashLog, cparams.hashLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_chainLog, cparams.chainLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_searchLog, cparams.searchLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_minMatch, cparams.searchLength);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_targetLength, cparams.targetLength);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_compressionStrategy, cparams.strategy);
 
     /* Preparation */
     switch(benchNb)
     {
     case 1:
-        buff2 = (void*)cparams;
+        buff2 = &cparams;
         break;
     case 2:
         g_cSize = ZSTD_compress(buff2, dstBuffSize, src, srcSize, cLevel);
         break;
 #ifndef ZSTD_DLL_IMPORT
     case 11:
-        buff2 = (void*)cparams;
+        buff2 = &cparams;
         break;
     case 12:
-        buff2 = (void*)cparams;
+        buff2 = &cparams;
         break;
     case 13 :
         g_cSize = ZSTD_compress(buff2, dstBuffSize, src, srcSize, cLevel);
@@ -494,8 +496,8 @@ static size_t benchMem(const void* src, size_t srcSize, U32 benchNb, int cLevel,
     case 31:
         goto _cleanOut;
 #endif
-    case 41 : 
-        buff2 = (void*)cparams;
+    case 41 :
+        buff2 = &cparams;
         break;
     case 42 :
         g_cSize = ZSTD_compress(buff2, dstBuffSize, src, srcSize, cLevel);
@@ -507,26 +509,29 @@ static size_t benchMem(const void* src, size_t srcSize, U32 benchNb, int cLevel,
     default : ;
     }
 
-
-     /* warming up memory */
+     /* warming up dstBuff */
     { size_t i; for (i=0; i<dstBuffSize; i++) dstBuff[i]=(BYTE)i; }
 
-
     /* benchmark loop */
-    {
-        void* dstBuffv = (void*)dstBuff;
-        r = BMK_benchFunction(benchFunction, buff2, 
-            NULL, NULL,  1, &src, &srcSize, 
-            &dstBuffv, &dstBuffSize, NULL, g_nbIterations);
-        if(r.error) {
-            DISPLAY("ERROR %d ! ! \n", r.error);
-            errorcode = r.error;
+    {   void* dstBuffv = dstBuff;
+        BMK_runOutcome_t const outcome = BMK_benchFunction(
+                    benchFunction, buff2,
+                    NULL, NULL,   /* initFn */
+                    1,  /* blockCount */
+                    &src, &srcSize,
+                    &dstBuffv, &dstBuffSize,
+                    NULL,
+                    g_nbIterations);
+        if (!BMK_isSuccessful_runOutcome(outcome)) {
+            DISPLAY("ERROR benchmarking function ! ! \n");
+            errorcode = 1;
             goto _cleanOut;
         }
 
-        DISPLAY("%2u#Speed: %f MB/s - Size: %f MB - %s\n", benchNb, (double)srcSize / r.result.nanoSecPerRun * 1000, (double)r.result.sumOfReturn / 1000000, benchName);
-    }
-    
+        {   BMK_runTime_t const result = BMK_extract_runTime(outcome);
+            DISPLAY("%2u#%-25.25s:%7.1f MB/s (%7u) \n", benchNb, benchName, (double)srcSize / result.nanoSecPerRun * 1000000000 / 1000000, (unsigned)result.sumOfReturn );
+    }   }
+
 _cleanOut:
     free(buff1);
     free(dstBuff);
@@ -538,82 +543,89 @@ _cleanOut:
 }
 
 
-static int benchSample(U32 benchNb, int cLevel, ZSTD_compressionParameters* cparams)
+static int benchSample(U32 benchNb,
+                       int cLevel, ZSTD_compressionParameters cparams)
 {
     size_t const benchedSize = g_sampleSize;
     const char* name = "Sample 10MiB";
 
     /* Allocation */
-    void* origBuff = malloc(benchedSize);
+    void* const origBuff = malloc(benchedSize);
     if (!origBuff) { DISPLAY("\nError: not enough memory!\n"); return 12; }
 
     /* Fill buffer */
     RDG_genBuffer(origBuff, benchedSize, g_compressibility, 0.0, 0);
 
     /* bench */
-    DISPLAY("\r%79s\r", "");
+    DISPLAY("\r%70s\r", "");
     DISPLAY(" %s : \n", name);
-    if (benchNb)
-        benchMem(origBuff, benchedSize, benchNb, cLevel, cparams);
-    else
-        for (benchNb=0; benchNb<100; benchNb++) benchMem(origBuff, benchedSize, benchNb, cLevel, cparams);
+    if (benchNb) {
+        benchMem(benchNb, origBuff, benchedSize, cLevel, cparams);
+    } else {  /* 0 == run all tests */
+        for (benchNb=0; benchNb<100; benchNb++) {
+            benchMem(benchNb, origBuff, benchedSize, cLevel, cparams);
+    }   }
 
     free(origBuff);
     return 0;
 }
 
 
-static int benchFiles(const char** fileNamesTable, const int nbFiles, U32 benchNb, int cLevel, ZSTD_compressionParameters* cparams)
+static int benchFiles(U32 benchNb,
+                      const char** fileNamesTable, const int nbFiles,
+                      int cLevel, ZSTD_compressionParameters cparams)
 {
     /* Loop for each file */
     int fileIdx;
     for (fileIdx=0; fileIdx<nbFiles; fileIdx++) {
         const char* const inFileName = fileNamesTable[fileIdx];
         FILE* const inFile = fopen( inFileName, "rb" );
-        U64   inFileSize;
         size_t benchedSize;
-        void* origBuff;
 
         /* Check file existence */
         if (inFile==NULL) { DISPLAY( "Pb opening %s\n", inFileName); return 11; }
 
         /* Memory allocation & restrictions */
-        inFileSize = UTIL_getFileSize(inFileName);
-        if (inFileSize == UTIL_FILESIZE_UNKNOWN) {
-            DISPLAY( "Cannot measure size of %s\n", inFileName);
-            fclose(inFile);
-            return 11;
-        }
-        benchedSize = BMK_findMaxMem(inFileSize*3) / 3;
-        if ((U64)benchedSize > inFileSize) benchedSize = (size_t)inFileSize;
-        if (benchedSize < inFileSize)
-            DISPLAY("Not enough memory for '%s' full size; testing %u MB only...\n", inFileName, (U32)(benchedSize>>20));
-
-        /* Alloc */
-        origBuff = malloc(benchedSize);
-        if (!origBuff) { DISPLAY("\nError: not enough memory!\n"); fclose(inFile); return 12; }
-
-        /* Fill input buffer */
-        DISPLAY("Loading %s...       \r", inFileName);
-        {
-            size_t readSize = fread(origBuff, 1, benchedSize, inFile);
-            fclose(inFile);
-            if (readSize != benchedSize) {
-                DISPLAY("\nError: problem reading file '%s' !!    \n", inFileName);
-                free(origBuff);
-                return 13;
+        {   U64 const inFileSize = UTIL_getFileSize(inFileName);
+            if (inFileSize == UTIL_FILESIZE_UNKNOWN) {
+                DISPLAY( "Cannot measure size of %s\n", inFileName);
+                fclose(inFile);
+                return 11;
+            }
+            benchedSize = BMK_findMaxMem(inFileSize*3) / 3;
+            if ((U64)benchedSize > inFileSize)
+                benchedSize = (size_t)inFileSize;
+            if ((U64)benchedSize < inFileSize) {
+                DISPLAY("Not enough memory for '%s' full size; testing %u MB only...\n",
+                        inFileName, (U32)(benchedSize>>20));
         }   }
 
-        /* bench */
-        DISPLAY("\r%79s\r", "");
-        DISPLAY(" %s : \n", inFileName);
-        if (benchNb)
-            benchMem(origBuff, benchedSize, benchNb, cLevel, cparams);
-        else
-            for (benchNb=0; benchNb<100; benchNb++) benchMem(origBuff, benchedSize, benchNb, cLevel, cparams);
+        /* Alloc */
+        {   void* const origBuff = malloc(benchedSize);
+            if (!origBuff) { DISPLAY("\nError: not enough memory!\n"); fclose(inFile); return 12; }
 
-        free(origBuff);
-    }
+            /* Fill input buffer */
+            DISPLAY("Loading %s...       \r", inFileName);
+            {   size_t const readSize = fread(origBuff, 1, benchedSize, inFile);
+                fclose(inFile);
+                if (readSize != benchedSize) {
+                    DISPLAY("\nError: problem reading file '%s' !!    \n", inFileName);
+                    free(origBuff);
+                    return 13;
+            }   }
+
+            /* bench */
+            DISPLAY("\r%70s\r", "");   /* blank line */
+            DISPLAY(" %s : \n", inFileName);
+            if (benchNb) {
+                benchMem(benchNb, origBuff, benchedSize, cLevel, cparams);
+            } else {
+                for (benchNb=0; benchNb<100; benchNb++) {
+                    benchMem(benchNb, origBuff, benchedSize, cLevel, cparams);
+            }   }
+
+            free(origBuff);
+    }   }
 
     return 0;
 }
@@ -649,7 +661,7 @@ static int badusage(const char* exename)
 
 int main(int argc, const char** argv)
 {
-    int i, filenamesStart=0, result;
+    int argNb, filenamesStart=0, result;
     const char* exename = argv[0];
     const char* input_filename = NULL;
     U32 benchNb = 0, main_pause = 0;
@@ -659,8 +671,8 @@ int main(int argc, const char** argv)
     DISPLAY(WELCOME_MESSAGE);
     if (argc<1) return badusage(exename);
 
-    for(i=1; i<argc; i++) {
-        const char* argument = argv[i];
+    for(argNb=1; argNb<argc; argNb++) {
+        const char* argument = argv[argNb];
         assert(argument != NULL);
 
         if (longCommandWArg(&argument, "--zstd=")) {
@@ -677,12 +689,14 @@ int main(int argc, const char** argv)
                 return 1;
             }
 
+            /* check end of string */
             if (argument[0] != 0) {
-                DISPLAY("invalid --zstd= format\n");
-                return 1; // check the end of string 
+                DISPLAY("invalid --zstd= format \n");
+                return 1;
             } else {
                 continue;
             }
+
         } else if (argument[0]=='-') { /* Commands (note : aggregated commands are allowed) */
             argument++;
             while (argument[0]!=0) {
@@ -698,34 +712,26 @@ int main(int argc, const char** argv)
 
                     /* Select specific algorithm to bench */
                 case 'b':
-                    {
-                        argument++;
-                        benchNb = readU32FromChar(&argument);
-                        break;
-                    }
+                    argument++;
+                    benchNb = readU32FromChar(&argument);
+                    break;
 
                     /* Modify Nb Iterations */
                 case 'i':
-                    {
-                        argument++;
-                        BMK_SetNbIterations((int)readU32FromChar(&argument));
-                    }
+                    argument++;
+                    BMK_SetNbIterations((int)readU32FromChar(&argument));
                     break;
 
                     /* Select compressibility of synthetic sample */
                 case 'P':
-                    {   argument++;
-                        g_compressibility = (double)readU32FromChar(&argument) / 100.;
-                    }
+                    argument++;
+                    g_compressibility = (double)readU32FromChar(&argument) / 100.;
                     break;
                 case 'l':
-                    {   argument++;
-                        cLevel = readU32FromChar(&argument);
-                        cparams = ZSTD_getCParams(cLevel, 0, 0);
-                    }
+                    argument++;
+                    cLevel = readU32FromChar(&argument);
+                    cparams = ZSTD_getCParams(cLevel, 0, 0);
                     break;
-
-
 
                     /* Unknown command */
                 default : return badusage(exename);
@@ -735,15 +741,15 @@ int main(int argc, const char** argv)
         }
 
         /* first provided filename is input */
-        if (!input_filename) { input_filename=argument; filenamesStart=i; continue; }
+        if (!input_filename) { input_filename=argument; filenamesStart=argNb; continue; }
     }
 
 
 
     if (filenamesStart==0)   /* no input file */
-        result = benchSample(benchNb, cLevel, &cparams);
+        result = benchSample(benchNb, cLevel, cparams);
     else
-        result = benchFiles(argv+filenamesStart, argc-filenamesStart, benchNb, cLevel, &cparams);
+        result = benchFiles(benchNb, argv+filenamesStart, argc-filenamesStart, cLevel, cparams);
 
     if (main_pause) { int unused; printf("press enter...\n"); unused = getchar(); (void)unused; }
 

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -597,7 +597,7 @@ static int benchFiles(U32 benchNb,
             if ((U64)benchedSize > inFileSize)
                 benchedSize = (size_t)inFileSize;
             if ((U64)benchedSize < inFileSize) {
-                DISPLAY("Not enough memory for '%s' full size; testing %u MB only...\n",
+                DISPLAY("Not enough memory for '%s' full size; testing %u MB only... \n",
                         inFileName, (U32)(benchedSize>>20));
         }   }
 

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -68,7 +68,7 @@ static const int g_maxNbVariations = 64;
 #define FADT_MIN 0
 #define FADT_MAX ((U32)-1)
 
-#define ZSTD_TARGETLENGTH_MIN 0 
+#define ZSTD_TARGETLENGTH_MIN 0
 #define ZSTD_TARGETLENGTH_MAX 999
 
 #define WLOG_RANGE (ZSTD_WINDOWLOG_MAX - ZSTD_WINDOWLOG_MIN + 1)
@@ -115,27 +115,27 @@ typedef struct {
 } paramValues_t;
 
 /* maximum value of parameters */
-static const U32 mintable[NUM_PARAMS] = 
+static const U32 mintable[NUM_PARAMS] =
         { ZSTD_WINDOWLOG_MIN, ZSTD_CHAINLOG_MIN, ZSTD_HASHLOG_MIN, ZSTD_SEARCHLOG_MIN, ZSTD_SEARCHLENGTH_MIN, ZSTD_TARGETLENGTH_MIN, ZSTD_fast, FADT_MIN };
 
 /* minimum value of parameters */
-static const U32 maxtable[NUM_PARAMS] = 
+static const U32 maxtable[NUM_PARAMS] =
         { ZSTD_WINDOWLOG_MAX, ZSTD_CHAINLOG_MAX, ZSTD_HASHLOG_MAX, ZSTD_SEARCHLOG_MAX, ZSTD_SEARCHLENGTH_MAX, ZSTD_TARGETLENGTH_MAX, ZSTD_btultra, FADT_MAX };
 
 /* # of values parameters can take on */
-static const U32 rangetable[NUM_PARAMS] = 
+static const U32 rangetable[NUM_PARAMS] =
         { WLOG_RANGE, CLOG_RANGE, HLOG_RANGE, SLOG_RANGE, SLEN_RANGE, TLEN_RANGE, STRT_RANGE, FADT_RANGE };
 
 /* ZSTD_cctxSetParameter() index to set */
-static const ZSTD_cParameter cctxSetParamTable[NUM_PARAMS] = 
+static const ZSTD_cParameter cctxSetParamTable[NUM_PARAMS] =
         { ZSTD_p_windowLog, ZSTD_p_chainLog, ZSTD_p_hashLog, ZSTD_p_searchLog, ZSTD_p_minMatch, ZSTD_p_targetLength, ZSTD_p_compressionStrategy, ZSTD_p_forceAttachDict };
 
 /* names of parameters */
-static const char* g_paramNames[NUM_PARAMS] = 
+static const char* g_paramNames[NUM_PARAMS] =
         { "windowLog", "chainLog", "hashLog","searchLog", "searchLength", "targetLength", "strategy", "forceAttachDict" };
 
 /* shortened names of parameters */
-static const char* g_shortParamNames[NUM_PARAMS] = 
+static const char* g_shortParamNames[NUM_PARAMS] =
         { "wlog", "clog", "hlog","slog", "slen", "tlen", "strt", "fadt" };
 
 /* maps value from { 0 to rangetable[param] - 1 } to valid paramvalues */
@@ -178,7 +178,7 @@ static int invRangeMap(varInds_t param, U32 value) {
                     hi = mid;
                 }
             }
-            return lo;    
+            return lo;
         }
         case fadt_ind:
             return (int)value + 1;
@@ -201,11 +201,11 @@ static void displayParamVal(FILE* f, varInds_t param, U32 value, int width) {
     switch(param) {
         case fadt_ind: if(width) { fprintf(f, "%*d", width, (int)value); } else { fprintf(f, "%d", (int)value); } break;
         case strt_ind: if(width) { fprintf(f, "%*s", width, g_stratName[value]); } else { fprintf(f, "%s", g_stratName[value]); } break;
-        case wlog_ind: 
-        case clog_ind: 
-        case hlog_ind: 
-        case slog_ind: 
-        case slen_ind: 
+        case wlog_ind:
+        case clog_ind:
+        case hlog_ind:
+        case slog_ind:
+        case slen_ind:
         case tlen_ind: if(width) { fprintf(f, "%*u", width, value); } else { fprintf(f, "%u", value); } break;
         case NUM_PARAMS:
             DISPLAY("Error, not a valid param\n "); break;
@@ -265,7 +265,7 @@ typedef struct {
 typedef struct {
     U32 cSpeed;  /* bytes / sec */
     U32 dSpeed;
-    U32 cMem;    /* bytes */    
+    U32 cMem;    /* bytes */
 } constraint_t;
 
 typedef struct winner_ll_node winner_ll_node;
@@ -285,7 +285,7 @@ static winner_ll_node* g_winners; /* linked list sorted ascending by cSize & cSp
  */
 
 /*-*******************************************************
-*  General Util Functions 
+*  General Util Functions
 *********************************************************/
 
 /* nullified useless params, to ensure count stats */
@@ -502,10 +502,10 @@ static int feasible(const BMK_result_t results, const constraint_t target) {
 }
 
 /* hill climbing value for part 1 */
-/* Scoring here is a linear reward for all set constraints normalized between 0 to 1 
- * (with 0 at 0 and 1 being fully fulfilling the constraint), summed with a logarithmic 
+/* Scoring here is a linear reward for all set constraints normalized between 0 to 1
+ * (with 0 at 0 and 1 being fully fulfilling the constraint), summed with a logarithmic
  * bonus to exceeding the constraint value. We also give linear ratio for compression ratio.
- * The constant factors are experimental. 
+ * The constant factors are experimental.
  */
 static double resultScore(const BMK_result_t res, const size_t srcSize, const constraint_t target) {
     double cs = 0., ds = 0., rt, cm = 0.;
@@ -516,7 +516,7 @@ static double resultScore(const BMK_result_t res, const size_t srcSize, const co
     if(target.cMem != (U32)-1) { cm = (double)target.cMem / res.cMem; }
     rt = ((double)srcSize / res.cSize);
 
-    ret = (MIN(1, cs) + MIN(1, ds)  + MIN(1, cm))*r1 + rt * rtr + 
+    ret = (MIN(1, cs) + MIN(1, ds)  + MIN(1, cm))*r1 + rt * rtr +
          (MAX(0, log(cs))+ MAX(0, log(ds))+ MAX(0, log(cm))) * r2;
 
     return ret;
@@ -532,7 +532,7 @@ static double resultDistLvl(const BMK_result_t result1, const BMK_result_t lvlRe
     return normalizedRatioGain1 * g_ratioMultiplier + normalizedCSpeedGain1;
 }
 
-/* return true if r2 strictly better than r1 */ 
+/* return true if r2 strictly better than r1 */
 static int compareResultLT(const BMK_result_t result1, const BMK_result_t result2, const constraint_t target, size_t srcSize) {
     if(feasible(result1, target) && feasible(result2, target)) {
         if(g_optmode) {
@@ -547,7 +547,7 @@ static int compareResultLT(const BMK_result_t result1, const BMK_result_t result
 
 static constraint_t relaxTarget(constraint_t target) {
     target.cMem = (U32)-1;
-    target.cSpeed *= ((double)g_strictness) / 100; 
+    target.cSpeed *= ((double)g_strictness) / 100;
     target.dSpeed *= ((double)g_strictness) / 100;
     return target;
 }
@@ -598,7 +598,7 @@ static void optimizerAdjustInput(paramValues_t* pc, const size_t maxBlockSize) {
             DISPLAY("Warning: hashlog too much larger than windowLog size, adjusted to %u\n", pc->vals[hlog_ind]);
         }
     }
-    
+
     if(pc->vals[slog_ind] != PARAM_UNSET && pc->vals[clog_ind] != PARAM_UNSET) {
         if(pc->vals[slog_ind] > pc->vals[clog_ind]) {
             pc->vals[clog_ind] = pc->vals[slog_ind];
@@ -608,17 +608,17 @@ static void optimizerAdjustInput(paramValues_t* pc, const size_t maxBlockSize) {
 }
 
 static int redundantParams(const paramValues_t paramValues, const constraint_t target, const size_t maxBlockSize) {
-    return 
+    return
        (ZSTD_estimateCStreamSize_usingCParams(pvalsToCParams(paramValues)) > (size_t)target.cMem) /* Uses too much memory */
     || ((1ULL << (paramValues.vals[wlog_ind] - 1)) >= maxBlockSize && paramValues.vals[wlog_ind] != mintable[wlog_ind]) /* wlog too much bigger than src size */
     || (paramValues.vals[clog_ind] > (paramValues.vals[wlog_ind] + (paramValues.vals[strt_ind] > ZSTD_btlazy2))) /* chainLog larger than windowLog*/
     || (paramValues.vals[slog_ind] > paramValues.vals[clog_ind]) /* searchLog larger than chainLog */
     || (paramValues.vals[hlog_ind] > paramValues.vals[wlog_ind] + 1); /* hashLog larger than windowLog + 1 */
-    
+
 }
 
 /*-************************************
-*  Display Functions 
+*  Display Functions
 **************************************/
 
 static void BMK_translateAdvancedParams(FILE* f, const paramValues_t params) {
@@ -629,7 +629,7 @@ static void BMK_translateAdvancedParams(FILE* f, const paramValues_t params) {
         if(g_silenceParams[v]) { continue; }
         if(!first) { fprintf(f, ","); }
         fprintf(f,"%s=", g_paramNames[v]);
-        
+
         if(v == strt_ind) { fprintf(f,"%u", params.vals[v]); }
         else { displayParamVal(f, v, params.vals[v], 0); }
         first = 0;
@@ -668,10 +668,10 @@ static void BMK_printWinner(FILE* f, const int cLevel, const BMK_result_t result
         snprintf(lvlstr, 15, "  Level %2d  ", cLevel);
     }
 
-    if(TIMED) { 
+    if(TIMED) {
         const U64 time = UTIL_clockSpanNano(g_time);
         const U64 minutes = time / (60ULL * TIMELOOP_NANOSEC);
-        fprintf(f, "%1lu:%2lu:%05.2f - ", (unsigned long) minutes / 60,(unsigned long) minutes % 60, (double)(time - minutes * TIMELOOP_NANOSEC * 60ULL)/TIMELOOP_NANOSEC); 
+        fprintf(f, "%1lu:%2lu:%05.2f - ", (unsigned long) minutes / 60,(unsigned long) minutes % 60, (double)(time - minutes * TIMELOOP_NANOSEC * 60ULL)/TIMELOOP_NANOSEC);
     }
 
     fprintf(f, "/* %s */   ", lvlstr);
@@ -735,7 +735,7 @@ static int insertWinner(const winnerInfo_t w, const constraint_t targetConstrain
                 tmp = cur_node->next;
                 cur_node->next = cur_node->next->next;
                 free(tmp);
-                break; 
+                break;
             }
             case SIZE_RESULT:
             {
@@ -754,7 +754,7 @@ static int insertWinner(const winnerInfo_t w, const constraint_t targetConstrain
                 cur_node->next = newnode;
                 return 0;
             }
-        } 
+        }
 
     }
 
@@ -792,9 +792,9 @@ static int insertWinner(const winnerInfo_t w, const constraint_t targetConstrain
             cur_node->next = newnode;
             return 0;
         }
-        default: 
+        default:
             return 1;
-    } 
+    }
 }
 
 static void BMK_printWinnerOpt(FILE* f, const U32 cLevel, const BMK_result_t result, const paramValues_t params, const constraint_t targetConstraints, const size_t srcSize)
@@ -814,7 +814,7 @@ static void BMK_printWinnerOpt(FILE* f, const U32 cLevel, const BMK_result_t res
             g_winner.result = result;
             g_winner.params = params;
         }
-    }  
+    }
 
     if(g_optmode && g_optimizer && (DEBUG || g_displayLevel == 3)) {
         winnerInfo_t w;
@@ -824,8 +824,8 @@ static void BMK_printWinnerOpt(FILE* f, const U32 cLevel, const BMK_result_t res
         insertWinner(w, targetConstraints);
 
         if(!DEBUG) { fprintf(f, "\033c"); }
-        fprintf(f, "\n"); 
-        
+        fprintf(f, "\n");
+
         /* the table */
         fprintf(f, "================================\n");
         for(n = g_winners; n != NULL; n = n->next) {
@@ -909,8 +909,8 @@ static size_t local_initDCtx(void* payload) {
 
 /* additional argument is just the context */
 static size_t local_defaultCompress(
-    const void* srcBuffer, size_t srcSize, 
-    void* dstBuffer, size_t dstSize, 
+    const void* srcBuffer, size_t srcSize,
+    void* dstBuffer, size_t dstSize,
     void* addArgs) {
     size_t moreToFlush = 1;
     ZSTD_CCtx* ctx = (ZSTD_CCtx*)addArgs;
@@ -937,8 +937,8 @@ static size_t local_defaultCompress(
 
 /* additional argument is just the context */
 static size_t local_defaultDecompress(
-    const void* srcBuffer, size_t srcSize, 
-    void* dstBuffer, size_t dstSize, 
+    const void* srcBuffer, size_t srcSize,
+    void* dstBuffer, size_t dstSize,
     void* addArgs) {
     size_t moreToFlush = 1;
     ZSTD_DCtx* dctx = (ZSTD_DCtx*)addArgs;
@@ -965,7 +965,7 @@ static size_t local_defaultDecompress(
 }
 
 /*-************************************
-*  Data Initialization Functions 
+*  Data Initialization Functions
 **************************************/
 
 typedef struct {
@@ -1041,7 +1041,7 @@ static int createBuffersFromMemory(buffers_t* buff, void * srcBuffer, const size
     buff->dstSizes = (size_t*)malloc(maxNbBlocks * sizeof(size_t));
 
     buff->resPtrs = (void**)calloc(maxNbBlocks, sizeof(void*));
-    buff->resSizes = (size_t*)malloc(maxNbBlocks * sizeof(size_t)); 
+    buff->resSizes = (size_t*)malloc(maxNbBlocks * sizeof(size_t));
 
     if(!buff->srcPtrs || !buff->srcSizes || !buff->dstPtrs || !buff->dstCapacities || !buff->dstSizes || !buff->resPtrs || !buff->resSizes) {
         DISPLAY("alloc error\n");
@@ -1090,18 +1090,18 @@ static int createBuffersFromMemory(buffers_t* buff, void * srcBuffer, const size
     buff->nbBlocks = blockNb;
 
     return 0;
-} 
+}
 
 /* allocates buffer's arguments. returns success / failuere */
-static int createBuffers(buffers_t* buff, const char* const * const fileNamesTable, 
+static int createBuffers(buffers_t* buff, const char* const * const fileNamesTable,
                           size_t nbFiles) {
     size_t pos = 0;
     size_t n;
     size_t totalSizeToLoad = UTIL_getTotalFileSize(fileNamesTable, (U32)nbFiles);
     size_t benchedSize = MIN(BMK_findMaxMem(totalSizeToLoad * 3) / 3, totalSizeToLoad);
     size_t* fileSizes = calloc(sizeof(size_t), nbFiles);
-    void* srcBuffer = NULL; 
-    int ret = 0;  
+    void* srcBuffer = NULL;
+    int ret = 0;
 
     if(!totalSizeToLoad || !benchedSize) {
         ret = 1;
@@ -1139,7 +1139,7 @@ static int createBuffers(buffers_t* buff, const char* const * const fileNamesTab
 
         if (fileSize + pos > benchedSize) fileSize = benchedSize - pos, nbFiles=n;   /* buffer too small - stop after this file */
         {
-            char* buffer = (char*)(srcBuffer); 
+            char* buffer = (char*)(srcBuffer);
             size_t const readSize = fread((buffer)+pos, 1, (size_t)fileSize, f);
             fclose(f);
             if (readSize != (size_t)fileSize) {
@@ -1181,14 +1181,14 @@ static int createContexts(contexts_t* ctx, const char* dictFileName) {
     ctx->dictBuffer = malloc(ctx->dictSize);
 
     f = fopen(dictFileName, "rb");
-    
+
     if(!f) {
         DISPLAY("unable to open file\n");
         fclose(f);
         freeContexts(*ctx);
         return 1;
     }
-    
+
     if(ctx->dictSize > 64 MB || !(ctx->dictBuffer)) {
         DISPLAY("dictionary too large\n");
         fclose(f);
@@ -1207,7 +1207,7 @@ static int createContexts(contexts_t* ctx, const char* dictFileName) {
 }
 
 /*-************************************
-*  Optimizer Memoization Functions 
+*  Optimizer Memoization Functions
 **************************************/
 
 /* return: new length */
@@ -1218,7 +1218,7 @@ static size_t sanitizeVarArray(varInds_t* varNew, const size_t varLength, const 
     for(i = 0; i < varLength; i++) {
         if( !((varArray[i] == clog_ind && strat == ZSTD_fast)
             || (varArray[i] == slog_ind && strat == ZSTD_fast)
-            || (varArray[i] == slog_ind && strat == ZSTD_dfast) 
+            || (varArray[i] == slog_ind && strat == ZSTD_dfast)
             || (varArray[i] == tlen_ind && strat != ZSTD_btopt && strat != ZSTD_btultra && strat != ZSTD_fast))) {
             varNew[j] = varArray[i];
             j++;
@@ -1305,7 +1305,7 @@ static void freeMemoTableArray(memoTable_t* const mtAll) {
 static memoTable_t* createMemoTableArray(const paramValues_t p, const varInds_t* const varyParams, const size_t varyLen, const U32 memoTableLog) {
     memoTable_t* mtAll = (memoTable_t*)calloc(sizeof(memoTable_t),(ZSTD_btultra + 1));
     ZSTD_strategy i, stratMin = ZSTD_fast, stratMax = ZSTD_btultra;
-    
+
     if(mtAll == NULL) {
         return NULL;
     }
@@ -1324,7 +1324,7 @@ static memoTable_t* createMemoTableArray(const paramValues_t p, const varInds_t*
         return mtAll;
     }
 
-    
+
     if(p.vals[strt_ind] != PARAM_UNSET) {
         stratMin = p.vals[strt_ind];
         stratMax = p.vals[strt_ind];
@@ -1348,7 +1348,7 @@ static memoTable_t* createMemoTableArray(const paramValues_t p, const varInds_t*
             return NULL;
         }
     }
-    
+
     return mtAll;
 }
 
@@ -1363,7 +1363,7 @@ static void randomConstrainedParams(paramValues_t* pc, const memoTable_t* memoTa
         int i;
         for(i = 0; i < NUM_PARAMS; i++) {
             varInds_t v = mt.varArray[i];
-            if(v == strt_ind) continue; 
+            if(v == strt_ind) continue;
             pc->vals[v] = rangeMap(v, FUZ_rand(&g_rand) % rangetable[v]);
         }
 
@@ -1382,7 +1382,7 @@ static void randomConstrainedParams(paramValues_t* pc, const memoTable_t* memoTa
 
 /* if in decodeOnly, then srcPtr's will be compressed blocks, and uncompressedBlocks will be written to dstPtrs */
 /* dictionary nullable, nothing else though. */
-static BMK_return_t BMK_benchMemInvertible(const buffers_t buf, const contexts_t ctx, 
+static BMK_return_t BMK_benchMemInvertible(const buffers_t buf, const contexts_t ctx,
                         const int cLevel, const paramValues_t* comprParams,
                         const BMK_mode_t mode, const BMK_loopMode_t loopMode, const unsigned nbSeconds) {
 
@@ -1427,9 +1427,9 @@ static BMK_return_t BMK_benchMemInvertible(const buffers_t buf, const contexts_t
 
         if(loopMode == BMK_timeMode) {
             BMK_customTimedReturn_t intermediateResultCompress;
-            BMK_customTimedReturn_t intermediateResultDecompress;  
-            BMK_timedFnState_t* timeStateCompress = BMK_createTimeState(nbSeconds);
-            BMK_timedFnState_t* timeStateDecompress = BMK_createTimeState(nbSeconds);
+            BMK_customTimedReturn_t intermediateResultDecompress;
+            BMK_timedFnState_t* timeStateCompress = BMK_createTimedFnState(nbSeconds);
+            BMK_timedFnState_t* timeStateDecompress = BMK_createTimedFnState(nbSeconds);
             if(mode == BMK_compressOnly) {
                 intermediateResultCompress.completed = 0;
                 intermediateResultDecompress.completed = 1;
@@ -1447,8 +1447,8 @@ static BMK_return_t BMK_benchMemInvertible(const buffers_t buf, const contexts_t
 
                 if(intermediateResultCompress.result.error) {
                     results.error = intermediateResultCompress.result.error;
-                    BMK_freeTimeState(timeStateCompress);
-                    BMK_freeTimeState(timeStateDecompress);
+                    BMK_freeTimedFnState(timeStateCompress);
+                    BMK_freeTimedFnState(timeStateDecompress);
                     return results;
                 }
                 results.result.cSpeed = (srcSize * TIMELOOP_NANOSEC) / intermediateResultCompress.result.result.nanoSecPerRun;
@@ -1461,21 +1461,21 @@ static BMK_return_t BMK_benchMemInvertible(const buffers_t buf, const contexts_t
 
                 if(intermediateResultDecompress.result.error) {
                     results.error = intermediateResultDecompress.result.error;
-                    BMK_freeTimeState(timeStateCompress);
-                    BMK_freeTimeState(timeStateDecompress);
+                    BMK_freeTimedFnState(timeStateCompress);
+                    BMK_freeTimedFnState(timeStateDecompress);
                     return results;
                 }
                 results.result.dSpeed = (srcSize * TIMELOOP_NANOSEC) / intermediateResultDecompress.result.result.nanoSecPerRun;
             }
 
-            BMK_freeTimeState(timeStateCompress);
-            BMK_freeTimeState(timeStateDecompress);
+            BMK_freeTimedFnState(timeStateCompress);
+            BMK_freeTimedFnState(timeStateDecompress);
 
         } else { /* iterMode; */
             if(mode != BMK_decodeOnly) {
 
                 BMK_customReturn_t compressionResults = BMK_benchFunction(&local_defaultCompress, (void*)cctx, &local_initCCtx, (void*)&cctxprep,
-                    nbBlocks, srcPtrs, srcSizes, dstPtrs, dstCapacities, dstSizes, nbSeconds); 
+                    nbBlocks, srcPtrs, srcSizes, dstPtrs, dstCapacities, dstSizes, nbSeconds);
                 if(compressionResults.error) {
                     results.error = compressionResults.error;
                     return results;
@@ -1537,7 +1537,7 @@ static int BMK_benchParam(BMK_result_t* resultPtr,
 }
 
 /* Benchmarking which stops when we are sufficiently sure the solution is infeasible / worse than the winner */
-#define VARIANCE 1.2 
+#define VARIANCE 1.2
 static int allBench(BMK_result_t* resultPtr,
                 const buffers_t buf, const contexts_t ctx,
                 const paramValues_t cParams,
@@ -1557,13 +1557,13 @@ static int allBench(BMK_result_t* resultPtr,
 
     /* calculate uncertainty in compression / decompression runs */
     if(benchres.cSpeed) {
-        loopDurationC = ((buf.srcSize * TIMELOOP_NANOSEC) / benchres.cSpeed); 
-        uncertaintyConstantC = ((loopDurationC + (double)(2 * g_clockGranularity))/loopDurationC); 
+        loopDurationC = ((buf.srcSize * TIMELOOP_NANOSEC) / benchres.cSpeed);
+        uncertaintyConstantC = ((loopDurationC + (double)(2 * g_clockGranularity))/loopDurationC);
     }
 
     if(benchres.dSpeed) {
-        loopDurationD = ((buf.srcSize * TIMELOOP_NANOSEC) / benchres.dSpeed); 
-        uncertaintyConstantD = ((loopDurationD + (double)(2 * g_clockGranularity))/loopDurationD);  
+        loopDurationD = ((buf.srcSize * TIMELOOP_NANOSEC) / benchres.dSpeed);
+        uncertaintyConstantD = ((loopDurationD + (double)(2 * g_clockGranularity))/loopDurationD);
     }
 
     /* anything with worse ratio in feas is definitely worse, discard */
@@ -1596,18 +1596,18 @@ static int allBench(BMK_result_t* resultPtr,
 
     /* compare by resultScore when in infeas */
     /* compare by compareResultLT when in feas */
-    if((!feas && (resultScore(benchres, buf.srcSize, target) > resultScore(*winnerResult, buf.srcSize, target))) || 
-       (feas && (compareResultLT(*winnerResult, benchres, target, buf.srcSize))) )  { 
-        return BETTER_RESULT; 
-    } else { 
-        return WORSE_RESULT; 
+    if((!feas && (resultScore(benchres, buf.srcSize, target) > resultScore(*winnerResult, buf.srcSize, target))) ||
+       (feas && (compareResultLT(*winnerResult, benchres, target, buf.srcSize))) )  {
+        return BETTER_RESULT;
+    } else {
+        return WORSE_RESULT;
     }
 }
 
 #define INFEASIBLE_THRESHOLD 200
 /* Memoized benchmarking, won't benchmark anything which has already been benchmarked before. */
 static int benchMemo(BMK_result_t* resultPtr,
-                const buffers_t buf, const contexts_t ctx, 
+                const buffers_t buf, const contexts_t ctx,
                 const paramValues_t cParams,
                 const constraint_t target,
                 BMK_result_t* winnerResult, memoTable_t* const memoTableArray,
@@ -1615,7 +1615,7 @@ static int benchMemo(BMK_result_t* resultPtr,
     static int bmcount = 0;
     int res;
 
-    if(memoTableGet(memoTableArray, cParams) >= INFEASIBLE_THRESHOLD || redundantParams(cParams, target, buf.maxBlockSize)) { return WORSE_RESULT; } 
+    if(memoTableGet(memoTableArray, cParams) >= INFEASIBLE_THRESHOLD || redundantParams(cParams, target, buf.maxBlockSize)) { return WORSE_RESULT; }
 
     res = allBench(resultPtr, buf, ctx, cParams, target, winnerResult, feas);
 
@@ -1659,7 +1659,7 @@ static void BMK_init_level_constraints(int bytePerSec_level1)
     }   }
 }
 
-static int BMK_seed(winnerInfo_t* winners, const paramValues_t params, 
+static int BMK_seed(winnerInfo_t* winners, const paramValues_t params,
                     const buffers_t buf, const contexts_t ctx)
 {
     BMK_result_t testResult;
@@ -1781,7 +1781,7 @@ static void playAround(FILE* f, winnerInfo_t* winners,
 
         if (nbVariations++ > g_maxNbVariations) break;
 
-        do { for(i = 0; i < 4; i++) { paramVaryOnce(FUZ_rand(&g_rand) % (strt_ind + 1), ((FUZ_rand(&g_rand) & 1) << 1) - 1, &p); } } 
+        do { for(i = 0; i < 4; i++) { paramVaryOnce(FUZ_rand(&g_rand) % (strt_ind + 1), ((FUZ_rand(&g_rand) & 1) << 1) - 1, &p); } }
         while(!paramValid(p));
 
         /* exclude faster if already played params */
@@ -1815,7 +1815,7 @@ static void BMK_selectRandomStart(
     }
 }
 
-static void BMK_benchFullTable(const buffers_t buf, const contexts_t ctx) 
+static void BMK_benchFullTable(const buffers_t buf, const contexts_t ctx)
 {
     paramValues_t params;
     winnerInfo_t winners[NB_LEVELS_TRACKED+1];
@@ -1888,7 +1888,7 @@ static int benchSample(double compressibility, int cLevel)
 
     buffers_t buf;
     contexts_t ctx;
-    
+
     if(srcBuffer == NULL) {
         DISPLAY("Out of Memory\n");
         return 2;
@@ -1967,12 +1967,12 @@ int benchFiles(const char** fileNamesTable, int nbFiles, const char* dictFileNam
 *  Local Optimization Functions
 **************************************/
 
-/* One iteration of hill climbing. Specifically, it first tries all 
+/* One iteration of hill climbing. Specifically, it first tries all
  * valid parameter configurations w/ manhattan distance 1 and picks the best one
  * failing that, it progressively tries candidates further and further away (up to #dim + 2)
- * if it finds a candidate exceeding winnerInfo, it will repeat. Otherwise, it will stop the 
- * current stage of hill climbing. 
- * Each iteration of hill climbing proceeds in 2 'phases'. Phase 1 climbs according to 
+ * if it finds a candidate exceeding winnerInfo, it will repeat. Otherwise, it will stop the
+ * current stage of hill climbing.
+ * Each iteration of hill climbing proceeds in 2 'phases'. Phase 1 climbs according to
  * the resultScore function, which is effectively a linear increase in reward until it reaches
  * the constraint-satisfying value, it which point any excess results in only logarithmic reward.
  * This aims to find some constraint-satisfying point.
@@ -1980,14 +1980,14 @@ int benchFiles(const char** fileNamesTable, int nbFiles, const char* dictFileNam
  * all feasible solutions valued over all infeasible solutions.
  */
 
-/* sanitize all params here. 
+/* sanitize all params here.
  * all generation after random should be sanitized. (maybe sanitize random)
  */
-static winnerInfo_t climbOnce(const constraint_t target, 
-                memoTable_t* mtAll, 
+static winnerInfo_t climbOnce(const constraint_t target,
+                memoTable_t* mtAll,
                 const buffers_t buf, const contexts_t ctx,
                 const paramValues_t init) {
-    /* 
+    /*
      * cparam - currently considered 'center'
      * candidate - params to benchmark/results
      * winner - best option found so far.
@@ -2017,8 +2017,8 @@ static winnerInfo_t climbOnce(const constraint_t target,
                 for(offset = -1; offset <= 1; offset += 2) {
                     CHECKTIME(winnerInfo);
                     candidateInfo.params = cparam;
-                    paramVaryOnce(mtAll[cparam.vals[strt_ind]].varArray[i], offset, &candidateInfo.params); 
-                    
+                    paramVaryOnce(mtAll[cparam.vals[strt_ind]].varArray[i], offset, &candidateInfo.params);
+
                     if(paramValid(candidateInfo.params)) {
                         int res;
                         res = benchMemo(&candidateInfo.result, buf, ctx,
@@ -2047,7 +2047,7 @@ static winnerInfo_t climbOnce(const constraint_t target,
                     /* param error checking already done here */
                     paramVariation(&candidateInfo.params, mtAll, (U32)dist);
 
-                    res = benchMemo(&candidateInfo.result, buf, ctx, 
+                    res = benchMemo(&candidateInfo.result, buf, ctx,
                         sanitizeParams(candidateInfo.params), target, &winnerInfo.result, mtAll, feas);
                     DEBUGOUTPUT("Res: %d\n", res);
                     if(res == BETTER_RESULT) { /* synonymous with better in this case*/
@@ -2065,8 +2065,8 @@ static winnerInfo_t climbOnce(const constraint_t target,
                 }
             }
 
-            if(!better) { /* infeas -> feas -> stop */ 
-                if(feas) { return winnerInfo; } 
+            if(!better) { /* infeas -> feas -> stop */
+                if(feas) { return winnerInfo; }
 
                 feas = 1;
                 better = 1;
@@ -2084,17 +2084,17 @@ static winnerInfo_t climbOnce(const constraint_t target,
 
 /* flexible parameters: iterations of failed climbing (or if we do non-random, maybe this is when everything is close to visitied)
    weight more on visit for bad results, less on good results/more on later results / ones with more failures.
-   allocate memoTable here. 
+   allocate memoTable here.
  */
 static winnerInfo_t optimizeFixedStrategy(
-    const buffers_t buf, const contexts_t ctx, 
+    const buffers_t buf, const contexts_t ctx,
     const constraint_t target, paramValues_t paramTarget,
-    const ZSTD_strategy strat, 
+    const ZSTD_strategy strat,
     memoTable_t* memoTableArray, const int tries) {
     int i = 0;
 
     paramValues_t init;
-    winnerInfo_t winnerInfo, candidateInfo; 
+    winnerInfo_t winnerInfo, candidateInfo;
     winnerInfo = initWinnerInfo(emptyParams());
     /* so climb is given the right fixed strategy */
     paramTarget.vals[strt_ind] = strat;
@@ -2104,7 +2104,7 @@ static winnerInfo_t optimizeFixedStrategy(
     init = paramTarget;
 
     for(i = 0; i < tries; i++) {
-        DEBUGOUTPUT("Restart\n"); 
+        DEBUGOUTPUT("Restart\n");
         do { randomConstrainedParams(&init, memoTableArray, strat); } while(redundantParams(init, target, buf.maxBlockSize));
         candidateInfo = climbOnce(target, memoTableArray, buf, ctx, init);
         if(compareResultLT(winnerInfo.result, candidateInfo.result, target, buf.srcSize)) {
@@ -2153,9 +2153,9 @@ static int nextStrategy(const int currentStrategy, const int bestStrategy) {
 
 /* main fn called when using --optimize */
 /* Does strategy selection by benchmarking default compression levels
- * then optimizes by strategy, starting with the best one and moving 
+ * then optimizes by strategy, starting with the best one and moving
  * progressively moving further away by number
- * args: 
+ * args:
  * fileNamesTable - list of files to benchmark
  * nbFiles - length of fileNamesTable
  * dictFileName - name of dictionary file if one, else NULL
@@ -2167,7 +2167,7 @@ static int nextStrategy(const int currentStrategy, const int bestStrategy) {
 static int g_maxTries = 5;
 #define TRY_DECAY 1
 
-static int optimizeForSize(const char* const * const fileNamesTable, const size_t nbFiles, const char* dictFileName, constraint_t target, paramValues_t paramTarget, 
+static int optimizeForSize(const char* const * const fileNamesTable, const size_t nbFiles, const char* dictFileName, constraint_t target, paramValues_t paramTarget,
     const int cLevelOpt, const int cLevelRun, const U32 memoTableLog)
 {
     varInds_t varArray [NUM_PARAMS];
@@ -2194,7 +2194,7 @@ static int optimizeForSize(const char* const * const fileNamesTable, const size_
     if(nbFiles == 1) {
         DISPLAYLEVEL(2, "Loading %s...       \r", fileNamesTable[0]);
     } else {
-        DISPLAYLEVEL(2, "Loading %lu Files...       \r", (unsigned long)nbFiles); 
+        DISPLAYLEVEL(2, "Loading %lu Files...       \r", (unsigned long)nbFiles);
     }
 
     /* sanitize paramTarget */
@@ -2231,14 +2231,14 @@ static int optimizeForSize(const char* const * const fileNamesTable, const size_
             ret = 3;
             goto _cleanUp;
         }
- 
-        g_lvltarget = winner.result; 
+
+        g_lvltarget = winner.result;
         g_lvltarget.cSpeed *= ((double)g_strictness) / 100;
         g_lvltarget.dSpeed *= ((double)g_strictness) / 100;
         g_lvltarget.cSize /= ((double)g_strictness) / 100;
 
-        target.cSpeed = (U32)g_lvltarget.cSpeed;  
-        target.dSpeed = (U32)g_lvltarget.dSpeed; 
+        target.cSpeed = (U32)g_lvltarget.cSpeed;
+        target.dSpeed = (U32)g_lvltarget.dSpeed;
 
         BMK_printWinnerOpt(stdout, cLevelOpt, winner.result, winner.params, target, buf.srcSize);
     }
@@ -2272,7 +2272,7 @@ static int optimizeForSize(const char* const * const fileNamesTable, const size_
     DISPLAYLEVEL(2, "\n");
     findClockGranularity();
 
-    {   
+    {
         paramValues_t CParams;
 
         /* find best solution from default params */
@@ -2305,13 +2305,13 @@ static int optimizeForSize(const char* const * const fileNamesTable, const size_
 
         DEBUGOUTPUT("Real Opt\n");
         /* start 'real' optimization */
-        {   
+        {
             int bestStrategy = (int)winner.params.vals[strt_ind];
             if(paramTarget.vals[strt_ind] == PARAM_UNSET) {
                 int st = bestStrategy;
                 int tries = g_maxTries;
 
-                { 
+                {
                     /* one iterations of hill climbing with the level-defined parameters. */
                     winnerInfo_t w1 = climbOnce(target, allMT, buf, ctx, winner.params);
                     if(compareResultLT(winner.result, w1.result, target, buf.srcSize)) {
@@ -2323,7 +2323,7 @@ static int optimizeForSize(const char* const * const fileNamesTable, const size_
                 while(st && tries > 0) {
                     winnerInfo_t wc;
                     DEBUGOUTPUT("StrategySwitch: %s\n", g_stratName[st]);
-                    
+
                     wc = optimizeFixedStrategy(buf, ctx, target, paramBase, st, allMT, tries);
 
                     if(compareResultLT(winner.result, wc.result, target, buf.srcSize)) {
@@ -2349,7 +2349,7 @@ static int optimizeForSize(const char* const * const fileNamesTable, const size_
             goto _cleanUp;
         }
         /* end summary */
-_displayCleanUp: 
+_displayCleanUp:
         if(g_displayLevel >= 0) { BMK_displayOneResult(stdout, winner, buf.srcSize); }
         BMK_translateAdvancedParams(stdout, winner.params);
         DISPLAYLEVEL(1, "grillParams size - optimizer completed \n");
@@ -2427,7 +2427,7 @@ static double readDoubleFromChar(const char** stringPtr)
     }
     (*stringPtr)++;
     while ((**stringPtr >='0') && (**stringPtr <='9')) {
-        result += (double)(**stringPtr - '0') / divide, divide *= 10, (*stringPtr)++ ; 
+        result += (double)(**stringPtr - '0') / divide, divide *= 10, (*stringPtr)++ ;
     }
     return result;
 }
@@ -2503,7 +2503,7 @@ int main(int argc, const char** argv)
     int seperateFiles = 0;
     double compressibility = COMPRESSIBILITY_DEFAULT;
     U32 memoTableLog = PARAM_UNSET;
-    constraint_t target = { 0, 0, (U32)-1 }; 
+    constraint_t target = { 0, 0, (U32)-1 };
 
     paramValues_t paramTarget = emptyParams();
     g_params = emptyParams();
@@ -2522,7 +2522,7 @@ int main(int argc, const char** argv)
             for ( ; ;) {
                 if(parse_params(&argument, &paramTarget)) { if(argument[0] == ',') { argument++; continue; } else break; }
                 PARSE_SUB_ARGS("compressionSpeed=" ,  "cSpeed=", target.cSpeed);
-                PARSE_SUB_ARGS("decompressionSpeed=", "dSpeed=", target.dSpeed); 
+                PARSE_SUB_ARGS("decompressionSpeed=", "dSpeed=", target.dSpeed);
                 PARSE_SUB_ARGS("compressionMemory=" , "cMem=", target.cMem);
                 PARSE_SUB_ARGS("strict=", "stc=", g_strictness);
                 PARSE_SUB_ARGS("maxTries=", "tries=", g_maxTries);
@@ -2701,7 +2701,7 @@ int main(int argc, const char** argv)
 
                 /* load dictionary file (only applicable for optimizer rn) */
                 case 'D':
-                    if(i == argc - 1) { /* last argument, return error. */ 
+                    if(i == argc - 1) { /* last argument, return error. */
                         DISPLAY("Dictionary file expected but not given : %d\n", i);
                         return 1;
                     } else {
@@ -2749,7 +2749,7 @@ int main(int argc, const char** argv)
             } else {
                 result = benchFiles(argv+filenamesStart, argc-filenamesStart, dictFileName, cLevelRun);
             }
-        }   
+        }
     }
 
     if (main_pause) { int unused; printf("press enter...\n"); unused = getchar(); (void)unused; }

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -1441,7 +1441,7 @@ BMK_benchMemInvertible( buffers_t buf, contexts_t ctx,
         dctxprep.dictBufferSize = dictBufferSize;
 
         while(!compressionCompleted) {
-            BMK_timedFnOutcome_t const cOutcome = BMK_benchFunctionTimed(timeStateCompress,
+            BMK_runOutcome_t const cOutcome = BMK_benchFunctionTimed(timeStateCompress,
                                             &local_defaultCompress, cctx,
                                             &local_initCCtx, &cctxprep,
                                             nbBlocks,
@@ -1449,22 +1449,22 @@ BMK_benchMemInvertible( buffers_t buf, contexts_t ctx,
                                             dstPtrs, dstCapacities,
                                             dstSizes);
 
-            if (!BMK_isSuccessful_timedFnOutcome(cOutcome)) {
+            if (!BMK_isSuccessful_runOutcome(cOutcome)) {
                 BMK_benchOutcome_t bOut;
                 bOut.tag = 1;   /* should rather be a function or a constant */
                 BMK_freeTimedFnState(timeStateCompress);
                 BMK_freeTimedFnState(timeStateDecompress);
                 return bOut;
             }
-            {   BMK_runTime_t const rResult = BMK_extract_timedFnResult(cOutcome);
+            {   BMK_runTime_t const rResult = BMK_extract_runTime(cOutcome);
                 bResult.cSpeed = (srcSize * TIMELOOP_NANOSEC) / rResult.nanoSecPerRun;
                 bResult.cSize = rResult.sumOfReturn;
             }
-            compressionCompleted = BMK_isCompleted_timedFnOutcome(cOutcome);
+            compressionCompleted = BMK_isCompleted_runOutcome(cOutcome);
         }
 
         while (!decompressionCompleted) {
-            BMK_timedFnOutcome_t const dOutcome = BMK_benchFunctionTimed(timeStateDecompress,
+            BMK_runOutcome_t const dOutcome = BMK_benchFunctionTimed(timeStateDecompress,
                                         &local_defaultDecompress, dctx,
                                         &local_initDCtx, &dctxprep,
                                         nbBlocks,
@@ -1472,17 +1472,17 @@ BMK_benchMemInvertible( buffers_t buf, contexts_t ctx,
                                         resPtrs, resSizes,
                                         NULL);
 
-            if (!BMK_isSuccessful_timedFnOutcome(dOutcome)) {
+            if (!BMK_isSuccessful_runOutcome(dOutcome)) {
                 BMK_benchOutcome_t bOut;
                 bOut.tag = 1;   /* should rather be a function or a constant */
                 BMK_freeTimedFnState(timeStateCompress);
                 BMK_freeTimedFnState(timeStateDecompress);
                 return bOut;
             }
-            {   BMK_runTime_t const rResult = BMK_extract_timedFnResult(dOutcome);
+            {   BMK_runTime_t const rResult = BMK_extract_runTime(dOutcome);
                 bResult.dSpeed = (srcSize * TIMELOOP_NANOSEC) / rResult.nanoSecPerRun;
             }
-            decompressionCompleted = BMK_isCompleted_timedFnOutcome(dOutcome);
+            decompressionCompleted = BMK_isCompleted_runOutcome(dOutcome);
         }
 
         BMK_freeTimedFnState(timeStateCompress);

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -27,7 +27,8 @@
 #include "util.h"
 #include "bench.h"
 #include "zstd_errors.h"
-#include "zstd_internal.h"
+#include "zstd_internal.h"     /* should not be needed */
+
 
 /*-************************************
 *  Constants
@@ -45,6 +46,7 @@ static const size_t maxMemory = (sizeof(size_t)==4)  ?  (2 GB - 64 MB) : (size_t
 
 static const U64 g_maxVariationTime = 60 * SEC_TO_MICRO;
 static const int g_maxNbVariations = 64;
+
 
 /*-************************************
 *  Macros
@@ -90,8 +92,8 @@ static const char* g_stratName[ZSTD_btultra+1] = {
                 "ZSTD_greedy  ", "ZSTD_lazy    ", "ZSTD_lazy2   ",
                 "ZSTD_btlazy2 ", "ZSTD_btopt   ", "ZSTD_btultra "};
 
-
 static const U32 tlen_table[TLEN_RANGE] = { 0, 1, 2, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 256, 512, 999 };
+
 
 /*-************************************
 *  Setup for Adding new params
@@ -212,6 +214,7 @@ static void displayParamVal(FILE* f, varInds_t param, U32 value, int width) {
     }
 }
 
+
 /*-************************************
 *  Benchmark Parameters/Global Variables
 **************************************/
@@ -283,6 +286,7 @@ static winner_ll_node* g_winners; /* linked list sorted ascending by cSize & cSp
  * g_maxTries
  * g_clockGranularity
  */
+
 
 /*-*******************************************************
 *  General Util Functions
@@ -653,7 +657,7 @@ static void BMK_displayOneResult(FILE* f, winnerInfo_t res, const size_t srcSize
             }
 
             fprintf(f, " },     /* R:%5.3f at %5.1f MB/s - %5.1f MB/s */\n",
-            (double)srcSize / res.result.cSize, (double)res.result.cSpeed / (1 MB), (double)res.result.dSpeed / (1 MB));
+            (double)srcSize / res.result.cSize, (double)res.result.cSpeed / MB_UNIT, (double)res.result.dSpeed / MB_UNIT);
 }
 
 /* Writes to f the results of a parameter benchmark */
@@ -836,7 +840,7 @@ static void BMK_printWinnerOpt(FILE* f, const U32 cLevel, const BMK_benchResult_
         }
         fprintf(f, "================================\n");
         fprintf(f, "Level Bounds: R: > %.3f AND C: < %.1f MB/s \n\n",
-            (double)srcSize / g_lvltarget.cSize, (double)g_lvltarget.cSpeed / (1 MB));
+            (double)srcSize / g_lvltarget.cSize, (double)g_lvltarget.cSpeed / MB_UNIT);
 
 
         fprintf(f, "Overall Winner: \n");
@@ -1718,16 +1722,16 @@ static int BMK_seed(winnerInfo_t* winners, const paramValues_t params,
                 /* too large compression speed difference for the compression benefit */
                 if (W_ratio > O_ratio)
                 DISPLAY ("Compression Speed : %5.3f @ %4.1f MB/s  vs  %5.3f @ %4.1f MB/s   : not enough for level %i\n",
-                         W_ratio, (double)testResult.cSpeed / (1 MB),
-                         O_ratio, (double)winners[cLevel].result.cSpeed / (1 MB),   cLevel);
+                         W_ratio, (double)testResult.cSpeed / MB_UNIT,
+                         O_ratio, (double)winners[cLevel].result.cSpeed / MB_UNIT,   cLevel);
                 continue;
             }
             if (W_DSpeed_note   < O_DSpeed_note  ) {
                 /* too large decompression speed difference for the compression benefit */
                 if (W_ratio > O_ratio)
                 DISPLAY ("Decompression Speed : %5.3f @ %4.1f MB/s  vs  %5.3f @ %4.1f MB/s   : not enough for level %i\n",
-                         W_ratio, (double)testResult.dSpeed / (1 MB),
-                         O_ratio, (double)winners[cLevel].result.dSpeed / (1 MB),   cLevel);
+                         W_ratio, (double)testResult.dSpeed / MB_UNIT,
+                         O_ratio, (double)winners[cLevel].result.dSpeed / MB_UNIT,   cLevel);
                 continue;
             }
 
@@ -1817,7 +1821,7 @@ static void BMK_benchFullTable(const buffers_t buf, const contexts_t ctx)
     if (f==NULL) { DISPLAY("error opening %s \n", rfName); exit(1); }
 
     if (g_target) {
-        BMK_init_level_constraints(g_target * (1 MB));
+        BMK_init_level_constraints(g_target * MB_UNIT);
     } else {
         /* baseline config for level 1 */
         paramValues_t const l1params = cParamsToPVals(ZSTD_getCParams(1, buf.maxBlockSize, ctx.dictSize));


### PR DESCRIPTION
and fixed associated user programs (`fullbench`, `paramgrill`).

This is a pre-requisite for the multi-dictionaries test tool.

This refactoring is larger than anticipated.
Hopefully, the resulting API, defined in `bench.h`, should prove usable for additional projects.

I'm still not satisfied with the large nb of parameters that some of these functions require.
Improving this aspect will need another refactoring round.

