### PR TITLE
Cold dictionary mitigation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+v1.3.6
+perf: much faster dictionary builder, by @jenniferliu
+api : reduced DDict size by 2 KB
+misc: tests/paramgrill, a parameter optimizer, by @GeorgeLu97
+
 v1.3.5
 perf: much faster dictionary compression, by @felixhandte
 perf: small quality improvement for dictionary generation, by @terrelln

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -181,7 +181,8 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
 </b><p>  When compressing multiple messages / blocks with the same dictionary, it's recommended to load it just once.
   ZSTD_createCDict() will create a digested dictionary, ready to start future compression operations without startup delay.
   ZSTD_CDict can be created once and shared by multiple threads concurrently, since its usage is read-only.
-  `dictBuffer` can be released after ZSTD_CDict creation, since its content is copied within CDict 
+  `dictBuffer` can be released after ZSTD_CDict creation, since its content is copied within CDict
+  Note : A ZSTD_CDict can be created with an empty dictionary, but it is inefficient for small data. 
 </p></pre><BR>
 
 <pre><b>size_t      ZSTD_freeCDict(ZSTD_CDict* CDict);
@@ -195,7 +196,9 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
 </b><p>  Compression using a digested Dictionary.
   Faster startup than ZSTD_compress_usingDict(), recommended when same dictionary is used multiple times.
   Note that compression level is decided during dictionary creation.
-  Frame parameters are hardcoded (dictID=yes, contentSize=yes, checksum=no) 
+  Frame parameters are hardcoded (dictID=yes, contentSize=yes, checksum=no)
+  Note : ZSTD_compress_usingCDict() can be used with a ZSTD_CDict created from an empty dictionary.
+         But it is inefficient for small data, and it is recommended to use ZSTD_compressCCtx(). 
 </p></pre><BR>
 
 <pre><b>ZSTD_DDict* ZSTD_createDDict(const void* dictBuffer, size_t dictSize);

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -91,25 +91,27 @@
 /* prefetch
  * can be disabled, by declaring NO_PREFETCH macro */
 #if defined(NO_PREFETCH)
-#  define PREFETCH(ptr)   /* disabled */
+#  define PREFETCH(ptr)     (void)(ptr)  /* disabled */
 #else
 #  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  /* _mm_prefetch() is not defined outside of x86/x64 */
 #    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
-#    define PREFETCH(ptr)   _mm_prefetch((const char*)ptr, _MM_HINT_T1)
+#    define PREFETCH(ptr)   _mm_prefetch((const char*)(ptr), _MM_HINT_T1)
 #  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
-#    define PREFETCH(ptr)   __builtin_prefetch(ptr, 0 /* rw==read */, 2 /* locality */)
+#    define PREFETCH(ptr)   __builtin_prefetch((ptr), 0 /* rw==read */, 2 /* locality */)
 #  else
-#    define PREFETCH(ptr)   /* disabled */
+#    define PREFETCH(ptr)   (void)(ptr)  /* disabled */
 #  endif
 #endif  /* NO_PREFETCH */
 
 #define CACHELINE_SIZE 64
 
-#define PREFETCH_AREA(ptr, size)  {    \
-    size_t pos;                        \
-    for (pos=0; pos<size; pos+=CACHELINE_SIZE) { \
-        PREFETCH( (const char*)ptr + pos); \
-    }                                  \
+#define PREFETCH_AREA(p, s)  {            \
+    const char* const _ptr = (const char*)(p);  \
+    size_t const _size = (size_t)(s);     \
+    size_t _pos;                          \
+    for (_pos=0; _pos<_size; _pos+=CACHELINE_SIZE) {  \
+        PREFETCH(_ptr + _pos);            \
+    }                                     \
 }
 
 /* disable warnings */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -89,7 +89,13 @@
 #endif
 
 /* prefetch
- * can be disabled, by declaring NO_PREFETCH macro */
+ * can be disabled, by declaring NO_PREFETCH macro
+ * All prefetch invocations use a single default locality 2,
+ * generating instruction prefetcht1,
+ * which, according to Intel, means "load data into L2 cache".
+ * This is a good enough "middle ground" for the time being,
+ * though in theory, it would be better to specialize locality depending on data being prefetched.
+ * Tests could not determine any sensible difference based on locality value. */
 #if defined(NO_PREFETCH)
 #  define PREFETCH(ptr)     (void)(ptr)  /* disabled */
 #else

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -95,19 +95,21 @@
 #else
 #  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  /* _mm_prefetch() is not defined outside of x86/x64 */
 #    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
-#    define PREFETCH(ptr)   _mm_prefetch((const char*)ptr, _MM_HINT_T0)
+#    define PREFETCH(ptr)   _mm_prefetch((const char*)ptr, _MM_HINT_T1)
 #  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
-#    define PREFETCH(ptr)   __builtin_prefetch(ptr, 0 /* rw==read */, 0 /* locality */)
+#    define PREFETCH(ptr)   __builtin_prefetch(ptr, 0 /* rw==read */, 2 /* locality */)
 #  else
 #    define PREFETCH(ptr)   /* disabled */
 #  endif
 #endif  /* NO_PREFETCH */
 
-#define PREFETCH_AREA(ptr, size)  {   \
-    size_t pos;                       \
-    for (pos=0; pos<size; pos++) {    \
-        PREFETCH( (const char*)(const void*)ptr + pos); \
-    }                                 \
+#define CACHELINE_SIZE 64
+
+#define PREFETCH_AREA(ptr, size)  {    \
+    size_t pos;                        \
+    for (pos=0; pos<size; pos+=CACHELINE_SIZE) { \
+        PREFETCH( (const char*)ptr + pos); \
+    }                                  \
 }
 
 /* disable warnings */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -97,11 +97,18 @@
 #    include <mmintrin.h>   /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
 #    define PREFETCH(ptr)   _mm_prefetch((const char*)ptr, _MM_HINT_T0)
 #  elif defined(__GNUC__) && ( (__GNUC__ >= 4) || ( (__GNUC__ == 3) && (__GNUC_MINOR__ >= 1) ) )
-#    define PREFETCH(ptr)   __builtin_prefetch(ptr, 0, 0)
+#    define PREFETCH(ptr)   __builtin_prefetch(ptr, 0 /* rw==read */, 0 /* locality */)
 #  else
 #    define PREFETCH(ptr)   /* disabled */
 #  endif
 #endif  /* NO_PREFETCH */
+
+#define PREFETCH_AREA(ptr, size)  {   \
+    size_t pos;                       \
+    for (pos=0; pos<size; pos++) {    \
+        PREFETCH( (const char*)(const void*)ptr + pos); \
+    }                                 \
+}
 
 /* disable warnings */
 #ifdef _MSC_VER    /* Visual Studio */

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -56,7 +56,8 @@
 *  Dependencies
 *********************************************************/
 #include <string.h>      /* memcpy, memmove, memset */
-#include "cpu.h"         /* prefetch */
+#include "compiler.h"    /* prefetch */
+#include "cpu.h"         /* bmi2 */
 #include "mem.h"         /* low level memory routines */
 #define FSE_STATIC_LINKING_ONLY
 #include "fse.h"

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -612,7 +612,7 @@ size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
                 if (litCSize + lhSize > srcSize) return ERROR(corruption_detected);
 
                 /* prefetch huffman table if cold */
-                if (dctx->ddictIsCold && (litSize > 256 /* heuristic */)) {
+                if (dctx->ddictIsCold && (litSize > 768 /* heuristic */)) {
                     PREFETCH_AREA(dctx->HUFptr, sizeof(dctx->entropy.hufTable));
                 }
 
@@ -917,8 +917,7 @@ static size_t ZSTD_buildSeqTable(ZSTD_seqSymbol* DTableSpace, const ZSTD_seqSymb
     case set_repeat:
         if (!flagRepeatTable) return ERROR(corruption_detected);
         /* prefetch FSE table if used */
-        if (ddictIsCold && (nbSeq > 16 /* heuristic */)) {
-        //if (ddictIsCold) {
+        if (ddictIsCold && (nbSeq > 24 /* heuristic */)) {
             const void* const pStart = *DTablePtr;
             size_t const pSize = sizeof(ZSTD_seqSymbol) * (SEQSYMBOL_TABLE_SIZE(maxLog));
             PREFETCH_AREA(pStart, pSize);

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1041,7 +1041,6 @@ size_t ZSTD_decodeSeqHeaders(ZSTD_DCtx* dctx, int* nbSeqPtr,
         size_t const dictSize = (const char*)dctx->prefixStart - (const char*)dctx->virtualStart;
         size_t const pSize = MIN(dictSize, (size_t)(64*nbSeq));
         const void* const pStart = (const char*)dctx->dictEnd - pSize;
-        DEBUGLOG(2, "dictSize: %zu  ;  prefetchSize: %zu", dictSize, pSize);
         PREFETCH_AREA(pStart, pSize);
         dctx->ddictIsCold = 0;
     }
@@ -2384,7 +2383,7 @@ size_t ZSTD_decompressBegin_usingDDict(ZSTD_DCtx* dctx, const ZSTD_DDict* ddict)
     assert(dctx != NULL);
     if (ddict) {
         dctx->ddictIsCold = (dctx->dictEnd != (const char*)ddict->dictContent + ddict->dictSize);
-        DEBUGLOG(2, "DDict is %s",
+        DEBUGLOG(4, "DDict is %s",
                     dctx->ddictIsCold ? "~cold~" : "hot!");
     }
     CHECK_F( ZSTD_decompressBegin(dctx) );

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -206,6 +206,7 @@ static void ZSTD_initDCtx_internal(ZSTD_DCtx* dctx)
     dctx->maxWindowSize = ZSTD_MAXWINDOWSIZE_DEFAULT;
     dctx->ddict       = NULL;
     dctx->ddictLocal  = NULL;
+    dctx->dictEnd     = NULL;
     dctx->ddictIsCold = 0;
     dctx->inBuff      = NULL;
     dctx->inBuffSize  = 0;

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1039,7 +1039,8 @@ size_t ZSTD_decodeSeqHeaders(ZSTD_DCtx* dctx, int* nbSeqPtr,
     /* prefetch dictionary content */
     if (dctx->ddictIsCold) {
         size_t const dictSize = (const char*)dctx->prefixStart - (const char*)dctx->virtualStart;
-        size_t const pSize = MIN(dictSize, (size_t)(64*nbSeq));
+        size_t const psmin = MIN(dictSize, (size_t)(64*nbSeq) /* heuristic */ );
+        size_t const pSize = MIN(psmin, 128 KB /* protection */ );
         const void* const pStart = (const char*)dctx->dictEnd - pSize;
         PREFETCH_AREA(pStart, pSize);
         dctx->ddictIsCold = 0;


### PR DESCRIPTION
In situation where there are many (~ several thousands) dictionaries in memory accessed in random order, the speed of dictionary decompression can be noticeably impacted (#1289), because dictionaries are always "cold", generating a lot of cache misses.

This patch mitigates this detrimental effect, by detecting when it happens, and issuing selected prefetching orders before starting decompression.

This version is more general than previously created `mitigationXp`. 
It preserves current performance when dictionary is re-used. 
It carefully triggers prefetching only when tables are necessary, 
and only when the amount of associated work is "large enough". 
Different heuristics have been tested to define this criteria, 
I've been conservative during their selection, as the more a host is already busy with other tasks, the less it likes its cache being polluted by too much prefetching. 
When in doubt or when benefit are small, prefetching is reduced or not selected.

This version also handles correctly pathological situations, such as very small blocks combined with very large dictionaries, poorly or highly compressible input, etc.

A few numbers, from #1289 : 
Using silesia/dickens, cut into fixed size blocks, with dictionaries of different sizes, all dictionaries are always cold : 

| block size | dict size | ratio | cold | this branch | improvement
| -- | -- | -- | -- | -- | -- |
| 4KB | - | 2.004 | 300 | 300 | - |
| 4KB | 4 KB | 2.185 | 175 | 235 | +34% |
| 4 KB | 8 KB | 2.252 | 165 | 216 | +31% |
| 4 KB | 110 KB | 2.574 | 118 | 141 | +19% |
| 1 KB | - | 1.713 | 202 | 202 | - |
| 1 KB | 4 KB | 2.035 | 92 | 145 | +57% |
| 1 KB | 8 KB | 2.105 | 87 | 140 | +60% |
| 1 KB | 110 KB | 2.432 | 73 | 79 | +8% |
