### PR TITLE
backtrace support compiled with more conditions

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -136,7 +136,6 @@ endif
 
 # enable backtrace symbol names for Linux & Darwin
 BACKTRACE ?= 0
-DEBUGFLAGS = -DBACKTRACE_ENABLE=$(BACKTRACE)
 ifeq (,$(filter Windows%, $(OS)))
 ifeq ($(BACKTRACE), 1)
 DEBUGFLAGS += -DBACKTRACE_ENABLE=1

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -134,11 +134,13 @@ else
 LZ4_MSG := $(NO_LZ4_MSG)
 endif
 
-# enable backtrace symbol names for Linux/Darwin
-ALL_SYMBOLS := 0
+# enable backtrace symbol names for Linux & Darwin
+BACKTRACE ?= 0
+DEBUGFLAGS = -DBACKTRACE_ENABLE=$(BACKTRACE)
 ifeq (,$(filter Windows%, $(OS)))
-ifeq ($(ALL_SYMBOLS), 1)
-DEBUGFLAGS_LD+=-rdynamic
+ifeq ($(BACKTRACE), 1)
+DEBUGFLAGS += -DBACKTRACE_ENABLE=1
+DEBUGFLAGS_LD += -rdynamic
 endif
 endif
 
@@ -168,12 +170,12 @@ endif
 	$(CC) $(FLAGS) $^ $(RES_FILE) -o $@$(EXT) $(LDFLAGS)
 
 .PHONY: zstd-release
-zstd-release: DEBUGFLAGS :=
+zstd-release: DEBUGFLAGS := -DBACKTRACE_ENABLE=0
 zstd-release: DEBUGFLAGS_LD :=
 zstd-release: zstd
 
 zstd32 : CPPFLAGS += $(THREAD_CPP)
-zstd32 : LDFLAGS += $(THREAD_LD)
+zstd32 : LDFLAGS  += $(THREAD_LD)
 zstd32 : CPPFLAGS += -DZSTD_LEGACY_SUPPORT=$(ZSTD_LEGACY_SUPPORT)
 zstd32 : $(ZSTDLIB_FILES) zstdcli.c fileio.c bench.c datagen.c dibio.c
 ifneq (,$(filter Windows%,$(OS)))
@@ -185,17 +187,17 @@ zstd-nolegacy : $(ZSTD_FILES) $(ZDICT_FILES) zstdcli.o fileio.c bench.o datagen.
 	$(CC) $(FLAGS) $^ -o $@$(EXT) $(LDFLAGS)
 
 zstd-nomt : THREAD_CPP :=
-zstd-nomt : THREAD_LD :=
+zstd-nomt : THREAD_LD  :=
 zstd-nomt : THREAD_MSG := - multi-threading disabled
 zstd-nomt : zstd
 
 zstd-nogz : ZLIBCPP :=
-zstd-nogz : ZLIBLD :=
+zstd-nogz : ZLIBLD  :=
 zstd-nogz : ZLIB_MSG := - gzip support is disabled
 zstd-nogz : zstd
 
 zstd-noxz : LZMACPP :=
-zstd-noxz : LZMALD :=
+zstd-noxz : LZMALD  :=
 zstd-noxz : LZMA_MSG := - xz/lzma support is disabled
 zstd-noxz : zstd
 

--- a/programs/README.md
+++ b/programs/README.md
@@ -61,12 +61,12 @@ There are however other Makefile targets that create different variations of CLI
   In which case, linking stage will fail if `lz4` library cannot be found.
   This is useful to prevent silent feature disabling.
 
-- __ALL_SYMBOLS__ : `zstd` can display a stack backtrace if the execution
+- __BACKTRACE__ : `zstd` can display a stack backtrace when execution
   generates a runtime exception. By default, this feature may be
   degraded/disabled on some platforms unless additional compiler directives are
-  applied. When triaging a runtime issue, enabling this feature can provided
+  applied. When triaging a runtime issue, enabling this feature can provide
   more context to determine the location of the fault.
-  Example : `make zstd ALL_SYMBOLS=1`
+  Example : `make zstd BACKTRACE=1`
 
 
 #### Aggregation of parameters

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -20,6 +20,14 @@
 #  define _POSIX_SOURCE 1          /* disable %llu warnings with MinGW on Windows */
 #endif
 
+#if defined(__has_feature) && !defined(BACKTRACE_ENABLE) /* Clang compiler */
+#  if (__has_feature(address_sanitizer))
+#    define BACKTRACE_ENABLE 0
+#  endif /* __has_feature(address_sanitizer) */
+#elif defined(__SANITIZE_ADDRESS__) && !defined(BACKTRACE_ENABLE) /* GCC compiler */
+#  define BACKTRACE_ENABLE 0
+#endif
+
 #if !defined(BACKTRACE_ENABLE)          \
    && ((defined(__linux__) && defined(__GLIBC__)) \
        || (defined(__APPLE__) && defined(__MACH__)) )

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -20,9 +20,10 @@
 #  define _POSIX_SOURCE 1          /* disable %llu warnings with MinGW on Windows */
 #endif
 
-#if !defined(BACKTRACES_ENABLE) && \
-   (defined(__GLIBC__) || (defined(__APPLE__) && defined(__MACH__)) )
-#  define BACKTRACES_ENABLE 1
+#if !defined(BACKTRACE_ENABLE)          \
+   && ((defined(__linux__) && defined(__GLIBC__)) \
+       || (defined(__APPLE__) && defined(__MACH__)) )
+#  define BACKTRACE_ENABLE 1
 #endif
 
 
@@ -37,7 +38,7 @@
 #include <assert.h>
 #include <errno.h>      /* errno */
 #include <signal.h>
-#ifdef BACKTRACES_ENABLE
+#ifdef BACKTRACE_ENABLE
 #  include <execinfo.h>   /* backtrace, backtrace_symbols */
 #endif
 
@@ -167,7 +168,7 @@ static void clearHandler(void)
 /*-*********************************************************
 *  Termination signal trapping (Print debug stack trace)
 ***********************************************************/
-#ifdef BACKTRACES_ENABLE
+#ifdef BACKTRACE_ENABLE
 
 #define MAX_STACK_FRAMES    50
 
@@ -208,7 +209,7 @@ static void ABRThandler(int sig) {
 
 void FIO_addAbortHandler()
 {
-#ifdef BACKTRACES_ENABLE
+#ifdef BACKTRACE_ENABLE
     signal(SIGABRT, ABRThandler);
     signal(SIGFPE, ABRThandler);
     signal(SIGILL, ABRThandler);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -38,7 +38,7 @@
 #include <assert.h>
 #include <errno.h>      /* errno */
 #include <signal.h>
-#ifdef BACKTRACE_ENABLE
+#if defined(BACKTRACE_ENABLE) && (BACKTRACE_ENABLE >= 1)
 #  include <execinfo.h>   /* backtrace, backtrace_symbols */
 #endif
 
@@ -168,7 +168,7 @@ static void clearHandler(void)
 /*-*********************************************************
 *  Termination signal trapping (Print debug stack trace)
 ***********************************************************/
-#ifdef BACKTRACE_ENABLE
+#if defined(BACKTRACE_ENABLE) && (BACKTRACE_ENABLE>=1)
 
 #define MAX_STACK_FRAMES    50
 
@@ -209,7 +209,7 @@ static void ABRThandler(int sig) {
 
 void FIO_addAbortHandler()
 {
-#ifdef BACKTRACE_ENABLE
+#if defined(BACKTRACE_ENABLE) && (BACKTRACE_ENABLE>=1)
     signal(SIGABRT, ABRThandler);
     signal(SIGFPE, ABRThandler);
     signal(SIGILL, ABRThandler);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -166,14 +166,20 @@ static void clearHandler(void)
 #  define BACKTRACE_ENABLE 0
 #endif
 
-#if !defined(BACKTRACE_ENABLE)          \
-   && ((defined(__linux__) && defined(__GLIBC__)) \
-       || (defined(__APPLE__) && defined(__MACH__)) )
-#  define BACKTRACE_ENABLE 1
+#if !defined(BACKTRACE_ENABLE)
+/* automatic detector : backtrace enabled by default on linux+glibc and osx */
+#  if (defined(__linux__) && defined(__GLIBC__)) \
+     || (defined(__APPLE__) && defined(__MACH__))
+#    define BACKTRACE_ENABLE 1
+#  else
+#    define BACKTRACE_ENABLE 0
+#  endif
 #endif
 
+/* note : after this point, BACKTRACE_ENABLE is necessarily defined */
 
-#if defined(BACKTRACE_ENABLE) && (BACKTRACE_ENABLE>=1)
+
+#if BACKTRACE_ENABLE
 
 #include <execinfo.h>   /* backtrace, backtrace_symbols */
 
@@ -216,7 +222,7 @@ static void ABRThandler(int sig) {
 
 void FIO_addAbortHandler()
 {
-#if defined(BACKTRACE_ENABLE) && (BACKTRACE_ENABLE>=1)
+#if BACKTRACE_ENABLE
     signal(SIGABRT, ABRThandler);
     signal(SIGFPE, ABRThandler);
     signal(SIGILL, ABRThandler);


### PR DESCRIPTION
following #1356,
only enable backtrace compilation on linux+glibc.

Also, disable backtrace by default from "release" compilation,
so that less platforms get impacted by the new requirements.
Can be manually enabled/disabled using `BACKTRACE=1/0`.