### PR TITLE
`ZSTD_btlazy2`: Avoid Erroneously Trampling on Match with Worse Dictionary Match

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -188,7 +188,7 @@ ZSTD_DUBT_findBetterDictMatch (
         if (matchLength > bestLength) {
             U32 matchIndex = dictMatchIndex + dictIndexDelta;
             if ( (4*(int)(matchLength-bestLength)) > (int)(ZSTD_highbit32(current-matchIndex+1) - ZSTD_highbit32((U32)offsetPtr[0]+1)) ) {
-                DEBUGLOG(2, "ZSTD_DUBT_findBestDictMatch(%u) : found better match length %u -> %u and offsetCode %u -> %u (dictMatchIndex %u, matchIndex %u)",
+                DEBUGLOG(9, "ZSTD_DUBT_findBetterDictMatch(%u) : found better match length %u -> %u and offsetCode %u -> %u (dictMatchIndex %u, matchIndex %u)",
                     current, (U32)bestLength, (U32)matchLength, (U32)*offsetPtr, ZSTD_REP_MOVE + current - matchIndex, dictMatchIndex, matchIndex);
                 bestLength = matchLength, *offsetPtr = ZSTD_REP_MOVE + current - matchIndex;
             }
@@ -197,7 +197,6 @@ ZSTD_DUBT_findBetterDictMatch (
             }
         }
 
-        DEBUGLOG(2, "matchLength:%6zu, match:%p, prefixStart:%p, ip:%p", matchLength, match, prefixStart, ip);
         if (match[matchLength] < ip[matchLength]) {
             if (dictMatchIndex <= btLow) { break; }   /* beyond tree size, stop the search */
             commonLengthSmaller = matchLength;    /* all smaller will now have at least this guaranteed common length */
@@ -212,7 +211,7 @@ ZSTD_DUBT_findBetterDictMatch (
 
     if (bestLength >= MINMATCH) {
         U32 const mIndex = current - ((U32)*offsetPtr - ZSTD_REP_MOVE); (void)mIndex;
-        DEBUGLOG(2, "ZSTD_DUBT_findBestDictMatch(%u) : found match of length %u and offsetCode %u (pos %u)",
+        DEBUGLOG(8, "ZSTD_DUBT_findBetterDictMatch(%u) : found match of length %u and offsetCode %u (pos %u)",
                     current, (U32)bestLength, (U32)*offsetPtr, mIndex);
     }
     return bestLength;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -173,7 +173,6 @@ ZSTD_DUBT_findBetterDictMatch (
     U32         const btLow = (btMask >= dictHighLimit - dictLowLimit) ? dictLowLimit : dictHighLimit - btMask;
 
     size_t commonLengthSmaller=0, commonLengthLarger=0, bestLength=0;
-    U32 matchEndIdx = current+8+1;
 
     (void)dictMode;
     assert(dictMode == ZSTD_dictMatchState);
@@ -188,8 +187,6 @@ ZSTD_DUBT_findBetterDictMatch (
 
         if (matchLength > bestLength) {
             U32 matchIndex = dictMatchIndex + dictIndexDelta;
-            if (matchLength > matchEndIdx - matchIndex)
-                matchEndIdx = matchIndex + (U32)matchLength;
             if ( (4*(int)(matchLength-bestLength)) > (int)(ZSTD_highbit32(current-matchIndex+1) - ZSTD_highbit32((U32)offsetPtr[0]+1)) ) {
                 DEBUGLOG(2, "ZSTD_DUBT_findBestDictMatch(%u) : found better match length %u -> %u and offsetCode %u -> %u (dictMatchIndex %u, matchIndex %u)",
                     current, (U32)bestLength, (U32)matchLength, (U32)*offsetPtr, ZSTD_REP_MOVE + current - matchIndex, dictMatchIndex, matchIndex);


### PR DESCRIPTION
This changeset switches the mitigation strategy away from the one taken in PR #1350 (which avoids missing the end-of-input check by restarting the dictionary search with `bestLength = 0`) to totally avoiding searching the dictionary when we're in that situation, since a precondition to being at risk of running past the end of the input is that we've already found an optimal match. So there's no utility in searching the dictionary. I suspect this will produce a small performance win.

Notably, this approach to avoiding the issue was already present in the `ZSTD_btopt` implementation. Not sure how it got missed in `ZSTD_btlazy2` :cry:.

In making this change, this patch fixes an unfortunate bug. Without this change, the `ZSTD_btlazy2` strategy unconditionally selects the best dictionary match (if one is found) over the best input match, even if the dictionary match is worse. Furthermore, it then skips trying to match against the input as if it had used the better match into the input that it found and discarded. In the worst case, this can lead to totally failing to compress very repetitive input. This changeset avoids that behavior by returning to only considering matches in the dictionary that are better than the best input match.

As a result, this PR fixes issue #1357.