### PR TITLE
Improved decompression speed

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -339,17 +339,8 @@ MEM_STATIC size_t BIT_getUpperBits(size_t bitContainer, U32 const start)
 
 MEM_STATIC size_t BIT_getMiddleBits(size_t bitContainer, U32 const start, U32 const nbBits)
 {
-#if defined(__BMI__) && defined(__GNUC__) && __GNUC__*1000+__GNUC_MINOR__ >= 4008  /* experimental */
-#  if defined(__x86_64__)
-    if (sizeof(bitContainer)==8)
-        return _bextr_u64(bitContainer, start, nbBits);
-    else
-#  endif
-        return _bextr_u32(bitContainer, start, nbBits);
-#else
     assert(nbBits < BIT_MASK_SIZE);
     return (bitContainer >> start) & BIT_mask[nbBits];
-#endif
 }
 
 MEM_STATIC size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
@@ -366,9 +357,11 @@ MEM_STATIC size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
  * @return : value extracted */
 MEM_STATIC size_t BIT_lookBits(const BIT_DStream_t* bitD, U32 nbBits)
 {
-#if defined(__BMI__) && defined(__GNUC__)   /* experimental; fails if bitD->bitsConsumed + nbBits > sizeof(bitD->bitContainer)*8 */
+#if 1
+    assert(bitD->bitsConsumed + nbBits <= sizeof(bitD->bitContainer)*8);
     return BIT_getMiddleBits(bitD->bitContainer, (sizeof(bitD->bitContainer)*8) - bitD->bitsConsumed - nbBits, nbBits);
 #else
+    /* previous code path, seems slower */
     U32 const regMask = sizeof(bitD->bitContainer)*8 - 1;
     return ((bitD->bitContainer << (bitD->bitsConsumed & regMask)) >> 1) >> ((regMask-nbBits) & regMask);
 #endif

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -339,9 +339,10 @@ MEM_STATIC size_t BIT_getUpperBits(size_t bitContainer, U32 const start)
 
 MEM_STATIC size_t BIT_getMiddleBits(size_t bitContainer, U32 const start, U32 const nbBits)
 {
+    U32 const regMask = sizeof(bitContainer)*8 - 1;
+    /* if start > regMask, bitstream is corrupted, and result is undefined */
     assert(nbBits < BIT_MASK_SIZE);
-    /* if start > bitMask, bitstream is corrupted, and result is undefined */
-    return (bitContainer >> start) & BIT_mask[nbBits];
+    return (bitContainer >> (start & regMask)) & BIT_mask[nbBits];
 }
 
 MEM_STATIC size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -340,7 +340,7 @@ MEM_STATIC size_t BIT_getUpperBits(size_t bitContainer, U32 const start)
 MEM_STATIC size_t BIT_getMiddleBits(size_t bitContainer, U32 const start, U32 const nbBits)
 {
     assert(nbBits < BIT_MASK_SIZE);
-    assert(start < sizeof(bitContainer)*8);
+    /* if start > bitMask, bitstream is corrupted, and result is undefined */
     return (bitContainer >> start) & BIT_mask[nbBits];
 }
 


### PR DESCRIPTION
When extracting bits from a register,
there are 2 possible methods : double shift, or shift+mask.

This patch arbitrates this choice in favor of shift+mask.

On my laptop, it results in a substantial speed boost on `clang` (+6.5%), and a moderate one on `gcc` (+2.5%). The `clang` win is remarkable.

But that's not the end of the story. The situation is different on other platforms : 
On `entropy`, with bmi2 : `clang` -2%, and `gcc` +1%.
On `entropy`, without bmi2 : `clang` +3%, and `gcc` +3%
On my outdated core 2 platform, necessarily without bmi2 : `clang` -2%, and `gcc` +0%.

So mileage vary. It might also vary depending on compiler versions.
In general, one should expect shift+mask to perform better when bmi2 is not present,
but it's not always the case (see core2 results). And, even with bmi2 activated, shift+mask sometimes ends up being better.

I'm not too sure what to think of this patch. 
I'll be glad to collect more signal on its usefulness.