### PR TITLE
Fix largeNbDicts bench for clangbuild

### DIFF
--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -766,8 +766,8 @@ int main (int argc, const char** argv)
     const char* dictionary = NULL;
     int cLevel = CLEVEL_DEFAULT;
     size_t blockSize = BLOCKSIZE_DEFAULT;
-    size_t nbDicts = 0;  /* determine nbDicts automatically: 1 dictionary per block */
-    size_t nbBlocks = 0; /* determine nbBlocks automatically, from source and blockSize */
+    unsigned nbDicts = 0;  /* determine nbDicts automatically: 1 dictionary per block */
+    unsigned nbBlocks = 0; /* determine nbBlocks automatically, from source and blockSize */
 
     for (int argNb = 1; argNb < argc ; argNb++) {
         const char* argument = argv[argNb];


### PR DESCRIPTION
Remove unsigned to size_t promotion to fix implicit down conversion errors in clangbuild target on the dev branch.

nbDicts/nbBlocks. that represent number of some objects, were generated as unsigned by the command line parser. There is no need to declare as size_t to just pass them to another function.
