### PR TITLE
Clarify special case of offset history update

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -919,6 +919,10 @@ This means that when `Repeated_Offset1` (most recent) is used, history is unmodi
 When `Repeated_Offset2` is used, it's swapped with `Repeated_Offset1`.
 If any other offset is used, it becomes `Repeated_Offset1` and the rest are shift back by one.
 
+In the case of an `offset_value` of 3 and the literal length of the current
+sequence is zero the value `Repeasted_Offset1 - 1_byte` is a new offset,
+becoming the lead of the offset history and the first two repeated offsets will
+be shifted back.
 
 Skippable Frames
 ----------------

--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -920,7 +920,7 @@ When `Repeated_Offset2` is used, it's swapped with `Repeated_Offset1`.
 If any other offset is used, it becomes `Repeated_Offset1` and the rest are shift back by one.
 
 In the case of an `offset_value` of 3 and the literal length of the current
-sequence is zero the value `Repeasted_Offset1 - 1_byte` is a new offset,
+sequence is zero the value `Repeated_Offset1 - 1_byte` is a new offset,
 becoming the lead of the offset history and the first two repeated offsets will
 be shifted back.
 
@@ -1415,7 +1415,7 @@ __`Content`__ : The rest of the dictionary is its content.
               As long as the amount of data decoded from this frame is less than or
               equal to `Window_Size`, sequence commands may specify offsets longer
               than the total length of decoded output so far to reference back to the
-              dictionary, even parts of the dictionary with offsets larger than `Window_Size`.  
+              dictionary, even parts of the dictionary with offsets larger than `Window_Size`.
               After the total output has surpassed `Window_Size` however,
               this is no longer allowed and the dictionary is no longer accessible.
 

--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1415,7 +1415,7 @@ __`Content`__ : The rest of the dictionary is its content.
               As long as the amount of data decoded from this frame is less than or
               equal to `Window_Size`, sequence commands may specify offsets longer
               than the total length of decoded output so far to reference back to the
-              dictionary, even parts of the dictionary with offsets larger than `Window_Size`.
+              dictionary, even parts of the dictionary with offsets larger than `Window_Size`.  
               After the total output has surpassed `Window_Size` however,
               this is no longer allowed and the dictionary is no longer accessible.
 


### PR DESCRIPTION
If the current sequence has literal length of zero then an offset value
of three is handled in a special manner. While I implemented a golang
decoder I had to consult the educational decoder for clarification on
the update of the offset history in that case. This commit provides the
clarification that the offset value Repeated_Offset1-1 is handled as a
new offset is added to the offset history accordingly.