### PR TITLE
Remove redundant check

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -413,9 +413,7 @@ size_t ZSTD_CCtxParam_setParameter(
         return CCtxParams->forceWindow;
 
     case ZSTD_p_forceAttachDict :
-        CCtxParams->attachDictPref = value ?
-                                    (value > 0 ? ZSTD_dictForceAttach : ZSTD_dictForceCopy) :
-                                     ZSTD_dictDefaultAttach;
+        CCtxParams->attachDictPref = (value > 0 ? ZSTD_dictForceAttach : ZSTD_dictDefaultAttach);
         return CCtxParams->attachDictPref;
 
     case ZSTD_p_nbWorkers :


### PR DESCRIPTION
Reported by static analysis tool: value being unsigned, both (value) and (value > 0) are equivalent.

![zstd-dead-code](https://user-images.githubusercontent.com/44025701/48327059-a8eba880-e662-11e8-8a81-71b5749ca3c9.png)