### PR TITLE
fixed minor gcc warning

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1219,7 +1219,8 @@ FIO_determineCompressedName(const char* srcFileName, const char* suffix)
     size_t const sfnSize = strlen(srcFileName);
     size_t const suffixSize = strlen(suffix);
 
-    if (dfnbCapacity <= sfnSize+suffixSize+1) {  /* resize name buffer */
+    if (dfnbCapacity <= sfnSize+suffixSize+1) {
+        /* resize buffer for dstName */
         free(dstFileNameBuffer);
         dfnbCapacity = sfnSize + suffixSize + 30;
         dstFileNameBuffer = (char*)malloc(dfnbCapacity);
@@ -1227,8 +1228,8 @@ FIO_determineCompressedName(const char* srcFileName, const char* suffix)
             EXM_THROW(30, "zstd: %s", strerror(errno));
     }   }
     assert(dstFileNameBuffer != NULL);
-    strncpy(dstFileNameBuffer, srcFileName, sfnSize+1 /* Include null */);
-    strncat(dstFileNameBuffer, suffix, suffixSize);
+    memcpy(dstFileNameBuffer, srcFileName, sfnSize);
+    memcpy(dstFileNameBuffer+sfnSize, suffix, suffixSize+1 /* Include terminating null */);
 
     return dstFileNameBuffer;
 }


### PR DESCRIPTION
`gcc-8` on Linux doesn't like `strncat` :
`warning: ‘strncat’ output truncated before terminating nul copying as many bytes from a string as its length`.

Not sure what was wrong, might as well be a false positive.
I can only produce this warning on gcc-8 on Linux.
gcc-8 on OS-X doesn't complain, neither clang nor gcc-7.

Anyway, the logic is simple enough to replaced by a simple `memcpy()`,
thus avoiding the shenanigans of null-terminated strings.