### PR TITLE
Prevent deadlock on malloc() failure.

### DIFF
--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -868,6 +868,8 @@ void COVER_best_finish(COVER_best_t *best, size_t compressedSize,
         if (!best->dict) {
           best->compressedSize = ERROR(GENERIC);
           best->dictSize = 0;
+          ZSTD_pthread_cond_signal(&best->cond);
+          ZSTD_pthread_mutex_unlock(&best->mutex);
           return;
         }
       }


### PR DESCRIPTION
If one of the helper threads executing `COVER_best_finish()` fails to allocate memory, it exits without releasing the mutex. Moreover, if every thread fails on `malloc()` then the main thread sleeps indifinetely on condition variable - that's why `cond_signal()` is also needed.