### PR TITLE
Fix #1082

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1914,9 +1914,9 @@ int FIO_decompressMultipleFilenames(const char** srcNamesTable, unsigned nbFiles
             EXM_THROW(72, "Write error : cannot properly close output file");
     } else {
         size_t suffixSize;
-        size_t dfnSize = FNSPACE;
+        size_t dfnbCapacity = FNSPACE;
         unsigned u;
-        char* dstFileName = (char*)malloc(FNSPACE);
+        char* dstFileName = (char*)malloc(dfnbCapacity);
         if (dstFileName==NULL)
             EXM_THROW(73, "not enough memory for dstFileName");
         for (u=0; u<nbFiles; u++) {   /* create dstFileName */
@@ -1930,27 +1930,34 @@ int FIO_decompressMultipleFilenames(const char** srcNamesTable, unsigned nbFiles
                 continue;
             }
             suffixSize = strlen(suffixPtr);
-            if (dfnSize+suffixSize <= sfnSize+1) {
+            if (dfnbCapacity+suffixSize <= sfnSize+1) {
                 free(dstFileName);
-                dfnSize = sfnSize + 20;
-                dstFileName = (char*)malloc(dfnSize);
+                dfnbCapacity = sfnSize + 20;
+                dstFileName = (char*)malloc(dfnbCapacity);
                 if (dstFileName==NULL)
                     EXM_THROW(74, "not enough memory for dstFileName");
             }
             if (sfnSize <= suffixSize
-                || (strcmp(suffixPtr, GZ_EXTENSION)
+                || (   strcmp(suffixPtr, ZSTD_EXTENSION)
+                #ifdef ZSTD_GZDECOMPRESS
+                    && strcmp(suffixPtr, GZ_EXTENSION)
+                #endif
+                #ifdef ZSTD_LZMADECOMPRESS
                     && strcmp(suffixPtr, XZ_EXTENSION)
-                    && strcmp(suffixPtr, ZSTD_EXTENSION)
                     && strcmp(suffixPtr, LZMA_EXTENSION)
-                    && strcmp(suffixPtr, LZ4_EXTENSION)) ) {
+                #endif
+                #ifdef ZSTD_LZ4DECOMPRESS
+                    && strcmp(suffixPtr, LZ4_EXTENSION)
+                #endif
+                    ) ) {
                 const char* suffixlist = ZSTD_EXTENSION
-                #ifdef ZSTD_GZCOMPRESS
+                #ifdef ZSTD_GZDECOMPRESS
                     "/" GZ_EXTENSION
                 #endif
-                #ifdef ZSTD_LZMACOMPRESS
+                #ifdef ZSTD_LZMADECOMPRESS
                     "/" XZ_EXTENSION "/" LZMA_EXTENSION
                 #endif
-                #ifdef ZSTD_LZ4COMPRESS
+                #ifdef ZSTD_LZ4DECOMPRESS
                     "/" LZ4_EXTENSION
                 #endif
                 ;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2010,7 +2010,7 @@ FIO_analyzeFrames(fileInfo_t* info, FILE* const srcFile)
               && (numBytesRead == 0)
               && (info->compressedSize > 0)
               && (info->compressedSize != UTIL_FILESIZE_UNKNOWN) ) {
-                return info_success;
+                break;  /* correct end of file => success */
             }
             EXIT_IF(feof(srcFile), info_not_zstd, "Error: reached end of file with incomplete frame");
             EXIT_IF(1, info_frame_error, "Error: did not reach end of file but ran out of frames");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2010,7 +2010,7 @@ FIO_analyzeFrames(fileInfo_t* info, FILE* const srcFile)
               && (numBytesRead == 0)
               && (info->compressedSize > 0)
               && (info->compressedSize != UTIL_FILESIZE_UNKNOWN) ) {
-                return 0;  /* successful end of file */
+                return info_success;
             }
             EXIT_IF(feof(srcFile), info_not_zstd, "Error: reached end of file with incomplete frame");
             EXIT_IF(1, info_frame_error, "Error: did not reach end of file but ran out of frames");
@@ -2031,7 +2031,7 @@ FIO_analyzeFrames(fileInfo_t* info, FILE* const srcFile)
                 info->windowSize = header.windowSize;
                 /* move to the end of the frame header */
                 {   size_t const headerSize = ZSTD_frameHeaderSize(headerBuffer, numBytesRead);
-                    EXIT_IF(ZSTD_isError(headerSize), 1, "Error: could not determine frame header size");
+                    EXIT_IF(ZSTD_isError(headerSize), info_frame_error, "Error: could not determine frame header size");
                     EXIT_IF(fseek(srcFile, ((long)headerSize)-((long)numBytesRead), SEEK_CUR) != 0,
                             info_frame_error, "Error: could not move to end of frame header");
                 }

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -547,7 +547,7 @@ int main(int argCount, const char* argv[])
     memset(&compressionParams, 0, sizeof(compressionParams));
 
     /* init crash handler */
-    //FIO_addAbortHandler();
+    FIO_addAbortHandler();
 
     /* command switches */
     for (argNb=1; argNb<argCount; argNb++) {

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -547,7 +547,7 @@ int main(int argCount, const char* argv[])
     memset(&compressionParams, 0, sizeof(compressionParams));
 
     /* init crash handler */
-    FIO_addAbortHandler();
+    //FIO_addAbortHandler();
 
     /* command switches */
     for (argNb=1; argNb<argCount; argNb++) {

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -201,7 +201,7 @@ test ! -f tmp.zst  # tmp.zst should not be created
 $ECHO "test : do not delete destination when source is not present"
 touch tmp    # create destination file
 $ZSTD -d -f tmp.zst && die "attempt to decompress a non existing file"
-! test -f tmp  # destination file should still be present (test disabled temporarily)
+test -f tmp  # destination file should still be present (test disabled temporarily)
 rm tmp*
 
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -198,10 +198,15 @@ $ECHO a | $ZSTD --rm > $INTOVOID   # --rm should remain silent
 rm tmp
 $ZSTD -f tmp && die "tmp not present : should have failed"
 test ! -f tmp.zst  # tmp.zst should not be created
-$ECHO "test : do not delete destination when source is not present"
+$ECHO "test : -d -f do not delete destination when source is not present"
 touch tmp    # create destination file
 $ZSTD -d -f tmp.zst && die "attempt to decompress a non existing file"
-test -f tmp  # destination file should still be present (test disabled temporarily)
+test -f tmp  # destination file should still be present
+$ECHO "test : -f do not delete destination when source is not present"
+rm tmp         # erase source file
+touch tmp.zst  # create destination file
+$ZSTD -f tmp && die "attempt to compress a non existing file"
+test -f tmp.zst  # destination file should still be present
 rm tmp*
 
 
@@ -824,6 +829,7 @@ roundTripTest -g1M -P50 "1 --single-thread --long=29" " --zstd=wlog=28 --memory=
 $ECHO "\n===>   adaptive mode "
 roundTripTest -g270000000 " --adapt"
 roundTripTest -g27000000 " --adapt=min=1,max=4"
+$ECHO "===>   test: --adapt must fail on incoherent bounds "
 ./datagen > tmp
 $ZSTD -f -vv --adapt=min=10,max=9 tmp && die "--adapt must fail on incoherent bounds"
 
@@ -834,6 +840,7 @@ if [ "$1" != "--test-large-data" ]; then
 fi
 
 
+#############################################################################
 
 $ECHO "\n===>   large files tests "
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -180,6 +180,8 @@ chmod 400 tmpro.zst
 $ZSTD -q tmpro && die "should have refused to overwrite read-only file"
 $ZSTD -q -f tmpro
 rm -f tmpro tmpro.zst
+
+
 $ECHO "test : file removal"
 $ZSTD -f --rm tmp
 test ! -f tmp  # tmp should no longer be present
@@ -196,9 +198,14 @@ $ECHO a | $ZSTD --rm > $INTOVOID   # --rm should remain silent
 rm tmp
 $ZSTD -f tmp && die "tmp not present : should have failed"
 test ! -f tmp.zst  # tmp.zst should not be created
+$ECHO "test : do not delete destination when source is not present"
+touch tmp    # create destination file
+$ZSTD -d -f tmp.zst && die "attempt to decompress a non existing file"
+! test -f tmp  # destination file should still be present (test disabled temporarily)
+rm tmp*
+
 
 $ECHO "test : compress multiple files"
-rm tmp*
 $ECHO hello > tmp1
 $ECHO world > tmp2
 $ZSTD tmp1 tmp2 -o "$INTOVOID"


### PR DESCRIPTION
Fix #1082 : 
`zstd -f` and `zstd -d -f` do no longer overwrite destination file
when source file does not exist.

This is achieved by reversing operation order within `fileio.c`.
opening source before destination,
thus skipping destination opening where there is a pb with source.

Added associated tests cases.