### PR TITLE
Fix libFuzzer location in makefile.

### DIFF
--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -99,7 +99,7 @@ libregression.a: $(FUZZ_HEADERS) $(PRGDIR)/util.h $(PRGDIR)/util.c regression_dr
 .PHONY: libFuzzer
 libFuzzer:
 	@$(RM) -rf Fuzzer
-	@git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer
+	@git clone https://chromium.googlesource.com/chromium/llvm-project/compiler-rt/lib/fuzzer Fuzzer
 	@cd Fuzzer && ./build.sh
 
 corpora/%_seed_corpus.zip:


### PR DESCRIPTION
libFuzzer's git repo was [moved into compiler-rt](https://reviews.llvm.org/D36908), so `make libFuzzer` clones an empty repo and dies.

change points to the new location within compiler-rt; `make libFuzzer` now builds libFuzzer.a