### PR TITLE
don't assume __linux__ means __GLIBC__ on BACKTRACES_ENABLE

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -21,7 +21,7 @@
 #endif
 
 #if !defined(BACKTRACES_ENABLE) && \
-   (defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) )
+   (defined(__GLIBC__) || (defined(__APPLE__) && defined(__MACH__)) )
 #  define BACKTRACES_ENABLE 1
 #endif
 


### PR DESCRIPTION
check for __GLIBC__ instead of __linux__ as musl libc doesn't provide
execinfo.h

fixes compilation on Alpine Linux and Void Linux musl arches.