### PR TITLE
Advanced API

### DIFF
--- a/contrib/adaptive-compression/adapt.c
+++ b/contrib/adaptive-compression/adapt.c
@@ -579,7 +579,7 @@ static void* compressionThread(void* arg)
                 params.cParams.windowLog = 23;
                 {
                     size_t const initError = ZSTD_compressBegin_advanced(ctx->cctx, job->src.start + job->dictSize - useDictSize, useDictSize, params, 0);
-                    size_t const windowSizeError = ZSTD_CCtx_setParameter(ctx->cctx, ZSTD_p_forceMaxWindow, 1);
+                    size_t const windowSizeError = ZSTD_CCtx_setParameter(ctx->cctx, ZSTD_c_forceMaxWindow, 1);
                     if (ZSTD_isError(initError) || ZSTD_isError(windowSizeError)) {
                         DISPLAY("Error: something went wrong while starting compression\n");
                         signalErrorToThreads(ctx);

--- a/contrib/seekable_format/zstdseek_compress.c
+++ b/contrib/seekable_format/zstdseek_compress.c
@@ -268,7 +268,7 @@ size_t ZSTD_seekable_compressStream(ZSTD_seekable_CStream* zcs, ZSTD_outBuffer* 
 static inline size_t ZSTD_seekable_seekTableSize(const ZSTD_frameLog* fl)
 {
     size_t const sizePerFrame = 8 + (fl->checksumFlag?4:0);
-    size_t const seekTableLen = ZSTD_skippableHeaderSize +
+    size_t const seekTableLen = ZSTD_SKIPPABLEHEADERSIZE +
                                 sizePerFrame * fl->size +
                                 ZSTD_seekTableFooterSize;
 
@@ -307,24 +307,24 @@ size_t ZSTD_seekable_writeSeekTable(ZSTD_frameLog* fl, ZSTD_outBuffer* output)
     size_t const seekTableLen = ZSTD_seekable_seekTableSize(fl);
 
     CHECK_Z(ZSTD_stwrite32(fl, output, ZSTD_MAGIC_SKIPPABLE_START | 0xE, 0));
-    CHECK_Z(ZSTD_stwrite32(fl, output, seekTableLen - ZSTD_skippableHeaderSize,
+    CHECK_Z(ZSTD_stwrite32(fl, output, seekTableLen - ZSTD_SKIPPABLEHEADERSIZE,
                            4));
 
     while (fl->seekTableIndex < fl->size) {
         CHECK_Z(ZSTD_stwrite32(fl, output,
                                fl->entries[fl->seekTableIndex].cSize,
-                               ZSTD_skippableHeaderSize +
+                               ZSTD_SKIPPABLEHEADERSIZE +
                                        sizePerFrame * fl->seekTableIndex + 0));
 
         CHECK_Z(ZSTD_stwrite32(fl, output,
                                fl->entries[fl->seekTableIndex].dSize,
-                               ZSTD_skippableHeaderSize +
+                               ZSTD_SKIPPABLEHEADERSIZE +
                                        sizePerFrame * fl->seekTableIndex + 4));
 
         if (fl->checksumFlag) {
             CHECK_Z(ZSTD_stwrite32(
                     fl, output, fl->entries[fl->seekTableIndex].checksum,
-                    ZSTD_skippableHeaderSize +
+                    ZSTD_SKIPPABLEHEADERSIZE +
                             sizePerFrame * fl->seekTableIndex + 8));
         }
 

--- a/contrib/seekable_format/zstdseek_decompress.c
+++ b/contrib/seekable_format/zstdseek_decompress.c
@@ -275,7 +275,7 @@ static size_t ZSTD_seekable_loadSeekTable(ZSTD_seekable* zs)
     {   U32 const numFrames = MEM_readLE32(zs->inBuff);
         U32 const sizePerEntry = 8 + (checksumFlag?4:0);
         U32 const tableSize = sizePerEntry * numFrames;
-        U32 const frameSize = tableSize + ZSTD_seekTableFooterSize + ZSTD_skippableHeaderSize;
+        U32 const frameSize = tableSize + ZSTD_seekTableFooterSize + ZSTD_SKIPPABLEHEADERSIZE;
 
         U32 remaining = frameSize - ZSTD_seekTableFooterSize; /* don't need to re-read footer */
         {
@@ -290,7 +290,7 @@ static size_t ZSTD_seekable_loadSeekTable(ZSTD_seekable* zs)
         if (MEM_readLE32(zs->inBuff) != (ZSTD_MAGIC_SKIPPABLE_START | 0xE)) {
             return ERROR(prefix_unknown);
         }
-        if (MEM_readLE32(zs->inBuff+4) + ZSTD_skippableHeaderSize != frameSize) {
+        if (MEM_readLE32(zs->inBuff+4) + ZSTD_SKIPPABLEHEADERSIZE != frameSize) {
             return ERROR(prefix_unknown);
         }
 

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -142,11 +142,13 @@ int         ZSTD_maxCLevel(void);               </b>/*!< maximum compression lev
 ZSTD_CCtx* ZSTD_createCCtx(void);
 size_t     ZSTD_freeCCtx(ZSTD_CCtx* cctx);
 </pre></b><BR>
-<pre><b>size_t ZSTD_compressCCtx(ZSTD_CCtx* ctx,
+<pre><b>size_t ZSTD_compressCCtx(ZSTD_CCtx* cctx,
                          void* dst, size_t dstCapacity,
                    const void* src, size_t srcSize,
                          int compressionLevel);
-</b><p>  Same as ZSTD_compress(), requires an allocated ZSTD_CCtx (see ZSTD_createCCtx()). 
+</b><p>  Same as ZSTD_compress(), using an explicit ZSTD_CCtx
+  The function will compress at requested compression level,
+  ignoring any other parameter 
 </p></pre><BR>
 
 <h3>Decompression context</h3><pre>  When decompressing many times,
@@ -158,10 +160,13 @@ size_t     ZSTD_freeCCtx(ZSTD_CCtx* cctx);
 ZSTD_DCtx* ZSTD_createDCtx(void);
 size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
 </pre></b><BR>
-<pre><b>size_t ZSTD_decompressDCtx(ZSTD_DCtx* ctx,
+<pre><b>size_t ZSTD_decompressDCtx(ZSTD_DCtx* dctx,
                            void* dst, size_t dstCapacity,
                      const void* src, size_t srcSize);
-</b><p>  Same as ZSTD_decompress(), requires an allocated ZSTD_DCtx (see ZSTD_createDCtx()) 
+</b><p>  Same as ZSTD_decompress(),
+  requires an allocated ZSTD_DCtx.
+  Compatible with sticky parameters.
+ 
 </p></pre><BR>
 
 <a name="Chapter6"></a><h2>Simple dictionary API</h2><pre></pre>
@@ -171,18 +176,22 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
                          const void* src, size_t srcSize,
                          const void* dict,size_t dictSize,
                                int compressionLevel);
-</b><p>  Compression using a predefined Dictionary (see dictBuilder/zdict.h).
+</b><p>  Compression at an explicit compression level using a Dictionary.
+  A dictionary can be any arbitrary data segment (also called a prefix),
+  or a buffer with specified information (see dictBuilder/zdict.h).
   Note : This function loads the dictionary, resulting in significant startup delay.
-  Note : When `dict == NULL || dictSize < 8` no dictionary is used. 
+         It's intended for a dictionary used only once.
+  Note 2 : When `dict == NULL || dictSize < 8` no dictionary is used. 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_decompress_usingDict(ZSTD_DCtx* dctx,
                                  void* dst, size_t dstCapacity,
                            const void* src, size_t srcSize,
                            const void* dict,size_t dictSize);
-</b><p>  Decompression using a predefined Dictionary (see dictBuilder/zdict.h).
+</b><p>  Decompression using a known Dictionary.
   Dictionary must be identical to the one used during compression.
   Note : This function loads the dictionary, resulting in significant startup delay.
+         It's intended for a dictionary used only once.
   Note : When `dict == NULL || dictSize < 8` no dictionary is used. 
 </p></pre><BR>
 
@@ -190,11 +199,12 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict(const void* dictBuffer, size_t dictSize,
                              int compressionLevel);
-</b><p>  When compressing multiple messages / blocks with the same dictionary, it's recommended to load it just once.
-  ZSTD_createCDict() will create a digested dictionary, ready to start future compression operations without startup delay.
+</b><p>  When compressing multiple messages / blocks using the same dictionary, it's recommended to load it only once.
+  ZSTD_createCDict() will create a digested dictionary, ready to start future compression operations without startup cost.
   ZSTD_CDict can be created once and shared by multiple threads concurrently, since its usage is read-only.
-  `dictBuffer` can be released after ZSTD_CDict creation, since its content is copied within CDict
-  Note : A ZSTD_CDict can be created with an empty dictionary, but it is inefficient for small data. 
+ `dictBuffer` can be released after ZSTD_CDict creation, because its content is copied within CDict.
+  Consider experimental function `ZSTD_createCDict_byReference()` if you prefer to not duplicate `dictBuffer` content.
+  Note : A ZSTD_CDict can be created from an empty dictBuffer, but it is inefficient when used to compress small data. 
 </p></pre><BR>
 
 <pre><b>size_t      ZSTD_freeCDict(ZSTD_CDict* CDict);
@@ -206,16 +216,14 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
                           const void* src, size_t srcSize,
                           const ZSTD_CDict* cdict);
 </b><p>  Compression using a digested Dictionary.
-  Faster startup than ZSTD_compress_usingDict(), recommended when same dictionary is used multiple times.
-  Note that compression level is decided during dictionary creation.
-  Frame parameters are hardcoded (dictID=yes, contentSize=yes, checksum=no)
-  Note : ZSTD_compress_usingCDict() can be used with a ZSTD_CDict created from an empty dictionary.
-         But it is inefficient for small data, and it is recommended to use ZSTD_compressCCtx(). 
+  Recommended when same dictionary is used multiple times.
+  Note : compression level is _decided at dictionary creation time_,
+     and frame parameters are hardcoded (dictID=yes, contentSize=yes, checksum=no) 
 </p></pre><BR>
 
 <pre><b>ZSTD_DDict* ZSTD_createDDict(const void* dictBuffer, size_t dictSize);
 </b><p>  Create a digested dictionary, ready to start decompression operation without startup delay.
-  dictBuffer can be released after DDict creation, as its content is copied inside DDict 
+  dictBuffer can be released after DDict creation, as its content is copied inside DDict. 
 </p></pre><BR>
 
 <pre><b>size_t      ZSTD_freeDDict(ZSTD_DDict* ddict);
@@ -227,7 +235,7 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
                             const void* src, size_t srcSize,
                             const ZSTD_DDict* ddict);
 </b><p>  Decompression using a digested Dictionary.
-  Faster startup than ZSTD_decompress_usingDict(), recommended when same dictionary is used multiple times. 
+  Recommended when same dictionary is used multiple times. 
 </p></pre><BR>
 
 <a name="Chapter8"></a><h2>Streaming</h2><pre></pre>
@@ -256,9 +264,9 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
 
   Parameters are sticky : when starting a new compression on the same context,
   it will re-use the same sticky parameters as previous compression session.
-  It's recommended to initialize the context before every usage.
+  When in doubt, it's recommended to fully initialize the context before usage.
   Use ZSTD_initCStream() to set the parameter to a selected compression level.
-  Use advanced API (ZSTD_CCtx_setParameter(), etc.) to set more detailed parameters.
+  Use advanced API (ZSTD_CCtx_setParameter(), etc.) to set more specific parameters.
 
   Use ZSTD_compressStream() as many times as necessary to consume input stream.
   The function will automatically update both `pos` fields within `input` and `output`.
@@ -267,7 +275,6 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
   in which case `input.pos < input.size`.
   The caller must check if input has been entirely consumed.
   If not, the caller must make some room to receive more compressed data,
-  typically by emptying output buffer, or allocating a new output buffer,
   and then present again remaining input data.
  @return : a size hint, preferred nb of bytes to use as input for next function call
            or an error code, which can be tested using ZSTD_isError().
@@ -312,25 +319,24 @@ size_t ZSTD_endStream(ZSTD_CStream* zcs, ZSTD_outBuffer* output);
   Use ZSTD_createDStream() and ZSTD_freeDStream() to create/release resources.
   ZSTD_DStream objects can be re-used multiple times.
 
-  Use ZSTD_initDStream() to start a new decompression operation,
-  or ZSTD_initDStream_usingDict() if decompression requires a dictionary.
+  Use ZSTD_initDStream() to start a new decompression operation.
  @return : recommended first input size
+  Alternatively, use advanced API to set specific properties.
 
   Use ZSTD_decompressStream() repetitively to consume your input.
   The function will update both `pos` fields.
   If `input.pos < input.size`, some input has not been consumed.
   It's up to the caller to present again remaining data.
-  The function tries to flush all data decoded immediately, repecting buffer sizes.
+  The function tries to flush all data decoded immediately, respecting output buffer size.
   If `output.pos < output.size`, decoder has flushed everything it could.
-  But if `output.pos == output.size`, there is no such guarantee,
-  it's likely that some decoded data was not flushed and still remains within internal buffers.
+  But if `output.pos == output.size`, there might be some data left within internal buffers.,
   In which case, call ZSTD_decompressStream() again to flush whatever remains in the buffer.
-  When no additional input is provided, amount of data flushed is necessarily <= ZSTD_BLOCKSIZE_MAX.
+  Note : with no additional input provided, amount of data flushed is necessarily <= ZSTD_BLOCKSIZE_MAX.
  @return : 0 when a frame is completely decoded and fully flushed,
         or an error code, which can be tested using ZSTD_isError(),
         or any other value > 0, which means there is still some decoding or flushing to do to complete current frame :
-                                the return value is a suggested next input size (a hint for better latency)
-                                that will never load more than the current frame.
+                                the return value is a suggested next input size (just a hint for better latency)
+                                that will never request more than the remaining frame size.
  
 <BR></pre>
 
@@ -355,10 +361,10 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 <BR></pre>
 
 <a name="Chapter12"></a><h2>Candidate API for promotion to stable status</h2><pre>
- The following symbols and constants belong to the "staging area" :
- they are considered to join "stable API" status by v1.4.0.
- The below proposal is written so that it can become stable "as is".
- It's still possible to suggest modifications.
+ The following symbols and constants form the "staging area" :
+ they are considered to join "stable API" by v1.4.0.
+ The proposal is written so that it can be made stable "as is",
+ though it's still possible to suggest improvements.
  Staging is in fact last chance for changes,
  the API is locked once reaching "stable" status.
  
@@ -370,8 +376,8 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 </b><p> `src` should point to the start of a ZSTD frame or skippable frame.
  `srcSize` must be >= first frame size
  @return : the compressed size of the first frame starting at `src`,
-           suitable to pass to `ZSTD_decompress` or similar,
-           or an error code if input is invalid 
+           suitable to pass as `srcSize` to `ZSTD_decompress` or similar,
+        or an error code if input is invalid 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx);
@@ -380,8 +386,8 @@ size_t ZSTD_sizeof_CStream(const ZSTD_CStream* zcs);
 size_t ZSTD_sizeof_DStream(const ZSTD_DStream* zds);
 size_t ZSTD_sizeof_CDict(const ZSTD_CDict* cdict);
 size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
-</b><p>  These functions give the current memory usage of selected object.
-  Object memory usage can evolve (increase or decrease) over time. 
+</b><p>  These functions give the _current_ memory usage of selected object.
+  Note that object memory usage can evolve (increase or decrease) over time. 
 </p></pre><BR>
 
 <a name="Chapter13"></a><h2>Advanced compression API</h2><pre></pre>
@@ -394,9 +400,9 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                ZSTD_btlazy2=6,
                ZSTD_btopt=7,
                ZSTD_btultra=8
-               </b>/* note : new strategies might be added in the future<b>
-                         at this stage, only the order (from fast to strong) is guaranteed.
-                         new strategy names may be introduced, pushing the maximum number upward */
+               </b>/* note : new strategies might be added in the future.<b>
+                         Only the order (from fast to strong) is guaranteed, not the exact position.
+                         new strategy names might be introduced, pushing the maximum number upward */
 } ZSTD_strategy;
 </b></pre><BR>
 <pre><b>typedef enum {
@@ -405,25 +411,25 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_p_compressionLevel=100, </b>/* Update all compression parameters according to pre-defined cLevel table<b>
                               * Default level is ZSTD_CLEVEL_DEFAULT==3.
                               * Special: value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT.
-                              * Note 1 : it's possible to pass a negative compression level by casting it to unsigned type.
+                              * Note 1 : it's possible to pass a negative compression level.
                               * Note 2 : setting a level sets all default values of other compression parameters */
     ZSTD_p_windowLog=101,    </b>/* Maximum allowed back-reference distance, expressed as power of 2.<b>
                               * Must be clamped between ZSTD_WINDOWLOG_MIN and ZSTD_WINDOWLOG_MAX.
                               * Special: value 0 means "use default windowLog".
                               * Note: Using a window size greater than 1<<ZSTD_WINDOWLOG_LIMIT_DEFAULT
-                              *       requires explicitly allowing such window size during decompression stage. */
+                              *       requires explicitly allowing such window size during decompression stage if using streaming. */
     ZSTD_p_hashLog=102,      </b>/* Size of the initial probe table, as a power of 2.<b>
-                              * Resulting table size is (1 << (hashLog+2)).
+                              * Resulting memory usage is (1 << (hashLog+2)).
                               * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX.
                               * Larger tables improve compression ratio of strategies <= dFast,
                               * and improve speed of strategies > dFast.
                               * Special: value 0 means "use default hashLog". */
     ZSTD_p_chainLog=103,     </b>/* Size of the multi-probe search table, as a power of 2.<b>
-                              * Resulting table size is (1 << (chainLog+2)).
+                              * Resulting memory usage is (1 << (chainLog+2)).
                               * Must be clamped between ZSTD_CHAINLOG_MIN and ZSTD_CHAINLOG_MAX.
                               * Larger tables result in better and slower compression.
                               * This parameter is useless when using "fast" strategy.
-                              * Note it's still useful when using "dfast" strategy,
+                              * It's still useful when using "dfast" strategy,
                               * in which case it defines a secondary probe table.
                               * Special: value 0 means "use default chainLog". */
     ZSTD_p_searchLog=104,    </b>/* Number of search attempts, as a power of 2.<b>
@@ -456,7 +462,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                                      * This parameter is designed to improve compression ratio
                                      * for large inputs, by finding large matches at long distance.
                                      * It increases memory usage and window size.
-                                     * Note: enabling this parameter increases ZSTD_p_windowLog to 128 MB
+                                     * Note: enabling this parameter increases default ZSTD_p_windowLog to 128 MB
                                      * except when expressly set to a different value. */
     ZSTD_p_ldmHashLog=161,   </b>/* Size of the table for long distance matching, as a power of 2.<b>
                               * Larger values increase memory usage and compression ratio,
@@ -490,10 +496,10 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     </b>/* These parameters are only useful if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
      * They return an error otherwise. */
     ZSTD_p_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
-                              * When nbWorkers >= 1, triggers asynchronous mode when used with ZSTD_compressStream2() :
-                              * ZSTD_compressStream2() consumes input and flush output if possible, but immediately gives back control to caller,
+                              * When nbWorkers >= 1, triggers asynchronous mode when used with ZSTD_compressStream*() :
+                              * ZSTD_compressStream*() consumes input and flush output if possible, but immediately gives back control to caller,
                               * while compression work is performed in parallel, within worker threads.
-                              * (note : a strong exception to this rule is when first invocation sets ZSTD_e_end :
+                              * (note : a strong exception to this rule is when first invocation of ZSTD_compressStream2() sets ZSTD_e_end :
                               *  in which case, ZSTD_compressStream2() delegates to ZSTD_compress2(), which is always a blocking call).
                               * More workers improve speed, but also increase memory usage.
                               * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
@@ -537,7 +543,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   otherwise they will either trigger an error or be automatically clamped.
  @return : a structure, ZSTD_bounds, which contains
          - an error status field, which must be tested using ZSTD_isError()
-         - both lower and upper bounds, inclusive
+         - lower and upper bounds, both inclusive
  
 </p></pre><BR>
 
@@ -550,33 +556,38 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
               the following parameters can be updated _during_ compression (within same frame):
               => compressionLevel, hashLog, chainLog, searchLog, minMatch, targetLength and strategy.
               new parameters will be active for next job only (after a flush()).
- @return : an error code (which can be tested using ZSTD_isError()). 
+ @return : an error code (which can be tested using ZSTD_isError()).
+ 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_setPledgedSrcSize(ZSTD_CCtx* cctx, unsigned long long pledgedSrcSize);
 </b><p>  Total input data size to be compressed as a single frame.
   This value will be controlled at end of frame, and trigger an error if not respected.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Note 1 : 0 means zero, empty.
+  Note 1 : pledgedSrcSize==0 actually means zero, aka an empty frame.
            In order to mean "unknown content size", pass constant ZSTD_CONTENTSIZE_UNKNOWN.
-           ZSTD_CONTENTSIZE_UNKNOWN is default value for any new compression job.
-  Note 2 : If all data is provided and consumed in a single round,
-           this value is automatically overriden by srcSize instead. 
+           ZSTD_CONTENTSIZE_UNKNOWN is default value for any new frame.
+  Note 2 : pledgedSrcSize is only valid once, for the next frame.
+           It's discarded at the end of the frame.
+  Note 3 : If all data is provided and consumed in a single round,
+           this value is automatically overriden by srcSize instead.
+ 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_loadDictionary(ZSTD_CCtx* cctx, const void* dict, size_t dictSize);
 </b><p>  Create an internal CDict from `dict` buffer.
   Decompression will have to use same dictionary.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Special: Adding a NULL (or 0-size) dictionary invalidates previous dictionary,
+  Special: Loading a NULL (or 0-size) dictionary invalidates previous dictionary,
            meaning "return to no-dictionary mode".
-  Note 1 : Dictionary will be used for all future compression jobs.
-           To return to "no-dictionary" situation, load a NULL dictionary
-  Note 2 : Loading a dictionary involves building tables, which are dependent on compression parameters.
-           For this reason, compression parameters cannot be changed anymore after loading a dictionary.
+  Note 1 : Dictionary is sticky, it will be used for all future compression jobs.
+           To return to "no-dictionary" situation, load a NULL dictionary (or reset parameters).
+  Note 2 : Loading a dictionary involves building tables.
            It's also a CPU consuming operation, with non-negligible impact on latency.
+           Tables are dependent on compression parameters, and for this reason,
+           compression parameters can no longer be changed after loading a dictionary.
   Note 3 :`dict` content will be copied internally.
-           Use ZSTD_CCtx_loadDictionary_byReference() to reference dictionary content instead.
+           Use experimental ZSTD_CCtx_loadDictionary_byReference() to reference content instead.
            In such a case, dictionary buffer must outlive its users.
   Note 4 : Use ZSTD_CCtx_loadDictionary_advanced()
            to precisely select how dictionary content must be interpreted. 
@@ -588,14 +599,14 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   and supercede any compression parameter previously set within CCtx.
   The dictionary will remain valid for future compression jobs using same CCtx.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Special : adding a NULL CDict means "return to no-dictionary mode".
+  Special : Referencing a NULL CDict means "return to no-dictionary mode".
   Note 1 : Currently, only one dictionary can be managed.
-           Adding a new dictionary effectively "discards" any previous one.
-  Note 2 : CDict is just referenced, its lifetime must outlive CCtx. 
+           Referencing a new dictionary effectively "discards" any previous one.
+  Note 2 : CDict is just referenced, its lifetime must outlive its usage within CCtx. 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_refPrefix(ZSTD_CCtx* cctx,
-                           const void* prefix, size_t prefixSize);
+                     const void* prefix, size_t prefixSize);
 </b><p>  Reference a prefix (single-usage dictionary) for next compression job.
   Decompression will need same prefix to properly regenerate data.
   Compressing with a prefix is similar in outcome as performing a diff and compressing it,
@@ -612,7 +623,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
            It's a CPU consuming operation, with non-negligible impact on latency.
            If there is a need to use the same prefix multiple times, consider loadDictionary instead.
   Note 4 : By default, the prefix is interpreted as raw content (ZSTD_dm_rawContent).
-           Use ZSTD_CCtx_refPrefix_advanced() to alter dictionary interpretation. 
+           Use experimental ZSTD_CCtx_refPrefix_advanced() to alter dictionary interpretation. 
 </p></pre><BR>
 
 <pre><b>typedef enum {
@@ -626,9 +637,9 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   - The session : will stop compressing current frame, and make CCtx ready to start a new one.
                   Useful after an error, or to interrupt any ongoing compression.
                   Any internal data not yet flushed is cancelled.
-                  But parameters and dictionary are kept unchanged.
-                  Therefore, same parameters and dictionary will be used for next frame.
-                  This action never fails.
+                  Compression parameters and dictionary remain unchanged.
+                  They will be used to compress next frame.
+                  Resetting session never fails.
   - The parameters : changes all parameters back to "default".
                   This removes any reference to any dictionary too.
                   Parameters can only be changed between 2 sessions (i.e. no compression is currently ongoing)
@@ -644,8 +655,8 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()
   - The function is always blocking, returns when compression is completed.
   Hint : compression runs faster if `dstCapacity` >=  `ZSTD_compressBound(srcSize)`.
-  @return : compressed size written into `dst` (<= `dstCapacity),
-            or an error code if it fails (which can be tested using ZSTD_isError()).
+ @return : compressed size written into `dst` (<= `dstCapacity),
+           or an error code if it fails (which can be tested using ZSTD_isError()).
  
 </p></pre><BR>
 
@@ -670,10 +681,10 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   - outpot->pos must be <= dstCapacity, input->pos must be <= srcSize
   - outpot->pos and input->pos will be updated. They are guaranteed to remain below their respective limit.
   - When nbWorkers==0 (default), function is blocking : it completes its job before returning to caller.
-  - When nbWorkers>=1, function is non-blocking : it just acquires a copy of input, and distributes jobs to internal worker threads,
+  - When nbWorkers>=1, function is non-blocking : it just acquires a copy of input, and distributes jobs to internal worker threads, flush whatever is available,
                                                   and then immediately returns, just indicating that there is some data remaining to be flushed.
                                                   The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
-  - Exception : if the first call requests a ZSTD_e_end directive, the function delegates to ZSTD_compress2() which is always blocking.
+  - Exception : if the first call requests a ZSTD_e_end directive and provides enough dstCapacity, the function delegates to ZSTD_compress2() which is always blocking.
   - @return provides a minimum amount of data remaining to be flushed from internal buffers
             or an error code, which can be tested using ZSTD_isError().
             if @return != 0, flush is not fully completed, there is still some data left within internal buffers.
@@ -688,11 +699,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 <pre><b>typedef enum {
 
-    ZSTD_d_windowLogMax=100, </b>/* Used to select a limit beyond which<b>
+    ZSTD_d_windowLogMax=100, </b>/* Select a size limit (in power of 2) beyond which<b>
                               * the streaming API will refuse to allocate memory buffer
                               * in order to protect the host from unreasonable memory requirements.
-                              * This parameter is only useful in streaming mode, as no internal buffer is allocated in single-pass mode.
-                              * By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT) */
+                              * This parameter is only useful in streaming mode, since no internal buffer is allocated in single-pass mode.
+                              * By default, a decompression context accepts window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT) */
 
     </b>/* note : additional experimental parameters are also available<b>
      * within the experimental section of the API.
@@ -705,7 +716,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 } ZSTD_dParameter;
 </b></pre><BR>
-<pre><b>ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam);    </b>/* not implemented yet */<b>
+<pre><b>ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam);
 </b><p>  All parameters must belong to an interval with lower and upper bounds,
   otherwise they will either trigger an error or be automatically clamped.
  @return : a structure, ZSTD_bounds, which contains
@@ -714,12 +725,12 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter param, int value);   </b>/* not implemented yet */<b>
+<pre><b>size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter param, int value);
 </b><p>  Set one compression parameter, selected by enum ZSTD_dParameter.
   All parameters have valid bounds. Bounds can be queried using ZSTD_dParam_getBounds().
   Providing a value beyond bound will either clamp it, or trigger an error (depending on parameter).
   Setting a parameter is only possible during frame initialization (before starting decompression).
- @return : an error code (which can be tested using ZSTD_isError()).
+ @return : 0, or an error code (which can be tested using ZSTD_isError()).
  
 </p></pre><BR>
 
@@ -772,7 +783,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 <pre><b>size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_ResetDirective reset);
 </b><p>  Return a DCtx to clean state.
-  Session and parameters can be reset jointly or separately
+  Session and parameters can be reset jointly or separately.
   Parameters can only be reset when no active frame is being decompressed.
  @return : 0, or an error code, which can be tested with ZSTD_isError()
  
@@ -832,7 +843,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_f_zstd1 = 0,           </b>/* zstd frame format, specified in zstd_compression_format.md (default) */<b>
     ZSTD_f_zstd1_magicless = 1, </b>/* Variant of zstd frame format, without initial 4-bytes magic number.<b>
                                  * Useful to save 4 bytes per generated frame.
-                                 * Decoder cannot recognise automatically this format, requiring instructions. */
+                                 * Decoder cannot recognise automatically this format, requiring this instruction. */
 } ZSTD_format_e;
 </b></pre><BR>
 <pre><b>typedef enum {
@@ -982,8 +993,9 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
-  Dictionary content is simply referenced, and therefore stays in dictBuffer.
-  It is important that dictBuffer outlives CDict, it must remain read accessible throughout the lifetime of CDict 
+  Dictionary content is just referenced, not duplicated.
+  As a consequence, `dictBuffer` **must** outlive CDict,
+  and its content must remain unmodified throughout the lifetime of CDict. 
 </p></pre><BR>
 
 <pre><b>ZSTD_compressionParameters ZSTD_getCParams(int compressionLevel, unsigned long long estimatedSrcSize, size_t dictSize);

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -19,16 +19,17 @@
 <li><a href="#Chapter9">Streaming compression - HowTo</a></li>
 <li><a href="#Chapter10">Streaming decompression - HowTo</a></li>
 <li><a href="#Chapter11">ADVANCED AND EXPERIMENTAL FUNCTIONS</a></li>
-<li><a href="#Chapter12">Frame size functions</a></li>
-<li><a href="#Chapter13">Memory management</a></li>
-<li><a href="#Chapter14">Advanced compression functions</a></li>
-<li><a href="#Chapter15">Advanced decompression functions</a></li>
-<li><a href="#Chapter16">Advanced streaming functions</a></li>
-<li><a href="#Chapter17">Buffer-less and synchronous inner streaming functions</a></li>
-<li><a href="#Chapter18">Buffer-less streaming compression (synchronous mode)</a></li>
-<li><a href="#Chapter19">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter20">New advanced API (experimental)</a></li>
-<li><a href="#Chapter21">Block level API</a></li>
+<li><a href="#Chapter12">Candidate API for promotion into stable</a></li>
+<li><a href="#Chapter13">Frame size functions</a></li>
+<li><a href="#Chapter14">Memory management</a></li>
+<li><a href="#Chapter15">Advanced compression functions</a></li>
+<li><a href="#Chapter16">Advanced decompression functions</a></li>
+<li><a href="#Chapter17">Advanced streaming functions</a></li>
+<li><a href="#Chapter18">Buffer-less and synchronous inner streaming functions</a></li>
+<li><a href="#Chapter19">Buffer-less streaming compression (synchronous mode)</a></li>
+<li><a href="#Chapter20">Buffer-less streaming decompression (synchronous mode)</a></li>
+<li><a href="#Chapter21">New advanced API (experimental)</a></li>
+<li><a href="#Chapter22">Block level API</a></li>
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
@@ -340,10 +341,16 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 <pre><b>size_t ZSTD_DStreamOutSize(void);   </b>/*!< recommended size for output buffer. Guarantee to successfully flush at least one complete block in all circumstances. */<b>
 </b></pre><BR>
 <a name="Chapter11"></a><h2>ADVANCED AND EXPERIMENTAL FUNCTIONS</h2><pre>
- The definitions in this section are considered experimental.
- They should never be used with a dynamic library, as prototypes may change in the future.
+ The definitions in the following section are considered experimental.
  They are provided for advanced scenarios.
+ They should never be used with a dynamic library, as prototypes may change in the future.
  Use them only in association with static linking.
+ 
+<BR></pre>
+
+<a name="Chapter12"></a><h2>Candidate API for promotion into stable</h2><pre>
+ The following symbols and constants are considered to join
+ "stable API" status by v1.4.0
  
 <BR></pre>
 
@@ -384,7 +391,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
     ZSTD_dlm_byRef,      </b>/**< Reference dictionary content -- the dictionary buffer must outlive its users. */<b>
 } ZSTD_dictLoadMethod_e;
 </b></pre><BR>
-<a name="Chapter12"></a><h2>Frame size functions</h2><pre></pre>
+<a name="Chapter13"></a><h2>Frame size functions</h2><pre></pre>
 
 <pre><b>size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
 </b><p>  `src` should point to the start of a ZSTD encoded frame or skippable frame
@@ -423,7 +430,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
            or an error code (if srcSize is too small) 
 </p></pre><BR>
 
-<a name="Chapter13"></a><h2>Memory management</h2><pre></pre>
+<a name="Chapter14"></a><h2>Memory management</h2><pre></pre>
 
 <pre><b>size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx);
 size_t ZSTD_sizeof_DCtx(const ZSTD_DCtx* dctx);
@@ -513,7 +520,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
  
 </p></pre><BR>
 
-<a name="Chapter14"></a><h2>Advanced compression functions</h2><pre></pre>
+<a name="Chapter15"></a><h2>Advanced compression functions</h2><pre></pre>
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
@@ -555,7 +562,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 </b><p>   Same as ZSTD_compress_usingCDict(), with fine-tune control over frame parameters 
 </p></pre><BR>
 
-<a name="Chapter15"></a><h2>Advanced decompression functions</h2><pre></pre>
+<a name="Chapter16"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
 </b><p>  Tells if the content of `buffer` starts with a valid Frame Identifier.
@@ -595,7 +602,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
   When identifying the exact failure cause, it's possible to use ZSTD_getFrameHeader(), which will provide a more precise error code. 
 </p></pre><BR>
 
-<a name="Chapter16"></a><h2>Advanced streaming functions</h2><pre></pre>
+<a name="Chapter17"></a><h2>Advanced streaming functions</h2><pre></pre>
 
 <h3>Advanced Streaming compression functions</h3><pre></pre><b><pre>size_t ZSTD_initCStream_srcSize(ZSTD_CStream* zcs, int compressionLevel, unsigned long long pledgedSrcSize);   </b>/**< pledgedSrcSize must be correct. If it is not known at init time, use ZSTD_CONTENTSIZE_UNKNOWN. Note that, for compatibility with older programs, "0" also disables frame content size field. It may be enabled in the future. */<b>
 size_t ZSTD_initCStream_usingDict(ZSTD_CStream* zcs, const void* dict, size_t dictSize, int compressionLevel); </b>/**< creates of an internal CDict (incompatible with static CCtx), except if dict == NULL or dictSize < 8, in which case no dict is used. Note: dict is loaded with ZSTD_dm_auto (treated as a full zstd dictionary if it begins with ZSTD_MAGIC_DICTIONARY, else as raw content) and ZSTD_dlm_byCopy.*/<b>
@@ -646,14 +653,14 @@ size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t di
 size_t ZSTD_initDStream_usingDDict(ZSTD_DStream* zds, const ZSTD_DDict* ddict);  </b>/**< note : ddict is referenced, it must outlive decompression session */<b>
 size_t ZSTD_resetDStream(ZSTD_DStream* zds);  </b>/**< re-use decompression parameters from previous init; saves dictionary loading */<b>
 </pre></b><BR>
-<a name="Chapter17"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
+<a name="Chapter18"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
   This is an advanced API, giving full control over buffer management, for users which need direct control over memory.
   But it's also a complex one, with several restrictions, documented below.
   Prefer normal streaming API for an easier experience.
  
 <BR></pre>
 
-<a name="Chapter18"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
+<a name="Chapter19"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
   A ZSTD_CCtx object is required to track streaming operations.
   Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.
   ZSTD_CCtx object can be re-used multiple times within successive compression operations.
@@ -689,7 +696,7 @@ size_t ZSTD_compressBegin_usingCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict); 
 size_t ZSTD_compressBegin_usingCDict_advanced(ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict, ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize);   </b>/* compression parameters are already set within cdict. pledgedSrcSize must be correct. If srcSize is not known, use macro ZSTD_CONTENTSIZE_UNKNOWN */<b>
 size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx, unsigned long long pledgedSrcSize); </b>/**<  note: if pledgedSrcSize is not known, use ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<a name="Chapter19"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
+<a name="Chapter20"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
   A ZSTD_DCtx object is required to track streaming operations.
   Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
   A ZSTD_DCtx object can be re-used multiple times.
@@ -780,7 +787,7 @@ size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long 
 </pre></b><BR>
 <pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
 </b></pre><BR>
-<a name="Chapter20"></a><h2>New advanced API (experimental)</h2><pre></pre>
+<a name="Chapter21"></a><h2>New advanced API (experimental)</h2><pre></pre>
 
 <pre><b>typedef enum {
     </b>/* Opened question : should we have a format ZSTD_f_auto ?<b>
@@ -1276,7 +1283,7 @@ size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx,
  
 </p></pre><BR>
 
-<a name="Chapter21"></a><h2>Block level API</h2><pre></pre>
+<a name="Chapter22"></a><h2>Block level API</h2><pre></pre>
 
 <pre><b></b><p>    Frame metadata cost is typically ~18 bytes, which can be non-negligible for very small blocks (< 100 bytes).
     User will have to take in charge required information to regenerate data, such as compressed and content sizes.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -1050,8 +1050,9 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int* value);
-</b><p> Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
+</b><p>  Get the requested compression parameter value, selected by enum ZSTD_cParameter,
+  and store it into int* value.
+ @return : 0, or an error code (which can be tested with ZSTD_isError()).
  
 </p></pre><BR>
 
@@ -1071,7 +1072,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
   - ZSTD_freeCCtxParams() : Free the memory.
 
   This can be used with ZSTD_estimateCCtxSize_advanced_usingCCtxParams()
-  for static allocation for single-threaded compression.
+  for static allocation of CCtx for single-threaded compression.
  
 </p></pre><BR>
 

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -20,17 +20,18 @@
 <li><a href="#Chapter10">Streaming decompression - HowTo</a></li>
 <li><a href="#Chapter11">ADVANCED AND EXPERIMENTAL FUNCTIONS</a></li>
 <li><a href="#Chapter12">Candidate API for promotion into stable</a></li>
-<li><a href="#Chapter13">Purely experimental API</a></li>
-<li><a href="#Chapter14">Frame size functions</a></li>
-<li><a href="#Chapter15">Memory management</a></li>
-<li><a href="#Chapter16">Advanced compression functions</a></li>
-<li><a href="#Chapter17">Advanced decompression functions</a></li>
-<li><a href="#Chapter18">Advanced streaming functions</a></li>
-<li><a href="#Chapter19">Buffer-less and synchronous inner streaming functions</a></li>
-<li><a href="#Chapter20">Buffer-less streaming compression (synchronous mode)</a></li>
-<li><a href="#Chapter21">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter22">New advanced API (experimental)</a></li>
-<li><a href="#Chapter23">Block level API</a></li>
+<li><a href="#Chapter13">Memory management</a></li>
+<li><a href="#Chapter14">Purely experimental API</a></li>
+<li><a href="#Chapter15">Frame size functions</a></li>
+<li><a href="#Chapter16">Memory management</a></li>
+<li><a href="#Chapter17">Advanced compression functions</a></li>
+<li><a href="#Chapter18">Advanced decompression functions</a></li>
+<li><a href="#Chapter19">Advanced streaming functions</a></li>
+<li><a href="#Chapter20">Buffer-less and synchronous inner streaming functions</a></li>
+<li><a href="#Chapter21">Buffer-less streaming compression (synchronous mode)</a></li>
+<li><a href="#Chapter22">Buffer-less streaming decompression (synchronous mode)</a></li>
+<li><a href="#Chapter23">New advanced API (experimental)</a></li>
+<li><a href="#Chapter24">Block level API</a></li>
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
@@ -357,10 +358,23 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 
 <pre><b>int ZSTD_minCLevel(void);  </b>/*!< minimum negative compression level allowed */<b>
 </b></pre><BR>
-<a name="Chapter13"></a><h2>Purely experimental API</h2><pre>
- The following symbols and constants are not planned
- to join "stable API" status anytime soon.
- Some of them might even be removed in the future.
+<a name="Chapter13"></a><h2>Memory management</h2><pre></pre>
+
+<pre><b>size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx);
+size_t ZSTD_sizeof_DCtx(const ZSTD_DCtx* dctx);
+size_t ZSTD_sizeof_CStream(const ZSTD_CStream* zcs);
+size_t ZSTD_sizeof_DStream(const ZSTD_DStream* zds);
+size_t ZSTD_sizeof_CDict(const ZSTD_CDict* cdict);
+size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
+</b><p>  These functions give the current memory usage of selected object.
+  Object memory usage can evolve when re-used. 
+</p></pre><BR>
+
+<a name="Chapter14"></a><h2>Purely experimental API</h2><pre>
+ The following symbols and constants
+ are not planned to join "stable API" status anytime soon.
+ Some will never reach "stable", and remain in the static_only section.
+ Some of them might be removed in the future.
  
 <BR></pre>
 
@@ -407,7 +421,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
     ZSTD_dlm_byRef = 1,   </b>/**< Reference dictionary content -- the dictionary buffer must outlive its users. */<b>
 } ZSTD_dictLoadMethod_e;
 </b></pre><BR>
-<a name="Chapter14"></a><h2>Frame size functions</h2><pre></pre>
+<a name="Chapter15"></a><h2>Frame size functions</h2><pre></pre>
 
 <pre><b>size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
 </b><p>  `src` should point to the start of a ZSTD encoded frame or skippable frame
@@ -446,17 +460,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
            or an error code (if srcSize is too small) 
 </p></pre><BR>
 
-<a name="Chapter15"></a><h2>Memory management</h2><pre></pre>
-
-<pre><b>size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx);
-size_t ZSTD_sizeof_DCtx(const ZSTD_DCtx* dctx);
-size_t ZSTD_sizeof_CStream(const ZSTD_CStream* zcs);
-size_t ZSTD_sizeof_DStream(const ZSTD_DStream* zds);
-size_t ZSTD_sizeof_CDict(const ZSTD_CDict* cdict);
-size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
-</b><p>  These functions give the current memory usage of selected object.
-  Object memory usage can evolve when re-used. 
-</p></pre><BR>
+<a name="Chapter16"></a><h2>Memory management</h2><pre></pre>
 
 <pre><b>size_t ZSTD_estimateCCtxSize(int compressionLevel);
 size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters cParams);
@@ -536,7 +540,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
  
 </p></pre><BR>
 
-<a name="Chapter16"></a><h2>Advanced compression functions</h2><pre></pre>
+<a name="Chapter17"></a><h2>Advanced compression functions</h2><pre></pre>
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
@@ -578,7 +582,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 </b><p>   Same as ZSTD_compress_usingCDict(), with fine-tune control over frame parameters 
 </p></pre><BR>
 
-<a name="Chapter17"></a><h2>Advanced decompression functions</h2><pre></pre>
+<a name="Chapter18"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
 </b><p>  Tells if the content of `buffer` starts with a valid Frame Identifier.
@@ -618,7 +622,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
   When identifying the exact failure cause, it's possible to use ZSTD_getFrameHeader(), which will provide a more precise error code. 
 </p></pre><BR>
 
-<a name="Chapter18"></a><h2>Advanced streaming functions</h2><pre></pre>
+<a name="Chapter19"></a><h2>Advanced streaming functions</h2><pre></pre>
 
 <h3>Advanced Streaming compression functions</h3><pre></pre><b><pre>size_t ZSTD_initCStream_srcSize(ZSTD_CStream* zcs, int compressionLevel, unsigned long long pledgedSrcSize);   </b>/**< pledgedSrcSize must be correct. If it is not known at init time, use ZSTD_CONTENTSIZE_UNKNOWN. Note that, for compatibility with older programs, "0" also disables frame content size field. It may be enabled in the future. */<b>
 size_t ZSTD_initCStream_usingDict(ZSTD_CStream* zcs, const void* dict, size_t dictSize, int compressionLevel); </b>/**< creates of an internal CDict (incompatible with static CCtx), except if dict == NULL or dictSize < 8, in which case no dict is used. Note: dict is loaded with ZSTD_dm_auto (treated as a full zstd dictionary if it begins with ZSTD_MAGIC_DICTIONARY, else as raw content) and ZSTD_dlm_byCopy.*/<b>
@@ -658,25 +662,23 @@ size_t ZSTD_initCStream_usingCDict_advanced(ZSTD_CStream* zcs, const ZSTD_CDict*
   + there is no active job (could be checked with ZSTD_frameProgression()), or
   + oldest job is still actively compressing data,
     but everything it has produced has also been flushed so far,
-    therefore flushing speed is currently limited by production speed of oldest job
-    irrespective of the speed of concurrent newer jobs.
+    therefore flush speed is limited by production speed of oldest job
+    irrespective of the speed of concurrent (and newer) jobs.
  
 </p></pre><BR>
 
-<h3>Advanced Streaming decompression functions</h3><pre></pre><b><pre>typedef enum { DStream_p_maxWindowSize } ZSTD_DStreamParameter_e;
-size_t ZSTD_setDStreamParameter(ZSTD_DStream* zds, ZSTD_DStreamParameter_e paramType, unsigned paramValue);   </b>/* obsolete : this API will be removed in a future version */<b>
-size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t dictSize); </b>/**< note: no dictionary will be used if dict == NULL or dictSize < 8 */<b>
+<h3>Advanced Streaming decompression functions</h3><pre></pre><b><pre>size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t dictSize); </b>/**< note: no dictionary will be used if dict == NULL or dictSize < 8 */<b>
 size_t ZSTD_initDStream_usingDDict(ZSTD_DStream* zds, const ZSTD_DDict* ddict);  </b>/**< note : ddict is referenced, it must outlive decompression session */<b>
 size_t ZSTD_resetDStream(ZSTD_DStream* zds);  </b>/**< re-use decompression parameters from previous init; saves dictionary loading */<b>
 </pre></b><BR>
-<a name="Chapter19"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
+<a name="Chapter20"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
   This is an advanced API, giving full control over buffer management, for users which need direct control over memory.
   But it's also a complex one, with several restrictions, documented below.
   Prefer normal streaming API for an easier experience.
  
 <BR></pre>
 
-<a name="Chapter20"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
+<a name="Chapter21"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
   A ZSTD_CCtx object is required to track streaming operations.
   Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.
   ZSTD_CCtx object can be re-used multiple times within successive compression operations.
@@ -712,7 +714,7 @@ size_t ZSTD_compressBegin_usingCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict); 
 size_t ZSTD_compressBegin_usingCDict_advanced(ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict, ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize);   </b>/* compression parameters are already set within cdict. pledgedSrcSize must be correct. If srcSize is not known, use macro ZSTD_CONTENTSIZE_UNKNOWN */<b>
 size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx, unsigned long long pledgedSrcSize); </b>/**<  note: if pledgedSrcSize is not known, use ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<a name="Chapter21"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
+<a name="Chapter22"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
   A ZSTD_DCtx object is required to track streaming operations.
   Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
   A ZSTD_DCtx object can be re-used multiple times.
@@ -803,7 +805,7 @@ size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long 
 </pre></b><BR>
 <pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
 </b></pre><BR>
-<a name="Chapter22"></a><h2>New advanced API (experimental)</h2><pre></pre>
+<a name="Chapter23"></a><h2>New advanced API (experimental)</h2><pre></pre>
 
 <pre><b>typedef enum {
     </b>/* Opened question : should we have a format ZSTD_f_auto ?<b>
@@ -1248,7 +1250,7 @@ size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx,
 </b><p>  Refuses allocating internal buffers for frames requiring a window size larger than provided limit.
   This is useful to prevent a decoder context from reserving too much memory for itself (potential attack scenario).
   This parameter is only useful in streaming mode, since no internal buffer is allocated in direct mode.
-  By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_MAX)
+  By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT)
  @return : 0, or an error code (which can be tested using ZSTD_isError()).
  
 </p></pre><BR>
@@ -1299,7 +1301,7 @@ size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx,
  
 </p></pre><BR>
 
-<a name="Chapter23"></a><h2>Block level API</h2><pre></pre>
+<a name="Chapter24"></a><h2>Block level API</h2><pre></pre>
 
 <pre><b></b><p>    Frame metadata cost is typically ~18 bytes, which can be non-negligible for very small blocks (< 100 bytes).
     User will have to take in charge required information to regenerate data, such as compressed and content sizes.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -248,13 +248,17 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
   A ZSTD_CStream object is required to track streaming operation.
   Use ZSTD_createCStream() and ZSTD_freeCStream() to create/release resources.
   ZSTD_CStream objects can be reused multiple times on consecutive compression operations.
-  It is recommended to re-use ZSTD_CStream in situations where many streaming operations will be achieved consecutively,
-  since it will play nicer with system's memory, by re-using already allocated memory.
-  Use one separate ZSTD_CStream per thread for parallel execution.
+  It is recommended to re-use ZSTD_CStream since it will play nicer with system's memory, by re-using already allocated memory.
 
-  Start a new compression by initializing ZSTD_CStream context.
-  Use ZSTD_initCStream() to start a new compression operation.
-  Use variants ZSTD_initCStream_usingDict() or ZSTD_initCStream_usingCDict() for streaming with dictionary (experimental section)
+  For parallel execution, use one separate ZSTD_CStream per thread.
+
+  note : since v1.3.0, ZSTD_CStream and ZSTD_CCtx are the same thing.
+
+  Parameters are sticky : when starting a new compression on the same context,
+  it will re-use the same sticky parameters as previous compression session.
+  It's recommended to initialize the context before every usage.
+  Use ZSTD_initCStream() to set the parameter to a selected compression level.
+  Use advanced API (ZSTD_CCtx_setParameter(), etc.) to set more detailed parameters.
 
   Use ZSTD_compressStream() as many times as necessary to consume input stream.
   The function will automatically update both `pos` fields within `input` and `output`.
@@ -265,10 +269,10 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
   If not, the caller must make some room to receive more compressed data,
   typically by emptying output buffer, or allocating a new output buffer,
   and then present again remaining input data.
-  @return : a size hint, preferred nb of bytes to use as input for next function call
-            or an error code, which can be tested using ZSTD_isError().
-            Note 1 : it's just a hint, to help latency a little, any other value will work fine.
-            Note 2 : size hint is guaranteed to be <= ZSTD_CStreamInSize()
+ @return : a size hint, preferred nb of bytes to use as input for next function call
+           or an error code, which can be tested using ZSTD_isError().
+           Note 1 : it's just a hint, to help latency a little, any value will work fine.
+           Note 2 : size hint is guaranteed to be <= ZSTD_CStreamInSize()
 
   At any moment, it's possible to flush whatever data might remain stuck within internal buffer,
   using ZSTD_flushStream(). `output->pos` will be updated.
@@ -390,7 +394,9 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                ZSTD_btlazy2=6,
                ZSTD_btopt=7,
                ZSTD_btultra=8
-               </b>/* note : new strategies might be added in the future */<b>
+               </b>/* note : new strategies might be added in the future<b>
+                         at this stage, only the order (from fast to strong) is guaranteed.
+                         new strategy names may be introduced, pushing the maximum number upward */
 } ZSTD_strategy;
 </b></pre><BR>
 <pre><b>typedef enum {
@@ -512,7 +518,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
      * ZSTD_p_forceMaxWindow
      * ZSTD_p_forceAttachDict
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
-     * note : never use experimentalParam names directly
+     * note : never ever use experimentalParam? names directly
      */
      ZSTD_p_experimentalParam1=500,
      ZSTD_p_experimentalParam2=10,
@@ -636,7 +642,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                  const void* src, size_t srcSize);
 </b><p>  Behave the same as ZSTD_compressCCtx(), but compression parameters are set using the advanced API.
   - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()
-  - The function is always blocking.
+  - The function is always blocking, returns when compression is completed.
   Hint : compression runs faster if `dstCapacity` >=  `ZSTD_compressBound(srcSize)`.
   @return : compressed size written into `dst` (<= `dstCapacity),
             or an error code if it fails (which can be tested using ZSTD_isError()).
@@ -648,24 +654,25 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_e_flush=1,    </b>/* flush any data provided so far,<b>
                         * it creates (at least) one new block, that can be decoded immediately on reception;
                         * frame will continue: any future data can still reference previously compressed data, improving compression. */
-    ZSTD_e_end=2       </b>/* flush any remaining data and close current frame.<b>
-                        * any additional data starts a new frame.
-                        * each frame is independent (does not reference any content from previous frame). */
+    ZSTD_e_end=2       </b>/* flush any remaining data _and_ close current frame.<b>
+                        * note that frame is only closed after compressed data is fully flushed (return value == 0).
+                        * After that point, any additional data starts a new frame.
+                        * note : each frame is independent (does not reference any content from previous frame). */
 } ZSTD_EndDirective;
 </b></pre><BR>
 <pre><b>size_t ZSTD_compressStream2( ZSTD_CCtx* cctx,
                              ZSTD_outBuffer* output,
                              ZSTD_inBuffer* input,
                              ZSTD_EndDirective endOp);
-</b><p>  Behave about the same as ZSTD_compressStream, with additional control on end directive.
+</b><p>  Behaves about the same as ZSTD_compressStream, with additional control on end directive.
   - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()
   - Compression parameters cannot be changed once compression is started (save a list of exceptions in multi-threading mode)
   - outpot->pos must be <= dstCapacity, input->pos must be <= srcSize
   - outpot->pos and input->pos will be updated. They are guaranteed to remain below their respective limit.
-  - In single-thread mode (default), function is blocking : it completes its job before returning to caller.
-  - In multi-thread mode, function is non-blocking : it just acquires a copy of input, and distribute job to internal worker threads,
-                                                     and then immediately returns, just indicating that there is some data remaining to be flushed.
-                                                     The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
+  - When nbWorkers==0 (default), function is blocking : it completes its job before returning to caller.
+  - When nbWorkers>=1, function is non-blocking : it just acquires a copy of input, and distributes jobs to internal worker threads,
+                                                  and then immediately returns, just indicating that there is some data remaining to be flushed.
+                                                  The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
   - Exception : if the first call requests a ZSTD_e_end directive, the function delegates to ZSTD_compress2() which is always blocking.
   - @return provides a minimum amount of data remaining to be flushed from internal buffers
             or an error code, which can be tested using ZSTD_isError().
@@ -679,12 +686,40 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
-</b><p>  Refuses allocating internal buffers for frames requiring a window size larger than provided limit.
-  This protects a decoder context from reserving too much memory for itself (potential attack scenario).
-  This parameter is only useful in streaming mode, since no internal buffer is allocated in single-pass mode.
-  By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT)
- @return : 0, or an error code (which can be tested using ZSTD_isError()).
+<pre><b>typedef enum {
+
+    ZSTD_d_windowLogMax=100, </b>/* Used to select a limit beyond which<b>
+                              * the streaming API will refuse to allocate memory buffer
+                              * in order to protect the host from unreasonable memory requirements.
+                              * This parameter is only useful in streaming mode, as no internal buffer is allocated in single-pass mode.
+                              * By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT) */
+
+    </b>/* note : additional experimental parameters are also available<b>
+     * within the experimental section of the API.
+     * At the time of this writing, they include :
+     * ZSTD_p_format
+     * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
+     * note : never ever use experimentalParam? names directly
+     */
+     ZSTD_d_experimentalParam1=1000
+
+} ZSTD_dParameter;
+</b></pre><BR>
+<pre><b>ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam);    </b>/* not implemented yet */<b>
+</b><p>  All parameters must belong to an interval with lower and upper bounds,
+  otherwise they will either trigger an error or be automatically clamped.
+ @return : a structure, ZSTD_bounds, which contains
+         - an error status field, which must be tested using ZSTD_isError()
+         - both lower and upper bounds, inclusive
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter param, int value);   </b>/* not implemented yet */<b>
+</b><p>  Set one compression parameter, selected by enum ZSTD_dParameter.
+  All parameters have valid bounds. Bounds can be queried using ZSTD_dParam_getBounds().
+  Providing a value beyond bound will either clamp it, or trigger an error (depending on parameter).
+  Setting a parameter is only possible during frame initialization (before starting decompression).
+ @return : an error code (which can be tested using ZSTD_isError()).
  
 </p></pre><BR>
 
@@ -711,7 +746,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
   Note 1 : Currently, only one dictionary can be managed.
            Referencing a new dictionary effectively "discards" any previous one.
-  Special : adding a NULL DDict means "return to no-dictionary mode".
+  Special: referencing a NULL DDict means "return to no-dictionary mode".
   Note 2 : DDict is just referenced, its lifetime must outlive its usage from DCtx.
  
 </p></pre><BR>
@@ -722,16 +757,16 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   This is the reverse operation of ZSTD_CCtx_refPrefix(),
   and must use the same prefix as the one used during compression.
   Prefix is **only used once**. Reference is discarded at end of frame.
-  End of frame is reached when ZSTD_DCtx_decompress_generic() returns 0.
+  End of frame is reached when ZSTD_decompressStream() returns 0.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
   Note 1 : Adding any prefix (including NULL) invalidates any previously set prefix or dictionary
   Note 2 : Prefix buffer is referenced. It **must** outlive decompression job.
            Prefix buffer must remain unmodified up to the end of frame,
-           reached when ZSTD_DCtx_decompress_generic() returns 0.
+           reached when ZSTD_decompressStream() returns 0.
   Note 3 : By default, the prefix is treated as raw content (ZSTD_dm_rawContent).
-           Use ZSTD_CCtx_refPrefix_advanced() to alter dictMode.
+           Use ZSTD_CCtx_refPrefix_advanced() to alter dictMode (Experimental section)
   Note 4 : Referencing a raw content prefix has almost no cpu nor memory cost.
-           A fulldict prefix requires building tables, hence is more costly.
+           A full dictionary is more costly, as it requires building tables.
  
 </p></pre><BR>
 
@@ -740,17 +775,6 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   Session and parameters can be reset jointly or separately
   Parameters can only be reset when no active frame is being decompressed.
  @return : 0, or an error code, which can be tested with ZSTD_isError()
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_decompress_generic(ZSTD_DCtx* dctx,
-                               ZSTD_outBuffer* output,
-                               ZSTD_inBuffer* input);
-</b><p>  Behave the same as ZSTD_decompressStream.
-  Decompression parameters cannot be changed once decompression is started.
- @return : an error code, which can be tested using ZSTD_isError()
-           if >0, a hint, nb of expected input bytes for next invocation.
-           `0` means : a frame has just been fully decoded and flushed.
  
 </p></pre><BR>
 
@@ -1152,6 +1176,15 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
   how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) 
 </p></pre><BR>
 
+<pre><b>size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
+</b><p>  Refuses allocating internal buffers for frames requiring a window size larger than provided limit.
+  This protects a decoder context from reserving too much memory for itself (potential attack scenario).
+  This parameter is only useful in streaming mode, since no internal buffer is allocated in single-pass mode.
+  By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT)
+ @return : 0, or an error code (which can be tested using ZSTD_isError()).
+ 
+</p></pre><BR>
+
 <pre><b>size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format);
 </b><p>  Instruct the decoder context about what kind of data to decode next.
   This instruction is mandatory to decode data without a fully-formed header,
@@ -1159,11 +1192,11 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  @return : 0, or an error code (which can be tested using ZSTD_isError()). 
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_decompress_generic_simpleArgs (
+<pre><b>size_t ZSTD_decompressStream_simpleArgs (
                 ZSTD_DCtx* dctx,
                 void* dst, size_t dstCapacity, size_t* dstPos,
           const void* src, size_t srcSize, size_t* srcPos);
-</b><p>  Same as ZSTD_decompress_generic(),
+</b><p>  Same as ZSTD_decompressStream(),
   but using only integral types as arguments.
   This can be helpful for binders from dynamic languages
   which have troubles handling structures containing memory pointers.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -31,7 +31,8 @@
 <li><a href="#Chapter21">Buffer-less and synchronous inner streaming functions</a></li>
 <li><a href="#Chapter22">Buffer-less streaming compression (synchronous mode)</a></li>
 <li><a href="#Chapter23">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter24">Block level API</a></li>
+<li><a href="#Chapter24">ZSTD_getFrameHeader() :</a></li>
+<li><a href="#Chapter25">Block level API</a></li>
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
@@ -574,15 +575,15 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
   Special: Adding any prefix (including NULL) invalidates any previous prefix or dictionary
   Note 1 : Prefix buffer is referenced. It **must** outlive compression job.
-           Its contain must remain unmodified up to end of compression (ZSTD_e_end).
+           Its content must remain unmodified during compression.
   Note 2 : If the intention is to diff some large src data blob with some prior version of itself,
            ensure that the window size is large enough to contain the entire source.
            See ZSTD_p_windowLog.
   Note 3 : Referencing a prefix involves building tables, which are dependent on compression parameters.
            It's a CPU consuming operation, with non-negligible impact on latency.
-           If there is a need to use same prefix multiple times, consider loadDictionary instead.
+           If there is a need to use the same prefix multiple times, consider loadDictionary instead.
   Note 4 : By default, the prefix is interpreted as raw content (ZSTD_dm_rawContent).
-           Use ZSTD_CCtx_refPrefix_advanced() to alter dictionary intepretation. 
+           Use ZSTD_CCtx_refPrefix_advanced() to alter dictionary interpretation. 
 </p></pre><BR>
 
 <pre><b>typedef enum {
@@ -622,11 +623,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               ZSTD_inBuffer* input,
                               ZSTD_EndDirective endOp);
 </b><p>  Behave about the same as ZSTD_compressStream. To note :
-  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_setParameter()
-  - Compression parameters cannot be changed once compression is started.
+  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()
+  - Compression parameters cannot be changed once compression is started (save a list of exceptions in multi-threading mode)
   - outpot->pos must be <= dstCapacity, input->pos must be <= srcSize
   - outpot->pos and input->pos will be updated. They are guaranteed to remain below their respective limit.
-  - In single-thread mode (default), function is blocking : it completed its job before returning to caller.
+  - In single-thread mode (default), function is blocking : it completes its job before returning to caller.
   - In multi-thread mode, function is non-blocking : it just acquires a copy of input, and distribute job to internal worker threads,
                                                      and then immediately returns, just indicating that there is some data remaining to be flushed.
                                                      The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
@@ -650,7 +651,94 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                 ZSTD_EndDirective endOp);
 </b><p>  Same as ZSTD_compress_generic(),
   but using only integral types as arguments.
-  This variant might be be helpful for binders from dynamic languages
+  This variant might be helpful for binders from dynamic languages
+  which have troubles handling structures containing memory pointers.
+ 
+</p></pre><BR>
+
+<pre><b> ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
+</b><p>  Refuses allocating internal buffers for frames requiring a window size larger than provided limit.
+  This protects a decoder context from reserving too much memory for itself (potential attack scenario).
+  This parameter is only useful in streaming mode, since no internal buffer is allocated in single-pass mode.
+  By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT)
+ @return : 0, or an error code (which can be tested using ZSTD_isError()).
+  
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_loadDictionary(ZSTD_DCtx* dctx, const void* dict, size_t dictSize);
+</b><p>  Create an internal DDict from dict buffer,
+  to be used to decompress next frames.
+  The dictionary remains valid for all future frames, until explicitly invalidated.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Special : Adding a NULL (or 0-size) dictionary invalidates any previous dictionary,
+            meaning "return to no-dictionary mode".
+  Note 1 : Loading a dictionary involves building tables,
+           which has a non-negligible impact on CPU usage and latency.
+           It's recommended to "load once, use many times", to amortize the cost
+  Note 2 :`dict` content will be copied internally, so `dict` can be released after loading.
+           Use ZSTD_DCtx_loadDictionary_byReference() to reference dictionary content instead.
+  Note 3 : Use ZSTD_DCtx_loadDictionary_advanced() to take control of
+           how dictionary content is loaded and interpreted.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_refDDict(ZSTD_DCtx* dctx, const ZSTD_DDict* ddict);
+</b><p>  Reference a prepared dictionary, to be used to decompress next frames.
+  The dictionary remains active for decompression of future frames using same DCtx.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Note 1 : Currently, only one dictionary can be managed.
+           Referencing a new dictionary effectively "discards" any previous one.
+  Special : adding a NULL DDict means "return to no-dictionary mode".
+  Note 2 : DDict is just referenced, its lifetime must outlive its usage from DCtx.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_refPrefix(ZSTD_DCtx* dctx,
+                     const void* prefix, size_t prefixSize);
+</b><p>  Reference a prefix (single-usage dictionary) for next compression job.
+  This is the reverse operation of ZSTD_CCtx_refPrefix(),
+  and must use the same prefix as the one used during compression.
+  Prefix is **only used once**. Reference is discarded at end of frame.
+  End of frame is reached when ZSTD_DCtx_decompress_generic() returns 0.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Note 1 : Adding any prefix (including NULL) invalidates any previously set prefix or dictionary
+  Note 2 : Prefix buffer is referenced. It **must** outlive decompression job.
+           Prefix buffer must remain unmodified up to the end of frame,
+           reached when ZSTD_DCtx_decompress_generic() returns 0.
+  Note 3 : By default, the prefix is treated as raw content (ZSTD_dm_rawContent).
+           Use ZSTD_CCtx_refPrefix_advanced() to alter dictMode.
+  Note 4 : Referencing a raw content prefix has almost no cpu nor memory cost.
+           A fulldict prefix requires building tables, hence is more costly.
+ 
+</p></pre><BR>
+
+<pre><b>void ZSTD_DCtx_reset(ZSTD_DCtx* dctx);     </b>/* <==== There is a discrepancy with ZSTD_CCtx_reset(): here it necessarily resets everything (context and parameters) */<b>
+</b><p>  Return a DCtx to clean state.
+  If a decompression was ongoing, any internal data not yet flushed is cancelled.
+  All parameters are back to default values, including sticky ones.
+  Dictionary (if any) is dropped.
+  Parameters can be modified again after a reset.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_decompress_generic(ZSTD_DCtx* dctx,
+                               ZSTD_outBuffer* output,
+                               ZSTD_inBuffer* input);
+</b><p>  Behave the same as ZSTD_decompressStream.
+  Decompression parameters cannot be changed once decompression is started.
+ @return : an error code, which can be tested using ZSTD_isError()
+           if >0, a hint, nb of expected input bytes for next invocation.
+           `0` means : a frame has just been fully decoded and flushed.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_decompress_generic_simpleArgs (
+                ZSTD_DCtx* dctx,
+                void* dst, size_t dstCapacity, size_t* dstPos,
+          const void* src, size_t srcSize, size_t* srcPos);
+</b><p>  Same as ZSTD_decompress_generic(),
+  but using only integral types as arguments.
+  This can be helpful for binders from dynamic languages
   which have troubles handling structures containing memory pointers.
  
 </p></pre><BR>
@@ -658,8 +746,8 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 <a name="Chapter15"></a><h2>experimental API (static linking only)</h2><pre>
  The following symbols and constants
  are not planned to join "stable API" status anytime soon.
- Some will never reach "stable", and remain in the static_only section.
- Some of them might be removed in the future.
+ Some of them will never reach "stable", and are planned to remain in the static_only section indefinitely.
+ Some of them might even be removed in the future.
  
 <BR></pre>
 
@@ -777,7 +865,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_frameHeaderSize(const void* src, size_t srcSize);
-</b><p>  srcSize must be >= ZSTD_frameHeaderSize_prefix.
+</b><p>  srcSize must be >= ZSTD_FRAMEHEADERSIZE_PREFIX.
  @return : size of the Frame Header,
            or an error code (if srcSize is too small) 
 </p></pre><BR>
@@ -917,7 +1005,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 
 <pre><b>size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* prefix, size_t prefixSize, ZSTD_dictContentType_e dictContentType);
 </b><p>  Same as ZSTD_CCtx_refPrefix(), but gives finer control over
-  and how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) 
+  how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value);
@@ -1027,6 +1115,32 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
   - `srcSize` is too small, and as a result, the frame header could not be decoded (only possible if `srcSize < ZSTD_FRAMEHEADERSIZE_MAX`).
   - This is not a Zstandard frame.
   When identifying the exact failure cause, it's possible to use ZSTD_getFrameHeader(), which will provide a more precise error code. 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_loadDictionary_byReference(ZSTD_DCtx* dctx, const void* dict, size_t dictSize);
+</b><p>  Same as ZSTD_DCtx_loadDictionary(),
+  but references `dict` content instead of copying it into `dctx`.
+  This saves memory if `dict` remains around.,
+  However, it's imperative that `dict` remains accessible (and unmodified) while being used, so it must outlive decompression. 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_loadDictionary_advanced(ZSTD_DCtx* dctx, const void* dict, size_t dictSize, ZSTD_dictLoadMethod_e dictLoadMethod, ZSTD_dictContentType_e dictContentType);
+</b><p>  Same as ZSTD_DCtx_loadDictionary(),
+  but gives direct control over
+  how to load the dictionary (by copy ? by reference ?)
+  and how to interpret it (automatic ? force raw mode ? full mode only ?). 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx, const void* prefix, size_t prefixSize, ZSTD_dictContentType_e dictContentType);
+</b><p>  Same as ZSTD_DCtx_refPrefix(), but gives finer control over
+  how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format);
+</b><p>  Instruct the decoder context about what kind of data to decode next.
+  This instruction is mandatory to decode data without a fully-formed header,
+  such ZSTD_f_zstd1_magicless for example.
+ @return : 0, or an error code (which can be tested using ZSTD_isError()). 
 </p></pre><BR>
 
 <a name="Chapter20"></a><h2>Advanced streaming functions</h2><pre></pre>
@@ -1202,126 +1316,24 @@ typedef struct {
     unsigned dictID;
     unsigned checksumFlag;
 } ZSTD_frameHeader;
-</b>/** ZSTD_getFrameHeader() :<b>
- *  decode Frame Header, or requires larger `srcSize`.
- * @return : 0, `zfhPtr` is correctly filled,
- *          >0, `srcSize` is too small, value is wanted `srcSize` amount,
- *           or an error code, which can be tested using ZSTD_isError() */
-size_t ZSTD_getFrameHeader(ZSTD_frameHeader* zfhPtr, const void* src, size_t srcSize);   </b>/**< doesn't consume input */<b>
-size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long long frameContentSize);  </b>/**< when frame content size is not known, pass in frameContentSize == ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
+<a name="Chapter24"></a><h2>ZSTD_getFrameHeader() :</h2><pre>  decode Frame Header, or requires larger `srcSize`.
+ @return : 0, `zfhPtr` is correctly filled,
+          >0, `srcSize` is too small, value is wanted `srcSize` amount,
+           or an error code, which can be tested using ZSTD_isError() 
+<BR></pre>
+
+<pre><b>size_t ZSTD_getFrameHeader(ZSTD_frameHeader* zfhPtr, const void* src, size_t srcSize);   </b>/**< doesn't consume input */<b>
 </b></pre><BR>
-<h3>Advanced decompression API</h3><pre></pre><b><pre></b>/* ==================================== */<b>
-</pre></b><BR>
-<pre><b>size_t ZSTD_DCtx_loadDictionary(ZSTD_DCtx* dctx, const void* dict, size_t dictSize);
-size_t ZSTD_DCtx_loadDictionary_byReference(ZSTD_DCtx* dctx, const void* dict, size_t dictSize);
-size_t ZSTD_DCtx_loadDictionary_advanced(ZSTD_DCtx* dctx, const void* dict, size_t dictSize, ZSTD_dictLoadMethod_e dictLoadMethod, ZSTD_dictContentType_e dictContentType);
-</b><p>  Create an internal DDict from dict buffer,
-  to be used to decompress next frames.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Special : Adding a NULL (or 0-size) dictionary invalidates any previous dictionary,
-            meaning "return to no-dictionary mode".
-  Note 1 : `dict` content will be copied internally.
-            Use ZSTD_DCtx_loadDictionary_byReference()
-            to reference dictionary content instead.
-            In which case, the dictionary buffer must outlive its users.
-  Note 2 : Loading a dictionary involves building tables,
-           which has a non-negligible impact on CPU usage and latency.
-  Note 3 : Use ZSTD_DCtx_loadDictionary_advanced() to select
-           how dictionary content will be interpreted and loaded.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_DCtx_refDDict(ZSTD_DCtx* dctx, const ZSTD_DDict* ddict);
-</b><p>  Reference a prepared dictionary, to be used to decompress next frames.
-  The dictionary remains active for decompression of future frames using same DCtx.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Note 1 : Currently, only one dictionary can be managed.
-           Referencing a new dictionary effectively "discards" any previous one.
-  Special : adding a NULL DDict means "return to no-dictionary mode".
-  Note 2 : DDict is just referenced, its lifetime must outlive its usage from DCtx.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_DCtx_refPrefix(ZSTD_DCtx* dctx,
-                        const void* prefix, size_t prefixSize);
-size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx,
-                        const void* prefix, size_t prefixSize,
-                        ZSTD_dictContentType_e dictContentType);
-</b><p>  Reference a prefix (single-usage dictionary) for next compression job.
-  This is the reverse operation of ZSTD_CCtx_refPrefix(),
-  and must use the same prefix as the one used during compression.
-  Prefix is **only used once**. Reference is discarded at end of frame.
-  End of frame is reached when ZSTD_DCtx_decompress_generic() returns 0.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Note 1 : Adding any prefix (including NULL) invalidates any previously set prefix or dictionary
-  Note 2 : Prefix buffer is referenced. It **must** outlive decompression job.
-           Prefix buffer must remain unmodified up to the end of frame,
-           reached when ZSTD_DCtx_decompress_generic() returns 0.
-  Note 3 : By default, the prefix is treated as raw content (ZSTD_dm_rawContent).
-           Use ZSTD_CCtx_refPrefix_advanced() to alter dictMode.
-  Note 4 : Referencing a raw content prefix has almost no cpu nor memory cost.
-           A fulldict prefix is more costly though.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
-</b><p>  Refuses allocating internal buffers for frames requiring a window size larger than provided limit.
-  This is useful to prevent a decoder context from reserving too much memory for itself (potential attack scenario).
-  This parameter is only useful in streaming mode, since no internal buffer is allocated in direct mode.
-  By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT)
- @return : 0, or an error code (which can be tested using ZSTD_isError()).
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format);
-</b><p>  Instruct the decoder context about what kind of data to decode next.
-  This instruction is mandatory to decode data without a fully-formed header,
-  such ZSTD_f_zstd1_magicless for example.
- @return : 0, or an error code (which can be tested using ZSTD_isError()).
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_getFrameHeader_advanced(ZSTD_frameHeader* zfhPtr,
-            const void* src, size_t srcSize, ZSTD_format_e format);
+<pre><b>size_t ZSTD_getFrameHeader_advanced(ZSTD_frameHeader* zfhPtr, const void* src, size_t srcSize, ZSTD_format_e format);
+size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long long frameContentSize);  </b>/**< when frame content size is not known, pass in frameContentSize == ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </b><p>  same as ZSTD_getFrameHeader(),
   with added capability to select a format (like ZSTD_f_zstd1_magicless) 
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_decompress_generic(ZSTD_DCtx* dctx,
-                               ZSTD_outBuffer* output,
-                               ZSTD_inBuffer* input);
-</b><p>  Behave the same as ZSTD_decompressStream.
-  Decompression parameters cannot be changed once decompression is started.
- @return : an error code, which can be tested using ZSTD_isError()
-           if >0, a hint, nb of expected input bytes for next invocation.
-           `0` means : a frame has just been fully decoded and flushed.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_decompress_generic_simpleArgs (
-                ZSTD_DCtx* dctx,
-                void* dst, size_t dstCapacity, size_t* dstPos,
-          const void* src, size_t srcSize, size_t* srcPos);
-</b><p>  Same as ZSTD_decompress_generic(),
-  but using only integral types as arguments.
-  Argument list is larger than ZSTD_{in,out}Buffer,
-  but can be helpful for binders from dynamic languages
-  which have troubles handling structures containing memory pointers.
- 
-</p></pre><BR>
-
-<pre><b>void ZSTD_DCtx_reset(ZSTD_DCtx* dctx);
-</b><p>  Return a DCtx to clean state.
-  If a decompression was ongoing, any internal data not yet flushed is cancelled.
-  All parameters are back to default values, including sticky ones.
-  Dictionary (if any) is dropped.
-  Parameters can be modified again after a reset.
- 
-</p></pre><BR>
-
-<a name="Chapter24"></a><h2>Block level API</h2><pre></pre>
+<pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
+</b></pre><BR>
+<a name="Chapter25"></a><h2>Block level API</h2><pre></pre>
 
 <pre><b></b><p>    Frame metadata cost is typically ~18 bytes, which can be non-negligible for very small blocks (< 100 bytes).
     User will have to take in charge required information to regenerate data, such as compressed and content sizes.
@@ -1335,10 +1347,10 @@ size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx,
       + copyCCtx() and copyDCtx() can be used too
     - Block size is limited, it must be <= ZSTD_getBlockSize() <= ZSTD_BLOCKSIZE_MAX == 128 KB
       + If input is larger than a block size, it's necessary to split input data into multiple blocks
-      + For inputs larger than a single block size, consider using the regular ZSTD_compress() instead.
+      + For inputs larger than a single block, really consider using regular ZSTD_compress() instead.
         Frame metadata is not that costly, and quickly becomes negligible as source size grows larger.
     - When a block is considered not compressible enough, ZSTD_compressBlock() result will be zero.
-      In which case, nothing is produced into `dst`.
+      In which case, nothing is produced into `dst` !
       + User must test for such outcome and deal directly with uncompressed data
       + ZSTD_decompressBlock() doesn't accept uncompressed data as input !!!
       + In case of multiple successive blocks, should some of them be uncompressed,

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -609,12 +609,12 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 </p></pre><BR>
 
 <pre><b>typedef enum {
-    ZSTD_CCtx_reset_session_only = 1,
-    ZSTD_CCtx_reset_parameters = 2,
-    ZSTD_CCtx_reset_session_and_parameters = 3
-} ZSTD_CCtx_reset_directive;
+    ZSTD_reset_session_only = 1,
+    ZSTD_reset_parameters = 2,
+    ZSTD_reset_session_and_parameters = 3
+} ZSTD_reset_directive;
 </b></pre><BR>
-<pre><b>size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_CCtx_reset_directive zcrd);
+<pre><b>size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_reset_directive reset);
 </b><p>  There are 2 different things that can be reset, independently or jointly :
   - The session : will stop compressing current frame, and make CCtx ready to start a new one.
                   Useful after an error, or to interrupt any ongoing compression.
@@ -734,12 +734,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
-<pre><b>void ZSTD_DCtx_reset(ZSTD_DCtx* dctx);     </b>/* <==== There is a discrepancy with ZSTD_CCtx_reset(): here it necessarily resets everything (context and parameters) */<b>
+<pre><b>size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_reset_directive reset);
 </b><p>  Return a DCtx to clean state.
-  If a decompression was ongoing, any internal data not yet flushed is cancelled.
-  All parameters are back to default values, including sticky ones.
-  Dictionary (if any) is dropped.
-  Parameters can be modified again after a reset.
+  Session and parameters can be reset jointly or separately
+  Parameters can only be reset when no active frame is being decompressed.
+ @return : 0, or an error code, which can be tested with ZSTD_isError()
  
 </p></pre><BR>
 

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -419,9 +419,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * More attempts result in better and slower compression.
                               * This parameter is useless when using "fast" and "dFast" strategies.
                               * Special: value 0 means "use default searchLog". */
-    ZSTD_p_minMatch=105,     </b>/* Minimum size of searched matches (note : repCode matches can be smaller).<b>
-                              * Larger values make faster compression and decompression, but decrease ratio.
-                              * Must be clamped between ZSTD_SEARCHLENGTH_MIN and ZSTD_SEARCHLENGTH_MAX.
+    ZSTD_p_minMatch=105,     </b>/* Minimum size of searched matches.<b>
+                              * Note that Zstandard can still find matches of smaller size,
+                              * it just tweaks its search algorithm to look for this size and larger.
+                              * Larger values increase compression and decompression speed, but decrease ratio.
+                              * Must be clamped between ZSTD_MINMATCH_MIN and ZSTD_MINMATCH_MAX.
                               * Note that currently, for all strategies < btopt, effective minimum is 4.
                               *                    , for all strategies > fast, effective maximum is 6.
                               * Special: value 0 means "use default minMatchLength". */
@@ -434,7 +436,6 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               *     Larger values make compression faster, and weaker.
                               * Special: value 0 means "use default targetLength". */
     ZSTD_p_compressionStrategy=107, </b>/* See ZSTD_strategy enum definition.<b>
-                              * Cast selected strategy as unsigned for ZSTD_CCtx_setParameter() compatibility.
                               * The higher the value of selected strategy, the more complex it is,
                               * resulting in stronger and slower compression.
                               * Special: value 0 means "use default strategy". */
@@ -536,13 +537,18 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               */
 } ZSTD_cParameter;
 </b></pre><BR>
-<pre><b>int ZSTD_cParam_lowerBound(ZSTD_cParameter cParam);
-int ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
-</b><p>  All parameters must respect lower/upper bounds,
-  otherwise they will either trigger an error
-  or be automatically clamped.
- @return : requested bound (inclusive)
-  note : if the request specifies a non-existing parameter, it will return 0.
+<pre><b>typedef struct {
+    size_t error;
+    int lowerBound;
+    int upperBound;
+} ZSTD_bounds;
+</b></pre><BR>
+<pre><b>ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter cParam);
+</b><p>  All parameters must belong to an interval with lower and upper bounds,
+  otherwise they will either trigger an error or be automatically clamped.
+ @return : a structure, ZSTD_bounds, which contains
+         - an error status field, which must be tested using ZSTD_isError()
+         - both lower and upper bounds, inclusive
  
 </p></pre><BR>
 
@@ -555,8 +561,7 @@ int ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
               the following parameters can be updated _during_ compression (within same frame):
               => compressionLevel, hashLog, chainLog, searchLog, minMatch, targetLength and strategy.
               new parameters will be active for next job only (after a flush()).
-  @result : informational value (typically, value being effectively set, after clamping),
-            or an error code (which can be tested with ZSTD_isError()). 
+ @return : an error code (which can be tested using ZSTD_isError()). 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_setPledgedSrcSize(ZSTD_CCtx* cctx, unsigned long long pledgedSrcSize);
@@ -767,7 +772,7 @@ int ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
     unsigned chainLog;        </b>/**< fully searched segment : larger == more compression, slower, more memory (useless for fast) */<b>
     unsigned hashLog;         </b>/**< dispatch table : larger == faster, more memory */<b>
     unsigned searchLog;       </b>/**< nb of searches : larger == more compression, slower */<b>
-    unsigned searchLength;    </b>/**< match length searched : larger == faster decompression, sometimes less compression */<b>
+    unsigned minMatch;         </b>/**< match length searched : larger == faster decompression, sometimes less compression */<b>
     unsigned targetLength;    </b>/**< acceptable match size for optimal parser (only) : larger == more compression, slower */<b>
     ZSTD_strategy strategy;   </b>/**< see ZSTD_strategy definition above */<b>
 } ZSTD_compressionParameters;

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -352,11 +352,12 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 <BR></pre>
 
 <a name="Chapter12"></a><h2>Candidate API for promotion to stable status</h2><pre>
- The following symbols and constants are currently considered
- to join "stable API" status by v1.4.0.
- The intention is that they should be able to become stable "as is", with no further modification.
- It is also last chance to gather comments / suggestions on this API,
- as the API is locked once reaching "stable" status.
+ The following symbols and constants are in "staging area" :
+ they are considered to join "stable API" status by v1.4.0.
+ The below proposal is created so that it's possible to make it stable "as is".
+ That being said, it's still possible to suggest modifications.
+ Staging is in fact last chance for changes,
+ because the API is locked once reaching "stable" status.
  
 <BR></pre>
 
@@ -478,7 +479,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
      * They return an error otherwise. */
     ZSTD_p_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
                               * When nbWorkers >= 1, triggers asynchronous mode :
-                              * ZSTD_compress_generic() consumes some input, flush some output if possible, and immediately gives back control to caller,
+                              * ZSTD_compress_generic() consumes input and flush output if possible, but immediately gives back control to caller,
                               * while compression work is performed in parallel, within worker threads.
                               * (note : a strong exception to this rule is when first invocation sets ZSTD_e_end : it becomes a blocking call).
                               * More workers improve speed, but also increase memory usage.
@@ -535,8 +536,8 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               */
 } ZSTD_cParameter;
 </b></pre><BR>
-<pre><b>unsigned ZSTD_cParam_lowerBound(ZSTD_cParameter cParam);
-unsigned ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
+<pre><b>int ZSTD_cParam_lowerBound(ZSTD_cParameter cParam);
+int ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
 </b><p>  All parameters must respect lower/upper bounds,
   otherwise they will either trigger an error
   or be automatically clamped.
@@ -545,14 +546,15 @@ unsigned ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned value);
+<pre><b>size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value);
 </b><p>  Set one compression parameter, selected by enum ZSTD_cParameter.
+  All parameters have valid bounds. Bounds can be queried using ZSTD_cParam_getBounds().
+  Providing a value beyond bound will either clamp it, or trigger an error (depending on parameter).
   Setting a parameter is generally only possible during frame initialization (before starting compression).
   Exception : when using multi-threading mode (nbWorkers >= 1),
               the following parameters can be updated _during_ compression (within same frame):
               => compressionLevel, hashLog, chainLog, searchLog, minMatch, targetLength and strategy.
               new parameters will be active for next job only (after a flush()).
-  Note : when original `value` type is not unsigned (like int, or enum), cast it to unsigned.
   @result : informational value (typically, value being effectively set, after clamping),
             or an error code (which can be tested with ZSTD_isError()). 
 </p></pre><BR>
@@ -1061,11 +1063,10 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned value);
+<pre><b>size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, int value);
 </b><p>  Similar to ZSTD_CCtx_setParameter.
   Set one compression parameter, selected by enum ZSTD_cParameter.
   Parameters must be applied to a ZSTD_CCtx using ZSTD_CCtx_setParametersUsingCCtxParams().
-  Note : when `value` is an enum, cast it to unsigned for proper type checking.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
  
 </p></pre><BR>

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -351,7 +351,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 <BR></pre>
 
 <a name="Chapter12"></a><h2>Candidate API for promotion to stable status</h2><pre>
- The following symbols and constants are in "staging area" :
+ The following symbols and constants belong to the "staging area" :
  they are considered to join "stable API" status by v1.4.0.
  The below proposal is written so that it can become stable "as is".
  It's still possible to suggest modifications.
@@ -771,9 +771,10 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 <a name="Chapter14"></a><h2>experimental API (static linking only)</h2><pre>
  The following symbols and constants
- are not planned to join "stable API" status anytime soon.
+ are not planned to join "stable API" status in the near future.
+ They can still change in future versions.
  Some of them are planned to remain in the static_only section indefinitely.
- Some of them might even be removed in the future (especially when redundant with existing stable functions)
+ Some of them might be removed in the future (especially when redundant with existing stable functions)
  
 <BR></pre>
 
@@ -788,9 +789,9 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 } ZSTD_compressionParameters;
 </b></pre><BR>
 <pre><b>typedef struct {
-    unsigned contentSizeFlag; </b>/**< 1: content size will be in frame header (when known) */<b>
-    unsigned checksumFlag;    </b>/**< 1: generate a 32-bits checksum using XXH64 algorithm at end of frame, for error detection */<b>
-    unsigned noDictIDFlag;    </b>/**< 1: no dictID will be saved into frame header (dictID is only useful for dictionary compression) */<b>
+    int contentSizeFlag; </b>/**< 1: content size will be in frame header (when known) */<b>
+    int checksumFlag;    </b>/**< 1: generate a 32-bits checksum using XXH64 algorithm at end of frame, for error detection */<b>
+    int noDictIDFlag;    </b>/**< 1: no dictID will be saved into frame header (dictID is only useful for dictionary compression) */<b>
 } ZSTD_frameParameters;
 </b></pre><BR>
 <pre><b>typedef struct {
@@ -858,14 +859,6 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 } ZSTD_dictAttachPref_e;
 </b></pre><BR>
 <a name="Chapter15"></a><h2>Frame size functions</h2><pre></pre>
-
-<pre><b>size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
-</b><p>  `src` should point to the start of a ZSTD encoded frame or skippable frame
-  `srcSize` must be >= first frame size
-  @return : the compressed size of the first frame starting at `src`,
-            suitable to pass to `ZSTD_decompress` or similar,
-            or an error code if input is invalid 
-</p></pre><BR>
 
 <pre><b>unsigned long long ZSTD_findDecompressedSize(const void* src, size_t srcSize);
 </b><p>  `src` should point the start of a series of ZSTD encoded and/or skippable frames
@@ -1035,7 +1028,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
   how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) 
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value);
+<pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int* value);
 </b><p> Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
  
@@ -1086,7 +1079,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_CCtxParam_getParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned* value);
+<pre><b>size_t ZSTD_CCtxParam_getParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, int* value);
 </b><p> Similar to ZSTD_CCtx_getParameter.
  Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -459,7 +459,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * Special: value 0 means "use default value" (default: 64). */
     ZSTD_p_ldmBucketSizeLog=163, </b>/* Log size of each bucket in the LDM hash table for collision resolution.<b>
                               * Larger values improve collision resolution but decrease compression speed.
-                              * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX .
+                              * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX.
                               * Special: value 0 means "use default value" (default: 3). */
     ZSTD_p_ldmHashEveryLog=164, </b>/* Frequency of inserting/looking up entries into the LDM hash table.<b>
                               * Must be clamped between 0 and (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN).
@@ -490,8 +490,13 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * 0 means default, which is dynamically determined based on compression parameters.
                               * Job size must be a minimum of overlapSize, or 1 MB, whichever is largest.
                               * The minimum size is automatically and transparently enforced */
-    ZSTD_p_overlapSizeLog=402, </b>/* Size of previous input reloaded at the beginning of each job, as a fraction of window size.<b>
-                              * 0 : no overlap;  6(default) : use 1/8th of windowSize;  >=9 : use full windowSize */
+    ZSTD_p_overlapSizeLog=402, </b>/* Size of previous job reloaded at the beginning of each job, as a fraction of window size.<b>
+                              * This value is enforced only when nbWorkers >= 1.
+                              * Larger values increase compression ratio, but decrease speed.
+                              * Values range from 0 (no overlap) to 9 (overlap a full windowSize).
+                              * Each rank (except 0) increase/decrease load size by a factor 2
+                              * 9: full window;  8: w/2;  7: w/4;  6: w/8;  5:w/16;  4: w/32;  3:w/64;  2:w/128;  1:w/256;
+                              * default value is 6 : use 1/8th of windowSize */
 
     </b>/* =================================================================== */<b>
     </b>/* experimental parameters - no stability guaranteed                   */<b>

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -19,7 +19,7 @@
 <li><a href="#Chapter9">Streaming compression - HowTo</a></li>
 <li><a href="#Chapter10">Streaming decompression - HowTo</a></li>
 <li><a href="#Chapter11">ADVANCED AND EXPERIMENTAL FUNCTIONS</a></li>
-<li><a href="#Chapter12">Candidate API for promotion into stable</a></li>
+<li><a href="#Chapter12">Candidate API for promotion to stable status</a></li>
 <li><a href="#Chapter13">Memory management</a></li>
 <li><a href="#Chapter14">Advanced compression API</a></li>
 <li><a href="#Chapter15">experimental API (static linking only)</a></li>
@@ -350,9 +350,12 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
  
 <BR></pre>
 
-<a name="Chapter12"></a><h2>Candidate API for promotion into stable</h2><pre>
- The following symbols and constants are considered to join
- "stable API" status by v1.4.0
+<a name="Chapter12"></a><h2>Candidate API for promotion to stable status</h2><pre>
+ The following symbols and constants are currently considered
+ to join "stable API" status by v1.4.0.
+ The intention is that they should be able to become stable "as is", with no further modification.
+ It is also last chance to gather comments / suggestions on this API,
+ as the API is locked once reaching "stable" status.
  
 <BR></pre>
 
@@ -367,27 +370,11 @@ size_t ZSTD_sizeof_DStream(const ZSTD_DStream* zds);
 size_t ZSTD_sizeof_CDict(const ZSTD_CDict* cdict);
 size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 </b><p>  These functions give the current memory usage of selected object.
-  Object memory usage can evolve when re-used. 
+  Object memory usage can evolve (increase or decrease) over time. 
 </p></pre><BR>
 
 <a name="Chapter14"></a><h2>Advanced compression API</h2><pre></pre>
 
-<pre><b>typedef enum {
-    </b>/* Opened question : should we have a format ZSTD_f_auto ?<b>
-     * Today, it would mean exactly the same as ZSTD_f_zstd1.
-     * But, in the future, should several formats become supported,
-     * on the compression side, it would mean "default format".
-     * On the decompression side, it would mean "automatic format detection",
-     * so that ZSTD_f_zstd1 would mean "accept *only* zstd frames".
-     * Since meaning is a little different, another option could be to define different enums for compression and decompression.
-     * This question could be kept for later, when there are actually multiple formats to support,
-     * but there is also the question of pinning enum values, and pinning value `0` is especially important */
-    ZSTD_f_zstd1 = 0,           </b>/* zstd frame format, specified in zstd_compression_format.md (default) */<b>
-    ZSTD_f_zstd1_magicless = 1, </b>/* Variant of zstd frame format, without initial 4-bytes magic number.<b>
-                                 * Useful to save 4 bytes per generated frame.
-                                 * Decoder cannot recognise automatically this format, requiring instructions. */
-} ZSTD_format_e;
-</b></pre><BR>
 <pre><b>typedef enum { ZSTD_fast=1,
                ZSTD_dfast=2,
                ZSTD_greedy=3,
@@ -400,50 +387,17 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
            } ZSTD_strategy;
 </b></pre><BR>
 <pre><b>typedef enum {
-    </b>/* Note: this enum and the behavior it controls are effectively internal<b>
-     * implementation details of the compressor. They are expected to continue
-     * to evolve and should be considered only in the context of extremely
-     * advanced performance tuning.
-     *
-     * Zstd currently supports the use of a CDict in two ways:
-     *
-     * - The contents of the CDict can be copied into the working context. This
-     *   means that the compression can search both the dictionary and input
-     *   while operating on a single set of internal tables. This makes
-     *   the compression faster per-byte of input. However, the initial copy of
-     *   the CDict's tables incurs a fixed cost at the beginning of the
-     *   compression. For small compressions (< 8 KB), that copy can dominate
-     *   the cost of the compression.
-     *
-     * - The CDict's tables can be used in-place. In this model, compression is
-     *   slower per input byte, because the compressor has to search two sets of
-     *   tables. However, this model incurs no start-up cost (as long as the
-     *   working context's tables can be reused). For small inputs, this can be
-     *   faster than copying the CDict's tables.
-     *
-     * Zstd has a simple internal heuristic that selects which strategy to use
-     * at the beginning of a compression. However, if experimentation shows that
-     * Zstd is making poor choices, it is possible to override that choice with
-     * this enum.
-     */
-    ZSTD_dictDefaultAttach = 0, </b>/* Use the default heuristic. */<b>
-    ZSTD_dictForceAttach   = 1, </b>/* Never copy the dictionary. */<b>
-    ZSTD_dictForceCopy     = 2, </b>/* Always copy the dictionary. */<b>
-} ZSTD_dictAttachPref_e;
-</b></pre><BR>
-<pre><b>typedef enum {
 
     </b>/* compression parameters */<b>
     ZSTD_p_compressionLevel=100, </b>/* Update all compression parameters according to pre-defined cLevel table<b>
                               * Default level is ZSTD_CLEVEL_DEFAULT==3.
                               * Special: value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT.
                               * Note 1 : it's possible to pass a negative compression level by casting it to unsigned type.
-                              * Note 2 : setting a level sets all default values of other compression parameters.
-                              * Note 3 : setting compressionLevel automatically updates ZSTD_p_compressLiterals. */
+                              * Note 2 : setting a level sets all default values of other compression parameters */
     ZSTD_p_windowLog=101,    </b>/* Maximum allowed back-reference distance, expressed as power of 2.<b>
                               * Must be clamped between ZSTD_WINDOWLOG_MIN and ZSTD_WINDOWLOG_MAX.
                               * Special: value 0 means "use default windowLog".
-                              * Note: Using a window size greater than ZSTD_MAXWINDOWSIZE_DEFAULT (default: 2^27)
+                              * Note: Using a window size greater than 1<<ZSTD_WINDOWLOG_LIMIT_DEFAULT
                               *       requires explicitly allowing such window size during decompression stage. */
     ZSTD_p_hashLog=102,      </b>/* Size of the initial probe table, as a power of 2.<b>
                               * Resulting table size is (1 << (hashLog+2)).
@@ -519,7 +473,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_p_dictIDFlag=202,   </b>/* When applicable, dictionary's ID is written into frame header (default:1) */<b>
 
     </b>/* multi-threading parameters */<b>
-    </b>/* These parameters are only useful if multi-threading is enabled (ZSTD_MULTITHREAD).<b>
+    </b>/* These parameters are only useful if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
      * They return an error otherwise. */
     ZSTD_p_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
                               * When nbWorkers >= 1, triggers asynchronous mode :
@@ -528,17 +482,17 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * (note : a strong exception to this rule is when first invocation sets ZSTD_e_end : it becomes a blocking call).
                               * More workers improve speed, but also increase memory usage.
                               * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
-    ZSTD_p_jobSize=401,      </b>/* Size of a compression job. This value is enforced only in non-blocking mode.<b>
-                              * Each compression job is completed in parallel, so this value indirectly controls the nb of active threads.
+    ZSTD_p_jobSize=401,      </b>/* Size of a compression job. This value is enforced only when nbWorkers >= 1.<b>
+                              * Each compression job is completed in parallel, so this value can indirectly impact the nb of active threads.
                               * 0 means default, which is dynamically determined based on compression parameters.
                               * Job size must be a minimum of overlapSize, or 1 MB, whichever is largest.
                               * The minimum size is automatically and transparently enforced */
-    ZSTD_p_overlapSizeLog=402, </b>/* Size of previous input reloaded at the beginning of each job.<b>
-                              * 0 => no overlap, 6(default) => use 1/8th of windowSize, >=9 => use full windowSize */
+    ZSTD_p_overlapSizeLog=402, </b>/* Size of previous input reloaded at the beginning of each job, as a fraction of window size.<b>
+                              * 0 : no overlap;  6(default) : use 1/8th of windowSize;  >=9 : use full windowSize */
 
     </b>/* =================================================================== */<b>
     </b>/* experimental parameters - no stability guaranteed                   */<b>
-    </b>/* note : should this be exported in a different section of zstd.h ?   */<b>
+    </b>/* => note : should this part be exported in a different section of zstd.h ? */<b>
     </b>/* =================================================================== */<b>
 
     </b>/* compression format */<b>
@@ -567,12 +521,6 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   Note : when original `value` type is not unsigned (like int, or enum), cast it to unsigned.
   @result : informational value (typically, value being effectively set, after clamping),
             or an error code (which can be tested with ZSTD_isError()). 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value);
-</b><p> Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
- 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_setPledgedSrcSize(ZSTD_CCtx* cctx, unsigned long long pledgedSrcSize);
@@ -644,29 +592,27 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 } ZSTD_CCtx_reset_directive;
 </b></pre><BR>
 <pre><b>size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_CCtx_reset_directive zcrd);
-</b><p>  Return a CCtx to clean state.
-  There 2 things that can be reset, independently or jointly :
-  - The session : will stop compressing current frame, and stand ready to start a new one.
-                  This action never fails.
+</b><p>  There are 2 different things that can be reset, independently or jointly :
+  - The session : will stop compressing current frame, and make CCtx ready to start a new one.
                   Useful after an error, or to interrupt any ongoing compression.
                   Any internal data not yet flushed is cancelled.
                   But parameters and dictionary are kept unchanged.
                   Therefore, same parameters and dictionary will be used for next frame.
+                  This action never fails.
   - The parameters : changes all parameters back to "default".
-                  This removes any dictionary too.
+                  This removes any reference to any dictionary too.
                   Parameters can only be changed between 2 sessions (i.e. no compression is currently ongoing)
                   otherwise the reset fails, and function returns an error value (which can be tested using ZSTD_isError())
   - Both : similar to resetting the session, followed by resetting parameters.
-                  This action never fails.
  
 </p></pre><BR>
 
 <pre><b>typedef enum {
     ZSTD_e_continue=0, </b>/* collect more data, encoder decides when to output compressed result, for optimal compression ratio */<b>
-    ZSTD_e_flush,      </b>/* flush any data provided so far,<b>
+    ZSTD_e_flush=1,    </b>/* flush any data provided so far,<b>
                         * it creates (at least) one new block, that can be decoded immediately on reception;
                         * frame will continue: any future data can still reference previously compressed data, improving compression. */
-    ZSTD_e_end         </b>/* flush any remaining data and close current frame.<b>
+    ZSTD_e_end=2       </b>/* flush any remaining data and close current frame.<b>
                         * any additional data starts a new frame.
                         * each frame is independent (does not reference any content from previous frame). */
 } ZSTD_EndDirective;
@@ -704,8 +650,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                 ZSTD_EndDirective endOp);
 </b><p>  Same as ZSTD_compress_generic(),
   but using only integral types as arguments.
-  Argument list is larger than ZSTD_{in,out}Buffer,
-  but can be helpful for binders from dynamic languages
+  This variant might be be helpful for binders from dynamic languages
   which have troubles handling structures containing memory pointers.
  
 </p></pre><BR>
@@ -749,6 +694,54 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_dlm_byCopy = 0,  </b>/**< Copy dictionary content internally */<b>
     ZSTD_dlm_byRef = 1,   </b>/**< Reference dictionary content -- the dictionary buffer must outlive its users. */<b>
 } ZSTD_dictLoadMethod_e;
+</b></pre><BR>
+<pre><b>typedef enum {
+    </b>/* Opened question : should we have a format ZSTD_f_auto ?<b>
+     * Today, it would mean exactly the same as ZSTD_f_zstd1.
+     * But, in the future, should several formats become supported,
+     * on the compression side, it would mean "default format".
+     * On the decompression side, it would mean "automatic format detection",
+     * so that ZSTD_f_zstd1 would mean "accept *only* zstd frames".
+     * Since meaning is a little different, another option could be to define different enums for compression and decompression.
+     * This question could be kept for later, when there are actually multiple formats to support,
+     * but there is also the question of pinning enum values, and pinning value `0` is especially important */
+    ZSTD_f_zstd1 = 0,           </b>/* zstd frame format, specified in zstd_compression_format.md (default) */<b>
+    ZSTD_f_zstd1_magicless = 1, </b>/* Variant of zstd frame format, without initial 4-bytes magic number.<b>
+                                 * Useful to save 4 bytes per generated frame.
+                                 * Decoder cannot recognise automatically this format, requiring instructions. */
+} ZSTD_format_e;
+</b></pre><BR>
+<pre><b>typedef enum {
+    </b>/* Note: this enum and the behavior it controls are effectively internal<b>
+     * implementation details of the compressor. They are expected to continue
+     * to evolve and should be considered only in the context of extremely
+     * advanced performance tuning.
+     *
+     * Zstd currently supports the use of a CDict in two ways:
+     *
+     * - The contents of the CDict can be copied into the working context. This
+     *   means that the compression can search both the dictionary and input
+     *   while operating on a single set of internal tables. This makes
+     *   the compression faster per-byte of input. However, the initial copy of
+     *   the CDict's tables incurs a fixed cost at the beginning of the
+     *   compression. For small compressions (< 8 KB), that copy can dominate
+     *   the cost of the compression.
+     *
+     * - The CDict's tables can be used in-place. In this model, compression is
+     *   slower per input byte, because the compressor has to search two sets of
+     *   tables. However, this model incurs no start-up cost (as long as the
+     *   working context's tables can be reused). For small inputs, this can be
+     *   faster than copying the CDict's tables.
+     *
+     * Zstd has a simple internal heuristic that selects which strategy to use
+     * at the beginning of a compression. However, if experimentation shows that
+     * Zstd is making poor choices, it is possible to override that choice with
+     * this enum.
+     */
+    ZSTD_dictDefaultAttach = 0, </b>/* Use the default heuristic. */<b>
+    ZSTD_dictForceAttach   = 1, </b>/* Never copy the dictionary. */<b>
+    ZSTD_dictForceCopy     = 2, </b>/* Always copy the dictionary. */<b>
+} ZSTD_dictAttachPref_e;
 </b></pre><BR>
 <a name="Chapter16"></a><h2>Frame size functions</h2><pre></pre>
 
@@ -925,6 +918,12 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 <pre><b>size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* prefix, size_t prefixSize, ZSTD_dictContentType_e dictContentType);
 </b><p>  Same as ZSTD_CCtx_refPrefix(), but gives finer control over
   and how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value);
+</b><p> Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+ 
 </p></pre><BR>
 
 <pre><b>ZSTD_CCtx_params* ZSTD_createCCtxParams(void);

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -461,12 +461,12 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * Larger values improve collision resolution but decrease compression speed.
                               * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX.
                               * Special: value 0 means "use default value" (default: 3). */
-    ZSTD_p_ldmHashEveryLog=164, </b>/* Frequency of inserting/looking up entries into the LDM hash table.<b>
+    ZSTD_p_ldmHashRateLog=164, </b>/* Frequency of inserting/looking up entries into the LDM hash table.<b>
                               * Must be clamped between 0 and (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN).
                               * Default is MAX(0, (windowLog - ldmHashLog)), optimizing hash table usage.
                               * Larger values improve compression speed.
                               * Deviating far from default value will likely result in a compression ratio decrease.
-                              * Special: value 0 means "automatically determine hashEveryLog". */
+                              * Special: value 0 means "automatically determine hashRateLog". */
 
     </b>/* frame parameters */<b>
     ZSTD_p_contentSizeFlag=200, </b>/* Content size will be written into frame header _whenever known_ (default:1)<b>

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -416,8 +416,8 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_c_windowLog=101,    </b>/* Maximum allowed back-reference distance, expressed as power of 2.<b>
                               * Must be clamped between ZSTD_WINDOWLOG_MIN and ZSTD_WINDOWLOG_MAX.
                               * Special: value 0 means "use default windowLog".
-                              * Note: Using a window size greater than 1<<ZSTD_WINDOWLOG_LIMIT_DEFAULT
-                              *       requires explicitly allowing such window size during decompression stage if using streaming. */
+                              * Note: Using a windowLog greater than ZSTD_WINDOWLOG_LIMIT_DEFAULT
+                              *       requires explicitly allowing such window size at decompression stage if using streaming. */
     ZSTD_c_hashLog=102,      </b>/* Size of the initial probe table, as a power of 2.<b>
                               * Resulting memory usage is (1 << (hashLog+2)).
                               * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX.
@@ -580,7 +580,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
   Special: Loading a NULL (or 0-size) dictionary invalidates previous dictionary,
            meaning "return to no-dictionary mode".
-  Note 1 : Dictionary is sticky, it will be used for all future compression jobs.
+  Note 1 : Dictionary is sticky, it will be used for all future compressed frames.
            To return to "no-dictionary" situation, load a NULL dictionary (or reset parameters).
   Note 2 : Loading a dictionary involves building tables.
            It's also a CPU consuming operation, with non-negligible impact on latency.
@@ -594,10 +594,10 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_refCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict);
-</b><p>  Reference a prepared dictionary, to be used for all next compression jobs.
+</b><p>  Reference a prepared dictionary, to be used for all next compressed frames.
   Note that compression parameters are enforced from within CDict,
   and supercede any compression parameter previously set within CCtx.
-  The dictionary will remain valid for future compression jobs using same CCtx.
+  The dictionary will remain valid for future compressed frames using same CCtx.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
   Special : Referencing a NULL CDict means "return to no-dictionary mode".
   Note 1 : Currently, only one dictionary can be managed.
@@ -607,14 +607,14 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 <pre><b>size_t ZSTD_CCtx_refPrefix(ZSTD_CCtx* cctx,
                      const void* prefix, size_t prefixSize);
-</b><p>  Reference a prefix (single-usage dictionary) for next compression job.
+</b><p>  Reference a prefix (single-usage dictionary) for next compressed frame.
+  A prefix is **only used once**. Tables are discarded at end of frame (ZSTD_e_end).
   Decompression will need same prefix to properly regenerate data.
   Compressing with a prefix is similar in outcome as performing a diff and compressing it,
   but performs much faster, especially during decompression (compression speed is tunable with compression level).
-  Note that prefix is **only used once**. Tables are discarded at end of compression job (ZSTD_e_end).
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
   Special: Adding any prefix (including NULL) invalidates any previous prefix or dictionary
-  Note 1 : Prefix buffer is referenced. It **must** outlive compression job.
+  Note 1 : Prefix buffer is referenced. It **must** outlive compression.
            Its content must remain unmodified during compression.
   Note 2 : If the intention is to diff some large src data blob with some prior version of itself,
            ensure that the window size is large enough to contain the entire source.
@@ -764,14 +764,14 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 <pre><b>size_t ZSTD_DCtx_refPrefix(ZSTD_DCtx* dctx,
                      const void* prefix, size_t prefixSize);
-</b><p>  Reference a prefix (single-usage dictionary) for next compression job.
+</b><p>  Reference a prefix (single-usage dictionary) to decompress next frame.
   This is the reverse operation of ZSTD_CCtx_refPrefix(),
   and must use the same prefix as the one used during compression.
   Prefix is **only used once**. Reference is discarded at end of frame.
   End of frame is reached when ZSTD_decompressStream() returns 0.
  @result : 0, or an error code (which can be tested with ZSTD_isError()).
   Note 1 : Adding any prefix (including NULL) invalidates any previously set prefix or dictionary
-  Note 2 : Prefix buffer is referenced. It **must** outlive decompression job.
+  Note 2 : Prefix buffer is referenced. It **must** outlive decompression.
            Prefix buffer must remain unmodified up to the end of frame,
            reached when ZSTD_decompressStream() returns 0.
   Note 3 : By default, the prefix is treated as raw content (ZSTD_dm_rawContent).
@@ -1066,7 +1066,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
   - ZSTD_CCtx_setParametersUsingCCtxParams() : Apply parameters to
                                     an existing CCtx.
                                     These parameters will be applied to
-                                    all subsequent compression jobs.
+                                    all subsequent frames.
   - ZSTD_compressStream2() : Do compression using the CCtx.
   - ZSTD_freeCCtxParams() : Free the memory.
 
@@ -1228,7 +1228,7 @@ size_t ZSTD_initCStream_usingCDict(ZSTD_CStream* zcs, const ZSTD_CDict* cdict); 
 size_t ZSTD_initCStream_usingCDict_advanced(ZSTD_CStream* zcs, const ZSTD_CDict* cdict, ZSTD_frameParameters fParams, unsigned long long pledgedSrcSize);  </b>/**< same as ZSTD_initCStream_usingCDict(), with control over frame parameters. pledgedSrcSize must be correct. If srcSize is not known at init time, use value ZSTD_CONTENTSIZE_UNKNOWN. */<b>
 </pre></b><BR>
 <pre><b>size_t ZSTD_resetCStream(ZSTD_CStream* zcs, unsigned long long pledgedSrcSize);
-</b><p>  start a new compression job, using same parameters from previous job.
+</b><p>  start a new frame, using same parameters from previous frame.
   This is typically useful to skip dictionary loading stage, since it will re-use it in-place.
   Note that zcs must be init at least once before using ZSTD_resetCStream().
   If pledgedSrcSize is not known at reset time, use macro ZSTD_CONTENTSIZE_UNKNOWN.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -20,16 +20,17 @@
 <li><a href="#Chapter10">Streaming decompression - HowTo</a></li>
 <li><a href="#Chapter11">ADVANCED AND EXPERIMENTAL FUNCTIONS</a></li>
 <li><a href="#Chapter12">Candidate API for promotion into stable</a></li>
-<li><a href="#Chapter13">Frame size functions</a></li>
-<li><a href="#Chapter14">Memory management</a></li>
-<li><a href="#Chapter15">Advanced compression functions</a></li>
-<li><a href="#Chapter16">Advanced decompression functions</a></li>
-<li><a href="#Chapter17">Advanced streaming functions</a></li>
-<li><a href="#Chapter18">Buffer-less and synchronous inner streaming functions</a></li>
-<li><a href="#Chapter19">Buffer-less streaming compression (synchronous mode)</a></li>
-<li><a href="#Chapter20">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter21">New advanced API (experimental)</a></li>
-<li><a href="#Chapter22">Block level API</a></li>
+<li><a href="#Chapter13">Purely experimental API</a></li>
+<li><a href="#Chapter14">Frame size functions</a></li>
+<li><a href="#Chapter15">Memory management</a></li>
+<li><a href="#Chapter16">Advanced compression functions</a></li>
+<li><a href="#Chapter17">Advanced decompression functions</a></li>
+<li><a href="#Chapter18">Advanced streaming functions</a></li>
+<li><a href="#Chapter19">Buffer-less and synchronous inner streaming functions</a></li>
+<li><a href="#Chapter20">Buffer-less streaming compression (synchronous mode)</a></li>
+<li><a href="#Chapter21">Buffer-less streaming decompression (synchronous mode)</a></li>
+<li><a href="#Chapter22">New advanced API (experimental)</a></li>
+<li><a href="#Chapter23">Block level API</a></li>
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
@@ -356,23 +357,38 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 
 <pre><b>int ZSTD_minCLevel(void);  </b>/*!< minimum negative compression level allowed */<b>
 </b></pre><BR>
-<pre><b>typedef enum { ZSTD_fast=1, ZSTD_dfast, ZSTD_greedy, ZSTD_lazy, ZSTD_lazy2,
-               ZSTD_btlazy2, ZSTD_btopt, ZSTD_btultra } ZSTD_strategy;   </b>/* from faster to stronger */<b>
+<a name="Chapter13"></a><h2>Purely experimental API</h2><pre>
+ The following symbols and constants are not planned
+ to join "stable API" status anytime soon.
+ Some of them might even be removed in the future.
+ 
+<BR></pre>
+
+<pre><b>typedef enum { ZSTD_fast=1,
+               ZSTD_dfast=2,
+               ZSTD_greedy=3,
+               ZSTD_lazy=4,
+               ZSTD_lazy2=5,
+               ZSTD_btlazy2=6,
+               ZSTD_btopt=7,
+               ZSTD_btultra=8
+               </b>/* note : new strategies might be added in the future */<b>
+           } ZSTD_strategy;
 </b></pre><BR>
 <pre><b>typedef struct {
-    unsigned windowLog;      </b>/**< largest match distance : larger == more compression, more memory needed during decompression */<b>
-    unsigned chainLog;       </b>/**< fully searched segment : larger == more compression, slower, more memory (useless for fast) */<b>
-    unsigned hashLog;        </b>/**< dispatch table : larger == faster, more memory */<b>
-    unsigned searchLog;      </b>/**< nb of searches : larger == more compression, slower */<b>
-    unsigned searchLength;   </b>/**< match length searched : larger == faster decompression, sometimes less compression */<b>
-    unsigned targetLength;   </b>/**< acceptable match size for optimal parser (only) : larger == more compression, slower */<b>
-    ZSTD_strategy strategy;
+    unsigned windowLog;       </b>/**< largest match distance : larger == more compression, more memory needed during decompression */<b>
+    unsigned chainLog;        </b>/**< fully searched segment : larger == more compression, slower, more memory (useless for fast) */<b>
+    unsigned hashLog;         </b>/**< dispatch table : larger == faster, more memory */<b>
+    unsigned searchLog;       </b>/**< nb of searches : larger == more compression, slower */<b>
+    unsigned searchLength;    </b>/**< match length searched : larger == faster decompression, sometimes less compression */<b>
+    unsigned targetLength;    </b>/**< acceptable match size for optimal parser (only) : larger == more compression, slower */<b>
+    ZSTD_strategy strategy;   </b>/**< see ZSTD_strategy definition above */<b>
 } ZSTD_compressionParameters;
 </b></pre><BR>
 <pre><b>typedef struct {
     unsigned contentSizeFlag; </b>/**< 1: content size will be in frame header (when known) */<b>
-    unsigned checksumFlag;    </b>/**< 1: generate a 32-bits checksum at end of frame, for error detection */<b>
-    unsigned noDictIDFlag;    </b>/**< 1: no dictID will be saved into frame header (if dictionary compression) */<b>
+    unsigned checksumFlag;    </b>/**< 1: generate a 32-bits checksum using XXH64 algorithm at end of frame, for error detection */<b>
+    unsigned noDictIDFlag;    </b>/**< 1: no dictID will be saved into frame header (dictID is only useful for dictionary compression) */<b>
 } ZSTD_frameParameters;
 </b></pre><BR>
 <pre><b>typedef struct {
@@ -381,17 +397,17 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 } ZSTD_parameters;
 </b></pre><BR>
 <pre><b>typedef enum {
-    ZSTD_dct_auto = 0,    </b>/* dictionary is "full" when starting with ZSTD_MAGIC_DICTIONARY, otherwise it is "rawContent" */<b>
-    ZSTD_dct_rawContent,  </b>/* ensures dictionary is always loaded as rawContent, even if it starts with ZSTD_MAGIC_DICTIONARY */<b>
-    ZSTD_dct_fullDict     </b>/* refuses to load a dictionary if it does not respect Zstandard's specification */<b>
+    ZSTD_dct_auto = 0,       </b>/* dictionary is "full" when starting with ZSTD_MAGIC_DICTIONARY, otherwise it is "rawContent" */<b>
+    ZSTD_dct_rawContent = 1, </b>/* ensures dictionary is always loaded as rawContent, even if it starts with ZSTD_MAGIC_DICTIONARY */<b>
+    ZSTD_dct_fullDict = 2    </b>/* refuses to load a dictionary if it does not respect Zstandard's specification, starting with ZSTD_MAGIC_DICTIONARY */<b>
 } ZSTD_dictContentType_e;
 </b></pre><BR>
 <pre><b>typedef enum {
-    ZSTD_dlm_byCopy = 0, </b>/**< Copy dictionary content internally */<b>
-    ZSTD_dlm_byRef,      </b>/**< Reference dictionary content -- the dictionary buffer must outlive its users. */<b>
+    ZSTD_dlm_byCopy = 0,  </b>/**< Copy dictionary content internally */<b>
+    ZSTD_dlm_byRef = 1,   </b>/**< Reference dictionary content -- the dictionary buffer must outlive its users. */<b>
 } ZSTD_dictLoadMethod_e;
 </b></pre><BR>
-<a name="Chapter13"></a><h2>Frame size functions</h2><pre></pre>
+<a name="Chapter14"></a><h2>Frame size functions</h2><pre></pre>
 
 <pre><b>size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
 </b><p>  `src` should point to the start of a ZSTD encoded frame or skippable frame
@@ -430,7 +446,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
            or an error code (if srcSize is too small) 
 </p></pre><BR>
 
-<a name="Chapter14"></a><h2>Memory management</h2><pre></pre>
+<a name="Chapter15"></a><h2>Memory management</h2><pre></pre>
 
 <pre><b>size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx);
 size_t ZSTD_sizeof_DCtx(const ZSTD_DCtx* dctx);
@@ -520,7 +536,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
  
 </p></pre><BR>
 
-<a name="Chapter15"></a><h2>Advanced compression functions</h2><pre></pre>
+<a name="Chapter16"></a><h2>Advanced compression functions</h2><pre></pre>
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
@@ -562,7 +578,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 </b><p>   Same as ZSTD_compress_usingCDict(), with fine-tune control over frame parameters 
 </p></pre><BR>
 
-<a name="Chapter16"></a><h2>Advanced decompression functions</h2><pre></pre>
+<a name="Chapter17"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
 </b><p>  Tells if the content of `buffer` starts with a valid Frame Identifier.
@@ -602,7 +618,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
   When identifying the exact failure cause, it's possible to use ZSTD_getFrameHeader(), which will provide a more precise error code. 
 </p></pre><BR>
 
-<a name="Chapter17"></a><h2>Advanced streaming functions</h2><pre></pre>
+<a name="Chapter18"></a><h2>Advanced streaming functions</h2><pre></pre>
 
 <h3>Advanced Streaming compression functions</h3><pre></pre><b><pre>size_t ZSTD_initCStream_srcSize(ZSTD_CStream* zcs, int compressionLevel, unsigned long long pledgedSrcSize);   </b>/**< pledgedSrcSize must be correct. If it is not known at init time, use ZSTD_CONTENTSIZE_UNKNOWN. Note that, for compatibility with older programs, "0" also disables frame content size field. It may be enabled in the future. */<b>
 size_t ZSTD_initCStream_usingDict(ZSTD_CStream* zcs, const void* dict, size_t dictSize, int compressionLevel); </b>/**< creates of an internal CDict (incompatible with static CCtx), except if dict == NULL or dictSize < 8, in which case no dict is used. Note: dict is loaded with ZSTD_dm_auto (treated as a full zstd dictionary if it begins with ZSTD_MAGIC_DICTIONARY, else as raw content) and ZSTD_dlm_byCopy.*/<b>
@@ -653,14 +669,14 @@ size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t di
 size_t ZSTD_initDStream_usingDDict(ZSTD_DStream* zds, const ZSTD_DDict* ddict);  </b>/**< note : ddict is referenced, it must outlive decompression session */<b>
 size_t ZSTD_resetDStream(ZSTD_DStream* zds);  </b>/**< re-use decompression parameters from previous init; saves dictionary loading */<b>
 </pre></b><BR>
-<a name="Chapter18"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
+<a name="Chapter19"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
   This is an advanced API, giving full control over buffer management, for users which need direct control over memory.
   But it's also a complex one, with several restrictions, documented below.
   Prefer normal streaming API for an easier experience.
  
 <BR></pre>
 
-<a name="Chapter19"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
+<a name="Chapter20"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
   A ZSTD_CCtx object is required to track streaming operations.
   Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.
   ZSTD_CCtx object can be re-used multiple times within successive compression operations.
@@ -696,7 +712,7 @@ size_t ZSTD_compressBegin_usingCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict); 
 size_t ZSTD_compressBegin_usingCDict_advanced(ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict, ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize);   </b>/* compression parameters are already set within cdict. pledgedSrcSize must be correct. If srcSize is not known, use macro ZSTD_CONTENTSIZE_UNKNOWN */<b>
 size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx, unsigned long long pledgedSrcSize); </b>/**<  note: if pledgedSrcSize is not known, use ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<a name="Chapter20"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
+<a name="Chapter21"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
   A ZSTD_DCtx object is required to track streaming operations.
   Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
   A ZSTD_DCtx object can be re-used multiple times.
@@ -787,7 +803,7 @@ size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long 
 </pre></b><BR>
 <pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
 </b></pre><BR>
-<a name="Chapter21"></a><h2>New advanced API (experimental)</h2><pre></pre>
+<a name="Chapter22"></a><h2>New advanced API (experimental)</h2><pre></pre>
 
 <pre><b>typedef enum {
     </b>/* Opened question : should we have a format ZSTD_f_auto ?<b>
@@ -1283,7 +1299,7 @@ size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx,
  
 </p></pre><BR>
 
-<a name="Chapter22"></a><h2>Block level API</h2><pre></pre>
+<a name="Chapter23"></a><h2>Block level API</h2><pre></pre>
 
 <pre><b></b><p>    Frame metadata cost is typically ~18 bytes, which can be non-negligible for very small blocks (< 100 bytes).
     User will have to take in charge required information to regenerate data, such as compressed and content sizes.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -408,23 +408,23 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 <pre><b>typedef enum {
 
     </b>/* compression parameters */<b>
-    ZSTD_p_compressionLevel=100, </b>/* Update all compression parameters according to pre-defined cLevel table<b>
+    ZSTD_c_compressionLevel=100, </b>/* Update all compression parameters according to pre-defined cLevel table<b>
                               * Default level is ZSTD_CLEVEL_DEFAULT==3.
                               * Special: value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT.
                               * Note 1 : it's possible to pass a negative compression level.
                               * Note 2 : setting a level sets all default values of other compression parameters */
-    ZSTD_p_windowLog=101,    </b>/* Maximum allowed back-reference distance, expressed as power of 2.<b>
+    ZSTD_c_windowLog=101,    </b>/* Maximum allowed back-reference distance, expressed as power of 2.<b>
                               * Must be clamped between ZSTD_WINDOWLOG_MIN and ZSTD_WINDOWLOG_MAX.
                               * Special: value 0 means "use default windowLog".
                               * Note: Using a window size greater than 1<<ZSTD_WINDOWLOG_LIMIT_DEFAULT
                               *       requires explicitly allowing such window size during decompression stage if using streaming. */
-    ZSTD_p_hashLog=102,      </b>/* Size of the initial probe table, as a power of 2.<b>
+    ZSTD_c_hashLog=102,      </b>/* Size of the initial probe table, as a power of 2.<b>
                               * Resulting memory usage is (1 << (hashLog+2)).
                               * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX.
                               * Larger tables improve compression ratio of strategies <= dFast,
                               * and improve speed of strategies > dFast.
                               * Special: value 0 means "use default hashLog". */
-    ZSTD_p_chainLog=103,     </b>/* Size of the multi-probe search table, as a power of 2.<b>
+    ZSTD_c_chainLog=103,     </b>/* Size of the multi-probe search table, as a power of 2.<b>
                               * Resulting memory usage is (1 << (chainLog+2)).
                               * Must be clamped between ZSTD_CHAINLOG_MIN and ZSTD_CHAINLOG_MAX.
                               * Larger tables result in better and slower compression.
@@ -432,11 +432,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * It's still useful when using "dfast" strategy,
                               * in which case it defines a secondary probe table.
                               * Special: value 0 means "use default chainLog". */
-    ZSTD_p_searchLog=104,    </b>/* Number of search attempts, as a power of 2.<b>
+    ZSTD_c_searchLog=104,    </b>/* Number of search attempts, as a power of 2.<b>
                               * More attempts result in better and slower compression.
                               * This parameter is useless when using "fast" and "dFast" strategies.
                               * Special: value 0 means "use default searchLog". */
-    ZSTD_p_minMatch=105,     </b>/* Minimum size of searched matches.<b>
+    ZSTD_c_minMatch=105,     </b>/* Minimum size of searched matches.<b>
                               * Note that Zstandard can still find matches of smaller size,
                               * it just tweaks its search algorithm to look for this size and larger.
                               * Larger values increase compression and decompression speed, but decrease ratio.
@@ -444,7 +444,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * Note that currently, for all strategies < btopt, effective minimum is 4.
                               *                    , for all strategies > fast, effective maximum is 6.
                               * Special: value 0 means "use default minMatchLength". */
-    ZSTD_p_targetLength=106, </b>/* Impact of this field depends on strategy.<b>
+    ZSTD_c_targetLength=106, </b>/* Impact of this field depends on strategy.<b>
                               * For strategies btopt & btultra:
                               *     Length of Match considered "good enough" to stop search.
                               *     Larger values make compression stronger, and slower.
@@ -452,33 +452,33 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               *     Distance between match sampling.
                               *     Larger values make compression faster, and weaker.
                               * Special: value 0 means "use default targetLength". */
-    ZSTD_p_compressionStrategy=107, </b>/* See ZSTD_strategy enum definition.<b>
+    ZSTD_c_compressionStrategy=107, </b>/* See ZSTD_strategy enum definition.<b>
                               * The higher the value of selected strategy, the more complex it is,
                               * resulting in stronger and slower compression.
                               * Special: value 0 means "use default strategy". */
 
     </b>/* LDM mode parameters */<b>
-    ZSTD_p_enableLongDistanceMatching=160, </b>/* Enable long distance matching.<b>
+    ZSTD_c_enableLongDistanceMatching=160, </b>/* Enable long distance matching.<b>
                                      * This parameter is designed to improve compression ratio
                                      * for large inputs, by finding large matches at long distance.
                                      * It increases memory usage and window size.
-                                     * Note: enabling this parameter increases default ZSTD_p_windowLog to 128 MB
+                                     * Note: enabling this parameter increases default ZSTD_c_windowLog to 128 MB
                                      * except when expressly set to a different value. */
-    ZSTD_p_ldmHashLog=161,   </b>/* Size of the table for long distance matching, as a power of 2.<b>
+    ZSTD_c_ldmHashLog=161,   </b>/* Size of the table for long distance matching, as a power of 2.<b>
                               * Larger values increase memory usage and compression ratio,
                               * but decrease compression speed.
                               * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX
                               * default: windowlog - 7.
                               * Special: value 0 means "automatically determine hashlog". */
-    ZSTD_p_ldmMinMatch=162,  </b>/* Minimum match size for long distance matcher.<b>
+    ZSTD_c_ldmMinMatch=162,  </b>/* Minimum match size for long distance matcher.<b>
                               * Larger/too small values usually decrease compression ratio.
                               * Must be clamped between ZSTD_LDM_MINMATCH_MIN and ZSTD_LDM_MINMATCH_MAX.
                               * Special: value 0 means "use default value" (default: 64). */
-    ZSTD_p_ldmBucketSizeLog=163, </b>/* Log size of each bucket in the LDM hash table for collision resolution.<b>
+    ZSTD_c_ldmBucketSizeLog=163, </b>/* Log size of each bucket in the LDM hash table for collision resolution.<b>
                               * Larger values improve collision resolution but decrease compression speed.
                               * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX.
                               * Special: value 0 means "use default value" (default: 3). */
-    ZSTD_p_ldmHashRateLog=164, </b>/* Frequency of inserting/looking up entries into the LDM hash table.<b>
+    ZSTD_c_ldmHashRateLog=164, </b>/* Frequency of inserting/looking up entries into the LDM hash table.<b>
                               * Must be clamped between 0 and (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN).
                               * Default is MAX(0, (windowLog - ldmHashLog)), optimizing hash table usage.
                               * Larger values improve compression speed.
@@ -486,16 +486,16 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * Special: value 0 means "automatically determine hashRateLog". */
 
     </b>/* frame parameters */<b>
-    ZSTD_p_contentSizeFlag=200, </b>/* Content size will be written into frame header _whenever known_ (default:1)<b>
+    ZSTD_c_contentSizeFlag=200, </b>/* Content size will be written into frame header _whenever known_ (default:1)<b>
                               * Content size must be known at the beginning of compression,
                               * it is provided using ZSTD_CCtx_setPledgedSrcSize() */
-    ZSTD_p_checksumFlag=201, </b>/* A 32-bits checksum of content is written at end of frame (default:0) */<b>
-    ZSTD_p_dictIDFlag=202,   </b>/* When applicable, dictionary's ID is written into frame header (default:1) */<b>
+    ZSTD_c_checksumFlag=201, </b>/* A 32-bits checksum of content is written at end of frame (default:0) */<b>
+    ZSTD_c_dictIDFlag=202,   </b>/* When applicable, dictionary's ID is written into frame header (default:1) */<b>
 
     </b>/* multi-threading parameters */<b>
     </b>/* These parameters are only useful if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
      * They return an error otherwise. */
-    ZSTD_p_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
+    ZSTD_c_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
                               * When nbWorkers >= 1, triggers asynchronous mode when used with ZSTD_compressStream*() :
                               * ZSTD_compressStream*() consumes input and flush output if possible, but immediately gives back control to caller,
                               * while compression work is performed in parallel, within worker threads.
@@ -503,12 +503,12 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               *  in which case, ZSTD_compressStream2() delegates to ZSTD_compress2(), which is always a blocking call).
                               * More workers improve speed, but also increase memory usage.
                               * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
-    ZSTD_p_jobSize=401,      </b>/* Size of a compression job. This value is enforced only when nbWorkers >= 1.<b>
+    ZSTD_c_jobSize=401,      </b>/* Size of a compression job. This value is enforced only when nbWorkers >= 1.<b>
                               * Each compression job is completed in parallel, so this value can indirectly impact the nb of active threads.
                               * 0 means default, which is dynamically determined based on compression parameters.
                               * Job size must be a minimum of overlapSize, or 1 MB, whichever is largest.
                               * The minimum size is automatically and transparently enforced */
-    ZSTD_p_overlapSizeLog=402, </b>/* Size of previous job reloaded at the beginning of each job, as a fraction of window size.<b>
+    ZSTD_c_overlapSizeLog=402, </b>/* Size of previous job reloaded at the beginning of each job, as a fraction of window size.<b>
                               * This value is enforced only when nbWorkers >= 1.
                               * Larger values increase compression ratio, but decrease speed.
                               * Values range from 0 (no overlap) to 9 (overlap a full windowSize).
@@ -519,17 +519,17 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     </b>/* note : additional experimental parameters are also available<b>
      * within the experimental section of the API.
      * At the time of this writing, they include :
-     * ZSTD_p_rsyncable
-     * ZSTD_p_format
-     * ZSTD_p_forceMaxWindow
-     * ZSTD_p_forceAttachDict
+     * ZSTD_c_rsyncable
+     * ZSTD_c_format
+     * ZSTD_c_forceMaxWindow
+     * ZSTD_c_forceAttachDict
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
-     ZSTD_p_experimentalParam1=500,
-     ZSTD_p_experimentalParam2=10,
-     ZSTD_p_experimentalParam3=1000,
-     ZSTD_p_experimentalParam4
+     ZSTD_c_experimentalParam1=500,
+     ZSTD_c_experimentalParam2=10,
+     ZSTD_c_experimentalParam3=1000,
+     ZSTD_c_experimentalParam4
 } ZSTD_cParameter;
 </b></pre><BR>
 <pre><b>typedef struct {
@@ -618,7 +618,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
            Its content must remain unmodified during compression.
   Note 2 : If the intention is to diff some large src data blob with some prior version of itself,
            ensure that the window size is large enough to contain the entire source.
-           See ZSTD_p_windowLog.
+           See ZSTD_c_windowLog.
   Note 3 : Referencing a prefix involves building tables, which are dependent on compression parameters.
            It's a CPU consuming operation, with non-negligible impact on latency.
            If there is a need to use the same prefix multiple times, consider loadDictionary instead.
@@ -708,7 +708,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     </b>/* note : additional experimental parameters are also available<b>
      * within the experimental section of the API.
      * At the time of this writing, they include :
-     * ZSTD_p_format
+     * ZSTD_c_format
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
@@ -921,7 +921,7 @@ size_t ZSTD_estimateDCtxSize(void);
   It will also consider src size to be arbitrarily "large", which is worst case.
   If srcSize is known to always be small, ZSTD_estimateCCtxSize_usingCParams() can provide a tighter estimation.
   ZSTD_estimateCCtxSize_usingCParams() can be used in tandem with ZSTD_getCParams() to create cParams from compressionLevel.
-  ZSTD_estimateCCtxSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_p_nbWorkers is >= 1.
+  ZSTD_estimateCCtxSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_c_nbWorkers is >= 1.
   Note : CCtx size estimation is only correct for single-threaded compression. 
 </p></pre><BR>
 
@@ -934,7 +934,7 @@ size_t ZSTD_estimateDStreamSize_fromFrame(const void* src, size_t srcSize);
   It will also consider src size to be arbitrarily "large", which is worst case.
   If srcSize is known to always be small, ZSTD_estimateCStreamSize_usingCParams() can provide a tighter estimation.
   ZSTD_estimateCStreamSize_usingCParams() can be used in tandem with ZSTD_getCParams() to create cParams from compressionLevel.
-  ZSTD_estimateCStreamSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_p_nbWorkers is >= 1.
+  ZSTD_estimateCStreamSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_c_nbWorkers is >= 1.
   Note : CStream size estimation is only correct for single-threaded compression.
   ZSTD_DStream memory budget depends on window Size.
   This information can be passed manually, using ZSTD_estimateDStreamSize,

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -510,6 +510,28 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * enum. See the comments on that enum for an
                               * explanation of the feature.
                               */
+    </b>/* Question : should rsyncable be categorized as experimental, or be candidate for stable ? */<b>
+    ZSTD_p_rsyncable,        </b>/* Enables rsyncable mode, which makes compressed<b>
+                              * files more rsync friendly by adding periodic
+                              * synchronization points to the compressed data.
+                              * The target average block size is
+                              * ZSTD_p_jobSize / 2. You can modify the job size
+                              * to increase or decrease the granularity of the
+                              * synchronization point. Once the jobSize is
+                              * smaller than the window size, you will start to
+                              * see degraded compression ratio.
+                              * NOTE: This only works when multithreading is
+                              * enabled.
+                              * NOTE: You probably don't want to use this with
+                              * long range mode, since that will decrease the
+                              * effectiveness of the synchronization points,
+                              * but your milage may vary.
+                              * NOTE: Rsyncable mode will limit the maximum
+                              * compression speed to approximately 400 MB/s.
+                              * If your compression level is already running
+                              * significantly slower than that (< 200 MB/s),
+                              * the speed won't be significantly impacted.
+                              */
 } ZSTD_cParameter;
 </b></pre><BR>
 <pre><b>size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned value);

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -625,9 +625,9 @@ int ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
     ZSTD_reset_session_only = 1,
     ZSTD_reset_parameters = 2,
     ZSTD_reset_session_and_parameters = 3
-} ZSTD_reset_directive;
+} ZSTD_ResetDirective;
 </b></pre><BR>
-<pre><b>size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_reset_directive reset);
+<pre><b>size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_ResetDirective reset);
 </b><p>  There are 2 different things that can be reset, independently or jointly :
   - The session : will stop compressing current frame, and make CCtx ready to start a new one.
                   Useful after an error, or to interrupt any ongoing compression.
@@ -735,7 +735,7 @@ int ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_reset_directive reset);
+<pre><b>size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_ResetDirective reset);
 </b><p>  Return a DCtx to clean state.
   Session and parameters can be reset jointly or separately
   Parameters can only be reset when no active frame is being decompressed.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -484,10 +484,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     </b>/* These parameters are only useful if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
      * They return an error otherwise. */
     ZSTD_p_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
-                              * When nbWorkers >= 1, triggers asynchronous mode :
-                              * ZSTD_compress_generic() consumes input and flush output if possible, but immediately gives back control to caller,
+                              * When nbWorkers >= 1, triggers asynchronous mode when used with ZSTD_compressStream2() :
+                              * ZSTD_compressStream2() consumes input and flush output if possible, but immediately gives back control to caller,
                               * while compression work is performed in parallel, within worker threads.
-                              * (note : a strong exception to this rule is when first invocation sets ZSTD_e_end : it becomes a blocking call).
+                              * (note : a strong exception to this rule is when first invocation sets ZSTD_e_end :
+                              *  in which case, ZSTD_compressStream2() delegates to ZSTD_compress2(), which is always a blocking call).
                               * More workers improve speed, but also increase memory usage.
                               * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
     ZSTD_p_jobSize=401,      </b>/* Size of a compression job. This value is enforced only when nbWorkers >= 1.<b>
@@ -630,6 +631,18 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
+<pre><b>size_t ZSTD_compress2( ZSTD_CCtx* cctx,
+                       void* dst, size_t dstCapacity,
+                 const void* src, size_t srcSize);
+</b><p>  Behave the same as ZSTD_compressCCtx(), but compression parameters are set using the advanced API.
+  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()
+  - The function is always blocking.
+  Hint : compression runs faster if `dstCapacity` >=  `ZSTD_compressBound(srcSize)`.
+  @return : compressed size written into `dst` (<= `dstCapacity),
+            or an error code if it fails (which can be tested using ZSTD_isError()).
+ 
+</p></pre><BR>
+
 <pre><b>typedef enum {
     ZSTD_e_continue=0, </b>/* collect more data, encoder decides when to output compressed result, for optimal compression ratio */<b>
     ZSTD_e_flush=1,    </b>/* flush any data provided so far,<b>
@@ -640,11 +653,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                         * each frame is independent (does not reference any content from previous frame). */
 } ZSTD_EndDirective;
 </b></pre><BR>
-<pre><b>size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
-                              ZSTD_outBuffer* output,
-                              ZSTD_inBuffer* input,
-                              ZSTD_EndDirective endOp);
-</b><p>  Behave about the same as ZSTD_compressStream. To note :
+<pre><b>size_t ZSTD_compressStream2( ZSTD_CCtx* cctx,
+                             ZSTD_outBuffer* output,
+                             ZSTD_inBuffer* input,
+                             ZSTD_EndDirective endOp);
+</b><p>  Behave about the same as ZSTD_compressStream, with additional control on end directive.
   - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()
   - Compression parameters cannot be changed once compression is started (save a list of exceptions in multi-threading mode)
   - outpot->pos must be <= dstCapacity, input->pos must be <= srcSize
@@ -653,7 +666,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   - In multi-thread mode, function is non-blocking : it just acquires a copy of input, and distribute job to internal worker threads,
                                                      and then immediately returns, just indicating that there is some data remaining to be flushed.
                                                      The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
-  - Exception : in multi-threading mode, if the first call requests a ZSTD_e_end directive, it is blocking : it will complete compression before giving back control to caller.
+  - Exception : if the first call requests a ZSTD_e_end directive, the function delegates to ZSTD_compress2() which is always blocking.
   - @return provides a minimum amount of data remaining to be flushed from internal buffers
             or an error code, which can be tested using ZSTD_isError().
             if @return != 0, flush is not fully completed, there is still some data left within internal buffers.
@@ -666,13 +679,13 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
-<pre><b> ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
+<pre><b>size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
 </b><p>  Refuses allocating internal buffers for frames requiring a window size larger than provided limit.
   This protects a decoder context from reserving too much memory for itself (potential attack scenario).
   This parameter is only useful in streaming mode, since no internal buffer is allocated in single-pass mode.
   By default, a decompression context accepts all window sizes <= (1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT)
  @return : 0, or an error code (which can be tested using ZSTD_isError()).
-  
+ 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_DCtx_loadDictionary(ZSTD_DCtx* dctx, const void* dict, size_t dictSize);
@@ -1018,7 +1031,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
                                     an existing CCtx.
                                     These parameters will be applied to
                                     all subsequent compression jobs.
-  - ZSTD_compress_generic() : Do compression using the CCtx.
+  - ZSTD_compressStream2() : Do compression using the CCtx.
   - ZSTD_freeCCtxParams() : Free the memory.
 
   This can be used with ZSTD_estimateCCtxSize_advanced_usingCCtxParams()
@@ -1068,12 +1081,12 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_compress_generic_simpleArgs (
+<pre><b>size_t ZSTD_compressStream2_simpleArgs (
                 ZSTD_CCtx* cctx,
                 void* dst, size_t dstCapacity, size_t* dstPos,
           const void* src, size_t srcSize, size_t* srcPos,
                 ZSTD_EndDirective endOp);
-</b><p>  Same as ZSTD_compress_generic(),
+</b><p>  Same as ZSTD_compressStream2(),
   but using only integral types as arguments.
   This variant might be helpful for binders from dynamic languages
   which have troubles handling structures containing memory pointers.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -772,7 +772,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     unsigned chainLog;        </b>/**< fully searched segment : larger == more compression, slower, more memory (useless for fast) */<b>
     unsigned hashLog;         </b>/**< dispatch table : larger == faster, more memory */<b>
     unsigned searchLog;       </b>/**< nb of searches : larger == more compression, slower */<b>
-    unsigned minMatch;         </b>/**< match length searched : larger == faster decompression, sometimes less compression */<b>
+    unsigned minMatch;        </b>/**< match length searched : larger == faster decompression, sometimes less compression */<b>
     unsigned targetLength;    </b>/**< acceptable match size for optimal parser (only) : larger == more compression, slower */<b>
     ZSTD_strategy strategy;   </b>/**< see ZSTD_strategy definition above */<b>
 } ZSTD_compressionParameters;

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -20,19 +20,18 @@
 <li><a href="#Chapter10">Streaming decompression - HowTo</a></li>
 <li><a href="#Chapter11">ADVANCED AND EXPERIMENTAL FUNCTIONS</a></li>
 <li><a href="#Chapter12">Candidate API for promotion to stable status</a></li>
-<li><a href="#Chapter13">Memory management</a></li>
-<li><a href="#Chapter14">Advanced compression API</a></li>
-<li><a href="#Chapter15">experimental API (static linking only)</a></li>
-<li><a href="#Chapter16">Frame size functions</a></li>
-<li><a href="#Chapter17">Memory management</a></li>
-<li><a href="#Chapter18">Advanced compression functions</a></li>
-<li><a href="#Chapter19">Advanced decompression functions</a></li>
-<li><a href="#Chapter20">Advanced streaming functions</a></li>
-<li><a href="#Chapter21">Buffer-less and synchronous inner streaming functions</a></li>
-<li><a href="#Chapter22">Buffer-less streaming compression (synchronous mode)</a></li>
-<li><a href="#Chapter23">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter24">ZSTD_getFrameHeader() :</a></li>
-<li><a href="#Chapter25">Block level API</a></li>
+<li><a href="#Chapter13">Advanced compression API</a></li>
+<li><a href="#Chapter14">experimental API (static linking only)</a></li>
+<li><a href="#Chapter15">Frame size functions</a></li>
+<li><a href="#Chapter16">Memory management</a></li>
+<li><a href="#Chapter17">Advanced compression functions</a></li>
+<li><a href="#Chapter18">Advanced decompression functions</a></li>
+<li><a href="#Chapter19">Advanced streaming functions</a></li>
+<li><a href="#Chapter20">Buffer-less and synchronous inner streaming functions</a></li>
+<li><a href="#Chapter21">Buffer-less streaming compression (synchronous mode)</a></li>
+<li><a href="#Chapter22">Buffer-less streaming decompression (synchronous mode)</a></li>
+<li><a href="#Chapter23">ZSTD_getFrameHeader() :</a></li>
+<li><a href="#Chapter24">Block level API</a></li>
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
@@ -354,16 +353,22 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 <a name="Chapter12"></a><h2>Candidate API for promotion to stable status</h2><pre>
  The following symbols and constants are in "staging area" :
  they are considered to join "stable API" status by v1.4.0.
- The below proposal is created so that it's possible to make it stable "as is".
- That being said, it's still possible to suggest modifications.
+ The below proposal is written so that it can become stable "as is".
+ It's still possible to suggest modifications.
  Staging is in fact last chance for changes,
- because the API is locked once reaching "stable" status.
+ the API is locked once reaching "stable" status.
  
 <BR></pre>
 
 <pre><b>int ZSTD_minCLevel(void);  </b>/*!< minimum negative compression level allowed */<b>
 </b></pre><BR>
-<a name="Chapter13"></a><h2>Memory management</h2><pre></pre>
+<pre><b>size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
+</b><p> `src` should point to the start of a ZSTD frame or skippable frame.
+ `srcSize` must be >= first frame size
+ @return : the compressed size of the first frame starting at `src`,
+           suitable to pass to `ZSTD_decompress` or similar,
+           or an error code if input is invalid 
+</p></pre><BR>
 
 <pre><b>size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx);
 size_t ZSTD_sizeof_DCtx(const ZSTD_DCtx* dctx);
@@ -375,7 +380,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   Object memory usage can evolve (increase or decrease) over time. 
 </p></pre><BR>
 
-<a name="Chapter14"></a><h2>Advanced compression API</h2><pre></pre>
+<a name="Chapter13"></a><h2>Advanced compression API</h2><pre></pre>
 
 <pre><b>typedef enum { ZSTD_fast=1,
                ZSTD_dfast=2,
@@ -764,7 +769,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
-<a name="Chapter15"></a><h2>experimental API (static linking only)</h2><pre>
+<a name="Chapter14"></a><h2>experimental API (static linking only)</h2><pre>
  The following symbols and constants
  are not planned to join "stable API" status anytime soon.
  Some of them are planned to remain in the static_only section indefinitely.
@@ -852,7 +857,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_dictForceCopy     = 2, </b>/* Always copy the dictionary. */<b>
 } ZSTD_dictAttachPref_e;
 </b></pre><BR>
-<a name="Chapter16"></a><h2>Frame size functions</h2><pre></pre>
+<a name="Chapter15"></a><h2>Frame size functions</h2><pre></pre>
 
 <pre><b>size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
 </b><p>  `src` should point to the start of a ZSTD encoded frame or skippable frame
@@ -891,7 +896,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
            or an error code (if srcSize is too small) 
 </p></pre><BR>
 
-<a name="Chapter17"></a><h2>Memory management</h2><pre></pre>
+<a name="Chapter16"></a><h2>Memory management</h2><pre></pre>
 
 <pre><b>size_t ZSTD_estimateCCtxSize(int compressionLevel);
 size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters cParams);
@@ -971,7 +976,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
  
 </p></pre><BR>
 
-<a name="Chapter18"></a><h2>Advanced compression functions</h2><pre></pre>
+<a name="Chapter17"></a><h2>Advanced compression functions</h2><pre></pre>
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
@@ -1110,7 +1115,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<a name="Chapter19"></a><h2>Advanced decompression functions</h2><pre></pre>
+<a name="Chapter18"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
 </b><p>  Tells if the content of `buffer` starts with a valid Frame Identifier.
@@ -1187,7 +1192,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<a name="Chapter20"></a><h2>Advanced streaming functions</h2><pre>  Warning : most of these functions are now redundant with the Advanced API.
+<a name="Chapter19"></a><h2>Advanced streaming functions</h2><pre>  Warning : most of these functions are now redundant with the Advanced API.
   Once Advanced API reaches "stable" status,
   redundant functions will be deprecated, and then at some point removed.
 <BR></pre>
@@ -1239,14 +1244,14 @@ size_t ZSTD_initCStream_usingCDict_advanced(ZSTD_CStream* zcs, const ZSTD_CDict*
 size_t ZSTD_initDStream_usingDDict(ZSTD_DStream* zds, const ZSTD_DDict* ddict);  </b>/**< note : ddict is referenced, it must outlive decompression session */<b>
 size_t ZSTD_resetDStream(ZSTD_DStream* zds);  </b>/**< re-use decompression parameters from previous init; saves dictionary loading */<b>
 </pre></b><BR>
-<a name="Chapter21"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
+<a name="Chapter20"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
   This is an advanced API, giving full control over buffer management, for users which need direct control over memory.
   But it's also a complex one, with several restrictions, documented below.
   Prefer normal streaming API for an easier experience.
  
 <BR></pre>
 
-<a name="Chapter22"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
+<a name="Chapter21"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
   A ZSTD_CCtx object is required to track streaming operations.
   Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.
   ZSTD_CCtx object can be re-used multiple times within successive compression operations.
@@ -1282,7 +1287,7 @@ size_t ZSTD_compressBegin_usingCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict); 
 size_t ZSTD_compressBegin_usingCDict_advanced(ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict, ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize);   </b>/* compression parameters are already set within cdict. pledgedSrcSize must be correct. If srcSize is not known, use macro ZSTD_CONTENTSIZE_UNKNOWN */<b>
 size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx, unsigned long long pledgedSrcSize); </b>/**<  note: if pledgedSrcSize is not known, use ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<a name="Chapter23"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
+<a name="Chapter22"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
   A ZSTD_DCtx object is required to track streaming operations.
   Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
   A ZSTD_DCtx object can be re-used multiple times.
@@ -1364,7 +1369,7 @@ typedef struct {
     unsigned checksumFlag;
 } ZSTD_frameHeader;
 </pre></b><BR>
-<a name="Chapter24"></a><h2>ZSTD_getFrameHeader() :</h2><pre>  decode Frame Header, or requires larger `srcSize`.
+<a name="Chapter23"></a><h2>ZSTD_getFrameHeader() :</h2><pre>  decode Frame Header, or requires larger `srcSize`.
  @return : 0, `zfhPtr` is correctly filled,
           >0, `srcSize` is too small, value is wanted `srcSize` amount,
            or an error code, which can be tested using ZSTD_isError() 
@@ -1380,7 +1385,7 @@ size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long 
 
 <pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
 </b></pre><BR>
-<a name="Chapter25"></a><h2>Block level API</h2><pre></pre>
+<a name="Chapter24"></a><h2>Block level API</h2><pre></pre>
 
 <pre><b></b><p>    Frame metadata cost is typically ~18 bytes, which can be non-negligible for very small blocks (< 100 bytes).
     User will have to take in charge required information to regenerate data, such as compressed and content sizes.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -21,16 +21,16 @@
 <li><a href="#Chapter11">ADVANCED AND EXPERIMENTAL FUNCTIONS</a></li>
 <li><a href="#Chapter12">Candidate API for promotion into stable</a></li>
 <li><a href="#Chapter13">Memory management</a></li>
-<li><a href="#Chapter14">Purely experimental API</a></li>
-<li><a href="#Chapter15">Frame size functions</a></li>
-<li><a href="#Chapter16">Memory management</a></li>
-<li><a href="#Chapter17">Advanced compression functions</a></li>
-<li><a href="#Chapter18">Advanced decompression functions</a></li>
-<li><a href="#Chapter19">Advanced streaming functions</a></li>
-<li><a href="#Chapter20">Buffer-less and synchronous inner streaming functions</a></li>
-<li><a href="#Chapter21">Buffer-less streaming compression (synchronous mode)</a></li>
-<li><a href="#Chapter22">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter23">New advanced API (experimental)</a></li>
+<li><a href="#Chapter14">Advanced compression API</a></li>
+<li><a href="#Chapter15">experimental API (static linking only)</a></li>
+<li><a href="#Chapter16">Frame size functions</a></li>
+<li><a href="#Chapter17">Memory management</a></li>
+<li><a href="#Chapter18">Advanced compression functions</a></li>
+<li><a href="#Chapter19">Advanced decompression functions</a></li>
+<li><a href="#Chapter20">Advanced streaming functions</a></li>
+<li><a href="#Chapter21">Buffer-less and synchronous inner streaming functions</a></li>
+<li><a href="#Chapter22">Buffer-less streaming compression (synchronous mode)</a></li>
+<li><a href="#Chapter23">Buffer-less streaming decompression (synchronous mode)</a></li>
 <li><a href="#Chapter24">Block level API</a></li>
 </ol>
 <hr>
@@ -370,14 +370,24 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
   Object memory usage can evolve when re-used. 
 </p></pre><BR>
 
-<a name="Chapter14"></a><h2>Purely experimental API</h2><pre>
- The following symbols and constants
- are not planned to join "stable API" status anytime soon.
- Some will never reach "stable", and remain in the static_only section.
- Some of them might be removed in the future.
- 
-<BR></pre>
+<a name="Chapter14"></a><h2>Advanced compression API</h2><pre></pre>
 
+<pre><b>typedef enum {
+    </b>/* Opened question : should we have a format ZSTD_f_auto ?<b>
+     * Today, it would mean exactly the same as ZSTD_f_zstd1.
+     * But, in the future, should several formats become supported,
+     * on the compression side, it would mean "default format".
+     * On the decompression side, it would mean "automatic format detection",
+     * so that ZSTD_f_zstd1 would mean "accept *only* zstd frames".
+     * Since meaning is a little different, another option could be to define different enums for compression and decompression.
+     * This question could be kept for later, when there are actually multiple formats to support,
+     * but there is also the question of pinning enum values, and pinning value `0` is especially important */
+    ZSTD_f_zstd1 = 0,           </b>/* zstd frame format, specified in zstd_compression_format.md (default) */<b>
+    ZSTD_f_zstd1_magicless = 1, </b>/* Variant of zstd frame format, without initial 4-bytes magic number.<b>
+                                 * Useful to save 4 bytes per generated frame.
+                                 * Decoder cannot recognise automatically this format, requiring instructions. */
+} ZSTD_format_e;
+</b></pre><BR>
 <pre><b>typedef enum { ZSTD_fast=1,
                ZSTD_dfast=2,
                ZSTD_greedy=3,
@@ -389,6 +399,325 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                </b>/* note : new strategies might be added in the future */<b>
            } ZSTD_strategy;
 </b></pre><BR>
+<pre><b>typedef enum {
+    </b>/* Note: this enum and the behavior it controls are effectively internal<b>
+     * implementation details of the compressor. They are expected to continue
+     * to evolve and should be considered only in the context of extremely
+     * advanced performance tuning.
+     *
+     * Zstd currently supports the use of a CDict in two ways:
+     *
+     * - The contents of the CDict can be copied into the working context. This
+     *   means that the compression can search both the dictionary and input
+     *   while operating on a single set of internal tables. This makes
+     *   the compression faster per-byte of input. However, the initial copy of
+     *   the CDict's tables incurs a fixed cost at the beginning of the
+     *   compression. For small compressions (< 8 KB), that copy can dominate
+     *   the cost of the compression.
+     *
+     * - The CDict's tables can be used in-place. In this model, compression is
+     *   slower per input byte, because the compressor has to search two sets of
+     *   tables. However, this model incurs no start-up cost (as long as the
+     *   working context's tables can be reused). For small inputs, this can be
+     *   faster than copying the CDict's tables.
+     *
+     * Zstd has a simple internal heuristic that selects which strategy to use
+     * at the beginning of a compression. However, if experimentation shows that
+     * Zstd is making poor choices, it is possible to override that choice with
+     * this enum.
+     */
+    ZSTD_dictDefaultAttach = 0, </b>/* Use the default heuristic. */<b>
+    ZSTD_dictForceAttach   = 1, </b>/* Never copy the dictionary. */<b>
+    ZSTD_dictForceCopy     = 2, </b>/* Always copy the dictionary. */<b>
+} ZSTD_dictAttachPref_e;
+</b></pre><BR>
+<pre><b>typedef enum {
+
+    </b>/* compression parameters */<b>
+    ZSTD_p_compressionLevel=100, </b>/* Update all compression parameters according to pre-defined cLevel table<b>
+                              * Default level is ZSTD_CLEVEL_DEFAULT==3.
+                              * Special: value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT.
+                              * Note 1 : it's possible to pass a negative compression level by casting it to unsigned type.
+                              * Note 2 : setting a level sets all default values of other compression parameters.
+                              * Note 3 : setting compressionLevel automatically updates ZSTD_p_compressLiterals. */
+    ZSTD_p_windowLog=101,    </b>/* Maximum allowed back-reference distance, expressed as power of 2.<b>
+                              * Must be clamped between ZSTD_WINDOWLOG_MIN and ZSTD_WINDOWLOG_MAX.
+                              * Special: value 0 means "use default windowLog".
+                              * Note: Using a window size greater than ZSTD_MAXWINDOWSIZE_DEFAULT (default: 2^27)
+                              *       requires explicitly allowing such window size during decompression stage. */
+    ZSTD_p_hashLog=102,      </b>/* Size of the initial probe table, as a power of 2.<b>
+                              * Resulting table size is (1 << (hashLog+2)).
+                              * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX.
+                              * Larger tables improve compression ratio of strategies <= dFast,
+                              * and improve speed of strategies > dFast.
+                              * Special: value 0 means "use default hashLog". */
+    ZSTD_p_chainLog=103,     </b>/* Size of the multi-probe search table, as a power of 2.<b>
+                              * Resulting table size is (1 << (chainLog+2)).
+                              * Must be clamped between ZSTD_CHAINLOG_MIN and ZSTD_CHAINLOG_MAX.
+                              * Larger tables result in better and slower compression.
+                              * This parameter is useless when using "fast" strategy.
+                              * Note it's still useful when using "dfast" strategy,
+                              * in which case it defines a secondary probe table.
+                              * Special: value 0 means "use default chainLog". */
+    ZSTD_p_searchLog=104,    </b>/* Number of search attempts, as a power of 2.<b>
+                              * More attempts result in better and slower compression.
+                              * This parameter is useless when using "fast" and "dFast" strategies.
+                              * Special: value 0 means "use default searchLog". */
+    ZSTD_p_minMatch=105,     </b>/* Minimum size of searched matches (note : repCode matches can be smaller).<b>
+                              * Larger values make faster compression and decompression, but decrease ratio.
+                              * Must be clamped between ZSTD_SEARCHLENGTH_MIN and ZSTD_SEARCHLENGTH_MAX.
+                              * Note that currently, for all strategies < btopt, effective minimum is 4.
+                              *                    , for all strategies > fast, effective maximum is 6.
+                              * Special: value 0 means "use default minMatchLength". */
+    ZSTD_p_targetLength=106, </b>/* Impact of this field depends on strategy.<b>
+                              * For strategies btopt & btultra:
+                              *     Length of Match considered "good enough" to stop search.
+                              *     Larger values make compression stronger, and slower.
+                              * For strategy fast:
+                              *     Distance between match sampling.
+                              *     Larger values make compression faster, and weaker.
+                              * Special: value 0 means "use default targetLength". */
+    ZSTD_p_compressionStrategy=107, </b>/* See ZSTD_strategy enum definition.<b>
+                              * Cast selected strategy as unsigned for ZSTD_CCtx_setParameter() compatibility.
+                              * The higher the value of selected strategy, the more complex it is,
+                              * resulting in stronger and slower compression.
+                              * Special: value 0 means "use default strategy". */
+
+    </b>/* LDM mode parameters */<b>
+    ZSTD_p_enableLongDistanceMatching=160, </b>/* Enable long distance matching.<b>
+                                     * This parameter is designed to improve compression ratio
+                                     * for large inputs, by finding large matches at long distance.
+                                     * It increases memory usage and window size.
+                                     * Note: enabling this parameter increases ZSTD_p_windowLog to 128 MB
+                                     * except when expressly set to a different value. */
+    ZSTD_p_ldmHashLog=161,   </b>/* Size of the table for long distance matching, as a power of 2.<b>
+                              * Larger values increase memory usage and compression ratio,
+                              * but decrease compression speed.
+                              * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX
+                              * default: windowlog - 7.
+                              * Special: value 0 means "automatically determine hashlog". */
+    ZSTD_p_ldmMinMatch=162,  </b>/* Minimum match size for long distance matcher.<b>
+                              * Larger/too small values usually decrease compression ratio.
+                              * Must be clamped between ZSTD_LDM_MINMATCH_MIN and ZSTD_LDM_MINMATCH_MAX.
+                              * Special: value 0 means "use default value" (default: 64). */
+    ZSTD_p_ldmBucketSizeLog=163, </b>/* Log size of each bucket in the LDM hash table for collision resolution.<b>
+                              * Larger values improve collision resolution but decrease compression speed.
+                              * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX .
+                              * Special: value 0 means "use default value" (default: 3). */
+    ZSTD_p_ldmHashEveryLog=164, </b>/* Frequency of inserting/looking up entries into the LDM hash table.<b>
+                              * Must be clamped between 0 and (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN).
+                              * Default is MAX(0, (windowLog - ldmHashLog)), optimizing hash table usage.
+                              * Larger values improve compression speed.
+                              * Deviating far from default value will likely result in a compression ratio decrease.
+                              * Special: value 0 means "automatically determine hashEveryLog". */
+
+    </b>/* frame parameters */<b>
+    ZSTD_p_contentSizeFlag=200, </b>/* Content size will be written into frame header _whenever known_ (default:1)<b>
+                              * Content size must be known at the beginning of compression,
+                              * it is provided using ZSTD_CCtx_setPledgedSrcSize() */
+    ZSTD_p_checksumFlag=201, </b>/* A 32-bits checksum of content is written at end of frame (default:0) */<b>
+    ZSTD_p_dictIDFlag=202,   </b>/* When applicable, dictionary's ID is written into frame header (default:1) */<b>
+
+    </b>/* multi-threading parameters */<b>
+    </b>/* These parameters are only useful if multi-threading is enabled (ZSTD_MULTITHREAD).<b>
+     * They return an error otherwise. */
+    ZSTD_p_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
+                              * When nbWorkers >= 1, triggers asynchronous mode :
+                              * ZSTD_compress_generic() consumes some input, flush some output if possible, and immediately gives back control to caller,
+                              * while compression work is performed in parallel, within worker threads.
+                              * (note : a strong exception to this rule is when first invocation sets ZSTD_e_end : it becomes a blocking call).
+                              * More workers improve speed, but also increase memory usage.
+                              * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
+    ZSTD_p_jobSize=401,      </b>/* Size of a compression job. This value is enforced only in non-blocking mode.<b>
+                              * Each compression job is completed in parallel, so this value indirectly controls the nb of active threads.
+                              * 0 means default, which is dynamically determined based on compression parameters.
+                              * Job size must be a minimum of overlapSize, or 1 MB, whichever is largest.
+                              * The minimum size is automatically and transparently enforced */
+    ZSTD_p_overlapSizeLog=402, </b>/* Size of previous input reloaded at the beginning of each job.<b>
+                              * 0 => no overlap, 6(default) => use 1/8th of windowSize, >=9 => use full windowSize */
+
+    </b>/* =================================================================== */<b>
+    </b>/* experimental parameters - no stability guaranteed                   */<b>
+    </b>/* note : should this be exported in a different section of zstd.h ?   */<b>
+    </b>/* =================================================================== */<b>
+
+    </b>/* compression format */<b>
+    ZSTD_p_format = 10,      </b>/* See ZSTD_format_e enum definition.<b>
+                              * Cast selected format as unsigned for ZSTD_CCtx_setParameter() compatibility. */
+
+    ZSTD_p_forceMaxWindow=1100, </b>/* Force back-reference distances to remain < windowSize,<b>
+                              * even when referencing into Dictionary content (default:0) */
+    ZSTD_p_forceAttachDict,  </b>/* Controls whether the contents of a CDict are<b>
+                              * used in place, or whether they are copied into
+                              * the working context.
+                              *
+                              * Accepts values from the ZSTD_dictAttachPref_e
+                              * enum. See the comments on that enum for an
+                              * explanation of the feature.
+                              */
+} ZSTD_cParameter;
+</b></pre><BR>
+<pre><b>size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned value);
+</b><p>  Set one compression parameter, selected by enum ZSTD_cParameter.
+  Setting a parameter is generally only possible during frame initialization (before starting compression).
+  Exception : when using multi-threading mode (nbWorkers >= 1),
+              the following parameters can be updated _during_ compression (within same frame):
+              => compressionLevel, hashLog, chainLog, searchLog, minMatch, targetLength and strategy.
+              new parameters will be active for next job only (after a flush()).
+  Note : when original `value` type is not unsigned (like int, or enum), cast it to unsigned.
+  @result : informational value (typically, value being effectively set, after clamping),
+            or an error code (which can be tested with ZSTD_isError()). 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value);
+</b><p> Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_setPledgedSrcSize(ZSTD_CCtx* cctx, unsigned long long pledgedSrcSize);
+</b><p>  Total input data size to be compressed as a single frame.
+  This value will be controlled at end of frame, and trigger an error if not respected.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Note 1 : 0 means zero, empty.
+           In order to mean "unknown content size", pass constant ZSTD_CONTENTSIZE_UNKNOWN.
+           ZSTD_CONTENTSIZE_UNKNOWN is default value for any new compression job.
+  Note 2 : If all data is provided and consumed in a single round,
+           this value is automatically overriden by srcSize instead. 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_loadDictionary(ZSTD_CCtx* cctx, const void* dict, size_t dictSize);
+</b><p>  Create an internal CDict from `dict` buffer.
+  Decompression will have to use same dictionary.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Special: Adding a NULL (or 0-size) dictionary invalidates previous dictionary,
+           meaning "return to no-dictionary mode".
+  Note 1 : Dictionary will be used for all future compression jobs.
+           To return to "no-dictionary" situation, load a NULL dictionary
+  Note 2 : Loading a dictionary involves building tables, which are dependent on compression parameters.
+           For this reason, compression parameters cannot be changed anymore after loading a dictionary.
+           It's also a CPU consuming operation, with non-negligible impact on latency.
+  Note 3 :`dict` content will be copied internally.
+           Use ZSTD_CCtx_loadDictionary_byReference() to reference dictionary content instead.
+           In such a case, dictionary buffer must outlive its users.
+  Note 4 : Use ZSTD_CCtx_loadDictionary_advanced()
+           to precisely select how dictionary content must be interpreted. 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_refCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict);
+</b><p>  Reference a prepared dictionary, to be used for all next compression jobs.
+  Note that compression parameters are enforced from within CDict,
+  and supercede any compression parameter previously set within CCtx.
+  The dictionary will remain valid for future compression jobs using same CCtx.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Special : adding a NULL CDict means "return to no-dictionary mode".
+  Note 1 : Currently, only one dictionary can be managed.
+           Adding a new dictionary effectively "discards" any previous one.
+  Note 2 : CDict is just referenced, its lifetime must outlive CCtx. 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_refPrefix(ZSTD_CCtx* cctx,
+                           const void* prefix, size_t prefixSize);
+</b><p>  Reference a prefix (single-usage dictionary) for next compression job.
+  Decompression will need same prefix to properly regenerate data.
+  Compressing with a prefix is similar in outcome as performing a diff and compressing it,
+  but performs much faster, especially during decompression (compression speed is tunable with compression level).
+  Note that prefix is **only used once**. Tables are discarded at end of compression job (ZSTD_e_end).
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Special: Adding any prefix (including NULL) invalidates any previous prefix or dictionary
+  Note 1 : Prefix buffer is referenced. It **must** outlive compression job.
+           Its contain must remain unmodified up to end of compression (ZSTD_e_end).
+  Note 2 : If the intention is to diff some large src data blob with some prior version of itself,
+           ensure that the window size is large enough to contain the entire source.
+           See ZSTD_p_windowLog.
+  Note 3 : Referencing a prefix involves building tables, which are dependent on compression parameters.
+           It's a CPU consuming operation, with non-negligible impact on latency.
+           If there is a need to use same prefix multiple times, consider loadDictionary instead.
+  Note 4 : By default, the prefix is interpreted as raw content (ZSTD_dm_rawContent).
+           Use ZSTD_CCtx_refPrefix_advanced() to alter dictionary intepretation. 
+</p></pre><BR>
+
+<pre><b>typedef enum {
+    ZSTD_CCtx_reset_session_only = 1,
+    ZSTD_CCtx_reset_parameters = 2,
+    ZSTD_CCtx_reset_session_and_parameters = 3
+} ZSTD_CCtx_reset_directive;
+</b></pre><BR>
+<pre><b>size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_CCtx_reset_directive zcrd);
+</b><p>  Return a CCtx to clean state.
+  There 2 things that can be reset, independently or jointly :
+  - The session : will stop compressing current frame, and stand ready to start a new one.
+                  This action never fails.
+                  Useful after an error, or to interrupt any ongoing compression.
+                  Any internal data not yet flushed is cancelled.
+                  But parameters and dictionary are kept unchanged.
+                  Therefore, same parameters and dictionary will be used for next frame.
+  - The parameters : changes all parameters back to "default".
+                  This removes any dictionary too.
+                  Parameters can only be changed between 2 sessions (i.e. no compression is currently ongoing)
+                  otherwise the reset fails, and function returns an error value (which can be tested using ZSTD_isError())
+  - Both : similar to resetting the session, followed by resetting parameters.
+                  This action never fails.
+ 
+</p></pre><BR>
+
+<pre><b>typedef enum {
+    ZSTD_e_continue=0, </b>/* collect more data, encoder decides when to output compressed result, for optimal compression ratio */<b>
+    ZSTD_e_flush,      </b>/* flush any data provided so far,<b>
+                        * it creates (at least) one new block, that can be decoded immediately on reception;
+                        * frame will continue: any future data can still reference previously compressed data, improving compression. */
+    ZSTD_e_end         </b>/* flush any remaining data and close current frame.<b>
+                        * any additional data starts a new frame.
+                        * each frame is independent (does not reference any content from previous frame). */
+} ZSTD_EndDirective;
+</b></pre><BR>
+<pre><b>size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
+                              ZSTD_outBuffer* output,
+                              ZSTD_inBuffer* input,
+                              ZSTD_EndDirective endOp);
+</b><p>  Behave about the same as ZSTD_compressStream. To note :
+  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_setParameter()
+  - Compression parameters cannot be changed once compression is started.
+  - outpot->pos must be <= dstCapacity, input->pos must be <= srcSize
+  - outpot->pos and input->pos will be updated. They are guaranteed to remain below their respective limit.
+  - In single-thread mode (default), function is blocking : it completed its job before returning to caller.
+  - In multi-thread mode, function is non-blocking : it just acquires a copy of input, and distribute job to internal worker threads,
+                                                     and then immediately returns, just indicating that there is some data remaining to be flushed.
+                                                     The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
+  - Exception : in multi-threading mode, if the first call requests a ZSTD_e_end directive, it is blocking : it will complete compression before giving back control to caller.
+  - @return provides a minimum amount of data remaining to be flushed from internal buffers
+            or an error code, which can be tested using ZSTD_isError().
+            if @return != 0, flush is not fully completed, there is still some data left within internal buffers.
+            This is useful for ZSTD_e_flush, since in this case more flushes are necessary to empty all buffers.
+            For ZSTD_e_end, @return == 0 when internal buffers are fully flushed and frame is completed.
+  - after a ZSTD_e_end directive, if internal buffer is not fully flushed (@return != 0),
+            only ZSTD_e_end or ZSTD_e_flush operations are allowed.
+            Before starting a new compression job, or changing compression parameters,
+            it is required to fully flush internal buffers.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_compress_generic_simpleArgs (
+                ZSTD_CCtx* cctx,
+                void* dst, size_t dstCapacity, size_t* dstPos,
+          const void* src, size_t srcSize, size_t* srcPos,
+                ZSTD_EndDirective endOp);
+</b><p>  Same as ZSTD_compress_generic(),
+  but using only integral types as arguments.
+  Argument list is larger than ZSTD_{in,out}Buffer,
+  but can be helpful for binders from dynamic languages
+  which have troubles handling structures containing memory pointers.
+ 
+</p></pre><BR>
+
+<a name="Chapter15"></a><h2>experimental API (static linking only)</h2><pre>
+ The following symbols and constants
+ are not planned to join "stable API" status anytime soon.
+ Some will never reach "stable", and remain in the static_only section.
+ Some of them might be removed in the future.
+ 
+<BR></pre>
+
 <pre><b>typedef struct {
     unsigned windowLog;       </b>/**< largest match distance : larger == more compression, more memory needed during decompression */<b>
     unsigned chainLog;        </b>/**< fully searched segment : larger == more compression, slower, more memory (useless for fast) */<b>
@@ -421,7 +750,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_dlm_byRef = 1,   </b>/**< Reference dictionary content -- the dictionary buffer must outlive its users. */<b>
 } ZSTD_dictLoadMethod_e;
 </b></pre><BR>
-<a name="Chapter15"></a><h2>Frame size functions</h2><pre></pre>
+<a name="Chapter16"></a><h2>Frame size functions</h2><pre></pre>
 
 <pre><b>size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
 </b><p>  `src` should point to the start of a ZSTD encoded frame or skippable frame
@@ -460,7 +789,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
            or an error code (if srcSize is too small) 
 </p></pre><BR>
 
-<a name="Chapter16"></a><h2>Memory management</h2><pre></pre>
+<a name="Chapter17"></a><h2>Memory management</h2><pre></pre>
 
 <pre><b>size_t ZSTD_estimateCCtxSize(int compressionLevel);
 size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters cParams);
@@ -540,7 +869,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
  
 </p></pre><BR>
 
-<a name="Chapter17"></a><h2>Advanced compression functions</h2><pre></pre>
+<a name="Chapter18"></a><h2>Advanced compression functions</h2><pre></pre>
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
@@ -582,7 +911,86 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 </b><p>   Same as ZSTD_compress_usingCDict(), with fine-tune control over frame parameters 
 </p></pre><BR>
 
-<a name="Chapter18"></a><h2>Advanced decompression functions</h2><pre></pre>
+<pre><b>size_t ZSTD_CCtx_loadDictionary_byReference(ZSTD_CCtx* cctx, const void* dict, size_t dictSize);
+</b><p>  Same as ZSTD_CCtx_loadDictionary(), but dictionary content is referenced, instead of being copied into CCtx.
+  It saves some memory, but also requires that `dict` outlives its usage within `cctx` 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_loadDictionary_advanced(ZSTD_CCtx* cctx, const void* dict, size_t dictSize, ZSTD_dictLoadMethod_e dictLoadMethod, ZSTD_dictContentType_e dictContentType);
+</b><p>  Same as ZSTD_CCtx_loadDictionary(), but gives finer control over
+  how to load the dictionary (by copy ? by reference ?)
+  and how to interpret it (automatic ? force raw mode ? full mode only ?) 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* prefix, size_t prefixSize, ZSTD_dictContentType_e dictContentType);
+</b><p>  Same as ZSTD_CCtx_refPrefix(), but gives finer control over
+  and how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) 
+</p></pre><BR>
+
+<pre><b>ZSTD_CCtx_params* ZSTD_createCCtxParams(void);
+size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
+</b><p>  Quick howto :
+  - ZSTD_createCCtxParams() : Create a ZSTD_CCtx_params structure
+  - ZSTD_CCtxParam_setParameter() : Push parameters one by one into
+                                    an existing ZSTD_CCtx_params structure.
+                                    This is similar to
+                                    ZSTD_CCtx_setParameter().
+  - ZSTD_CCtx_setParametersUsingCCtxParams() : Apply parameters to
+                                    an existing CCtx.
+                                    These parameters will be applied to
+                                    all subsequent compression jobs.
+  - ZSTD_compress_generic() : Do compression using the CCtx.
+  - ZSTD_freeCCtxParams() : Free the memory.
+
+  This can be used with ZSTD_estimateCCtxSize_advanced_usingCCtxParams()
+  for static allocation for single-threaded compression.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtxParams_reset(ZSTD_CCtx_params* params);
+</b><p>  Reset params to default values.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtxParams_init(ZSTD_CCtx_params* cctxParams, int compressionLevel);
+</b><p>  Initializes the compression parameters of cctxParams according to
+  compression level. All other parameters are reset to their default values.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtxParams_init_advanced(ZSTD_CCtx_params* cctxParams, ZSTD_parameters params);
+</b><p>  Initializes the compression and frame parameters of cctxParams according to
+  params. All other parameters are reset to their default values.
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned value);
+</b><p>  Similar to ZSTD_CCtx_setParameter.
+  Set one compression parameter, selected by enum ZSTD_cParameter.
+  Parameters must be applied to a ZSTD_CCtx using ZSTD_CCtx_setParametersUsingCCtxParams().
+  Note : when `value` is an enum, cast it to unsigned for proper type checking.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtxParam_getParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned* value);
+</b><p> Similar to ZSTD_CCtx_getParameter.
+ Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
+ 
+</p></pre><BR>
+
+<pre><b>size_t ZSTD_CCtx_setParametersUsingCCtxParams(
+        ZSTD_CCtx* cctx, const ZSTD_CCtx_params* params);
+</b><p>  Apply a set of ZSTD_CCtx_params to the compression context.
+  This can be done even after compression is started,
+    if nbWorkers==0, this will have no impact until a new compression is started.
+    if nbWorkers>=1, new parameters will be picked up at next job,
+       with a few restrictions (windowLog, pledgedSrcSize, nbWorkers, jobSize, and overlapLog are not updated).
+ 
+</p></pre><BR>
+
+<a name="Chapter19"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
 </b><p>  Tells if the content of `buffer` starts with a valid Frame Identifier.
@@ -622,7 +1030,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
   When identifying the exact failure cause, it's possible to use ZSTD_getFrameHeader(), which will provide a more precise error code. 
 </p></pre><BR>
 
-<a name="Chapter19"></a><h2>Advanced streaming functions</h2><pre></pre>
+<a name="Chapter20"></a><h2>Advanced streaming functions</h2><pre></pre>
 
 <h3>Advanced Streaming compression functions</h3><pre></pre><b><pre>size_t ZSTD_initCStream_srcSize(ZSTD_CStream* zcs, int compressionLevel, unsigned long long pledgedSrcSize);   </b>/**< pledgedSrcSize must be correct. If it is not known at init time, use ZSTD_CONTENTSIZE_UNKNOWN. Note that, for compatibility with older programs, "0" also disables frame content size field. It may be enabled in the future. */<b>
 size_t ZSTD_initCStream_usingDict(ZSTD_CStream* zcs, const void* dict, size_t dictSize, int compressionLevel); </b>/**< creates of an internal CDict (incompatible with static CCtx), except if dict == NULL or dictSize < 8, in which case no dict is used. Note: dict is loaded with ZSTD_dm_auto (treated as a full zstd dictionary if it begins with ZSTD_MAGIC_DICTIONARY, else as raw content) and ZSTD_dlm_byCopy.*/<b>
@@ -671,14 +1079,14 @@ size_t ZSTD_initCStream_usingCDict_advanced(ZSTD_CStream* zcs, const ZSTD_CDict*
 size_t ZSTD_initDStream_usingDDict(ZSTD_DStream* zds, const ZSTD_DDict* ddict);  </b>/**< note : ddict is referenced, it must outlive decompression session */<b>
 size_t ZSTD_resetDStream(ZSTD_DStream* zds);  </b>/**< re-use decompression parameters from previous init; saves dictionary loading */<b>
 </pre></b><BR>
-<a name="Chapter20"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
+<a name="Chapter21"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
   This is an advanced API, giving full control over buffer management, for users which need direct control over memory.
   But it's also a complex one, with several restrictions, documented below.
   Prefer normal streaming API for an easier experience.
  
 <BR></pre>
 
-<a name="Chapter21"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
+<a name="Chapter22"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
   A ZSTD_CCtx object is required to track streaming operations.
   Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.
   ZSTD_CCtx object can be re-used multiple times within successive compression operations.
@@ -714,7 +1122,7 @@ size_t ZSTD_compressBegin_usingCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict); 
 size_t ZSTD_compressBegin_usingCDict_advanced(ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict, ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize);   </b>/* compression parameters are already set within cdict. pledgedSrcSize must be correct. If srcSize is not known, use macro ZSTD_CONTENTSIZE_UNKNOWN */<b>
 size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx, unsigned long long pledgedSrcSize); </b>/**<  note: if pledgedSrcSize is not known, use ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<a name="Chapter22"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
+<a name="Chapter23"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
   A ZSTD_DCtx object is required to track streaming operations.
   Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
   A ZSTD_DCtx object can be re-used multiple times.
@@ -805,393 +1213,6 @@ size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long 
 </pre></b><BR>
 <pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
 </b></pre><BR>
-<a name="Chapter23"></a><h2>New advanced API (experimental)</h2><pre></pre>
-
-<pre><b>typedef enum {
-    </b>/* Opened question : should we have a format ZSTD_f_auto ?<b>
-     * Today, it would mean exactly the same as ZSTD_f_zstd1.
-     * But, in the future, should several formats become supported,
-     * on the compression side, it would mean "default format".
-     * On the decompression side, it would mean "automatic format detection",
-     * so that ZSTD_f_zstd1 would mean "accept *only* zstd frames".
-     * Since meaning is a little different, another option could be to define different enums for compression and decompression.
-     * This question could be kept for later, when there are actually multiple formats to support,
-     * but there is also the question of pinning enum values, and pinning value `0` is especially important */
-    ZSTD_f_zstd1 = 0,        </b>/* zstd frame format, specified in zstd_compression_format.md (default) */<b>
-    ZSTD_f_zstd1_magicless,  </b>/* Variant of zstd frame format, without initial 4-bytes magic number.<b>
-                              * Useful to save 4 bytes per generated frame.
-                              * Decoder cannot recognise automatically this format, requiring instructions. */
-} ZSTD_format_e;
-</b></pre><BR>
-<pre><b>typedef enum {
-    </b>/* Note: this enum and the behavior it controls are effectively internal<b>
-     * implementation details of the compressor. They are expected to continue
-     * to evolve and should be considered only in the context of extremely
-     * advanced performance tuning.
-     *
-     * Zstd currently supports the use of a CDict in two ways:
-     *
-     * - The contents of the CDict can be copied into the working context. This
-     *   means that the compression can search both the dictionary and input
-     *   while operating on a single set of internal tables. This makes
-     *   the compression faster per-byte of input. However, the initial copy of
-     *   the CDict's tables incurs a fixed cost at the beginning of the
-     *   compression. For small compressions (< 8 KB), that copy can dominate
-     *   the cost of the compression.
-     *
-     * - The CDict's tables can be used in-place. In this model, compression is
-     *   slower per input byte, because the compressor has to search two sets of
-     *   tables. However, this model incurs no start-up cost (as long as the
-     *   working context's tables can be reused). For small inputs, this can be
-     *   faster than copying the CDict's tables.
-     *
-     * Zstd has a simple internal heuristic that selects which strategy to use
-     * at the beginning of a compression. However, if experimentation shows that
-     * Zstd is making poor choices, it is possible to override that choice with
-     * this enum.
-     */
-    ZSTD_dictDefaultAttach = 0, </b>/* Use the default heuristic. */<b>
-    ZSTD_dictForceAttach   = 1, </b>/* Never copy the dictionary. */<b>
-    ZSTD_dictForceCopy     = 2, </b>/* Always copy the dictionary. */<b>
-} ZSTD_dictAttachPref_e;
-</b></pre><BR>
-<pre><b>typedef enum {
-    </b>/* compression format */<b>
-    ZSTD_p_format = 10,      </b>/* See ZSTD_format_e enum definition.<b>
-                              * Cast selected format as unsigned for ZSTD_CCtx_setParameter() compatibility. */
-
-    </b>/* compression parameters */<b>
-    ZSTD_p_compressionLevel=100, </b>/* Update all compression parameters according to pre-defined cLevel table<b>
-                              * Default level is ZSTD_CLEVEL_DEFAULT==3.
-                              * Special: value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT.
-                              * Note 1 : it's possible to pass a negative compression level by casting it to unsigned type.
-                              * Note 2 : setting a level sets all default values of other compression parameters.
-                              * Note 3 : setting compressionLevel automatically updates ZSTD_p_compressLiterals. */
-    ZSTD_p_windowLog,        </b>/* Maximum allowed back-reference distance, expressed as power of 2.<b>
-                              * Must be clamped between ZSTD_WINDOWLOG_MIN and ZSTD_WINDOWLOG_MAX.
-                              * Special: value 0 means "use default windowLog".
-                              * Note: Using a window size greater than ZSTD_MAXWINDOWSIZE_DEFAULT (default: 2^27)
-                              *       requires explicitly allowing such window size during decompression stage. */
-    ZSTD_p_hashLog,          </b>/* Size of the initial probe table, as a power of 2.<b>
-                              * Resulting table size is (1 << (hashLog+2)).
-                              * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX.
-                              * Larger tables improve compression ratio of strategies <= dFast,
-                              * and improve speed of strategies > dFast.
-                              * Special: value 0 means "use default hashLog". */
-    ZSTD_p_chainLog,         </b>/* Size of the multi-probe search table, as a power of 2.<b>
-                              * Resulting table size is (1 << (chainLog+2)).
-                              * Must be clamped between ZSTD_CHAINLOG_MIN and ZSTD_CHAINLOG_MAX.
-                              * Larger tables result in better and slower compression.
-                              * This parameter is useless when using "fast" strategy.
-                              * Note it's still useful when using "dfast" strategy,
-                              * in which case it defines a secondary probe table.
-                              * Special: value 0 means "use default chainLog". */
-    ZSTD_p_searchLog,        </b>/* Number of search attempts, as a power of 2.<b>
-                              * More attempts result in better and slower compression.
-                              * This parameter is useless when using "fast" and "dFast" strategies.
-                              * Special: value 0 means "use default searchLog". */
-    ZSTD_p_minMatch,         </b>/* Minimum size of searched matches (note : repCode matches can be smaller).<b>
-                              * Larger values make faster compression and decompression, but decrease ratio.
-                              * Must be clamped between ZSTD_SEARCHLENGTH_MIN and ZSTD_SEARCHLENGTH_MAX.
-                              * Note that currently, for all strategies < btopt, effective minimum is 4.
-                              *                    , for all strategies > fast, effective maximum is 6.
-                              * Special: value 0 means "use default minMatchLength". */
-    ZSTD_p_targetLength,     </b>/* Impact of this field depends on strategy.<b>
-                              * For strategies btopt & btultra:
-                              *     Length of Match considered "good enough" to stop search.
-                              *     Larger values make compression stronger, and slower.
-                              * For strategy fast:
-                              *     Distance between match sampling.
-                              *     Larger values make compression faster, and weaker.
-                              * Special: value 0 means "use default targetLength". */
-    ZSTD_p_compressionStrategy, </b>/* See ZSTD_strategy enum definition.<b>
-                              * Cast selected strategy as unsigned for ZSTD_CCtx_setParameter() compatibility.
-                              * The higher the value of selected strategy, the more complex it is,
-                              * resulting in stronger and slower compression.
-                              * Special: value 0 means "use default strategy". */
-
-    ZSTD_p_enableLongDistanceMatching=160, </b>/* Enable long distance matching.<b>
-                                         * This parameter is designed to improve compression ratio
-                                         * for large inputs, by finding large matches at long distance.
-                                         * It increases memory usage and window size.
-                                         * Note: enabling this parameter increases ZSTD_p_windowLog to 128 MB
-                                         * except when expressly set to a different value. */
-    ZSTD_p_ldmHashLog,       </b>/* Size of the table for long distance matching, as a power of 2.<b>
-                              * Larger values increase memory usage and compression ratio,
-                              * but decrease compression speed.
-                              * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX
-                              * default: windowlog - 7.
-                              * Special: value 0 means "automatically determine hashlog". */
-    ZSTD_p_ldmMinMatch,      </b>/* Minimum match size for long distance matcher.<b>
-                              * Larger/too small values usually decrease compression ratio.
-                              * Must be clamped between ZSTD_LDM_MINMATCH_MIN and ZSTD_LDM_MINMATCH_MAX.
-                              * Special: value 0 means "use default value" (default: 64). */
-    ZSTD_p_ldmBucketSizeLog, </b>/* Log size of each bucket in the LDM hash table for collision resolution.<b>
-                              * Larger values improve collision resolution but decrease compression speed.
-                              * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX .
-                              * Special: value 0 means "use default value" (default: 3). */
-    ZSTD_p_ldmHashEveryLog,  </b>/* Frequency of inserting/looking up entries in the LDM hash table.<b>
-                              * Must be clamped between 0 and (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN).
-                              * Default is MAX(0, (windowLog - ldmHashLog)), optimizing hash table usage.
-                              * Larger values improve compression speed.
-                              * Deviating far from default value will likely result in a compression ratio decrease.
-                              * Special: value 0 means "automatically determine hashEveryLog". */
-
-    </b>/* frame parameters */<b>
-    ZSTD_p_contentSizeFlag=200, </b>/* Content size will be written into frame header _whenever known_ (default:1)<b>
-                              * Content size must be known at the beginning of compression,
-                              * it is provided using ZSTD_CCtx_setPledgedSrcSize() */
-    ZSTD_p_checksumFlag,     </b>/* A 32-bits checksum of content is written at end of frame (default:0) */<b>
-    ZSTD_p_dictIDFlag,       </b>/* When applicable, dictionary's ID is written into frame header (default:1) */<b>
-
-    </b>/* multi-threading parameters */<b>
-    </b>/* These parameters are only useful if multi-threading is enabled (ZSTD_MULTITHREAD).<b>
-     * They return an error otherwise. */
-    ZSTD_p_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
-                              * When nbWorkers >= 1, triggers asynchronous mode :
-                              * ZSTD_compress_generic() consumes some input, flush some output if possible, and immediately gives back control to caller,
-                              * while compression work is performed in parallel, within worker threads.
-                              * (note : a strong exception to this rule is when first invocation sets ZSTD_e_end : it becomes a blocking call).
-                              * More workers improve speed, but also increase memory usage.
-                              * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
-    ZSTD_p_jobSize,          </b>/* Size of a compression job. This value is enforced only in non-blocking mode.<b>
-                              * Each compression job is completed in parallel, so this value indirectly controls the nb of active threads.
-                              * 0 means default, which is dynamically determined based on compression parameters.
-                              * Job size must be a minimum of overlapSize, or 1 MB, whichever is largest.
-                              * The minimum size is automatically and transparently enforced */
-    ZSTD_p_overlapSizeLog,   </b>/* Size of previous input reloaded at the beginning of each job.<b>
-                              * 0 => no overlap, 6(default) => use 1/8th of windowSize, >=9 => use full windowSize */
-
-    </b>/* =================================================================== */<b>
-    </b>/* experimental parameters - no stability guaranteed                   */<b>
-    </b>/* =================================================================== */<b>
-
-    ZSTD_p_forceMaxWindow=1100, </b>/* Force back-reference distances to remain < windowSize,<b>
-                              * even when referencing into Dictionary content (default:0) */
-    ZSTD_p_forceAttachDict,  </b>/* Controls whether the contents of a CDict are<b>
-                              * used in place, or whether they are copied into
-                              * the working context.
-                              *
-                              * Accepts values from the ZSTD_dictAttachPref_e
-                              * enum. See the comments on that enum for an
-                              * explanation of the feature.
-                              */
-} ZSTD_cParameter;
-</b></pre><BR>
-<pre><b>size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned value);
-</b><p>  Set one compression parameter, selected by enum ZSTD_cParameter.
-  Setting a parameter is generally only possible during frame initialization (before starting compression).
-  Exception : when using multi-threading mode (nbThreads >= 1),
-              following parameters can be updated _during_ compression (within same frame):
-              => compressionLevel, hashLog, chainLog, searchLog, minMatch, targetLength and strategy.
-              new parameters will be active on next job, or after a flush().
-  Note : when `value` type is not unsigned (int, or enum), cast it to unsigned for proper type checking.
-  @result : informational value (typically, value being set, correctly clamped),
-            or an error code (which can be tested with ZSTD_isError()). 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value);
-</b><p> Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_setPledgedSrcSize(ZSTD_CCtx* cctx, unsigned long long pledgedSrcSize);
-</b><p>  Total input data size to be compressed as a single frame.
-  This value will be controlled at the end, and result in error if not respected.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Note 1 : 0 means zero, empty.
-           In order to mean "unknown content size", pass constant ZSTD_CONTENTSIZE_UNKNOWN.
-           ZSTD_CONTENTSIZE_UNKNOWN is default value for any new compression job.
-  Note 2 : If all data is provided and consumed in a single round,
-           this value is overriden by srcSize instead. 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_loadDictionary(ZSTD_CCtx* cctx, const void* dict, size_t dictSize);
-size_t ZSTD_CCtx_loadDictionary_byReference(ZSTD_CCtx* cctx, const void* dict, size_t dictSize);
-size_t ZSTD_CCtx_loadDictionary_advanced(ZSTD_CCtx* cctx, const void* dict, size_t dictSize, ZSTD_dictLoadMethod_e dictLoadMethod, ZSTD_dictContentType_e dictContentType);
-</b><p>  Create an internal CDict from `dict` buffer.
-  Decompression will have to use same dictionary.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Special: Adding a NULL (or 0-size) dictionary invalidates previous dictionary,
-           meaning "return to no-dictionary mode".
-  Note 1 : Dictionary will be used for all future compression jobs.
-           To return to "no-dictionary" situation, load a NULL dictionary
-  Note 2 : Loading a dictionary involves building tables, which are dependent on compression parameters.
-           For this reason, compression parameters cannot be changed anymore after loading a dictionary.
-           It's also a CPU consuming operation, with non-negligible impact on latency.
-  Note 3 :`dict` content will be copied internally.
-           Use ZSTD_CCtx_loadDictionary_byReference() to reference dictionary content instead.
-           In such a case, dictionary buffer must outlive its users.
-  Note 4 : Use ZSTD_CCtx_loadDictionary_advanced()
-           to precisely select how dictionary content must be interpreted. 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_refCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict);
-</b><p>  Reference a prepared dictionary, to be used for all next compression jobs.
-  Note that compression parameters are enforced from within CDict,
-  and supercede any compression parameter previously set within CCtx.
-  The dictionary will remain valid for future compression jobs using same CCtx.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Special : adding a NULL CDict means "return to no-dictionary mode".
-  Note 1 : Currently, only one dictionary can be managed.
-           Adding a new dictionary effectively "discards" any previous one.
-  Note 2 : CDict is just referenced, its lifetime must outlive CCtx. 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_refPrefix(ZSTD_CCtx* cctx,
-                           const void* prefix, size_t prefixSize);
-size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx,
-                           const void* prefix, size_t prefixSize,
-                           ZSTD_dictContentType_e dictContentType);
-</b><p>  Reference a prefix (single-usage dictionary) for next compression job.
-  Decompression will need same prefix to properly regenerate data.
-  Compressing with a prefix is similar in outcome as performing a diff and compressing it,
-  but performs much faster, especially during decompression (compression speed is tunable with compression level).
-  Note that prefix is **only used once**. Tables are discarded at end of compression job (ZSTD_e_end).
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
-  Special: Adding any prefix (including NULL) invalidates any previous prefix or dictionary
-  Note 1 : Prefix buffer is referenced. It **must** outlive compression job.
-           Its contain must remain unmodified up to end of compression (ZSTD_e_end).
-  Note 2 : If the intention is to diff some large src data blob with some prior version of itself,
-           ensure that the window size is large enough to contain the entire source.
-           See ZSTD_p_windowLog.
-  Note 3 : Referencing a prefix involves building tables, which are dependent on compression parameters.
-           It's a CPU consuming operation, with non-negligible impact on latency.
-           If there is a need to use same prefix multiple times, consider loadDictionary instead.
-  Note 4 : By default, the prefix is treated as raw content (ZSTD_dm_rawContent).
-           Use ZSTD_CCtx_refPrefix_advanced() to alter dictMode. 
-</p></pre><BR>
-
-<pre><b>void ZSTD_CCtx_reset(ZSTD_CCtx* cctx);
-</b><p>  Return a CCtx to clean state.
-  Useful after an error, or to interrupt an ongoing compression job and start a new one.
-  Any internal data not yet flushed is cancelled.
-  The parameters and dictionary are kept unchanged, to reset them use ZSTD_CCtx_resetParameters().
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_resetParameters(ZSTD_CCtx* cctx);
-</b><p>  All parameters are back to default values (compression level is ZSTD_CLEVEL_DEFAULT).
-  Dictionary (if any) is dropped.
-  Resetting parameters is only possible during frame initialization (before starting compression).
-  To reset the context use ZSTD_CCtx_reset().
-  @return 0 or an error code (which can be checked with ZSTD_isError()).
- 
-</p></pre><BR>
-
-<pre><b>typedef enum {
-    ZSTD_e_continue=0, </b>/* collect more data, encoder decides when to output compressed result, for optimal compression ratio */<b>
-    ZSTD_e_flush,      </b>/* flush any data provided so far,<b>
-                        * it creates (at least) one new block, that can be decoded immediately on reception;
-                        * frame will continue: any future data can still reference previously compressed data, improving compression. */
-    ZSTD_e_end         </b>/* flush any remaining data and close current frame.<b>
-                        * any additional data starts a new frame.
-                        * each frame is independent (does not reference any content from previous frame). */
-} ZSTD_EndDirective;
-</b></pre><BR>
-<pre><b>size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
-                              ZSTD_outBuffer* output,
-                              ZSTD_inBuffer* input,
-                              ZSTD_EndDirective endOp);
-</b><p>  Behave about the same as ZSTD_compressStream. To note :
-  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_setParameter()
-  - Compression parameters cannot be changed once compression is started.
-  - outpot->pos must be <= dstCapacity, input->pos must be <= srcSize
-  - outpot->pos and input->pos will be updated. They are guaranteed to remain below their respective limit.
-  - In single-thread mode (default), function is blocking : it completed its job before returning to caller.
-  - In multi-thread mode, function is non-blocking : it just acquires a copy of input, and distribute job to internal worker threads,
-                                                     and then immediately returns, just indicating that there is some data remaining to be flushed.
-                                                     The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
-  - Exception : in multi-threading mode, if the first call requests a ZSTD_e_end directive, it is blocking : it will complete compression before giving back control to caller.
-  - @return provides a minimum amount of data remaining to be flushed from internal buffers
-            or an error code, which can be tested using ZSTD_isError().
-            if @return != 0, flush is not fully completed, there is still some data left within internal buffers.
-            This is useful for ZSTD_e_flush, since in this case more flushes are necessary to empty all buffers.
-            For ZSTD_e_end, @return == 0 when internal buffers are fully flushed and frame is completed.
-  - after a ZSTD_e_end directive, if internal buffer is not fully flushed (@return != 0),
-            only ZSTD_e_end or ZSTD_e_flush operations are allowed.
-            Before starting a new compression job, or changing compression parameters,
-            it is required to fully flush internal buffers.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_compress_generic_simpleArgs (
-                ZSTD_CCtx* cctx,
-                void* dst, size_t dstCapacity, size_t* dstPos,
-          const void* src, size_t srcSize, size_t* srcPos,
-                ZSTD_EndDirective endOp);
-</b><p>  Same as ZSTD_compress_generic(),
-  but using only integral types as arguments.
-  Argument list is larger than ZSTD_{in,out}Buffer,
-  but can be helpful for binders from dynamic languages
-  which have troubles handling structures containing memory pointers.
- 
-</p></pre><BR>
-
-<pre><b>ZSTD_CCtx_params* ZSTD_createCCtxParams(void);
-size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
-</b><p>  Quick howto :
-  - ZSTD_createCCtxParams() : Create a ZSTD_CCtx_params structure
-  - ZSTD_CCtxParam_setParameter() : Push parameters one by one into
-                                    an existing ZSTD_CCtx_params structure.
-                                    This is similar to
-                                    ZSTD_CCtx_setParameter().
-  - ZSTD_CCtx_setParametersUsingCCtxParams() : Apply parameters to
-                                    an existing CCtx.
-                                    These parameters will be applied to
-                                    all subsequent compression jobs.
-  - ZSTD_compress_generic() : Do compression using the CCtx.
-  - ZSTD_freeCCtxParams() : Free the memory.
-
-  This can be used with ZSTD_estimateCCtxSize_advanced_usingCCtxParams()
-  for static allocation for single-threaded compression.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtxParams_reset(ZSTD_CCtx_params* params);
-</b><p>  Reset params to default values.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtxParams_init(ZSTD_CCtx_params* cctxParams, int compressionLevel);
-</b><p>  Initializes the compression parameters of cctxParams according to
-  compression level. All other parameters are reset to their default values.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtxParams_init_advanced(ZSTD_CCtx_params* cctxParams, ZSTD_parameters params);
-</b><p>  Initializes the compression and frame parameters of cctxParams according to
-  params. All other parameters are reset to their default values.
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned value);
-</b><p>  Similar to ZSTD_CCtx_setParameter.
-  Set one compression parameter, selected by enum ZSTD_cParameter.
-  Parameters must be applied to a ZSTD_CCtx using ZSTD_CCtx_setParametersUsingCCtxParams().
-  Note : when `value` is an enum, cast it to unsigned for proper type checking.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtxParam_getParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned* value);
-</b><p> Similar to ZSTD_CCtx_getParameter.
- Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
- 
-</p></pre><BR>
-
-<pre><b>size_t ZSTD_CCtx_setParametersUsingCCtxParams(
-        ZSTD_CCtx* cctx, const ZSTD_CCtx_params* params);
-</b><p>  Apply a set of ZSTD_CCtx_params to the compression context.
-  This can be done even after compression is started,
-    if nbWorkers==0, this will have no impact until a new compression is started.
-    if nbWorkers>=1, new parameters will be picked up at next job,
-       with a few restrictions (windowLog, pledgedSrcSize, nbWorkers, jobSize, and overlapLog are not updated).
- 
-</p></pre><BR>
-
 <h3>Advanced decompression API</h3><pre></pre><b><pre></b>/* ==================================== */<b>
 </pre></b><BR>
 <pre><b>size_t ZSTD_DCtx_loadDictionary(ZSTD_DCtx* dctx, const void* dict, size_t dictSize);

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -503,48 +503,20 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * 9: full window;  8: w/2;  7: w/4;  6: w/8;  5:w/16;  4: w/32;  3:w/64;  2:w/128;  1:w/256;
                               * default value is 6 : use 1/8th of windowSize */
 
-    </b>/* =================================================================== */<b>
-    </b>/* experimental parameters - no stability guaranteed                   */<b>
-    </b>/* => note : should this part be exported in a different section of zstd.h ? */<b>
-    </b>/* =================================================================== */<b>
-
-    </b>/* compression format */<b>
-    ZSTD_p_format = 10,      </b>/* See ZSTD_format_e enum definition.<b>
-                              * Cast selected format as unsigned for ZSTD_CCtx_setParameter() compatibility. */
-
-    ZSTD_p_forceMaxWindow=1100, </b>/* Force back-reference distances to remain < windowSize,<b>
-                              * even when referencing into Dictionary content (default:0) */
-    ZSTD_p_forceAttachDict,  </b>/* Controls whether the contents of a CDict are<b>
-                              * used in place, or whether they are copied into
-                              * the working context.
-                              *
-                              * Accepts values from the ZSTD_dictAttachPref_e
-                              * enum. See the comments on that enum for an
-                              * explanation of the feature.
-                              */
-
-    </b>/* Question : should rsyncable remain experimental, or be part of candidate for stable ? */<b>
-    ZSTD_p_rsyncable,        </b>/* Enables rsyncable mode, which makes compressed<b>
-                              * files more rsync friendly by adding periodic
-                              * synchronization points to the compressed data.
-                              * The target average block size is
-                              * ZSTD_p_jobSize / 2. You can modify the job size
-                              * to increase or decrease the granularity of the
-                              * synchronization point. Once the jobSize is
-                              * smaller than the window size, you will start to
-                              * see degraded compression ratio.
-                              * NOTE: This only works when multithreading is
-                              * enabled.
-                              * NOTE: You probably don't want to use this with
-                              * long range mode, since that will decrease the
-                              * effectiveness of the synchronization points,
-                              * but your milage may vary.
-                              * NOTE: Rsyncable mode will limit the maximum
-                              * compression speed to approximately 400 MB/s.
-                              * If your compression level is already running
-                              * significantly slower than that (< 200 MB/s),
-                              * the speed won't be significantly impacted.
-                              */
+    </b>/* note : additional experimental parameters are also available<b>
+     * within the experimental section of the API.
+     * At the time of this writing, they include :
+     * ZSTD_p_rsyncable
+     * ZSTD_p_format
+     * ZSTD_p_forceMaxWindow
+     * ZSTD_p_forceAttachDict
+     * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
+     * note : never use experimentalParam names directly
+     */
+     ZSTD_p_experimentalParam1=500,
+     ZSTD_p_experimentalParam2=10,
+     ZSTD_p_experimentalParam3=1000,
+     ZSTD_p_experimentalParam4
 } ZSTD_cParameter;
 </b></pre><BR>
 <pre><b>typedef struct {

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -68,7 +68,7 @@
 
 <a name="Chapter2"></a><h2>Version</h2><pre></pre>
 
-<pre><b>unsigned ZSTD_versionNumber(void);   </b>/**< useful to check dll version */<b>
+<pre><b>unsigned ZSTD_versionNumber(void);   </b>/**< to check runtime library version */<b>
 </b></pre><BR>
 <a name="Chapter3"></a><h2>Default constant</h2><pre></pre>
 
@@ -310,8 +310,8 @@ size_t ZSTD_endStream(ZSTD_CStream* zcs, ZSTD_outBuffer* output);
   ZSTD_DStream objects can be re-used multiple times.
 
   Use ZSTD_initDStream() to start a new decompression operation,
-   or ZSTD_initDStream_usingDict() if decompression requires a dictionary.
-   @return : recommended first input size
+  or ZSTD_initDStream_usingDict() if decompression requires a dictionary.
+ @return : recommended first input size
 
   Use ZSTD_decompressStream() repetitively to consume your input.
   The function will update both `pos` fields.
@@ -385,7 +385,7 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                ZSTD_btopt=7,
                ZSTD_btultra=8
                </b>/* note : new strategies might be added in the future */<b>
-           } ZSTD_strategy;
+} ZSTD_strategy;
 </b></pre><BR>
 <pre><b>typedef enum {
 
@@ -510,7 +510,8 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               * enum. See the comments on that enum for an
                               * explanation of the feature.
                               */
-    </b>/* Question : should rsyncable be categorized as experimental, or be candidate for stable ? */<b>
+
+    </b>/* Question : should rsyncable remain experimental, or be part of candidate for stable ? */<b>
     ZSTD_p_rsyncable,        </b>/* Enables rsyncable mode, which makes compressed<b>
                               * files more rsync friendly by adding periodic
                               * synchronization points to the compressed data.
@@ -534,6 +535,16 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
                               */
 } ZSTD_cParameter;
 </b></pre><BR>
+<pre><b>unsigned ZSTD_cParam_lowerBound(ZSTD_cParameter cParam);
+unsigned ZSTD_cParam_upperBound(ZSTD_cParameter cParam);
+</b><p>  All parameters must respect lower/upper bounds,
+  otherwise they will either trigger an error
+  or be automatically clamped.
+ @return : requested bound (inclusive)
+  note : if the request specifies a non-existing parameter, it will return 0.
+ 
+</p></pre><BR>
+
 <pre><b>size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned value);
 </b><p>  Set one compression parameter, selected by enum ZSTD_cParameter.
   Setting a parameter is generally only possible during frame initialization (before starting compression).
@@ -666,18 +677,6 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_compress_generic_simpleArgs (
-                ZSTD_CCtx* cctx,
-                void* dst, size_t dstCapacity, size_t* dstPos,
-          const void* src, size_t srcSize, size_t* srcPos,
-                ZSTD_EndDirective endOp);
-</b><p>  Same as ZSTD_compress_generic(),
-  but using only integral types as arguments.
-  This variant might be helpful for binders from dynamic languages
-  which have troubles handling structures containing memory pointers.
- 
-</p></pre><BR>
-
 <pre><b> ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
 </b><p>  Refuses allocating internal buffers for frames requiring a window size larger than provided limit.
   This protects a decoder context from reserving too much memory for itself (potential attack scenario).
@@ -753,22 +752,11 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
  
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_decompress_generic_simpleArgs (
-                ZSTD_DCtx* dctx,
-                void* dst, size_t dstCapacity, size_t* dstPos,
-          const void* src, size_t srcSize, size_t* srcPos);
-</b><p>  Same as ZSTD_decompress_generic(),
-  but using only integral types as arguments.
-  This can be helpful for binders from dynamic languages
-  which have troubles handling structures containing memory pointers.
- 
-</p></pre><BR>
-
 <a name="Chapter15"></a><h2>experimental API (static linking only)</h2><pre>
  The following symbols and constants
  are not planned to join "stable API" status anytime soon.
- Some of them will never reach "stable", and are planned to remain in the static_only section indefinitely.
- Some of them might even be removed in the future.
+ Some of them are planned to remain in the static_only section indefinitely.
+ Some of them might even be removed in the future (especially when redundant with existing stable functions)
  
 <BR></pre>
 
@@ -998,19 +986,20 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
   both values are optional, select `0` if unknown. 
 </p></pre><BR>
 
-<pre><b>size_t ZSTD_compress_advanced (ZSTD_CCtx* cctx,
-                      void* dst, size_t dstCapacity,
-                const void* src, size_t srcSize,
-                const void* dict,size_t dictSize,
-                      ZSTD_parameters params);
-</b><p>   Same as ZSTD_compress_usingDict(), with fine-tune control over each compression parameter 
+<pre><b>size_t ZSTD_compress_advanced(ZSTD_CCtx* cctx,
+                              void* dst, size_t dstCapacity,
+                        const void* src, size_t srcSize,
+                        const void* dict,size_t dictSize,
+                              ZSTD_parameters params);
+</b><p>  Same as ZSTD_compress_usingDict(), with fine-tune control over compression parameters (by structure) 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_compress_usingCDict_advanced(ZSTD_CCtx* cctx,
-                      void* dst, size_t dstCapacity,
-                const void* src, size_t srcSize,
-                const ZSTD_CDict* cdict, ZSTD_frameParameters fParams);
-</b><p>   Same as ZSTD_compress_usingCDict(), with fine-tune control over frame parameters 
+                                  void* dst, size_t dstCapacity,
+                            const void* src, size_t srcSize,
+                            const ZSTD_CDict* cdict,
+                                  ZSTD_frameParameters fParams);
+</b><p>  Same as ZSTD_compress_usingCDict(), with fine-tune control over frame parameters 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_CCtx_loadDictionary_byReference(ZSTD_CCtx* cctx, const void* dict, size_t dictSize);
@@ -1098,6 +1087,18 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
+<pre><b>size_t ZSTD_compress_generic_simpleArgs (
+                ZSTD_CCtx* cctx,
+                void* dst, size_t dstCapacity, size_t* dstPos,
+          const void* src, size_t srcSize, size_t* srcPos,
+                ZSTD_EndDirective endOp);
+</b><p>  Same as ZSTD_compress_generic(),
+  but using only integral types as arguments.
+  This variant might be helpful for binders from dynamic languages
+  which have troubles handling structures containing memory pointers.
+ 
+</p></pre><BR>
+
 <a name="Chapter19"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
@@ -1164,7 +1165,21 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  @return : 0, or an error code (which can be tested using ZSTD_isError()). 
 </p></pre><BR>
 
-<a name="Chapter20"></a><h2>Advanced streaming functions</h2><pre></pre>
+<pre><b>size_t ZSTD_decompress_generic_simpleArgs (
+                ZSTD_DCtx* dctx,
+                void* dst, size_t dstCapacity, size_t* dstPos,
+          const void* src, size_t srcSize, size_t* srcPos);
+</b><p>  Same as ZSTD_decompress_generic(),
+  but using only integral types as arguments.
+  This can be helpful for binders from dynamic languages
+  which have troubles handling structures containing memory pointers.
+ 
+</p></pre><BR>
+
+<a name="Chapter20"></a><h2>Advanced streaming functions</h2><pre>  Warning : most of these functions are now redundant with the Advanced API.
+  Once Advanced API reaches "stable" status,
+  redundant functions will be deprecated, and then at some point removed.
+<BR></pre>
 
 <h3>Advanced Streaming compression functions</h3><pre></pre><b><pre>size_t ZSTD_initCStream_srcSize(ZSTD_CStream* zcs, int compressionLevel, unsigned long long pledgedSrcSize);   </b>/**< pledgedSrcSize must be correct. If it is not known at init time, use ZSTD_CONTENTSIZE_UNKNOWN. Note that, for compatibility with older programs, "0" also disables frame content size field. It may be enabled in the future. */<b>
 size_t ZSTD_initCStream_usingDict(ZSTD_CStream* zcs, const void* dict, size_t dictSize, int compressionLevel); </b>/**< creates of an internal CDict (incompatible with static CCtx), except if dict == NULL or dictSize < 8, in which case no dict is used. Note: dict is loaded with ZSTD_dm_auto (treated as a full zstd dictionary if it begins with ZSTD_MAGIC_DICTIONARY, else as raw content) and ZSTD_dlm_byCopy.*/<b>

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -78,7 +78,6 @@ static const U32 repStartValue[ZSTD_REP_NUM] = { 1, 4, 8 };
 #define BIT0   1
 
 #define ZSTD_WINDOWLOG_ABSOLUTEMIN 10
-#define ZSTD_WINDOWLOG_DEFAULTMAX 27 /* Default maximum allowed window log */
 static const size_t ZSTD_fcs_fieldSize[4] = { 0, 2, 4, 8 };
 static const size_t ZSTD_did_fieldSize[4] = { 0, 1, 2, 4 };
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -128,7 +128,7 @@ static size_t ZSTD_sizeof_mtctx(const ZSTD_CCtx* cctx)
 #ifdef ZSTD_MULTITHREAD
     return ZSTDMT_sizeof_CCtx(cctx->mtctx);
 #else
-    (void) cctx;
+    (void)cctx;
     return 0;
 #endif
 }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -232,62 +232,62 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
 
     switch(param)
     {
-    case ZSTD_p_compressionLevel:
+    case ZSTD_c_compressionLevel:
         bounds.lowerBound = ZSTD_minCLevel();
         bounds.upperBound = ZSTD_maxCLevel();
         return bounds;
 
-    case ZSTD_p_windowLog:
+    case ZSTD_c_windowLog:
         bounds.lowerBound = ZSTD_WINDOWLOG_MIN;
         bounds.upperBound = ZSTD_WINDOWLOG_MAX;
         return bounds;
 
-    case ZSTD_p_hashLog:
+    case ZSTD_c_hashLog:
         bounds.lowerBound = ZSTD_HASHLOG_MIN;
         bounds.upperBound = ZSTD_HASHLOG_MAX;
         return bounds;
 
-    case ZSTD_p_chainLog:
+    case ZSTD_c_chainLog:
         bounds.lowerBound = ZSTD_CHAINLOG_MIN;
         bounds.upperBound = ZSTD_CHAINLOG_MAX;
         return bounds;
 
-    case ZSTD_p_searchLog:
+    case ZSTD_c_searchLog:
         bounds.lowerBound = ZSTD_SEARCHLOG_MIN;
         bounds.upperBound = ZSTD_SEARCHLOG_MAX;
         return bounds;
 
-    case ZSTD_p_minMatch:
+    case ZSTD_c_minMatch:
         bounds.lowerBound = ZSTD_MINMATCH_MIN;
         bounds.upperBound = ZSTD_MINMATCH_MAX;
         return bounds;
 
-    case ZSTD_p_targetLength:
+    case ZSTD_c_targetLength:
         bounds.lowerBound = ZSTD_TARGETLENGTH_MIN;
         bounds.upperBound = ZSTD_TARGETLENGTH_MAX;
         return bounds;
 
-    case ZSTD_p_compressionStrategy:
+    case ZSTD_c_compressionStrategy:
         bounds.lowerBound = (int)ZSTD_fast;
         bounds.upperBound = (int)ZSTD_btultra;  /* note : how to ensure at compile time that this is the highest value strategy ? */
         return bounds;
 
-    case ZSTD_p_contentSizeFlag:
+    case ZSTD_c_contentSizeFlag:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
 
-    case ZSTD_p_checksumFlag:
+    case ZSTD_c_checksumFlag:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
 
-    case ZSTD_p_dictIDFlag:
+    case ZSTD_c_dictIDFlag:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
 
-    case ZSTD_p_nbWorkers:
+    case ZSTD_c_nbWorkers:
         bounds.lowerBound = 0;
 #ifdef ZSTD_MULTITHREAD
         bounds.upperBound = ZSTDMT_NBWORKERS_MAX;
@@ -296,7 +296,7 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
 #endif
         return bounds;
 
-    case ZSTD_p_jobSize:
+    case ZSTD_c_jobSize:
         bounds.lowerBound = 0;
 #ifdef ZSTD_MULTITHREAD
         bounds.upperBound = ZSTDMT_JOBSIZE_MAX;
@@ -305,54 +305,54 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
 #endif
         return bounds;
 
-    case ZSTD_p_overlapSizeLog:
+    case ZSTD_c_overlapSizeLog:
         bounds.lowerBound = ZSTD_OVERLAPLOG_MIN;
         bounds.upperBound = ZSTD_OVERLAPLOG_MAX;
         return bounds;
 
-    case ZSTD_p_enableLongDistanceMatching:
+    case ZSTD_c_enableLongDistanceMatching:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
 
-    case ZSTD_p_ldmHashLog:
+    case ZSTD_c_ldmHashLog:
         bounds.lowerBound = ZSTD_LDM_HASHLOG_MIN;
         bounds.upperBound = ZSTD_LDM_HASHLOG_MAX;
         return bounds;
 
-    case ZSTD_p_ldmMinMatch:
+    case ZSTD_c_ldmMinMatch:
         bounds.lowerBound = ZSTD_LDM_MINMATCH_MIN;
         bounds.upperBound = ZSTD_LDM_MINMATCH_MAX;
         return bounds;
 
-    case ZSTD_p_ldmBucketSizeLog:
+    case ZSTD_c_ldmBucketSizeLog:
         bounds.lowerBound = ZSTD_LDM_BUCKETSIZELOG_MIN;
         bounds.upperBound = ZSTD_LDM_BUCKETSIZELOG_MAX;
         return bounds;
 
-    case ZSTD_p_ldmHashRateLog:
+    case ZSTD_c_ldmHashRateLog:
         bounds.lowerBound = ZSTD_LDM_HASHRATELOG_MIN;
         bounds.upperBound = ZSTD_LDM_HASHRATELOG_MAX;
         return bounds;
 
     /* experimental parameters */
-    case ZSTD_p_rsyncable:
+    case ZSTD_c_rsyncable:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
 
-    case ZSTD_p_forceMaxWindow :
+    case ZSTD_c_forceMaxWindow :
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
 
-    case ZSTD_p_format:
+    case ZSTD_c_format:
         ZSTD_STATIC_ASSERT((int)ZSTD_f_zstd1 < (int)ZSTD_f_zstd1_magicless);
         bounds.lowerBound = (int)ZSTD_f_zstd1;
         bounds.upperBound = (int)ZSTD_f_zstd1_magicless;
         return bounds;
 
-    case ZSTD_p_forceAttachDict:
+    case ZSTD_c_forceAttachDict:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
@@ -374,31 +374,31 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
 {
     switch(param)
     {
-    case ZSTD_p_compressionLevel:
-    case ZSTD_p_hashLog:
-    case ZSTD_p_chainLog:
-    case ZSTD_p_searchLog:
-    case ZSTD_p_minMatch:
-    case ZSTD_p_targetLength:
-    case ZSTD_p_compressionStrategy:
+    case ZSTD_c_compressionLevel:
+    case ZSTD_c_hashLog:
+    case ZSTD_c_chainLog:
+    case ZSTD_c_searchLog:
+    case ZSTD_c_minMatch:
+    case ZSTD_c_targetLength:
+    case ZSTD_c_compressionStrategy:
         return 1;
 
-    case ZSTD_p_format:
-    case ZSTD_p_windowLog:
-    case ZSTD_p_contentSizeFlag:
-    case ZSTD_p_checksumFlag:
-    case ZSTD_p_dictIDFlag:
-    case ZSTD_p_forceMaxWindow :
-    case ZSTD_p_nbWorkers:
-    case ZSTD_p_jobSize:
-    case ZSTD_p_overlapSizeLog:
-    case ZSTD_p_rsyncable:
-    case ZSTD_p_enableLongDistanceMatching:
-    case ZSTD_p_ldmHashLog:
-    case ZSTD_p_ldmMinMatch:
-    case ZSTD_p_ldmBucketSizeLog:
-    case ZSTD_p_ldmHashRateLog:
-    case ZSTD_p_forceAttachDict:
+    case ZSTD_c_format:
+    case ZSTD_c_windowLog:
+    case ZSTD_c_contentSizeFlag:
+    case ZSTD_c_checksumFlag:
+    case ZSTD_c_dictIDFlag:
+    case ZSTD_c_forceMaxWindow :
+    case ZSTD_c_nbWorkers:
+    case ZSTD_c_jobSize:
+    case ZSTD_c_overlapSizeLog:
+    case ZSTD_c_rsyncable:
+    case ZSTD_c_enableLongDistanceMatching:
+    case ZSTD_c_ldmHashLog:
+    case ZSTD_c_ldmMinMatch:
+    case ZSTD_c_ldmBucketSizeLog:
+    case ZSTD_c_ldmHashRateLog:
+    case ZSTD_c_forceAttachDict:
     default:
         return 0;
     }
@@ -416,52 +416,52 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
 
     switch(param)
     {
-    case ZSTD_p_format :
+    case ZSTD_c_format :
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_compressionLevel:
+    case ZSTD_c_compressionLevel:
         if (cctx->cdict) return ERROR(stage_wrong);
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_windowLog:
-    case ZSTD_p_hashLog:
-    case ZSTD_p_chainLog:
-    case ZSTD_p_searchLog:
-    case ZSTD_p_minMatch:
-    case ZSTD_p_targetLength:
-    case ZSTD_p_compressionStrategy:
+    case ZSTD_c_windowLog:
+    case ZSTD_c_hashLog:
+    case ZSTD_c_chainLog:
+    case ZSTD_c_searchLog:
+    case ZSTD_c_minMatch:
+    case ZSTD_c_targetLength:
+    case ZSTD_c_compressionStrategy:
         if (cctx->cdict) return ERROR(stage_wrong);
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_contentSizeFlag:
-    case ZSTD_p_checksumFlag:
-    case ZSTD_p_dictIDFlag:
+    case ZSTD_c_contentSizeFlag:
+    case ZSTD_c_checksumFlag:
+    case ZSTD_c_dictIDFlag:
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_forceMaxWindow :  /* Force back-references to remain < windowSize,
+    case ZSTD_c_forceMaxWindow :  /* Force back-references to remain < windowSize,
                                    * even when referencing into Dictionary content.
                                    * default : 0 when using a CDict, 1 when using a Prefix */
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_forceAttachDict:
+    case ZSTD_c_forceAttachDict:
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_nbWorkers:
+    case ZSTD_c_nbWorkers:
         if ((value!=0) && cctx->staticSize) {
             return ERROR(parameter_unsupported);  /* MT not compatible with static alloc */
         }
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_jobSize:
-    case ZSTD_p_overlapSizeLog:
-    case ZSTD_p_rsyncable:
+    case ZSTD_c_jobSize:
+    case ZSTD_c_overlapSizeLog:
+    case ZSTD_c_rsyncable:
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
-    case ZSTD_p_enableLongDistanceMatching:
-    case ZSTD_p_ldmHashLog:
-    case ZSTD_p_ldmMinMatch:
-    case ZSTD_p_ldmBucketSizeLog:
-    case ZSTD_p_ldmHashRateLog:
+    case ZSTD_c_enableLongDistanceMatching:
+    case ZSTD_c_ldmHashLog:
+    case ZSTD_c_ldmMinMatch:
+    case ZSTD_c_ldmBucketSizeLog:
+    case ZSTD_c_ldmHashRateLog:
         if (cctx->cdict) return ERROR(stage_wrong);
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
@@ -475,13 +475,13 @@ size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* CCtxParams,
     DEBUGLOG(4, "ZSTD_CCtxParam_setParameter (%i, %i)", (int)param, value);
     switch(param)
     {
-    case ZSTD_p_format :
+    case ZSTD_c_format :
         if (value > (int)ZSTD_f_zstd1_magicless)
             return ERROR(parameter_unsupported);
         CCtxParams->format = (ZSTD_format_e)value;
         return (size_t)CCtxParams->format;
 
-    case ZSTD_p_compressionLevel : {
+    case ZSTD_c_compressionLevel : {
         int cLevel = value;
         if (cLevel > ZSTD_maxCLevel()) cLevel = ZSTD_maxCLevel();
         if (cLevel) {  /* 0 : does not change current level */
@@ -491,75 +491,75 @@ size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* CCtxParams,
         return 0;  /* return type (size_t) cannot represent negative values */
     }
 
-    case ZSTD_p_windowLog :
+    case ZSTD_c_windowLog :
         if (value!=0)   /* 0 => use default */
             CLAMPCHECK(value, ZSTD_WINDOWLOG_MIN, ZSTD_WINDOWLOG_MAX);
         CCtxParams->cParams.windowLog = value;
         return CCtxParams->cParams.windowLog;
 
-    case ZSTD_p_hashLog :
+    case ZSTD_c_hashLog :
         if (value!=0)   /* 0 => use default */
             CLAMPCHECK(value, ZSTD_HASHLOG_MIN, ZSTD_HASHLOG_MAX);
         CCtxParams->cParams.hashLog = value;
         return CCtxParams->cParams.hashLog;
 
-    case ZSTD_p_chainLog :
+    case ZSTD_c_chainLog :
         if (value!=0)   /* 0 => use default */
             CLAMPCHECK(value, ZSTD_CHAINLOG_MIN, ZSTD_CHAINLOG_MAX);
         CCtxParams->cParams.chainLog = value;
         return CCtxParams->cParams.chainLog;
 
-    case ZSTD_p_searchLog :
+    case ZSTD_c_searchLog :
         if (value!=0)   /* 0 => use default */
             CLAMPCHECK(value, ZSTD_SEARCHLOG_MIN, ZSTD_SEARCHLOG_MAX);
         CCtxParams->cParams.searchLog = value;
         return value;
 
-    case ZSTD_p_minMatch :
+    case ZSTD_c_minMatch :
         if (value!=0)   /* 0 => use default */
             CLAMPCHECK(value, ZSTD_MINMATCH_MIN, ZSTD_MINMATCH_MAX);
         CCtxParams->cParams.minMatch = value;
         return CCtxParams->cParams.minMatch;
 
-    case ZSTD_p_targetLength :
+    case ZSTD_c_targetLength :
         /* all values are valid. 0 => use default */
         CCtxParams->cParams.targetLength = value;
         return CCtxParams->cParams.targetLength;
 
-    case ZSTD_p_compressionStrategy :
+    case ZSTD_c_compressionStrategy :
         if (value!=0)   /* 0 => use default */
             CLAMPCHECK(value, (int)ZSTD_fast, (int)ZSTD_btultra);
         CCtxParams->cParams.strategy = (ZSTD_strategy)value;
         return (size_t)CCtxParams->cParams.strategy;
 
-    case ZSTD_p_contentSizeFlag :
+    case ZSTD_c_contentSizeFlag :
         /* Content size written in frame header _when known_ (default:1) */
         DEBUGLOG(4, "set content size flag = %u", (value!=0));
         CCtxParams->fParams.contentSizeFlag = value != 0;
         return CCtxParams->fParams.contentSizeFlag;
 
-    case ZSTD_p_checksumFlag :
+    case ZSTD_c_checksumFlag :
         /* A 32-bits content checksum will be calculated and written at end of frame (default:0) */
         CCtxParams->fParams.checksumFlag = value != 0;
         return CCtxParams->fParams.checksumFlag;
 
-    case ZSTD_p_dictIDFlag : /* When applicable, dictionary's dictID is provided in frame header (default:1) */
+    case ZSTD_c_dictIDFlag : /* When applicable, dictionary's dictID is provided in frame header (default:1) */
         DEBUGLOG(4, "set dictIDFlag = %u", (value!=0));
         CCtxParams->fParams.noDictIDFlag = !value;
         return !CCtxParams->fParams.noDictIDFlag;
 
-    case ZSTD_p_forceMaxWindow :
+    case ZSTD_c_forceMaxWindow :
         CCtxParams->forceWindow = (value != 0);
         return CCtxParams->forceWindow;
 
-    case ZSTD_p_forceAttachDict : {
+    case ZSTD_c_forceAttachDict : {
         const ZSTD_dictAttachPref_e pref = (ZSTD_dictAttachPref_e)value;
         CLAMPCHECK(pref, ZSTD_dictDefaultAttach, ZSTD_dictForceCopy);
         CCtxParams->attachDictPref = pref;
         return CCtxParams->attachDictPref;
     }
 
-    case ZSTD_p_nbWorkers :
+    case ZSTD_c_nbWorkers :
 #ifndef ZSTD_MULTITHREAD
         if (value!=0) return ERROR(parameter_unsupported);
         return 0;
@@ -567,50 +567,50 @@ size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* CCtxParams,
         return ZSTDMT_CCtxParam_setNbWorkers(CCtxParams, value);
 #endif
 
-    case ZSTD_p_jobSize :
+    case ZSTD_c_jobSize :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
         return ZSTDMT_CCtxParam_setMTCtxParameter(CCtxParams, ZSTDMT_p_jobSize, value);
 #endif
 
-    case ZSTD_p_overlapSizeLog :
+    case ZSTD_c_overlapSizeLog :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
         return ZSTDMT_CCtxParam_setMTCtxParameter(CCtxParams, ZSTDMT_p_overlapSectionLog, value);
 #endif
 
-    case ZSTD_p_rsyncable :
+    case ZSTD_c_rsyncable :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
         return ZSTDMT_CCtxParam_setMTCtxParameter(CCtxParams, ZSTDMT_p_rsyncable, value);
 #endif
 
-    case ZSTD_p_enableLongDistanceMatching :
+    case ZSTD_c_enableLongDistanceMatching :
         CCtxParams->ldmParams.enableLdm = (value!=0);
         return CCtxParams->ldmParams.enableLdm;
 
-    case ZSTD_p_ldmHashLog :
+    case ZSTD_c_ldmHashLog :
         if (value!=0)   /* 0 ==> auto */
             CLAMPCHECK(value, ZSTD_HASHLOG_MIN, ZSTD_HASHLOG_MAX);
         CCtxParams->ldmParams.hashLog = value;
         return CCtxParams->ldmParams.hashLog;
 
-    case ZSTD_p_ldmMinMatch :
+    case ZSTD_c_ldmMinMatch :
         if (value!=0)   /* 0 ==> default */
             CLAMPCHECK(value, ZSTD_LDM_MINMATCH_MIN, ZSTD_LDM_MINMATCH_MAX);
         CCtxParams->ldmParams.minMatchLength = value;
         return CCtxParams->ldmParams.minMatchLength;
 
-    case ZSTD_p_ldmBucketSizeLog :
+    case ZSTD_c_ldmBucketSizeLog :
         if (value!=0)   /* 0 ==> default */
             CLAMPCHECK(value, ZSTD_LDM_BUCKETSIZELOG_MIN, ZSTD_LDM_BUCKETSIZELOG_MAX);
         CCtxParams->ldmParams.bucketSizeLog = value;
         return CCtxParams->ldmParams.bucketSizeLog;
 
-    case ZSTD_p_ldmHashRateLog :
+    case ZSTD_c_ldmHashRateLog :
         if (value > ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN)
             return ERROR(parameter_outOfBound);
         CCtxParams->ldmParams.hashRateLog = value;
@@ -630,88 +630,88 @@ size_t ZSTD_CCtxParam_getParameter(
 {
     switch(param)
     {
-    case ZSTD_p_format :
+    case ZSTD_c_format :
         *value = CCtxParams->format;
         break;
-    case ZSTD_p_compressionLevel :
+    case ZSTD_c_compressionLevel :
         *value = CCtxParams->compressionLevel;
         break;
-    case ZSTD_p_windowLog :
+    case ZSTD_c_windowLog :
         *value = CCtxParams->cParams.windowLog;
         break;
-    case ZSTD_p_hashLog :
+    case ZSTD_c_hashLog :
         *value = CCtxParams->cParams.hashLog;
         break;
-    case ZSTD_p_chainLog :
+    case ZSTD_c_chainLog :
         *value = CCtxParams->cParams.chainLog;
         break;
-    case ZSTD_p_searchLog :
+    case ZSTD_c_searchLog :
         *value = CCtxParams->cParams.searchLog;
         break;
-    case ZSTD_p_minMatch :
+    case ZSTD_c_minMatch :
         *value = CCtxParams->cParams.minMatch;
         break;
-    case ZSTD_p_targetLength :
+    case ZSTD_c_targetLength :
         *value = CCtxParams->cParams.targetLength;
         break;
-    case ZSTD_p_compressionStrategy :
+    case ZSTD_c_compressionStrategy :
         *value = (unsigned)CCtxParams->cParams.strategy;
         break;
-    case ZSTD_p_contentSizeFlag :
+    case ZSTD_c_contentSizeFlag :
         *value = CCtxParams->fParams.contentSizeFlag;
         break;
-    case ZSTD_p_checksumFlag :
+    case ZSTD_c_checksumFlag :
         *value = CCtxParams->fParams.checksumFlag;
         break;
-    case ZSTD_p_dictIDFlag :
+    case ZSTD_c_dictIDFlag :
         *value = !CCtxParams->fParams.noDictIDFlag;
         break;
-    case ZSTD_p_forceMaxWindow :
+    case ZSTD_c_forceMaxWindow :
         *value = CCtxParams->forceWindow;
         break;
-    case ZSTD_p_forceAttachDict :
+    case ZSTD_c_forceAttachDict :
         *value = CCtxParams->attachDictPref;
         break;
-    case ZSTD_p_nbWorkers :
+    case ZSTD_c_nbWorkers :
 #ifndef ZSTD_MULTITHREAD
         assert(CCtxParams->nbWorkers == 0);
 #endif
         *value = CCtxParams->nbWorkers;
         break;
-    case ZSTD_p_jobSize :
+    case ZSTD_c_jobSize :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
         *value = CCtxParams->jobSize;
         break;
 #endif
-    case ZSTD_p_overlapSizeLog :
+    case ZSTD_c_overlapSizeLog :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
         *value = CCtxParams->overlapSizeLog;
         break;
 #endif
-    case ZSTD_p_rsyncable :
+    case ZSTD_c_rsyncable :
 #ifndef ZSTD_MULTITHREAD
         return ERROR(parameter_unsupported);
 #else
         *value = CCtxParams->rsyncable;
         break;
 #endif
-    case ZSTD_p_enableLongDistanceMatching :
+    case ZSTD_c_enableLongDistanceMatching :
         *value = CCtxParams->ldmParams.enableLdm;
         break;
-    case ZSTD_p_ldmHashLog :
+    case ZSTD_c_ldmHashLog :
         *value = CCtxParams->ldmParams.hashLog;
         break;
-    case ZSTD_p_ldmMinMatch :
+    case ZSTD_c_ldmMinMatch :
         *value = CCtxParams->ldmParams.minMatchLength;
         break;
-    case ZSTD_p_ldmBucketSizeLog :
+    case ZSTD_c_ldmBucketSizeLog :
         *value = CCtxParams->ldmParams.bucketSizeLog;
         break;
-    case ZSTD_p_ldmHashRateLog :
+    case ZSTD_c_ldmHashRateLog :
         *value = CCtxParams->ldmParams.hashRateLog;
         break;
     default: return ERROR(parameter_unsupported);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -303,6 +303,7 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
 #else
         bounds.upperBound = 0;
 #endif
+        return bounds;
 
     case ZSTD_p_overlapSizeLog:
         bounds.lowerBound = ZSTD_OVERLAPLOG_MIN;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -263,13 +263,39 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
         return bounds;
 
     case ZSTD_p_targetLength:
+        bounds.lowerBound = ZSTD_TARGETLENGTH_MIN;
+        bounds.upperBound = ZSTD_TARGETLENGTH_MAX;
+        return bounds;
+
     case ZSTD_p_compressionStrategy:
-    case ZSTD_p_format:
+        bounds.lowerBound = (int)ZSTD_fast;
+        bounds.upperBound = (int)ZSTD_btultra;
+        return bounds;
+
     case ZSTD_p_contentSizeFlag:
+        bounds.lowerBound = 0;
+        bounds.upperBound = 1;
+        return bounds;
+
     case ZSTD_p_checksumFlag:
+        bounds.lowerBound = 0;
+        bounds.upperBound = 1;
+        return bounds;
+
     case ZSTD_p_dictIDFlag:
-    case ZSTD_p_forceMaxWindow :
+        bounds.lowerBound = 0;
+        bounds.upperBound = 1;
+        return bounds;
+
     case ZSTD_p_nbWorkers:
+        bounds.lowerBound = 0;
+#ifdef ZSTD_MULTITHREAD
+        bounds.upperBound = ZSTDMT_NBWORKERS_MAX;
+#else
+        bounds.upperBound = 0;
+#endif
+        return bounds;
+
     case ZSTD_p_jobSize:
     case ZSTD_p_overlapSizeLog:
     case ZSTD_p_rsyncable:
@@ -278,6 +304,13 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
     case ZSTD_p_ldmMinMatch:
     case ZSTD_p_ldmBucketSizeLog:
     case ZSTD_p_ldmHashEveryLog:
+
+    /* experimental parameters */
+    case ZSTD_p_forceMaxWindow :
+        bounds.lowerBound = 0;
+        bounds.upperBound = 1;
+        return bounds;
+    case ZSTD_p_format:
     case ZSTD_p_forceAttachDict:
     default:
         {   ZSTD_bounds const boundError = { ERROR(parameter_unsupported), 0, 0 };

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -620,13 +620,13 @@ size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* CCtxParams,
     }
 }
 
-size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value)
+size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int* value)
 {
     return ZSTD_CCtxParam_getParameter(&cctx->requestedParams, param, value);
 }
 
 size_t ZSTD_CCtxParam_getParameter(
-        ZSTD_CCtx_params* CCtxParams, ZSTD_cParameter param, unsigned* value)
+        ZSTD_CCtx_params* CCtxParams, ZSTD_cParameter param, int* value)
 {
     switch(param)
     {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -330,9 +330,9 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
         bounds.upperBound = ZSTD_LDM_BUCKETSIZELOG_MAX;
         return bounds;
 
-    case ZSTD_p_ldmHashEveryLog:
-        bounds.lowerBound = ZSTD_LDM_HASHEVERYLOG_MIN;
-        bounds.upperBound = ZSTD_LDM_HASHEVERYLOG_MAX;
+    case ZSTD_p_ldmHashRateLog:
+        bounds.lowerBound = ZSTD_LDM_HASHRATELOG_MIN;
+        bounds.upperBound = ZSTD_LDM_HASHRATELOG_MAX;
         return bounds;
 
     /* experimental parameters */
@@ -397,7 +397,7 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     case ZSTD_p_ldmHashLog:
     case ZSTD_p_ldmMinMatch:
     case ZSTD_p_ldmBucketSizeLog:
-    case ZSTD_p_ldmHashEveryLog:
+    case ZSTD_p_ldmHashRateLog:
     case ZSTD_p_forceAttachDict:
     default:
         return 0;
@@ -461,7 +461,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
     case ZSTD_p_ldmHashLog:
     case ZSTD_p_ldmMinMatch:
     case ZSTD_p_ldmBucketSizeLog:
-    case ZSTD_p_ldmHashEveryLog:
+    case ZSTD_p_ldmHashRateLog:
         if (cctx->cdict) return ERROR(stage_wrong);
         return ZSTD_CCtxParam_setParameter(&cctx->requestedParams, param, value);
 
@@ -610,11 +610,11 @@ size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* CCtxParams,
         CCtxParams->ldmParams.bucketSizeLog = value;
         return CCtxParams->ldmParams.bucketSizeLog;
 
-    case ZSTD_p_ldmHashEveryLog :
+    case ZSTD_p_ldmHashRateLog :
         if (value > ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN)
             return ERROR(parameter_outOfBound);
-        CCtxParams->ldmParams.hashEveryLog = value;
-        return CCtxParams->ldmParams.hashEveryLog;
+        CCtxParams->ldmParams.hashRateLog = value;
+        return CCtxParams->ldmParams.hashRateLog;
 
     default: return ERROR(parameter_unsupported);
     }
@@ -711,8 +711,8 @@ size_t ZSTD_CCtxParam_getParameter(
     case ZSTD_p_ldmBucketSizeLog :
         *value = CCtxParams->ldmParams.bucketSizeLog;
         break;
-    case ZSTD_p_ldmHashEveryLog :
-        *value = CCtxParams->ldmParams.hashEveryLog;
+    case ZSTD_p_ldmHashRateLog :
+        *value = CCtxParams->ldmParams.hashRateLog;
         break;
     default: return ERROR(parameter_unsupported);
     }
@@ -1119,7 +1119,7 @@ static U32 ZSTD_equivalentLdmParams(ldmParams_t ldmParams1,
             ldmParams1.hashLog == ldmParams2.hashLog &&
             ldmParams1.bucketSizeLog == ldmParams2.bucketSizeLog &&
             ldmParams1.minMatchLength == ldmParams2.minMatchLength &&
-            ldmParams1.hashEveryLog == ldmParams2.hashEveryLog);
+            ldmParams1.hashRateLog == ldmParams2.hashRateLog);
 }
 
 typedef enum { ZSTDb_not_buffered, ZSTDb_buffered } ZSTD_buffered_policy_e;
@@ -1317,7 +1317,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
         /* Adjust long distance matching parameters */
         ZSTD_ldm_adjustParameters(&params.ldmParams, &params.cParams);
         assert(params.ldmParams.hashLog >= params.ldmParams.bucketSizeLog);
-        assert(params.ldmParams.hashEveryLog < 32);
+        assert(params.ldmParams.hashRateLog < 32);
         zc->ldmState.hashPower = ZSTD_rollingHash_primePower(params.ldmParams.minMatchLength);
     }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -61,7 +61,7 @@ static void ZSTD_initCCtx(ZSTD_CCtx* cctx, ZSTD_customMem memManager)
     memset(cctx, 0, sizeof(*cctx));
     cctx->customMem = memManager;
     cctx->bmi2 = ZSTD_cpuid_bmi2(ZSTD_cpuid());
-    {   size_t const err = ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_parameters);
+    {   size_t const err = ZSTD_CCtx_reset(cctx, ZSTD_reset_parameters);
         assert(!ZSTD_isError(err));
         (void)err;
     }
@@ -672,15 +672,15 @@ size_t ZSTD_CCtx_refPrefix_advanced(
 
 /*! ZSTD_CCtx_reset() :
  *  Also dumps dictionary */
-size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_CCtx_reset_directive zcrd)
+size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_reset_directive reset)
 {
-    if ( (zcrd == ZSTD_CCtx_reset_session_only)
-      || (zcrd == ZSTD_CCtx_reset_session_and_parameters) ) {
+    if ( (reset == ZSTD_reset_session_only)
+      || (reset == ZSTD_reset_session_and_parameters) ) {
         cctx->streamStage = zcss_init;
         cctx->pledgedSrcSizePlusOne = 0;
     }
-    if ( (zcrd == ZSTD_CCtx_reset_parameters)
-      || (zcrd == ZSTD_CCtx_reset_session_and_parameters) ) {
+    if ( (reset == ZSTD_reset_parameters)
+      || (reset == ZSTD_reset_session_and_parameters) ) {
         if (cctx->streamStage != zcss_init) return ERROR(stage_wrong);
         cctx->cdict = NULL;
         return ZSTD_CCtxParams_reset(&cctx->requestedParams);
@@ -3703,7 +3703,7 @@ size_t ZSTD_compressStream_generic(ZSTD_CStream* zcs,
                 ip = iend;
                 op += cSize;
                 zcs->frameEnded = 1;
-                ZSTD_CCtx_reset(zcs, ZSTD_CCtx_reset_session_only);
+                ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
                 someMoreWork = 0; break;
             }
             /* complete loading into inBuffer */
@@ -3756,7 +3756,7 @@ size_t ZSTD_compressStream_generic(ZSTD_CStream* zcs,
                     if (zcs->frameEnded) {
                         DEBUGLOG(5, "Frame completed directly in outBuffer");
                         someMoreWork = 0;
-                        ZSTD_CCtx_reset(zcs, ZSTD_CCtx_reset_session_only);
+                        ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
                     }
                     break;
                 }
@@ -3784,7 +3784,7 @@ size_t ZSTD_compressStream_generic(ZSTD_CStream* zcs,
                 if (zcs->frameEnded) {
                     DEBUGLOG(5, "Frame completed on flush");
                     someMoreWork = 0;
-                    ZSTD_CCtx_reset(zcs, ZSTD_CCtx_reset_session_only);
+                    ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
                     break;
                 }
                 zcs->streamStage = zcss_load;
@@ -3878,7 +3878,7 @@ size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
         {   size_t const flushMin = ZSTDMT_compressStream_generic(cctx->mtctx, output, input, endOp);
             if ( ZSTD_isError(flushMin)
               || (endOp == ZSTD_e_end && flushMin == 0) ) { /* compression completed */
-                ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
+                ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
             }
             DEBUGLOG(5, "completed ZSTD_compress_generic delegating to ZSTDMT_compressStream_generic");
             return flushMin;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4060,19 +4060,21 @@ size_t ZSTD_compress2(ZSTD_CCtx* cctx,
                       void* dst, size_t dstCapacity,
                       const void* src, size_t srcSize)
 {
-    size_t oPos = 0;
-    size_t iPos = 0;
-    size_t const result = ZSTD_compressStream2_simpleArgs(cctx,
-                                    dst, dstCapacity, &oPos,
-                                    src, srcSize, &iPos,
-                                    ZSTD_e_end);
-    assert(iPos == srcSize);
-    if (ZSTD_isError(result)) return result;
-    if (result != 0) {  /* compression not completed, due to lack of output space */
-        assert(oPos == dstCapacity);
-        return ERROR(dstSize_tooSmall);
+    ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
+    {   size_t oPos = 0;
+        size_t iPos = 0;
+        size_t const result = ZSTD_compressStream2_simpleArgs(cctx,
+                                        dst, dstCapacity, &oPos,
+                                        src, srcSize, &iPos,
+                                        ZSTD_e_end);
+        if (ZSTD_isError(result)) return result;
+        assert(iPos == srcSize);
+        if (result != 0) {  /* compression not completed, due to lack of output space */
+            assert(oPos == dstCapacity);
+            return ERROR(dstSize_tooSmall);
+        }
+        return oPos;
     }
-    return oPos;
 }
 
 /*======   Finalize   ======*/

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2624,7 +2624,7 @@ static size_t ZSTD_writeFrameHeader(void* dst, size_t dstCapacity,
     size_t pos=0;
 
     assert(!(params.fParams.contentSizeFlag && pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN));
-    if (dstCapacity < ZSTD_frameHeaderSize_max) return ERROR(dstSize_tooSmall);
+    if (dstCapacity < ZSTD_FRAMEHEADERSIZE_MAX) return ERROR(dstSize_tooSmall);
     DEBUGLOG(4, "ZSTD_writeFrameHeader : dictIDFlag : %u ; dictID : %u ; dictIDSizeCode : %u",
                 !params.fParams.noDictIDFlag, dictID,  dictIDSizeCode);
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3862,7 +3862,7 @@ size_t ZSTD_compress_generic (ZSTD_CCtx* cctx,
         {   size_t const flushMin = ZSTDMT_compressStream_generic(cctx->mtctx, output, input, endOp);
             if ( ZSTD_isError(flushMin)
               || (endOp == ZSTD_e_end && flushMin == 0) ) { /* compression completed */
-                ZSTD_CCtx_reset(cctx);
+                ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
             }
             DEBUGLOG(5, "completed ZSTD_compress_generic delegating to ZSTDMT_compressStream_generic");
             return flushMin;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -266,9 +266,9 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     }
 }
 
-size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned value)
+size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
 {
-    DEBUGLOG(4, "ZSTD_CCtx_setParameter (%u, %u)", (U32)param, value);
+    DEBUGLOG(4, "ZSTD_CCtx_setParameter (%i, %i)", (int)param, value);
     if (cctx->streamStage != zcss_init) {
         if (ZSTD_isUpdateAuthorized(param)) {
             cctx->cParamsChanged = 1;
@@ -331,20 +331,20 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned v
     }
 }
 
-size_t ZSTD_CCtxParam_setParameter(
-        ZSTD_CCtx_params* CCtxParams, ZSTD_cParameter param, unsigned value)
+size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* CCtxParams,
+                                   ZSTD_cParameter param, int value)
 {
-    DEBUGLOG(4, "ZSTD_CCtxParam_setParameter (%u, %u)", (U32)param, value);
+    DEBUGLOG(4, "ZSTD_CCtxParam_setParameter (%i, %i)", (int)param, value);
     switch(param)
     {
     case ZSTD_p_format :
-        if (value > (unsigned)ZSTD_f_zstd1_magicless)
+        if (value > (int)ZSTD_f_zstd1_magicless)
             return ERROR(parameter_unsupported);
         CCtxParams->format = (ZSTD_format_e)value;
         return (size_t)CCtxParams->format;
 
     case ZSTD_p_compressionLevel : {
-        int cLevel = (int)value;  /* cast expected to restore negative sign */
+        int cLevel = value;
         if (cLevel > ZSTD_maxCLevel()) cLevel = ZSTD_maxCLevel();
         if (cLevel) {  /* 0 : does not change current level */
             CCtxParams->compressionLevel = cLevel;
@@ -390,7 +390,7 @@ size_t ZSTD_CCtxParam_setParameter(
 
     case ZSTD_p_compressionStrategy :
         if (value>0)   /* 0 => use default */
-            CLAMPCHECK(value, (unsigned)ZSTD_fast, (unsigned)ZSTD_btultra);
+            CLAMPCHECK(value, (int)ZSTD_fast, (int)ZSTD_btultra);
         CCtxParams->cParams.strategy = (ZSTD_strategy)value;
         return (size_t)CCtxParams->cParams.strategy;
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -672,7 +672,7 @@ size_t ZSTD_CCtx_refPrefix_advanced(
 
 /*! ZSTD_CCtx_reset() :
  *  Also dumps dictionary */
-size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_reset_directive reset)
+size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_ResetDirective reset)
 {
     if ( (reset == ZSTD_reset_session_only)
       || (reset == ZSTD_reset_session_and_parameters) ) {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4068,11 +4068,11 @@ size_t ZSTD_compress2(ZSTD_CCtx* cctx,
                                         src, srcSize, &iPos,
                                         ZSTD_e_end);
         if (ZSTD_isError(result)) return result;
-        assert(iPos == srcSize);
         if (result != 0) {  /* compression not completed, due to lack of output space */
             assert(oPos == dstCapacity);
             return ERROR(dstSize_tooSmall);
         }
+        assert(iPos == srcSize);   /* all input is expected consumed */
         return oPos;
     }
 }

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -161,7 +161,7 @@ typedef struct {
     U32 hashLog;            /* Log size of hashTable */
     U32 bucketSizeLog;      /* Log bucket size for collision resolution, at most 8 */
     U32 minMatchLength;     /* Minimum match length */
-    U32 hashEveryLog;       /* Log number of entries to skip */
+    U32 hashRateLog;       /* Log number of entries to skip */
     U32 windowLog;          /* Window log for the LDM */
 } ldmParams_t;
 

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -18,7 +18,7 @@ void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
     const ZSTD_compressionParameters* const cParams = &ms->cParams;
     U32* const hashLarge = ms->hashTable;
     U32  const hBitsL = cParams->hashLog;
-    U32  const mls = cParams->searchLength;
+    U32  const mls = cParams->minMatch;
     U32* const hashSmall = ms->chainTable;
     U32  const hBitsS = cParams->chainLog;
     const BYTE* const base = ms->window.base;
@@ -309,7 +309,7 @@ size_t ZSTD_compressBlock_doubleFast(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize)
 {
-    const U32 mls = ms->cParams.searchLength;
+    const U32 mls = ms->cParams.minMatch;
     switch(mls)
     {
     default: /* includes case 3 */
@@ -329,7 +329,7 @@ size_t ZSTD_compressBlock_doubleFast_dictMatchState(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize)
 {
-    const U32 mls = ms->cParams.searchLength;
+    const U32 mls = ms->cParams.minMatch;
     switch(mls)
     {
     default: /* includes case 3 */
@@ -483,7 +483,7 @@ size_t ZSTD_compressBlock_doubleFast_extDict(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize)
 {
-    U32 const mls = ms->cParams.searchLength;
+    U32 const mls = ms->cParams.minMatch;
     switch(mls)
     {
     default: /* includes case 3 */

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -18,7 +18,7 @@ void ZSTD_fillHashTable(ZSTD_matchState_t* ms,
     const ZSTD_compressionParameters* const cParams = &ms->cParams;
     U32* const hashTable = ms->hashTable;
     U32  const hBits = cParams->hashLog;
-    U32  const mls = cParams->searchLength;
+    U32  const mls = cParams->minMatch;
     const BYTE* const base = ms->window.base;
     const BYTE* ip = base + ms->nextToUpdate;
     const BYTE* const iend = ((const BYTE*)end) - HASH_READ_SIZE;
@@ -235,7 +235,7 @@ size_t ZSTD_compressBlock_fast(
         void const* src, size_t srcSize)
 {
     ZSTD_compressionParameters const* cParams = &ms->cParams;
-    U32 const mls = cParams->searchLength;
+    U32 const mls = cParams->minMatch;
     assert(ms->dictMatchState == NULL);
     switch(mls)
     {
@@ -256,7 +256,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState(
         void const* src, size_t srcSize)
 {
     ZSTD_compressionParameters const* cParams = &ms->cParams;
-    U32 const mls = cParams->searchLength;
+    U32 const mls = cParams->minMatch;
     assert(ms->dictMatchState != NULL);
     switch(mls)
     {
@@ -375,7 +375,7 @@ size_t ZSTD_compressBlock_fast_extDict(
         void const* src, size_t srcSize)
 {
     ZSTD_compressionParameters const* cParams = &ms->cParams;
-    U32 const mls = cParams->searchLength;
+    U32 const mls = cParams->minMatch;
     switch(mls)
     {
     default: /* includes case 3 */

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -392,7 +392,7 @@ ZSTD_BtFindBestMatch_selectMLS (  ZSTD_matchState_t* ms,
                             const BYTE* ip, const BYTE* const iLimit,
                                   size_t* offsetPtr)
 {
-    switch(ms->cParams.searchLength)
+    switch(ms->cParams.minMatch)
     {
     default : /* includes case 3 */
     case 4 : return ZSTD_BtFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_noDict);
@@ -408,7 +408,7 @@ static size_t ZSTD_BtFindBestMatch_dictMatchState_selectMLS (
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    switch(ms->cParams.searchLength)
+    switch(ms->cParams.minMatch)
     {
     default : /* includes case 3 */
     case 4 : return ZSTD_BtFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dictMatchState);
@@ -424,7 +424,7 @@ static size_t ZSTD_BtFindBestMatch_extDict_selectMLS (
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    switch(ms->cParams.searchLength)
+    switch(ms->cParams.minMatch)
     {
     default : /* includes case 3 */
     case 4 : return ZSTD_BtFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_extDict);
@@ -469,7 +469,7 @@ static U32 ZSTD_insertAndFindFirstIndex_internal(
 
 U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip) {
     const ZSTD_compressionParameters* const cParams = &ms->cParams;
-    return ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, ms->cParams.searchLength);
+    return ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, ms->cParams.minMatch);
 }
 
 
@@ -566,7 +566,7 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_selectMLS (
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    switch(ms->cParams.searchLength)
+    switch(ms->cParams.minMatch)
     {
     default : /* includes case 3 */
     case 4 : return ZSTD_HcFindBestMatch_generic(ms, ip, iLimit, offsetPtr, 4, ZSTD_noDict);
@@ -582,7 +582,7 @@ static size_t ZSTD_HcFindBestMatch_dictMatchState_selectMLS (
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    switch(ms->cParams.searchLength)
+    switch(ms->cParams.minMatch)
     {
     default : /* includes case 3 */
     case 4 : return ZSTD_HcFindBestMatch_generic(ms, ip, iLimit, offsetPtr, 4, ZSTD_dictMatchState);
@@ -598,7 +598,7 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_extDict_selectMLS (
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    switch(ms->cParams.searchLength)
+    switch(ms->cParams.minMatch)
     {
     default : /* includes case 3 */
     case 4 : return ZSTD_HcFindBestMatch_generic(ms, ip, iLimit, offsetPtr, 4, ZSTD_extDict);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -543,7 +543,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     void const* src, size_t srcSize)
 {
     const ZSTD_compressionParameters* const cParams = &ms->cParams;
-    unsigned const minMatch = cParams->searchLength;
+    unsigned const minMatch = cParams->minMatch;
     ZSTD_blockCompressor const blockCompressor =
         ZSTD_selectBlockCompressor(cParams->strategy, ZSTD_matchState_dictMode(ms));
     /* Input bounds */

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -37,8 +37,8 @@ void ZSTD_ldm_adjustParameters(ldmParams_t* params,
         params->hashLog = MAX(ZSTD_HASHLOG_MIN, params->windowLog - LDM_HASH_RLOG);
         assert(params->hashLog <= ZSTD_HASHLOG_MAX);
     }
-    if (params->hashEveryLog == 0) {
-        params->hashEveryLog = params->windowLog < params->hashLog
+    if (params->hashRateLog == 0) {
+        params->hashRateLog = params->windowLog < params->hashLog
                                    ? 0
                                    : params->windowLog - params->hashLog;
     }
@@ -119,20 +119,20 @@ static void ZSTD_ldm_insertEntry(ldmState_t* ldmState,
  *
  *  Gets the small hash, checksum, and tag from the rollingHash.
  *
- *  If the tag matches (1 << ldmParams.hashEveryLog)-1, then
+ *  If the tag matches (1 << ldmParams.hashRateLog)-1, then
  *  creates an ldmEntry from the offset, and inserts it into the hash table.
  *
  *  hBits is the length of the small hash, which is the most significant hBits
  *  of rollingHash. The checksum is the next 32 most significant bits, followed
- *  by ldmParams.hashEveryLog bits that make up the tag. */
+ *  by ldmParams.hashRateLog bits that make up the tag. */
 static void ZSTD_ldm_makeEntryAndInsertByTag(ldmState_t* ldmState,
                                              U64 const rollingHash,
                                              U32 const hBits,
                                              U32 const offset,
                                              ldmParams_t const ldmParams)
 {
-    U32 const tag = ZSTD_ldm_getTag(rollingHash, hBits, ldmParams.hashEveryLog);
-    U32 const tagMask = ((U32)1 << ldmParams.hashEveryLog) - 1;
+    U32 const tag = ZSTD_ldm_getTag(rollingHash, hBits, ldmParams.hashRateLog);
+    U32 const tagMask = ((U32)1 << ldmParams.hashRateLog) - 1;
     if (tag == tagMask) {
         U32 const hash = ZSTD_ldm_getSmallHash(rollingHash, hBits);
         U32 const checksum = ZSTD_ldm_getChecksum(rollingHash, hBits);
@@ -247,8 +247,8 @@ static size_t ZSTD_ldm_generateSequences_internal(
     U64 const hashPower = ldmState->hashPower;
     U32 const hBits = params->hashLog - params->bucketSizeLog;
     U32 const ldmBucketSize = 1U << params->bucketSizeLog;
-    U32 const hashEveryLog = params->hashEveryLog;
-    U32 const ldmTagMask = (1U << params->hashEveryLog) - 1;
+    U32 const hashRateLog = params->hashRateLog;
+    U32 const ldmTagMask = (1U << params->hashRateLog) - 1;
     /* Prefix and extDict parameters */
     U32 const dictLimit = ldmState->window.dictLimit;
     U32 const lowestIndex = extDict ? ldmState->window.lowLimit : dictLimit;
@@ -283,7 +283,7 @@ static size_t ZSTD_ldm_generateSequences_internal(
         lastHashed = ip;
 
         /* Do not insert and do not look for a match */
-        if (ZSTD_ldm_getTag(rollingHash, hBits, hashEveryLog) != ldmTagMask) {
+        if (ZSTD_ldm_getTag(rollingHash, hBits, hashRateLog) != ldmTagMask) {
            ip++;
            continue;
         }

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -87,7 +87,7 @@ size_t ZSTD_ldm_getTableSize(ldmParams_t params);
 size_t ZSTD_ldm_getMaxNbSeq(ldmParams_t params, size_t maxChunkSize);
 
 /** ZSTD_ldm_adjustParameters() :
- *  If the params->hashEveryLog is not set, set it to its default value based on
+ *  If the params->hashRateLog is not set, set it to its default value based on
  *  windowLog and params->hashLog.
  *
  *  Ensures that params->bucketSizeLog is <= params->hashLog (setting it to

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -21,7 +21,7 @@ extern "C" {
 *  Long distance matching
 ***************************************/
 
-#define ZSTD_LDM_DEFAULT_WINDOW_LOG ZSTD_WINDOWLOG_DEFAULTMAX
+#define ZSTD_LDM_DEFAULT_WINDOW_LOG ZSTD_WINDOWLOG_LIMIT_DEFAULT
 
 /**
  * ZSTD_ldm_generateSequences():

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -488,7 +488,7 @@ void ZSTD_updateTree_internal(
 }
 
 void ZSTD_updateTree(ZSTD_matchState_t* ms, const BYTE* ip, const BYTE* iend) {
-    ZSTD_updateTree_internal(ms, ip, iend, ms->cParams.searchLength, ZSTD_noDict);
+    ZSTD_updateTree_internal(ms, ip, iend, ms->cParams.minMatch, ZSTD_noDict);
 }
 
 FORCE_INLINE_TEMPLATE
@@ -728,7 +728,7 @@ FORCE_INLINE_TEMPLATE U32 ZSTD_BtGetAllMatches (
                         ZSTD_match_t* matches, U32 const lengthToBeat)
 {
     const ZSTD_compressionParameters* const cParams = &ms->cParams;
-    U32 const matchLengthSearch = cParams->searchLength;
+    U32 const matchLengthSearch = cParams->minMatch;
     DEBUGLOG(8, "ZSTD_BtGetAllMatches");
     if (ip < ms->window.base + ms->nextToUpdate) return 0;   /* skipped area */
     ZSTD_updateTree_internal(ms, ip, iHighLimit, matchLengthSearch, dictMode);
@@ -796,7 +796,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     const ZSTD_compressionParameters* const cParams = &ms->cParams;
 
     U32 const sufficient_len = MIN(cParams->targetLength, ZSTD_OPT_NUM -1);
-    U32 const minMatch = (cParams->searchLength == 3) ? 3 : 4;
+    U32 const minMatch = (cParams->minMatch == 3) ? 3 : 4;
 
     ZSTD_optimal_t* const opt = optStatePtr->priceTable;
     ZSTD_match_t* const matches = optStatePtr->matchTable;

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -467,7 +467,7 @@ static int ZSTDMT_serialState_reset(serialState_t* serialState, ZSTDMT_seqPool* 
         DEBUGLOG(4, "LDM window size = %u KB", (1U << params.cParams.windowLog) >> 10);
         ZSTD_ldm_adjustParameters(&params.ldmParams, &params.cParams);
         assert(params.ldmParams.hashLog >= params.ldmParams.bucketSizeLog);
-        assert(params.ldmParams.hashEveryLog < 32);
+        assert(params.ldmParams.hashRateLog < 32);
         serialState->ldmState.hashPower =
                 ZSTD_rollingHash_primePower(params.ldmParams.minMatchLength);
     } else {

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -10,7 +10,6 @@
 
 
 /* ======   Tuning parameters   ====== */
-#define ZSTDMT_NBWORKERS_MAX 200
 #define ZSTDMT_JOBSIZE_MAX  (MEM_32bits() ? (512 MB) : (2 GB))  /* note : limited by `jobSize` type, which is `unsigned` */
 #define ZSTDMT_OVERLAPLOG_DEFAULT 6
 

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -10,7 +10,6 @@
 
 
 /* ======   Tuning parameters   ====== */
-#define ZSTDMT_JOBSIZE_MAX  (MEM_32bits() ? (512 MB) : (2 GB))  /* note : limited by `jobSize` type, which is `unsigned` */
 #define ZSTDMT_OVERLAPLOG_DEFAULT 6
 
 

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -672,7 +672,7 @@ static void ZSTDMT_compressionJob(void* jobDescription)
         if (ZSTD_isError(initError)) JOB_ERROR(initError);
     } else {  /* srcStart points at reloaded section */
         U64 const pledgedSrcSize = job->firstJob ? job->fullFrameSize : job->src.size;
-        {   size_t const forceWindowError = ZSTD_CCtxParam_setParameter(&jobParams, ZSTD_p_forceMaxWindow, !job->firstJob);
+        {   size_t const forceWindowError = ZSTD_CCtxParam_setParameter(&jobParams, ZSTD_c_forceMaxWindow, !job->firstJob);
             if (ZSTD_isError(forceWindowError)) JOB_ERROR(forceWindowError);
         }
         {   size_t const initError = ZSTD_compressBegin_advanced_internal(cctx,

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1844,7 +1844,9 @@ typedef struct {
  * Otherwise, we will load as many bytes as possible and instruct the caller
  * to continue as normal.
  */
-static syncPoint_t findSynchronizationPoint(ZSTDMT_CCtx const* mtctx, ZSTD_inBuffer const input) {
+static syncPoint_t
+findSynchronizationPoint(ZSTDMT_CCtx const* mtctx, ZSTD_inBuffer const input)
+{
     BYTE const* const istart = (BYTE const*)input.src + input.pos;
     U64 const primePower = mtctx->rsync.primePower;
     U64 const hitMask = mtctx->rsync.hitMask;
@@ -1906,6 +1908,13 @@ static syncPoint_t findSynchronizationPoint(ZSTDMT_CCtx const* mtctx, ZSTD_inBuf
         }
     }
     return syncPoint;
+}
+
+size_t ZSTDMT_nextInputSizeHint(const ZSTDMT_CCtx* mtctx)
+{
+    size_t hintInSize = mtctx->targetSectionSize - mtctx->inBuff.filled;
+    if (hintInSize==0) hintInSize = mtctx->targetSectionSize;
+    return hintInSize;
 }
 
 /** ZSTDMT_compressStream_generic() :

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -60,6 +60,7 @@ ZSTDLIB_API size_t ZSTDMT_compressCCtx(ZSTDMT_CCtx* mtctx,
 ZSTDLIB_API size_t ZSTDMT_initCStream(ZSTDMT_CCtx* mtctx, int compressionLevel);
 ZSTDLIB_API size_t ZSTDMT_resetCStream(ZSTDMT_CCtx* mtctx, unsigned long long pledgedSrcSize);  /**< if srcSize is not known at reset time, use ZSTD_CONTENTSIZE_UNKNOWN. Note: for compatibility with older programs, 0 means the same as ZSTD_CONTENTSIZE_UNKNOWN, but it will change in the future to mean "empty" */
 
+ZSTDLIB_API size_t ZSTDMT_nextInputSizeHint(const ZSTDMT_CCtx* mtctx);
 ZSTDLIB_API size_t ZSTDMT_compressStream(ZSTDMT_CCtx* mtctx, ZSTD_outBuffer* output, ZSTD_inBuffer* input);
 
 ZSTDLIB_API size_t ZSTDMT_flushStream(ZSTDMT_CCtx* mtctx, ZSTD_outBuffer* output);   /**< @return : 0 == all flushed; >0 : still some data to be flushed; or an error code (ZSTD_isError()) */

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -28,6 +28,10 @@
 #include "zstd.h"            /* ZSTD_inBuffer, ZSTD_outBuffer, ZSTDLIB_API */
 
 
+/* ===   Constants   === */
+#define ZSTDMT_NBWORKERS_MAX 200
+
+
 /* ===   Memory management   === */
 typedef struct ZSTDMT_CCtx_s ZSTDMT_CCtx;
 ZSTDLIB_API ZSTDMT_CCtx* ZSTDMT_createCCtx(unsigned nbWorkers);

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -30,6 +30,10 @@
 
 /* ===   Constants   === */
 #define ZSTDMT_NBWORKERS_MAX 200
+#ifndef ZSTDMT_JOBSIZE_MIN
+#  define ZSTDMT_JOBSIZE_MIN (1U << 20)   /* 1 MB - Minimum size of each compression job */
+#endif
+#define ZSTDMT_JOBSIZE_MAX  (MEM_32bits() ? (512 MB) : (1 GB))  /* note : limited by `jobSize` type, which is `int` */
 
 
 /* ===   Memory management   === */
@@ -63,10 +67,6 @@ ZSTDLIB_API size_t ZSTDMT_endStream(ZSTDMT_CCtx* mtctx, ZSTD_outBuffer* output);
 
 
 /* ===   Advanced functions and parameters  === */
-
-#ifndef ZSTDMT_JOBSIZE_MIN
-#  define ZSTDMT_JOBSIZE_MIN (1U << 20)   /* 1 MB - Minimum size of each compression job */
-#endif
 
 ZSTDLIB_API size_t ZSTDMT_compress_advanced(ZSTDMT_CCtx* mtctx,
                                            void* dst, size_t dstCapacity,

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -37,7 +37,7 @@
  *  It's possible to set a different limit using ZSTD_DCtx_setMaxWindowSize().
  */
 #ifndef ZSTD_MAXWINDOWSIZE_DEFAULT
-#  define ZSTD_MAXWINDOWSIZE_DEFAULT (((U32)1 << ZSTD_WINDOWLOG_DEFAULTMAX) + 1)
+#  define ZSTD_MAXWINDOWSIZE_DEFAULT (((U32)1 << ZSTD_WINDOWLOG_LIMIT_DEFAULT) + 1)
 #endif
 
 /*!
@@ -1233,20 +1233,6 @@ size_t ZSTD_resetDStream(ZSTD_DStream* dctx)
     return ZSTD_FRAMEHEADERSIZE_PREFIX;
 }
 
-size_t ZSTD_setDStreamParameter(ZSTD_DStream* dctx,
-                                ZSTD_DStreamParameter_e paramType, unsigned paramValue)
-{
-    if (dctx->streamStage != zdss_init) return ERROR(stage_wrong);
-    switch(paramType)
-    {
-        default : return ERROR(parameter_unsupported);
-        case DStream_p_maxWindowSize :
-            DEBUGLOG(4, "setting maxWindowSize = %u KB", paramValue >> 10);
-            dctx->maxWindowSize = paramValue ? paramValue : (U32)(-1);
-            break;
-    }
-    return 0;
-}
 
 size_t ZSTD_DCtx_refDDict(ZSTD_DCtx* dctx, const ZSTD_DDict* ddict)
 {
@@ -1296,7 +1282,7 @@ size_t ZSTD_estimateDStreamSize(size_t windowSize)
 
 size_t ZSTD_estimateDStreamSize_fromFrame(const void* src, size_t srcSize)
 {
-    U32 const windowSizeMax = 1U << ZSTD_WINDOWLOG_MAX;   /* note : should be user-selectable */
+    U32 const windowSizeMax = 1U << ZSTD_WINDOWLOG_MAX;   /* note : should be user-selectable, but requires an additional parameter (or a dctx) */
     ZSTD_frameHeader zfh;
     size_t const err = ZSTD_getFrameHeader(&zfh, src, srcSize);
     if (ZSTD_isError(err)) return err;

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1269,11 +1269,8 @@ ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam)
             bounds.upperBound = (int)ZSTD_f_zstd1_magicless;
             ZSTD_STATIC_ASSERT(ZSTD_f_zstd1 < ZSTD_f_zstd1_magicless);
             return bounds;
-        default:
-            bounds.error = ERROR(parameter_unsupported);
-            return bounds;
+        default:;
     }
-    assert(0);
     bounds.error = ERROR(parameter_unsupported);
     return bounds;
 }
@@ -1307,10 +1304,8 @@ size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter dParam, int value
             CHECK_DBOUNDS(ZSTD_d_format, value);
             dctx->format = (ZSTD_format_e)value;
             return 0;
-        default:
-            return ERROR(parameter_unsupported);
+        default:;
     }
-    assert(0);  /* should be unreachable */
     return ERROR(parameter_unsupported);
 }
 

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1241,19 +1241,24 @@ size_t ZSTD_DCtx_refDDict(ZSTD_DCtx* dctx, const ZSTD_DDict* ddict)
     return 0;
 }
 
+/* ZSTD_DCtx_setMaxWindowSize() :
+ * note : no direct equivalence in ZSTD_DCtx_setParameter,
+ * since this version sets windowSize, and the other sets windowLog */
 size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize)
 {
+    ZSTD_bounds const bounds = ZSTD_dParam_getBounds(ZSTD_d_windowLogMax);
+    size_t const min = (size_t)1 << bounds.lowerBound;
+    size_t const max = (size_t)1 << bounds.upperBound;
     if (dctx->streamStage != zdss_init) return ERROR(stage_wrong);
+    if (maxWindowSize < min) return ERROR(parameter_outOfBound);
+    if (maxWindowSize > max) return ERROR(parameter_outOfBound);
     dctx->maxWindowSize = maxWindowSize;
     return 0;
 }
 
 size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format)
 {
-    DEBUGLOG(4, "ZSTD_DCtx_setFormat : %u", (unsigned)format);
-    if (dctx->streamStage != zdss_init) return ERROR(stage_wrong);
-    dctx->format = format;
-    return 0;
+    return ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, format);
 }
 
 ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam)

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1585,7 +1585,7 @@ size_t ZSTD_decompress_generic_simpleArgs (
     return cErr;
 }
 
-size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_reset_directive reset)
+size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_ResetDirective reset)
 {
     if ( (reset == ZSTD_reset_session_only)
       || (reset == ZSTD_reset_session_and_parameters) ) {

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -42,7 +42,7 @@
 
 /*!
  *  NO_FORWARD_PROGRESS_MAX :
- *  maximum allowed nb of calls to ZSTD_decompressStream() and ZSTD_decompress_generic()
+ *  maximum allowed nb of calls to ZSTD_decompressStream()
  *  without any forward progress
  *  (defined as: no byte read from input, and no byte flushed to output)
  *  before triggering an error.
@@ -1565,13 +1565,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
     }
 }
 
-
-size_t ZSTD_decompress_generic(ZSTD_DCtx* dctx, ZSTD_outBuffer* output, ZSTD_inBuffer* input)
-{
-    return ZSTD_decompressStream(dctx, output, input);
-}
-
-size_t ZSTD_decompress_generic_simpleArgs (
+size_t ZSTD_decompressStream_simpleArgs (
                             ZSTD_DCtx* dctx,
                             void* dst, size_t dstCapacity, size_t* dstPos,
                       const void* src, size_t srcSize, size_t* srcPos)
@@ -1579,11 +1573,12 @@ size_t ZSTD_decompress_generic_simpleArgs (
     ZSTD_outBuffer output = { dst, dstCapacity, *dstPos };
     ZSTD_inBuffer  input  = { src, srcSize, *srcPos };
     /* ZSTD_compress_generic() will check validity of dstPos and srcPos */
-    size_t const cErr = ZSTD_decompress_generic(dctx, &output, &input);
+    size_t const cErr = ZSTD_decompressStream(dctx, &output, &input);
     *dstPos = output.pos;
     *srcPos = input.pos;
     return cErr;
 }
+
 
 size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_ResetDirective reset)
 {

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1301,7 +1301,7 @@ size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter dParam, int value
     switch(dParam) {
         case ZSTD_d_windowLogMax:
             CHECK_DBOUNDS(ZSTD_d_windowLogMax, value);
-            dctx->maxWindowSize = 1 << value;
+            dctx->maxWindowSize = ((size_t)1) << value;
             return 0;
         case ZSTD_d_format:
             CHECK_DBOUNDS(ZSTD_d_format, value);

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1585,9 +1585,18 @@ size_t ZSTD_decompress_generic_simpleArgs (
     return cErr;
 }
 
-void ZSTD_DCtx_reset(ZSTD_DCtx* dctx)
+size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_reset_directive reset)
 {
-    (void)ZSTD_initDStream(dctx);
-    dctx->format = ZSTD_f_zstd1;
-    dctx->maxWindowSize = ZSTD_MAXWINDOWSIZE_DEFAULT;
+    if ( (reset == ZSTD_reset_session_only)
+      || (reset == ZSTD_reset_session_and_parameters) ) {
+        (void)ZSTD_initDStream(dctx);
+    }
+    if ( (reset == ZSTD_reset_parameters)
+      || (reset == ZSTD_reset_session_and_parameters) ) {
+        if (dctx->streamStage != zdss_init)
+            return ERROR(stage_wrong);
+        dctx->format = ZSTD_f_zstd1;
+        dctx->maxWindowSize = ZSTD_MAXWINDOWSIZE_DEFAULT;
+    }
+    return 0;
 }

--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -255,7 +255,7 @@ static dictItem ZDICT_analyzePos(
     }
 
     {   int i;
-        U32 searchLength;
+        U32 mml;
         U32 refinedStart = start;
         U32 refinedEnd = end;
 
@@ -263,7 +263,7 @@ static dictItem ZDICT_analyzePos(
         DISPLAYLEVEL(4, "found %3u matches of length >= %i at pos %7u  ", (U32)(end-start), MINMATCHLENGTH, (U32)pos);
         DISPLAYLEVEL(4, "\n");
 
-        for (searchLength = MINMATCHLENGTH ; ; searchLength++) {
+        for (mml = MINMATCHLENGTH ; ; mml++) {
             BYTE currentChar = 0;
             U32 currentCount = 0;
             U32 currentID = refinedStart;
@@ -271,13 +271,13 @@ static dictItem ZDICT_analyzePos(
             U32 selectedCount = 0;
             U32 selectedID = currentID;
             for (id =refinedStart; id < refinedEnd; id++) {
-                if (b[suffix[id] + searchLength] != currentChar) {
+                if (b[suffix[id] + mml] != currentChar) {
                     if (currentCount > selectedCount) {
                         selectedCount = currentCount;
                         selectedID = currentID;
                     }
                     currentID = id;
-                    currentChar = b[ suffix[id] + searchLength];
+                    currentChar = b[ suffix[id] + mml];
                     currentCount = 0;
                 }
                 currentCount ++;

--- a/lib/dll/libzstd.def
+++ b/lib/dll/libzstd.def
@@ -78,7 +78,6 @@ EXPORTS
     ZSTD_nextSrcSizeToDecompress
     ZSTD_resetCStream
     ZSTD_resetDStream
-    ZSTD_setDStreamParameter
     ZSTD_sizeof_CCtx
     ZSTD_sizeof_CDict
     ZSTD_sizeof_CStream

--- a/lib/legacy/zstd_v04.c
+++ b/lib/legacy/zstd_v04.c
@@ -240,17 +240,7 @@ MEM_STATIC size_t MEM_readLEST(const void* memPtr)
 /* *************************************
 *  Types
 ***************************************/
-#define ZSTD_WINDOWLOG_MAX 26
-#define ZSTD_WINDOWLOG_MIN 18
 #define ZSTD_WINDOWLOG_ABSOLUTEMIN 11
-#define ZSTD_CONTENTLOG_MAX (ZSTD_WINDOWLOG_MAX+1)
-#define ZSTD_CONTENTLOG_MIN 4
-#define ZSTD_HASHLOG_MAX 28
-#define ZSTD_HASHLOG_MIN 4
-#define ZSTD_SEARCHLOG_MAX (ZSTD_CONTENTLOG_MAX-1)
-#define ZSTD_SEARCHLOG_MIN 1
-#define ZSTD_SEARCHLENGTH_MAX 7
-#define ZSTD_SEARCHLENGTH_MIN 4
 
 /** from faster to stronger */
 typedef enum { ZSTD_fast, ZSTD_greedy, ZSTD_lazy, ZSTD_lazy2, ZSTD_btlazy2 } ZSTD_strategy;

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -168,7 +168,7 @@ ZSTDLIB_API size_t     ZSTD_freeCCtx(ZSTD_CCtx* cctx);
 
 /*! ZSTD_compressCCtx() :
  *  Same as ZSTD_compress(), requires an allocated ZSTD_CCtx (see ZSTD_createCCtx()). */
-ZSTDLIB_API size_t ZSTD_compressCCtx(ZSTD_CCtx* ctx,
+ZSTDLIB_API size_t ZSTD_compressCCtx(ZSTD_CCtx* cctx,
                                      void* dst, size_t dstCapacity,
                                const void* src, size_t srcSize,
                                      int compressionLevel);
@@ -184,8 +184,11 @@ ZSTDLIB_API ZSTD_DCtx* ZSTD_createDCtx(void);
 ZSTDLIB_API size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
 
 /*! ZSTD_decompressDCtx() :
- *  Same as ZSTD_decompress(), requires an allocated ZSTD_DCtx (see ZSTD_createDCtx()) */
-ZSTDLIB_API size_t ZSTD_decompressDCtx(ZSTD_DCtx* ctx,
+ *  Same as ZSTD_decompress(),
+ *  requires an allocated ZSTD_DCtx.
+ *  Compatible with sticky parameters.
+ */
+ZSTDLIB_API size_t ZSTD_decompressDCtx(ZSTD_DCtx* dctx,
                                        void* dst, size_t dstCapacity,
                                  const void* src, size_t srcSize);
 
@@ -799,11 +802,11 @@ ZSTDLIB_API size_t ZSTD_compressStream2( ZSTD_CCtx* cctx,
 /* ============================== */
 
 /* The advanced API pushes parameters one by one into an existing DCtx context.
- * Parameters are "sticky, and remain valid for all futures decompression jobs
- * started with the same DCtx context.
+ * Parameters are sticky, and remain valid for all following decompression jobs
+ * using the same DCtx context.
  * It's possible to reset parameters to default values using ZSTD_DCtx_reset().
- * Note : No new decompression function is provided,
- * use existing ZSTD_decompressDCtx() and ZSTD_decompressStream().
+ * Note : This API is compatible with existing ZSTD_decompressDCtx() and ZSTD_decompressStream().
+ *        Therefore, no new decompression function is necessary.
  */
 
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -510,23 +510,23 @@ typedef enum { ZSTD_fast=1,
 typedef enum {
 
     /* compression parameters */
-    ZSTD_p_compressionLevel=100, /* Update all compression parameters according to pre-defined cLevel table
+    ZSTD_c_compressionLevel=100, /* Update all compression parameters according to pre-defined cLevel table
                               * Default level is ZSTD_CLEVEL_DEFAULT==3.
                               * Special: value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT.
                               * Note 1 : it's possible to pass a negative compression level.
                               * Note 2 : setting a level sets all default values of other compression parameters */
-    ZSTD_p_windowLog=101,    /* Maximum allowed back-reference distance, expressed as power of 2.
+    ZSTD_c_windowLog=101,    /* Maximum allowed back-reference distance, expressed as power of 2.
                               * Must be clamped between ZSTD_WINDOWLOG_MIN and ZSTD_WINDOWLOG_MAX.
                               * Special: value 0 means "use default windowLog".
                               * Note: Using a window size greater than 1<<ZSTD_WINDOWLOG_LIMIT_DEFAULT
                               *       requires explicitly allowing such window size during decompression stage if using streaming. */
-    ZSTD_p_hashLog=102,      /* Size of the initial probe table, as a power of 2.
+    ZSTD_c_hashLog=102,      /* Size of the initial probe table, as a power of 2.
                               * Resulting memory usage is (1 << (hashLog+2)).
                               * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX.
                               * Larger tables improve compression ratio of strategies <= dFast,
                               * and improve speed of strategies > dFast.
                               * Special: value 0 means "use default hashLog". */
-    ZSTD_p_chainLog=103,     /* Size of the multi-probe search table, as a power of 2.
+    ZSTD_c_chainLog=103,     /* Size of the multi-probe search table, as a power of 2.
                               * Resulting memory usage is (1 << (chainLog+2)).
                               * Must be clamped between ZSTD_CHAINLOG_MIN and ZSTD_CHAINLOG_MAX.
                               * Larger tables result in better and slower compression.
@@ -534,11 +534,11 @@ typedef enum {
                               * It's still useful when using "dfast" strategy,
                               * in which case it defines a secondary probe table.
                               * Special: value 0 means "use default chainLog". */
-    ZSTD_p_searchLog=104,    /* Number of search attempts, as a power of 2.
+    ZSTD_c_searchLog=104,    /* Number of search attempts, as a power of 2.
                               * More attempts result in better and slower compression.
                               * This parameter is useless when using "fast" and "dFast" strategies.
                               * Special: value 0 means "use default searchLog". */
-    ZSTD_p_minMatch=105,     /* Minimum size of searched matches.
+    ZSTD_c_minMatch=105,     /* Minimum size of searched matches.
                               * Note that Zstandard can still find matches of smaller size,
                               * it just tweaks its search algorithm to look for this size and larger.
                               * Larger values increase compression and decompression speed, but decrease ratio.
@@ -546,7 +546,7 @@ typedef enum {
                               * Note that currently, for all strategies < btopt, effective minimum is 4.
                               *                    , for all strategies > fast, effective maximum is 6.
                               * Special: value 0 means "use default minMatchLength". */
-    ZSTD_p_targetLength=106, /* Impact of this field depends on strategy.
+    ZSTD_c_targetLength=106, /* Impact of this field depends on strategy.
                               * For strategies btopt & btultra:
                               *     Length of Match considered "good enough" to stop search.
                               *     Larger values make compression stronger, and slower.
@@ -554,33 +554,33 @@ typedef enum {
                               *     Distance between match sampling.
                               *     Larger values make compression faster, and weaker.
                               * Special: value 0 means "use default targetLength". */
-    ZSTD_p_compressionStrategy=107, /* See ZSTD_strategy enum definition.
+    ZSTD_c_compressionStrategy=107, /* See ZSTD_strategy enum definition.
                               * The higher the value of selected strategy, the more complex it is,
                               * resulting in stronger and slower compression.
                               * Special: value 0 means "use default strategy". */
 
     /* LDM mode parameters */
-    ZSTD_p_enableLongDistanceMatching=160, /* Enable long distance matching.
+    ZSTD_c_enableLongDistanceMatching=160, /* Enable long distance matching.
                                      * This parameter is designed to improve compression ratio
                                      * for large inputs, by finding large matches at long distance.
                                      * It increases memory usage and window size.
-                                     * Note: enabling this parameter increases default ZSTD_p_windowLog to 128 MB
+                                     * Note: enabling this parameter increases default ZSTD_c_windowLog to 128 MB
                                      * except when expressly set to a different value. */
-    ZSTD_p_ldmHashLog=161,   /* Size of the table for long distance matching, as a power of 2.
+    ZSTD_c_ldmHashLog=161,   /* Size of the table for long distance matching, as a power of 2.
                               * Larger values increase memory usage and compression ratio,
                               * but decrease compression speed.
                               * Must be clamped between ZSTD_HASHLOG_MIN and ZSTD_HASHLOG_MAX
                               * default: windowlog - 7.
                               * Special: value 0 means "automatically determine hashlog". */
-    ZSTD_p_ldmMinMatch=162,  /* Minimum match size for long distance matcher.
+    ZSTD_c_ldmMinMatch=162,  /* Minimum match size for long distance matcher.
                               * Larger/too small values usually decrease compression ratio.
                               * Must be clamped between ZSTD_LDM_MINMATCH_MIN and ZSTD_LDM_MINMATCH_MAX.
                               * Special: value 0 means "use default value" (default: 64). */
-    ZSTD_p_ldmBucketSizeLog=163, /* Log size of each bucket in the LDM hash table for collision resolution.
+    ZSTD_c_ldmBucketSizeLog=163, /* Log size of each bucket in the LDM hash table for collision resolution.
                               * Larger values improve collision resolution but decrease compression speed.
                               * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX.
                               * Special: value 0 means "use default value" (default: 3). */
-    ZSTD_p_ldmHashRateLog=164, /* Frequency of inserting/looking up entries into the LDM hash table.
+    ZSTD_c_ldmHashRateLog=164, /* Frequency of inserting/looking up entries into the LDM hash table.
                               * Must be clamped between 0 and (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN).
                               * Default is MAX(0, (windowLog - ldmHashLog)), optimizing hash table usage.
                               * Larger values improve compression speed.
@@ -588,16 +588,16 @@ typedef enum {
                               * Special: value 0 means "automatically determine hashRateLog". */
 
     /* frame parameters */
-    ZSTD_p_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)
+    ZSTD_c_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)
                               * Content size must be known at the beginning of compression,
                               * it is provided using ZSTD_CCtx_setPledgedSrcSize() */
-    ZSTD_p_checksumFlag=201, /* A 32-bits checksum of content is written at end of frame (default:0) */
-    ZSTD_p_dictIDFlag=202,   /* When applicable, dictionary's ID is written into frame header (default:1) */
+    ZSTD_c_checksumFlag=201, /* A 32-bits checksum of content is written at end of frame (default:0) */
+    ZSTD_c_dictIDFlag=202,   /* When applicable, dictionary's ID is written into frame header (default:1) */
 
     /* multi-threading parameters */
     /* These parameters are only useful if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).
      * They return an error otherwise. */
-    ZSTD_p_nbWorkers=400,    /* Select how many threads will be spawned to compress in parallel.
+    ZSTD_c_nbWorkers=400,    /* Select how many threads will be spawned to compress in parallel.
                               * When nbWorkers >= 1, triggers asynchronous mode when used with ZSTD_compressStream*() :
                               * ZSTD_compressStream*() consumes input and flush output if possible, but immediately gives back control to caller,
                               * while compression work is performed in parallel, within worker threads.
@@ -605,12 +605,12 @@ typedef enum {
                               *  in which case, ZSTD_compressStream2() delegates to ZSTD_compress2(), which is always a blocking call).
                               * More workers improve speed, but also increase memory usage.
                               * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
-    ZSTD_p_jobSize=401,      /* Size of a compression job. This value is enforced only when nbWorkers >= 1.
+    ZSTD_c_jobSize=401,      /* Size of a compression job. This value is enforced only when nbWorkers >= 1.
                               * Each compression job is completed in parallel, so this value can indirectly impact the nb of active threads.
                               * 0 means default, which is dynamically determined based on compression parameters.
                               * Job size must be a minimum of overlapSize, or 1 MB, whichever is largest.
                               * The minimum size is automatically and transparently enforced */
-    ZSTD_p_overlapSizeLog=402, /* Size of previous job reloaded at the beginning of each job, as a fraction of window size.
+    ZSTD_c_overlapSizeLog=402, /* Size of previous job reloaded at the beginning of each job, as a fraction of window size.
                               * This value is enforced only when nbWorkers >= 1.
                               * Larger values increase compression ratio, but decrease speed.
                               * Values range from 0 (no overlap) to 9 (overlap a full windowSize).
@@ -621,17 +621,17 @@ typedef enum {
     /* note : additional experimental parameters are also available
      * within the experimental section of the API.
      * At the time of this writing, they include :
-     * ZSTD_p_rsyncable
-     * ZSTD_p_format
-     * ZSTD_p_forceMaxWindow
-     * ZSTD_p_forceAttachDict
+     * ZSTD_c_rsyncable
+     * ZSTD_c_format
+     * ZSTD_c_forceMaxWindow
+     * ZSTD_c_forceAttachDict
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
-     ZSTD_p_experimentalParam1=500,
-     ZSTD_p_experimentalParam2=10,
-     ZSTD_p_experimentalParam3=1000,
-     ZSTD_p_experimentalParam4
+     ZSTD_c_experimentalParam1=500,
+     ZSTD_c_experimentalParam2=10,
+     ZSTD_c_experimentalParam3=1000,
+     ZSTD_c_experimentalParam4
 } ZSTD_cParameter;
 
 
@@ -720,7 +720,7 @@ ZSTDLIB_API size_t ZSTD_CCtx_refCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict);
  *           Its content must remain unmodified during compression.
  *  Note 2 : If the intention is to diff some large src data blob with some prior version of itself,
  *           ensure that the window size is large enough to contain the entire source.
- *           See ZSTD_p_windowLog.
+ *           See ZSTD_c_windowLog.
  *  Note 3 : Referencing a prefix involves building tables, which are dependent on compression parameters.
  *           It's a CPU consuming operation, with non-negligible impact on latency.
  *           If there is a need to use the same prefix multiple times, consider loadDictionary instead.
@@ -829,7 +829,7 @@ typedef enum {
     /* note : additional experimental parameters are also available
      * within the experimental section of the API.
      * At the time of this writing, they include :
-     * ZSTD_p_format
+     * ZSTD_c_format
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
@@ -1095,7 +1095,7 @@ ZSTDLIB_API size_t ZSTD_frameHeaderSize(const void* src, size_t srcSize);
  *  It will also consider src size to be arbitrarily "large", which is worst case.
  *  If srcSize is known to always be small, ZSTD_estimateCCtxSize_usingCParams() can provide a tighter estimation.
  *  ZSTD_estimateCCtxSize_usingCParams() can be used in tandem with ZSTD_getCParams() to create cParams from compressionLevel.
- *  ZSTD_estimateCCtxSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_p_nbWorkers is >= 1.
+ *  ZSTD_estimateCCtxSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_c_nbWorkers is >= 1.
  *  Note : CCtx size estimation is only correct for single-threaded compression. */
 ZSTDLIB_API size_t ZSTD_estimateCCtxSize(int compressionLevel);
 ZSTDLIB_API size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters cParams);
@@ -1107,7 +1107,7 @@ ZSTDLIB_API size_t ZSTD_estimateDCtxSize(void);
  *  It will also consider src size to be arbitrarily "large", which is worst case.
  *  If srcSize is known to always be small, ZSTD_estimateCStreamSize_usingCParams() can provide a tighter estimation.
  *  ZSTD_estimateCStreamSize_usingCParams() can be used in tandem with ZSTD_getCParams() to create cParams from compressionLevel.
- *  ZSTD_estimateCStreamSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_p_nbWorkers is >= 1.
+ *  ZSTD_estimateCStreamSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParam_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_c_nbWorkers is >= 1.
  *  Note : CStream size estimation is only correct for single-threaded compression.
  *  ZSTD_DStream memory budget depends on window Size.
  *  This information can be passed manually, using ZSTD_estimateDStreamSize,
@@ -1269,7 +1269,7 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
  /* Enables rsyncable mode,
   * which makes compressed files more rsync friendly
   * by adding periodic synchronization points to the compressed data.
-  * The target average block size is ZSTD_p_jobSize / 2.
+  * The target average block size is ZSTD_c_jobSize / 2.
   * It's possible to modify the job size to increase or decrease
   * the granularity of the synchronization point.
   * Once the jobSize is smaller than the window size,
@@ -1282,22 +1282,22 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
   * If the selected compression level is already running significantly slower,
   * the overall speed won't be significantly impacted.
   */
- #define ZSTD_p_rsyncable ZSTD_p_experimentalParam1
+ #define ZSTD_c_rsyncable ZSTD_c_experimentalParam1
 
 /* Select a compression format.
  * The value must be of type ZSTD_format_e.
  * See ZSTD_format_e enum definition for details */
-#define ZSTD_p_format ZSTD_p_experimentalParam2
+#define ZSTD_c_format ZSTD_c_experimentalParam2
 
 /* Force back-reference distances to remain < windowSize,
  * even when referencing into Dictionary content (default:0) */
-#define ZSTD_p_forceMaxWindow ZSTD_p_experimentalParam3
+#define ZSTD_c_forceMaxWindow ZSTD_c_experimentalParam3
 
 /* Controls whether the contents of a CDict
  * are used in place, or copied into the working context.
  * Accepts values from the ZSTD_dictAttachPref_e enum.
  * See the comments on that enum for an explanation of the feature. */
-#define ZSTD_p_forceAttachDict ZSTD_p_experimentalParam4
+#define ZSTD_c_forceAttachDict ZSTD_c_experimentalParam4
 
 /*! ZSTD_CCtx_getParameter() :
  * Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -408,13 +408,25 @@ ZSTDLIB_API size_t ZSTD_DStreamOutSize(void);   /*!< recommended size for output
 /****************************************************************************************
  *   Candidate API for promotion to stable status
  ****************************************************************************************
- * The following symbols and constants are in "staging area" :
+ * The following symbols and constants belong to the "staging area" :
  * they are considered to join "stable API" status by v1.4.0.
- * The below proposal is created so that it's possible to make it stable "as is".
- * That being said, it's still possible to suggest modifications.
+ * The below proposal is written so that it can become stable "as is".
+ * It's still possible to suggest modifications.
  * Staging is in fact last chance for changes,
- * because the API is locked once reaching "stable" status.
+ * the API is locked once reaching "stable" status.
  * ***************************************************************************************/
+
+
+ /* ===  Constants   === */
+
+ /* all magic numbers are supposed read/written to/from files/memory using little-endian convention */
+ #define ZSTD_MAGICNUMBER            0xFD2FB528    /* valid since v0.8.0 */
+ #define ZSTD_MAGIC_DICTIONARY       0xEC30A437    /* valid since v0.7.0 */
+ #define ZSTD_MAGIC_SKIPPABLE_START  0x184D2A50    /* all 16 values, from 0x184D2A50 to 0x184D2A5F, signal the beginning of a skippable frame */
+ #define ZSTD_MAGIC_SKIPPABLE_MASK   0xFFFFFFF0
+
+ #define ZSTD_BLOCKSIZELOG_MAX  17
+ #define ZSTD_BLOCKSIZE_MAX     (1<<ZSTD_BLOCKSIZELOG_MAX)
 
 
 /* ===   query limits   === */
@@ -422,22 +434,18 @@ ZSTDLIB_API size_t ZSTD_DStreamOutSize(void);   /*!< recommended size for output
 ZSTDLIB_API int ZSTD_minCLevel(void);  /*!< minimum negative compression level allowed */
 
 
+/* ===   frame size   === */
 
-/* ---  Constants  ---*/
-
-/* all magic numbers are supposed read/written to/from files/memory using little-endian convention */
-#define ZSTD_MAGICNUMBER            0xFD2FB528    /* valid since v0.8.0 */
-#define ZSTD_MAGIC_DICTIONARY       0xEC30A437    /* valid since v0.7.0 */
-#define ZSTD_MAGIC_SKIPPABLE_START  0x184D2A50    /* all 16 values, from 0x184D2A50 to 0x184D2A5F, signal the beginning of a skippable frame */
-#define ZSTD_MAGIC_SKIPPABLE_MASK   0xFFFFFFF0
-
-#define ZSTD_BLOCKSIZELOG_MAX 17
-#define ZSTD_BLOCKSIZE_MAX   (1<<ZSTD_BLOCKSIZELOG_MAX)
+/*! ZSTD_findFrameCompressedSize() :
+ * `src` should point to the start of a ZSTD frame or skippable frame.
+ * `srcSize` must be >= first frame size
+ * @return : the compressed size of the first frame starting at `src`,
+ *           suitable to pass to `ZSTD_decompress` or similar,
+ *           or an error code if input is invalid */
+ZSTDLIB_API size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
 
 
-/***************************************
-*  Memory management
-***************************************/
+/* ===   Memory management   === */
 
 /*! ZSTD_sizeof_*() :
  *  These functions give the current memory usage of selected object.
@@ -881,9 +889,10 @@ ZSTDLIB_API size_t ZSTD_decompress_generic(ZSTD_DCtx* dctx,
  *   experimental API (static linking only)
  ****************************************************************************************
  * The following symbols and constants
- * are not planned to join "stable API" status anytime soon.
+ * are not planned to join "stable API" status in the near future.
+ * They can still change in future versions.
  * Some of them are planned to remain in the static_only section indefinitely.
- * Some of them might even be removed in the future (especially when redundant with existing stable functions)
+ * Some of them might be removed in the future (especially when redundant with existing stable functions)
  * ***************************************************************************************/
 
 #define ZSTD_FRAMEHEADERSIZE_PREFIX 5   /* minimum input size required to query frame header size */
@@ -1021,14 +1030,6 @@ typedef enum {
 /***************************************
 *  Frame size functions
 ***************************************/
-
-/*! ZSTD_findFrameCompressedSize() :
- *  `src` should point to the start of a ZSTD encoded frame or skippable frame
- *  `srcSize` must be >= first frame size
- *  @return : the compressed size of the first frame starting at `src`,
- *            suitable to pass to `ZSTD_decompress` or similar,
- *            or an error code if input is invalid */
-ZSTDLIB_API size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize);
 
 /*! ZSTD_findDecompressedSize() :
  *  `src` should point the start of a series of ZSTD encoded and/or skippable frames

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -620,12 +620,13 @@ typedef enum {
      * ZSTD_c_forceMaxWindow
      * ZSTD_c_forceAttachDict
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
-     * note : never ever use experimentalParam? names directly
+     * note : never ever use experimentalParam? names directly;
+     *        also, the enums values themselves are unstable and can still change.
      */
      ZSTD_c_experimentalParam1=500,
      ZSTD_c_experimentalParam2=10,
      ZSTD_c_experimentalParam3=1000,
-     ZSTD_c_experimentalParam4
+     ZSTD_c_experimentalParam4=1001
 } ZSTD_cParameter;
 
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -750,6 +750,8 @@ ZSTDLIB_API size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_ResetDirective reset);
 
 /*! ZSTD_compress2() :
  *  Behave the same as ZSTD_compressCCtx(), but compression parameters are set using the advanced API.
+ *  ZSTD_compress2() always starts a new frame.
+ *  Should cctx hold data from a previously unfinished frame, everything about it is forgotten.
  *  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()
  *  - The function is always blocking, returns when compression is completed.
  *  Hint : compression runs faster if `dstCapacity` >=  `ZSTD_compressBound(srcSize)`.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -438,12 +438,6 @@ ZSTDLIB_API size_t ZSTD_DStreamOutSize(void);   /*!< recommended size for output
 #define ZSTD_BLOCKSIZELOG_MAX  17
 #define ZSTD_BLOCKSIZE_MAX     (1<<ZSTD_BLOCKSIZELOG_MAX)
 
-#define ZSTD_WINDOWLOG_LIMIT_DEFAULT 27   /* by default, the streaming decoder will refuse any frame
-                                           * requiring larger than (1<<ZSTD_WINDOWLOG_LIMIT_DEFAULT) window size,
-                                           * to preserve memory from unreasonable requirements.
-                                           * This limit can be overriden using ZSTD_DCtx_setParameter().
-                                           * This limit does not apply to one-pass decoders (such as ZSTD_decompress()), since no additional memory is allocated */
-
 
 /* ===   query limits   === */
 
@@ -950,6 +944,12 @@ ZSTDLIB_API size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_ResetDirective reset);
 #define ZSTD_OVERLAPLOG_MIN       0
 #define ZSTD_OVERLAPLOG_MAX       9
 
+#define ZSTD_WINDOWLOG_LIMIT_DEFAULT 27   /* by default, the streaming decoder will refuse any frame
+                                           * requiring larger than (1<<ZSTD_WINDOWLOG_LIMIT_DEFAULT) window size,
+                                           * to preserve host's memory from unreasonable requirements.
+                                           * This limit can be overriden using ZSTD_DCtx_setParameter(,ZSTD_d_windowLogMax,).
+                                           * The limit does not apply for one-pass decoders (such as ZSTD_decompress()), since no additional memory is allocated */
+
 
 /* LDM parameter bounds */
 #define ZSTD_LDM_HASHLOG_MIN      ZSTD_HASHLOG_MIN
@@ -1300,8 +1300,9 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
 #define ZSTD_c_forceAttachDict ZSTD_c_experimentalParam4
 
 /*! ZSTD_CCtx_getParameter() :
- * Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
- * @result : 0, or an error code (which can be tested with ZSTD_isError()).
+ *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,
+ *  and store it into int* value.
+ * @return : 0, or an error code (which can be tested with ZSTD_isError()).
  */
 ZSTDLIB_API size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int* value);
 
@@ -1321,7 +1322,7 @@ ZSTDLIB_API size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param
  *  - ZSTD_freeCCtxParams() : Free the memory.
  *
  *  This can be used with ZSTD_estimateCCtxSize_advanced_usingCCtxParams()
- *  for static allocation for single-threaded compression.
+ *  for static allocation of CCtx for single-threaded compression.
  */
 ZSTDLIB_API ZSTD_CCtx_params* ZSTD_createCCtxParams(void);
 ZSTDLIB_API size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -600,48 +600,20 @@ typedef enum {
                               * 9: full window;  8: w/2;  7: w/4;  6: w/8;  5:w/16;  4: w/32;  3:w/64;  2:w/128;  1:w/256;
                               * default value is 6 : use 1/8th of windowSize */
 
-    /* =================================================================== */
-    /* experimental parameters - no stability guaranteed                   */
-    /* => note : should this part be exported in a different section of zstd.h ? */
-    /* =================================================================== */
-
-    /* compression format */
-    ZSTD_p_format = 10,      /* See ZSTD_format_e enum definition.
-                              * Cast selected format as unsigned for ZSTD_CCtx_setParameter() compatibility. */
-
-    ZSTD_p_forceMaxWindow=1100, /* Force back-reference distances to remain < windowSize,
-                              * even when referencing into Dictionary content (default:0) */
-    ZSTD_p_forceAttachDict,  /* Controls whether the contents of a CDict are
-                              * used in place, or whether they are copied into
-                              * the working context.
-                              *
-                              * Accepts values from the ZSTD_dictAttachPref_e
-                              * enum. See the comments on that enum for an
-                              * explanation of the feature.
-                              */
-
-    /* Question : should rsyncable remain experimental, or be part of candidate for stable ? */
-    ZSTD_p_rsyncable,        /* Enables rsyncable mode, which makes compressed
-                              * files more rsync friendly by adding periodic
-                              * synchronization points to the compressed data.
-                              * The target average block size is
-                              * ZSTD_p_jobSize / 2. You can modify the job size
-                              * to increase or decrease the granularity of the
-                              * synchronization point. Once the jobSize is
-                              * smaller than the window size, you will start to
-                              * see degraded compression ratio.
-                              * NOTE: This only works when multithreading is
-                              * enabled.
-                              * NOTE: You probably don't want to use this with
-                              * long range mode, since that will decrease the
-                              * effectiveness of the synchronization points,
-                              * but your milage may vary.
-                              * NOTE: Rsyncable mode will limit the maximum
-                              * compression speed to approximately 400 MB/s.
-                              * If your compression level is already running
-                              * significantly slower than that (< 200 MB/s),
-                              * the speed won't be significantly impacted.
-                              */
+    /* note : additional experimental parameters are also available
+     * within the experimental section of the API.
+     * At the time of this writing, they include :
+     * ZSTD_p_rsyncable
+     * ZSTD_p_format
+     * ZSTD_p_forceMaxWindow
+     * ZSTD_p_forceAttachDict
+     * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
+     * note : never use experimentalParam names directly
+     */
+     ZSTD_p_experimentalParam1=500,
+     ZSTD_p_experimentalParam2=10,
+     ZSTD_p_experimentalParam3=1000,
+     ZSTD_p_experimentalParam4
 } ZSTD_cParameter;
 
 
@@ -1237,6 +1209,43 @@ ZSTDLIB_API size_t ZSTD_CCtx_loadDictionary_advanced(ZSTD_CCtx* cctx, const void
  *  Same as ZSTD_CCtx_refPrefix(), but gives finer control over
  *  how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?) */
 ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* prefix, size_t prefixSize, ZSTD_dictContentType_e dictContentType);
+
+/* ===   experimental parameters   === */
+/* these parameters can be used with ZSTD_setParameter()
+ * they are not guaranteed to remain supported in the future */
+
+ /* Enables rsyncable mode,
+  * which makes compressed files more rsync friendly
+  * by adding periodic synchronization points to the compressed data.
+  * The target average block size is ZSTD_p_jobSize / 2.
+  * It's possible to modify the job size to increase or decrease
+  * the granularity of the synchronization point.
+  * Once the jobSize is smaller than the window size,
+  * it will result in compression ratio degradation.
+  * NOTE 1: rsyncable mode only works when multithreading is enabled.
+  * NOTE 2: rsyncable performs poorly in combination with long range mode,
+  * since it will decrease the effectiveness of synchronization points,
+  * though mileage may vary.
+  * NOTE 3: Rsyncable mode limits maximum compression speed to ~400 MB/s.
+  * If the selected compression level is already running significantly slower,
+  * the overall speed won't be significantly impacted.
+  */
+ #define ZSTD_p_rsyncable ZSTD_p_experimentalParam1
+
+/* Select a compression format.
+ * The value must be of type ZSTD_format_e.
+ * See ZSTD_format_e enum definition for details */
+#define ZSTD_p_format ZSTD_p_experimentalParam2
+
+/* Force back-reference distances to remain < windowSize,
+ * even when referencing into Dictionary content (default:0) */
+#define ZSTD_p_forceMaxWindow ZSTD_p_experimentalParam3
+
+/* Controls whether the contents of a CDict
+ * are used in place, or copied into the working context.
+ * Accepts values from the ZSTD_dictAttachPref_e enum.
+ * See the comments on that enum for an explanation of the feature. */
+#define ZSTD_p_forceAttachDict ZSTD_p_experimentalParam4
 
 /*! ZSTD_CCtx_getParameter() :
  * Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -392,16 +392,24 @@ ZSTDLIB_API size_t ZSTD_DStreamOutSize(void);   /*!< recommended size for output
 
 
 
-#if defined(ZSTD_STATIC_LINKING_ONLY) && !defined(ZSTD_H_ZSTD_STATIC_LINKING_ONLY)
-#define ZSTD_H_ZSTD_STATIC_LINKING_ONLY
-
 /****************************************************************************************
  *   ADVANCED AND EXPERIMENTAL FUNCTIONS
  ****************************************************************************************
- * The definitions in this section are considered experimental.
- * They should never be used with a dynamic library, as prototypes may change in the future.
+ * The definitions in the following section are considered experimental.
  * They are provided for advanced scenarios.
+ * They should never be used with a dynamic library, as prototypes may change in the future.
  * Use them only in association with static linking.
+ * ***************************************************************************************/
+
+#if defined(ZSTD_STATIC_LINKING_ONLY) && !defined(ZSTD_H_ZSTD_STATIC_LINKING_ONLY)
+#define ZSTD_H_ZSTD_STATIC_LINKING_ONLY
+
+
+/****************************************************************************************
+ *   Candidate API for promotion into stable
+ ****************************************************************************************
+ * The following symbols and constants are considered to join
+ * "stable API" status by v1.4.0
  * ***************************************************************************************/
 
 ZSTDLIB_API int ZSTD_minCLevel(void);  /*!< minimum negative compression level allowed */
@@ -438,11 +446,7 @@ ZSTDLIB_API int ZSTD_minCLevel(void);  /*!< minimum negative compression level a
 #define ZSTD_FRAMEHEADERSIZE_PREFIX 5   /* minimum input size to know frame header size */
 #define ZSTD_FRAMEHEADERSIZE_MIN    6
 #define ZSTD_FRAMEHEADERSIZE_MAX   18   /* for static allocation */
-static const size_t ZSTD_frameHeaderSize_prefix = ZSTD_FRAMEHEADERSIZE_PREFIX;
-static const size_t ZSTD_frameHeaderSize_min = ZSTD_FRAMEHEADERSIZE_MIN;
-static const size_t ZSTD_frameHeaderSize_max = ZSTD_FRAMEHEADERSIZE_MAX;
-static const size_t ZSTD_skippableHeaderSize = 8;  /* magic number + skippable frame length */
-
+#define ZSTD_SKIPPABLEHEADERSIZE    8
 
 
 /* ---  Advanced types  --- */

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -957,9 +957,9 @@ typedef struct {
 } ZSTD_compressionParameters;
 
 typedef struct {
-    unsigned contentSizeFlag; /**< 1: content size will be in frame header (when known) */
-    unsigned checksumFlag;    /**< 1: generate a 32-bits checksum using XXH64 algorithm at end of frame, for error detection */
-    unsigned noDictIDFlag;    /**< 1: no dictID will be saved into frame header (dictID is only useful for dictionary compression) */
+    int contentSizeFlag; /**< 1: content size will be in frame header (when known) */
+    int checksumFlag;    /**< 1: generate a 32-bits checksum using XXH64 algorithm at end of frame, for error detection */
+    int noDictIDFlag;    /**< 1: no dictID will be saved into frame header (dictID is only useful for dictionary compression) */
 } ZSTD_frameParameters;
 
 typedef struct {
@@ -1242,7 +1242,7 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
  * Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
  * @result : 0, or an error code (which can be tested with ZSTD_isError()).
  */
-ZSTDLIB_API size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, unsigned* value);
+ZSTDLIB_API size_t ZSTD_CCtx_getParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int* value);
 
 
 /*! ZSTD_CCtx_params :
@@ -1295,7 +1295,7 @@ ZSTDLIB_API size_t ZSTD_CCtxParam_setParameter(ZSTD_CCtx_params* params, ZSTD_cP
  * Get the requested value of one compression parameter, selected by enum ZSTD_cParameter.
  * @result : 0, or an error code (which can be tested with ZSTD_isError()).
  */
-ZSTDLIB_API size_t ZSTD_CCtxParam_getParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, unsigned* value);
+ZSTDLIB_API size_t ZSTD_CCtxParam_getParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, int* value);
 
 /*! ZSTD_CCtx_setParametersUsingCCtxParams() :
  *  Apply a set of ZSTD_CCtx_params to the compression context.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -729,10 +729,10 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix(ZSTD_CCtx* cctx,
 
 
 typedef enum {
-    ZSTD_CCtx_reset_session_only = 1,
-    ZSTD_CCtx_reset_parameters = 2,
-    ZSTD_CCtx_reset_session_and_parameters = 3
-} ZSTD_CCtx_reset_directive;
+    ZSTD_reset_session_only = 1,
+    ZSTD_reset_parameters = 2,
+    ZSTD_reset_session_and_parameters = 3
+} ZSTD_reset_directive;
 
 /*! ZSTD_CCtx_reset() :
  *  There are 2 different things that can be reset, independently or jointly :
@@ -748,7 +748,7 @@ typedef enum {
  *                  otherwise the reset fails, and function returns an error value (which can be tested using ZSTD_isError())
  *  - Both : similar to resetting the session, followed by resetting parameters.
  */
-ZSTDLIB_API size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_CCtx_reset_directive zcrd);
+ZSTDLIB_API size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_reset_directive reset);
 
 
 
@@ -873,12 +873,11 @@ ZSTDLIB_API size_t ZSTD_DCtx_refPrefix(ZSTD_DCtx* dctx,
 
 /*! ZSTD_DCtx_reset() :
  *  Return a DCtx to clean state.
- *  If a decompression was ongoing, any internal data not yet flushed is cancelled.
- *  All parameters are back to default values, including sticky ones.
- *  Dictionary (if any) is dropped.
- *  Parameters can be modified again after a reset.
+ *  Session and parameters can be reset jointly or separately
+ *  Parameters can only be reset when no active frame is being decompressed.
+ * @return : 0, or an error code, which can be tested with ZSTD_isError()
  */
-ZSTDLIB_API void ZSTD_DCtx_reset(ZSTD_DCtx* dctx);     /* <==== There is a discrepancy with ZSTD_CCtx_reset(): here it necessarily resets everything (context and parameters) */
+ZSTDLIB_API size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_reset_directive reset);
 
 
 /*! ZSTD_decompress_generic() :

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -722,7 +722,7 @@ typedef enum {
     ZSTD_reset_session_only = 1,
     ZSTD_reset_parameters = 2,
     ZSTD_reset_session_and_parameters = 3
-} ZSTD_reset_directive;
+} ZSTD_ResetDirective;
 
 /*! ZSTD_CCtx_reset() :
  *  There are 2 different things that can be reset, independently or jointly :
@@ -738,7 +738,7 @@ typedef enum {
  *                  otherwise the reset fails, and function returns an error value (which can be tested using ZSTD_isError())
  *  - Both : similar to resetting the session, followed by resetting parameters.
  */
-ZSTDLIB_API size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_reset_directive reset);
+ZSTDLIB_API size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_ResetDirective reset);
 
 
 
@@ -853,7 +853,7 @@ ZSTDLIB_API size_t ZSTD_DCtx_refPrefix(ZSTD_DCtx* dctx,
  *  Parameters can only be reset when no active frame is being decompressed.
  * @return : 0, or an error code, which can be tested with ZSTD_isError()
  */
-ZSTDLIB_API size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_reset_directive reset);
+ZSTDLIB_API size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_ResetDirective reset);
 
 
 /*! ZSTD_decompress_generic() :

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -895,22 +895,22 @@ ZSTDLIB_API size_t ZSTD_decompress_generic(ZSTD_DCtx* dctx,
                                            * This limit does not apply to one-pass decoders (such as ZSTD_decompress()), since no additional memory is allocated */
 
 /* compression parameter bounds */
-#define ZSTD_WINDOWLOG_MAX_32   30
-#define ZSTD_WINDOWLOG_MAX_64   31
-#define ZSTD_WINDOWLOG_MAX    ((int)(sizeof(size_t) == 4 ? ZSTD_WINDOWLOG_MAX_32 : ZSTD_WINDOWLOG_MAX_64))
-#define ZSTD_WINDOWLOG_MIN      10
-#define ZSTD_HASHLOG_MAX      ((ZSTD_WINDOWLOG_MAX < 30) ? ZSTD_WINDOWLOG_MAX : 30)
-#define ZSTD_HASHLOG_MIN         6
-#define ZSTD_CHAINLOG_MAX_32    29
-#define ZSTD_CHAINLOG_MAX_64    30
-#define ZSTD_CHAINLOG_MAX     ((int)(sizeof(size_t) == 4 ? ZSTD_CHAINLOG_MAX_32 : ZSTD_CHAINLOG_MAX_64))
-#define ZSTD_CHAINLOG_MIN       ZSTD_HASHLOG_MIN
-#define ZSTD_SEARCHLOG_MAX     (ZSTD_WINDOWLOG_MAX-1)
-#define ZSTD_SEARCHLOG_MIN       1
-#define ZSTD_MINMATCH_MAX        7   /* only for ZSTD_fast, other strategies are limited to 6 */
-#define ZSTD_MINMATCH_MIN        3   /* only for ZSTD_btopt+, faster strategies are limited to 4 */
-#define ZSTD_TARGETLENGTH_MAX   ZSTD_BLOCKSIZE_MAX
-#define ZSTD_TARGETLENGTH_MIN    0   /* note : comparing this constant to an unsigned results in a tautological test */
+#define ZSTD_WINDOWLOG_MAX_32    30
+#define ZSTD_WINDOWLOG_MAX_64    31
+#define ZSTD_WINDOWLOG_MAX     ((int)(sizeof(size_t) == 4 ? ZSTD_WINDOWLOG_MAX_32 : ZSTD_WINDOWLOG_MAX_64))
+#define ZSTD_WINDOWLOG_MIN       10
+#define ZSTD_HASHLOG_MAX       ((ZSTD_WINDOWLOG_MAX < 30) ? ZSTD_WINDOWLOG_MAX : 30)
+#define ZSTD_HASHLOG_MIN          6
+#define ZSTD_CHAINLOG_MAX_32     29
+#define ZSTD_CHAINLOG_MAX_64     30
+#define ZSTD_CHAINLOG_MAX      ((int)(sizeof(size_t) == 4 ? ZSTD_CHAINLOG_MAX_32 : ZSTD_CHAINLOG_MAX_64))
+#define ZSTD_CHAINLOG_MIN        ZSTD_HASHLOG_MIN
+#define ZSTD_SEARCHLOG_MAX      (ZSTD_WINDOWLOG_MAX-1)
+#define ZSTD_SEARCHLOG_MIN        1
+#define ZSTD_MINMATCH_MAX         7   /* only for ZSTD_fast, other strategies are limited to 6 */
+#define ZSTD_MINMATCH_MIN         3   /* only for ZSTD_btopt+, faster strategies are limited to 4 */
+#define ZSTD_TARGETLENGTH_MAX    ZSTD_BLOCKSIZE_MAX
+#define ZSTD_TARGETLENGTH_MIN     0   /* note : comparing this constant to an unsigned results in a tautological test */
 
 /* LDM parameter bounds */
 #define ZSTD_LDM_MINMATCH_MAX   4096
@@ -927,7 +927,7 @@ typedef struct {
     unsigned chainLog;        /**< fully searched segment : larger == more compression, slower, more memory (useless for fast) */
     unsigned hashLog;         /**< dispatch table : larger == faster, more memory */
     unsigned searchLog;       /**< nb of searches : larger == more compression, slower */
-    unsigned minMatch;         /**< match length searched : larger == faster decompression, sometimes less compression */
+    unsigned minMatch;        /**< match length searched : larger == faster decompression, sometimes less compression */
     unsigned targetLength;    /**< acceptable match size for optimal parser (only) : larger == more compression, slower */
     ZSTD_strategy strategy;   /**< see ZSTD_strategy definition above */
 } ZSTD_compressionParameters;

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -640,7 +640,7 @@ typedef struct {
  *  otherwise they will either trigger an error or be automatically clamped.
  * @return : a structure, ZSTD_bounds, which contains
  *         - an error status field, which must be tested using ZSTD_isError()
- *         - both lower and upper bounds, inclusive
+ *         - lower and upper bounds, both inclusive
  */
 ZSTDLIB_API ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter cParam);
 
@@ -834,16 +834,16 @@ typedef enum {
  *         - an error status field, which must be tested using ZSTD_isError()
  *         - both lower and upper bounds, inclusive
  */
-ZSTDLIB_API ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam);    /* not implemented yet */
+ZSTDLIB_API ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam);
 
 /*! ZSTD_DCtx_setParameter() :
  *  Set one compression parameter, selected by enum ZSTD_dParameter.
  *  All parameters have valid bounds. Bounds can be queried using ZSTD_dParam_getBounds().
  *  Providing a value beyond bound will either clamp it, or trigger an error (depending on parameter).
  *  Setting a parameter is only possible during frame initialization (before starting decompression).
- * @return : an error code (which can be tested using ZSTD_isError()).
+ * @return : 0, or an error code (which can be tested using ZSTD_isError()).
  */
-ZSTDLIB_API size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter param, int value);   /* not implemented yet */
+ZSTDLIB_API size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter param, int value);
 
 
 /*! ZSTD_DCtx_loadDictionary() :
@@ -895,7 +895,7 @@ ZSTDLIB_API size_t ZSTD_DCtx_refPrefix(ZSTD_DCtx* dctx,
 
 /*! ZSTD_DCtx_reset() :
  *  Return a DCtx to clean state.
- *  Session and parameters can be reset jointly or separately
+ *  Session and parameters can be reset jointly or separately.
  *  Parameters can only be reset when no active frame is being decompressed.
  * @return : 0, or an error code, which can be tested with ZSTD_isError()
  */
@@ -1003,7 +1003,7 @@ typedef enum {
     ZSTD_f_zstd1 = 0,           /* zstd frame format, specified in zstd_compression_format.md (default) */
     ZSTD_f_zstd1_magicless = 1, /* Variant of zstd frame format, without initial 4-bytes magic number.
                                  * Useful to save 4 bytes per generated frame.
-                                 * Decoder cannot recognise automatically this format, requiring instructions. */
+                                 * Decoder cannot recognise automatically this format, requiring this instruction. */
 } ZSTD_format_e;
 
 typedef enum {
@@ -1439,6 +1439,12 @@ ZSTDLIB_API size_t ZSTD_DCtx_refPrefix_advanced(ZSTD_DCtx* dctx, const void* pre
  * @return : 0, or an error code (which can be tested using ZSTD_isError()).
  */
 ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize);
+
+/* ZSTD_d_format
+ * experimental parameter,
+ * allowing selection between ZSTD_format_e input compression formats
+ */
+#define ZSTD_d_format ZSTD_d_experimentalParam1
 
 /*! ZSTD_DCtx_setFormat() :
  *  Instruct the decoder context about what kind of data to decode next.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -555,12 +555,12 @@ typedef enum {
                               * Larger values improve collision resolution but decrease compression speed.
                               * The maximum value is ZSTD_LDM_BUCKETSIZELOG_MAX.
                               * Special: value 0 means "use default value" (default: 3). */
-    ZSTD_p_ldmHashEveryLog=164, /* Frequency of inserting/looking up entries into the LDM hash table.
+    ZSTD_p_ldmHashRateLog=164, /* Frequency of inserting/looking up entries into the LDM hash table.
                               * Must be clamped between 0 and (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN).
                               * Default is MAX(0, (windowLog - ldmHashLog)), optimizing hash table usage.
                               * Larger values improve compression speed.
                               * Deviating far from default value will likely result in a compression ratio decrease.
-                              * Special: value 0 means "automatically determine hashEveryLog". */
+                              * Special: value 0 means "automatically determine hashRateLog". */
 
     /* frame parameters */
     ZSTD_p_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)
@@ -926,8 +926,8 @@ ZSTDLIB_API size_t ZSTD_decompress_generic(ZSTD_DCtx* dctx,
 #define ZSTD_LDM_MINMATCH_MAX     4096
 #define ZSTD_LDM_BUCKETSIZELOG_MIN   1
 #define ZSTD_LDM_BUCKETSIZELOG_MAX   8
-#define ZSTD_LDM_HASHEVERYLOG_MIN    0
-#define ZSTD_LDM_HASHEVERYLOG_MAX (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN)
+#define ZSTD_LDM_HASHRATELOG_MIN     0
+#define ZSTD_LDM_HASHRATELOG_MAX (ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN)
 
 /* internal */
 #define ZSTD_HASHLOG3_MAX           17

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -133,7 +133,7 @@ BMK_advancedParams_t BMK_initAdvancedParams(void) {
         0, /* ldmMinMatch */
         0, /* ldmHashLog */
         0, /* ldmBuckSizeLog */
-        0  /* ldmHashEveryLog */
+        0  /* ldmHashRateLog */
     };
     return res;
 }
@@ -171,7 +171,7 @@ static void BMK_initCCtx(ZSTD_CCtx* ctx,
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmMinMatch, adv->ldmMinMatch);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmHashLog, adv->ldmHashLog);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmBucketSizeLog, adv->ldmBucketSizeLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmHashEveryLog, adv->ldmHashEveryLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmHashRateLog, adv->ldmHashRateLog);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_windowLog, comprParams->windowLog);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_hashLog, comprParams->hashLog);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_chainLog, comprParams->chainLog);

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -162,23 +162,23 @@ static void BMK_initCCtx(ZSTD_CCtx* ctx,
     const ZSTD_compressionParameters* comprParams, const BMK_advancedParams_t* adv) {
     ZSTD_CCtx_reset(ctx, ZSTD_reset_session_and_parameters);
     if (adv->nbWorkers==1) {
-        ZSTD_CCtx_setParameter(ctx, ZSTD_p_nbWorkers, 0);
+        ZSTD_CCtx_setParameter(ctx, ZSTD_c_nbWorkers, 0);
     } else {
-        ZSTD_CCtx_setParameter(ctx, ZSTD_p_nbWorkers, adv->nbWorkers);
+        ZSTD_CCtx_setParameter(ctx, ZSTD_c_nbWorkers, adv->nbWorkers);
     }
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_compressionLevel, cLevel);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_enableLongDistanceMatching, adv->ldmFlag);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmMinMatch, adv->ldmMinMatch);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmHashLog, adv->ldmHashLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmBucketSizeLog, adv->ldmBucketSizeLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_ldmHashRateLog, adv->ldmHashRateLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_windowLog, comprParams->windowLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_hashLog, comprParams->hashLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_chainLog, comprParams->chainLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_searchLog, comprParams->searchLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_minMatch, comprParams->minMatch);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_targetLength, comprParams->targetLength);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_compressionStrategy, comprParams->strategy);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionLevel, cLevel);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_enableLongDistanceMatching, adv->ldmFlag);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_ldmMinMatch, adv->ldmMinMatch);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_ldmHashLog, adv->ldmHashLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_ldmBucketSizeLog, adv->ldmBucketSizeLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_ldmHashRateLog, adv->ldmHashRateLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_windowLog, comprParams->windowLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_hashLog, comprParams->hashLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_chainLog, comprParams->chainLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_searchLog, comprParams->searchLog);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_minMatch, comprParams->minMatch);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_targetLength, comprParams->targetLength);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionStrategy, comprParams->strategy);
     ZSTD_CCtx_loadDictionary(ctx, dictBuffer, dictBufferSize);
 }
 

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -160,8 +160,7 @@ typedef struct {
 static void BMK_initCCtx(ZSTD_CCtx* ctx,
     const void* dictBuffer, size_t dictBufferSize, int cLevel,
     const ZSTD_compressionParameters* comprParams, const BMK_advancedParams_t* adv) {
-    ZSTD_CCtx_reset(ctx);
-    ZSTD_CCtx_resetParameters(ctx);
+    ZSTD_CCtx_reset(ctx, ZSTD_CCtx_reset_session_and_parameters);
     if (adv->nbWorkers==1) {
         ZSTD_CCtx_setParameter(ctx, ZSTD_p_nbWorkers, 0);
     } else {

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -160,7 +160,7 @@ typedef struct {
 static void BMK_initCCtx(ZSTD_CCtx* ctx,
     const void* dictBuffer, size_t dictBufferSize, int cLevel,
     const ZSTD_compressionParameters* comprParams, const BMK_advancedParams_t* adv) {
-    ZSTD_CCtx_reset(ctx, ZSTD_CCtx_reset_session_and_parameters);
+    ZSTD_CCtx_reset(ctx, ZSTD_reset_session_and_parameters);
     if (adv->nbWorkers==1) {
         ZSTD_CCtx_setParameter(ctx, ZSTD_p_nbWorkers, 0);
     } else {
@@ -184,7 +184,7 @@ static void BMK_initCCtx(ZSTD_CCtx* ctx,
 
 static void BMK_initDCtx(ZSTD_DCtx* dctx,
     const void* dictBuffer, size_t dictBufferSize) {
-    ZSTD_DCtx_reset(dctx);
+    ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters);
     ZSTD_DCtx_loadDictionary(dctx, dictBuffer, dictBufferSize);
 }
 

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -243,7 +243,7 @@ static size_t local_defaultDecompress(
         if(out.pos == out.size) {
             return (size_t)-ZSTD_error_dstSize_tooSmall;
         }
-        moreToFlush = ZSTD_decompress_generic(dctx, &out, &in);
+        moreToFlush = ZSTD_decompressStream(dctx, &out, &in);
         if (ZSTD_isError(moreToFlush)) {
             return moreToFlush;
         }

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -223,22 +223,8 @@ static size_t local_defaultCompress(
                     void* dstBuffer, size_t dstSize,
                     void* addArgs)
 {
-    size_t moreToFlush = 1;
     ZSTD_CCtx* const cctx = (ZSTD_CCtx*)addArgs;
-    ZSTD_inBuffer in;
-    ZSTD_outBuffer out;
-    in.src = srcBuffer; in.size = srcSize; in.pos = 0;
-    out.dst = dstBuffer; out.size = dstSize; out.pos = 0;
-    while (moreToFlush) {
-        if(out.pos == out.size) {
-            return (size_t)-ZSTD_error_dstSize_tooSmall;
-        }
-        moreToFlush = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
-        if (ZSTD_isError(moreToFlush)) {
-            return moreToFlush;
-        }
-    }
-    return out.pos;
+    return ZSTD_compress2(cctx, dstBuffer, dstSize, srcBuffer, srcSize);
 }
 
 /* `addArgs` is the context */

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -176,7 +176,7 @@ static void BMK_initCCtx(ZSTD_CCtx* ctx,
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_hashLog, comprParams->hashLog);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_chainLog, comprParams->chainLog);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_searchLog, comprParams->searchLog);
-    ZSTD_CCtx_setParameter(ctx, ZSTD_p_minMatch, comprParams->searchLength);
+    ZSTD_CCtx_setParameter(ctx, ZSTD_p_minMatch, comprParams->minMatch);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_targetLength, comprParams->targetLength);
     ZSTD_CCtx_setParameter(ctx, ZSTD_p_compressionStrategy, comprParams->strategy);
     ZSTD_CCtx_loadDictionary(ctx, dictBuffer, dictBufferSize);

--- a/programs/benchzstd.h
+++ b/programs/benchzstd.h
@@ -115,7 +115,7 @@ typedef struct {
     unsigned ldmMinMatch;       /* below: parameters for long distance matching, see zstd.1.md */
     unsigned ldmHashLog;
     unsigned ldmBucketSizeLog;
-    unsigned ldmHashEveryLog;
+    unsigned ldmHashRateLog;
 } BMK_advancedParams_t;
 
 /* returns default parameters used by nonAdvanced functions */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -346,9 +346,9 @@ void FIO_setLdmBucketSizeLog(unsigned ldmBucketSizeLog) {
     g_ldmBucketSizeLog = ldmBucketSizeLog;
 }
 
-static U32 g_ldmHashEveryLog = FIO_LDM_PARAM_NOTSET;
-void FIO_setLdmHashEveryLog(unsigned ldmHashEveryLog) {
-    g_ldmHashEveryLog = ldmHashEveryLog;
+static U32 g_ldmHashRateLog = FIO_LDM_PARAM_NOTSET;
+void FIO_setLdmHashRateLog(unsigned ldmHashRateLog) {
+    g_ldmHashRateLog = ldmHashRateLog;
 }
 
 
@@ -541,8 +541,8 @@ static cRess_t FIO_createCResources(const char* dictFileName, int cLevel,
         if (g_ldmBucketSizeLog != FIO_LDM_PARAM_NOTSET) {
             CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmBucketSizeLog, g_ldmBucketSizeLog) );
         }
-        if (g_ldmHashEveryLog != FIO_LDM_PARAM_NOTSET) {
-            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmHashEveryLog, g_ldmHashEveryLog) );
+        if (g_ldmHashRateLog != FIO_LDM_PARAM_NOTSET) {
+            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmHashRateLog, g_ldmHashRateLog) );
         }
         /* compression parameters */
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_windowLog, comprParams.windowLog) );

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2164,7 +2164,7 @@ FIO_analyzeFrames(fileInfo_t* info, FILE* const srcFile)
                 info->numActualFrames++;
             }
             /* Skippable frame */
-            else if ((magicNumber & 0xFFFFFFF0U) == ZSTD_MAGIC_SKIPPABLE_START) {
+            else if ((magicNumber & ZSTD_MAGIC_SKIPPABLE_MASK) == ZSTD_MAGIC_SKIPPABLE_START) {
                 U32 const frameSize = MEM_readLE32(headerBuffer + 4);
                 long const seek = (long)(8 + frameSize - numBytesRead);
                 ERROR_IF(LONG_SEEK(srcFile, seek, SEEK_CUR) != 0,

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1305,7 +1305,7 @@ static dRess_t FIO_createDResources(const char* dictFileName)
     /* Allocation */
     ress.dctx = ZSTD_createDStream();
     if (ress.dctx==NULL) EXM_THROW(60, "Can't create ZSTD_DStream");
-    CHECK( ZSTD_setDStreamParameter(ress.dctx, DStream_p_maxWindowSize, g_memLimit) );
+    CHECK( ZSTD_DCtx_setMaxWindowSize(ress.dctx, g_memLimit) );
     ress.srcBufferSize = ZSTD_DStreamInSize();
     ress.srcBuffer = malloc(ress.srcBufferSize);
     ress.dstBufferSize = ZSTD_DStreamOutSize();

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2103,7 +2103,7 @@ FIO_analyzeFrames(fileInfo_t* info, FILE* const srcFile)
     for ( ; ; ) {
         BYTE headerBuffer[ZSTD_FRAMEHEADERSIZE_MAX];
         size_t const numBytesRead = fread(headerBuffer, 1, sizeof(headerBuffer), srcFile);
-        if (numBytesRead < ZSTD_frameHeaderSize_min) {
+        if (numBytesRead < ZSTD_FRAMEHEADERSIZE_MIN) {
             if ( feof(srcFile)
               && (numBytesRead == 0)
               && (info->compressedSize > 0)

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -533,7 +533,7 @@ static cRess_t FIO_createCResources(const char* dictFileName, int cLevel,
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_dictIDFlag, g_dictIDFlag) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_checksumFlag, g_checksumFlag) );
         /* compression level */
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, (unsigned)cLevel) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, cLevel) );
         /* long distance matching */
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_enableLongDistanceMatching, g_ldmFlag) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmHashLog, g_ldmHashLog) );
@@ -551,7 +551,7 @@ static cRess_t FIO_createCResources(const char* dictFileName, int cLevel,
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_searchLog, comprParams.searchLog) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_minMatch, comprParams.searchLength) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_targetLength, comprParams.targetLength) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionStrategy, (U32)comprParams.strategy) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionStrategy, comprParams.strategy) );
         /* multi-threading */
 #ifdef ZSTD_MULTITHREAD
         DISPLAYLEVEL(5,"set nb workers = %u \n", g_nbWorkers);
@@ -994,14 +994,14 @@ FIO_compressZstdFrame(const cRess_t* ressPtr,
                             if (compressionLevel > ZSTD_maxCLevel()) compressionLevel = ZSTD_maxCLevel();
                             if (compressionLevel > g_maxAdaptLevel) compressionLevel = g_maxAdaptLevel;
                             compressionLevel += (compressionLevel == 0);   /* skip 0 */
-                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, (unsigned)compressionLevel);
+                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, compressionLevel);
                         }
                         if (speedChange == faster) {
                             DISPLAYLEVEL(6, "faster speed , lighter compression \n")
                             compressionLevel --;
                             if (compressionLevel < g_minAdaptLevel) compressionLevel = g_minAdaptLevel;
                             compressionLevel -= (compressionLevel == 0);   /* skip 0 */
-                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, (unsigned)compressionLevel);
+                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, compressionLevel);
                         }
                         speedChange = noChange;
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -549,7 +549,7 @@ static cRess_t FIO_createCResources(const char* dictFileName, int cLevel,
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_chainLog, comprParams.chainLog) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_hashLog, comprParams.hashLog) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_searchLog, comprParams.searchLog) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_minMatch, comprParams.searchLength) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_minMatch, comprParams.minMatch) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_targetLength, comprParams.targetLength) );
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionStrategy, comprParams.strategy) );
         /* multi-threading */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -884,7 +884,7 @@ FIO_compressZstdFrame(const cRess_t* ressPtr,
             size_t const oldIPos = inBuff.pos;
             ZSTD_outBuffer outBuff = { ress.dstBuffer, ress.dstBufferSize, 0 };
             size_t const toFlushNow = ZSTD_toFlushNow(ress.cctx);
-            CHECK_V(stillToFlush, ZSTD_compress_generic(ress.cctx, &outBuff, &inBuff, directive));
+            CHECK_V(stillToFlush, ZSTD_compressStream2(ress.cctx, &outBuff, &inBuff, directive));
 
             /* count stats */
             inputPresented++;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -529,42 +529,42 @@ static cRess_t FIO_createCResources(const char* dictFileName, int cLevel,
         if (g_adaptiveMode && !g_ldmFlag && !comprParams.windowLog)
             comprParams.windowLog = ADAPT_WINDOWLOG_DEFAULT;
 
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_contentSizeFlag, 1) );  /* always enable content size when available (note: supposed to be default) */
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_dictIDFlag, g_dictIDFlag) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_checksumFlag, g_checksumFlag) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_contentSizeFlag, 1) );  /* always enable content size when available (note: supposed to be default) */
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_dictIDFlag, g_dictIDFlag) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_checksumFlag, g_checksumFlag) );
         /* compression level */
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, cLevel) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_compressionLevel, cLevel) );
         /* long distance matching */
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_enableLongDistanceMatching, g_ldmFlag) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmHashLog, g_ldmHashLog) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmMinMatch, g_ldmMinMatch) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_enableLongDistanceMatching, g_ldmFlag) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_ldmHashLog, g_ldmHashLog) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_ldmMinMatch, g_ldmMinMatch) );
         if (g_ldmBucketSizeLog != FIO_LDM_PARAM_NOTSET) {
-            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmBucketSizeLog, g_ldmBucketSizeLog) );
+            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_ldmBucketSizeLog, g_ldmBucketSizeLog) );
         }
         if (g_ldmHashRateLog != FIO_LDM_PARAM_NOTSET) {
-            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_ldmHashRateLog, g_ldmHashRateLog) );
+            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_ldmHashRateLog, g_ldmHashRateLog) );
         }
         /* compression parameters */
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_windowLog, comprParams.windowLog) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_chainLog, comprParams.chainLog) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_hashLog, comprParams.hashLog) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_searchLog, comprParams.searchLog) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_minMatch, comprParams.minMatch) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_targetLength, comprParams.targetLength) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionStrategy, comprParams.strategy) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_windowLog, comprParams.windowLog) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_chainLog, comprParams.chainLog) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_hashLog, comprParams.hashLog) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_searchLog, comprParams.searchLog) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_minMatch, comprParams.minMatch) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_targetLength, comprParams.targetLength) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_compressionStrategy, comprParams.strategy) );
         /* multi-threading */
 #ifdef ZSTD_MULTITHREAD
         DISPLAYLEVEL(5,"set nb workers = %u \n", g_nbWorkers);
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_nbWorkers, g_nbWorkers) );
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_jobSize, g_blockSize) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_nbWorkers, g_nbWorkers) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_jobSize, g_blockSize) );
         if ( (g_overlapLog == FIO_OVERLAP_LOG_NOTSET)
           && (cLevel == ZSTD_maxCLevel()) )
             g_overlapLog = 9;   /* full overlap */
         if (g_overlapLog != FIO_OVERLAP_LOG_NOTSET) {
             DISPLAYLEVEL(3,"set overlapLog = %u \n", g_overlapLog);
-            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_overlapSizeLog, g_overlapLog) );
+            CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_overlapSizeLog, g_overlapLog) );
         }
-        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_rsyncable, g_rsyncable) );
+        CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_rsyncable, g_rsyncable) );
 #endif
         /* dictionary */
         CHECK( ZSTD_CCtx_setPledgedSrcSize(ress.cctx, srcSize) );  /* set the value temporarily for dictionary loading, to adapt compression parameters */
@@ -994,14 +994,14 @@ FIO_compressZstdFrame(const cRess_t* ressPtr,
                             if (compressionLevel > ZSTD_maxCLevel()) compressionLevel = ZSTD_maxCLevel();
                             if (compressionLevel > g_maxAdaptLevel) compressionLevel = g_maxAdaptLevel;
                             compressionLevel += (compressionLevel == 0);   /* skip 0 */
-                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, compressionLevel);
+                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_compressionLevel, compressionLevel);
                         }
                         if (speedChange == faster) {
                             DISPLAYLEVEL(6, "faster speed , lighter compression \n")
                             compressionLevel --;
                             if (compressionLevel < g_minAdaptLevel) compressionLevel = g_minAdaptLevel;
                             compressionLevel -= (compressionLevel == 0);   /* skip 0 */
-                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_p_compressionLevel, compressionLevel);
+                            ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_compressionLevel, compressionLevel);
                         }
                         speedChange = noChange;
 

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -56,7 +56,7 @@ void FIO_setChecksumFlag(unsigned checksumFlag);
 void FIO_setDictIDFlag(unsigned dictIDFlag);
 void FIO_setLdmBucketSizeLog(unsigned ldmBucketSizeLog);
 void FIO_setLdmFlag(unsigned ldmFlag);
-void FIO_setLdmHashEveryLog(unsigned ldmHashEveryLog);
+void FIO_setLdmHashRateLog(unsigned ldmHashRateLog);
 void FIO_setLdmHashLog(unsigned ldmHashLog);
 void FIO_setLdmMinMatch(unsigned ldmMinMatch);
 void FIO_setMemLimit(unsigned memLimit);

--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -127,6 +127,10 @@ Does not spawn a thread for compression, use a single thread for both I/O and co
 \fBzstd\fR will dynamically adapt compression level to perceived I/O conditions\. Compression level adaptation can be observed live by using command \fB\-v\fR\. Adaptation can be constrained between supplied \fBmin\fR and \fBmax\fR levels\. The feature works when combined with multi\-threading and \fB\-\-long\fR mode\. It does not work with \fB\-\-single\-thread\fR\. It sets window size to 8 MB by default (can be changed manually, see \fBwlog\fR)\. Due to the chaotic nature of dynamic adaptation, compressed result is not reproducible\. \fInote\fR : at the time of this writing, \fB\-\-adapt\fR can remain stuck at low speed when combined with multiple worker threads (>=2)\.
 .
 .TP
+\fB\-\-rsyncable\fR
+\fBzstd\fR will periodically synchronize the compression state to make the compressed file more rsync\-friendly\. There is a negligible impact to compression ratio, and the faster compression levels will see a small compression speed hit\. This feature does not work with \fB\-\-single\-thread\fR\. You probably don\'t want to use it with long range mode, since it will decrease the effectiveness of the synchronization points, but your milage may vary\.
+.
+.TP
 \fB\-D file\fR
 use \fBfile\fR as Dictionary to compress or decompress FILE(s)
 .
@@ -355,14 +359,14 @@ More searches increases the chance to find a match which usually increases compr
 The minimum \fIslog\fR is 1 and the maximum is 26\.
 .
 .TP
-\fBsearchLength\fR=\fIslen\fR, \fBslen\fR=\fIslen\fR
+\fBminMatch\fR=\fImml\fR, \fBmml\fR=\fImml\fR
 Specify the minimum searched length of a match in a hash table\.
 .
 .IP
 Larger search lengths usually decrease compression ratio but improve decompression speed\.
 .
 .IP
-The minimum \fIslen\fR is 3 and the maximum is 7\.
+The minimum \fImml\fR is 3 and the maximum is 7\.
 .
 .TP
 \fBtargetLen\fR=\fItlen\fR, \fBtlen\fR=\fItlen\fR
@@ -388,7 +392,7 @@ Determine \fBoverlapSize\fR, amount of data reloaded from previous job\. This pa
 The minimum \fIovlog\fR is 0, and the maximum is 9\. 0 means "no overlap", hence completely independent jobs\. 9 means "full overlap", meaning up to \fBwindowSize\fR is reloaded from previous job\. Reducing \fIovlog\fR by 1 reduces the amount of reload by a factor 2\. Default \fIovlog\fR is 6, which means "reload \fBwindowSize / 8\fR"\. Exception : the maximum compression level (22) has a default \fIovlog\fR of 9\.
 .
 .TP
-\fBldmHashLog\fR=\fIldmhlog\fR, \fBldmhlog\fR=\fIldmhlog\fR
+\fBldmHashLog\fR=\fIlhlog\fR, \fBlhlog\fR=\fIlhlog\fR
 Specify the maximum size for a hash table used for long distance matching\.
 .
 .IP
@@ -398,10 +402,10 @@ This option is ignored unless long distance matching is enabled\.
 Bigger hash tables usually improve compression ratio at the expense of more memory during compression and a decrease in compression speed\.
 .
 .IP
-The minimum \fIldmhlog\fR is 6 and the maximum is 26 (default: 20)\.
+The minimum \fIlhlog\fR is 6 and the maximum is 26 (default: 20)\.
 .
 .TP
-\fBldmSearchLength\fR=\fIldmslen\fR, \fBldmslen\fR=\fIldmslen\fR
+\fBldmMinMatch\fR=\fIlmml\fR, \fBlmml\fR=\fIlmml\fR
 Specify the minimum searched length of a match for long distance matching\.
 .
 .IP
@@ -411,10 +415,10 @@ This option is ignored unless long distance matching is enabled\.
 Larger/very small values usually decrease compression ratio\.
 .
 .IP
-The minimum \fIldmslen\fR is 4 and the maximum is 4096 (default: 64)\.
+The minimum \fIlmml\fR is 4 and the maximum is 4096 (default: 64)\.
 .
 .TP
-\fBldmBucketSizeLog\fR=\fIldmblog\fR, \fBldmblog\fR=\fIldmblog\fR
+\fBldmBucketSizeLog\fR=\fIlblog\fR, \fBlblog\fR=\fIlblog\fR
 Specify the size of each bucket for the hash table used for long distance matching\.
 .
 .IP
@@ -424,10 +428,10 @@ This option is ignored unless long distance matching is enabled\.
 Larger bucket sizes improve collision resolution but decrease compression speed\.
 .
 .IP
-The minimum \fIldmblog\fR is 0 and the maximum is 8 (default: 3)\.
+The minimum \fIlblog\fR is 0 and the maximum is 8 (default: 3)\.
 .
 .TP
-\fBldmHashEveryLog\fR=\fIldmhevery\fR, \fBldmhevery\fR=\fIldmhevery\fR
+\fBldmHashEveryLog\fR=\fIlhevery\fR, \fBlhevery\fR=\fIlhevery\fR
 Specify the frequency of inserting entries into the long distance matching hash table\.
 .
 .IP
@@ -437,13 +441,13 @@ This option is ignored unless long distance matching is enabled\.
 Larger values will improve compression speed\. Deviating far from the default value will likely result in a decrease in compression ratio\.
 .
 .IP
-The default value is \fBwlog \- ldmhlog\fR\.
+The default value is \fBwlog \- lhlog\fR\.
 .
 .SS "Example"
 The following parameters sets advanced compression options to something similar to predefined level 19 for files bigger than 256 KB:
 .
 .P
-\fB\-\-zstd\fR=wlog=23,clog=23,hlog=22,slog=6,slen=3,tlen=48,strat=6
+\fB\-\-zstd\fR=wlog=23,clog=23,hlog=22,slog=6,mml=3,tlen=48,strat=6
 .
 .SS "\-B#:"
 Select the size of each compression job\. This parameter is available only when multi\-threading is enabled\. Default value is \fB4 * windowSize\fR, which means it varies depending on compression level\. \fB\-B#\fR makes it possible to select a custom value\. Note that job size must respect a minimum value which is enforced transparently\. This minimum is either 1 MB, or \fBoverlapSize\fR, whichever is largest\.

--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -431,7 +431,7 @@ Larger bucket sizes improve collision resolution but decrease compression speed\
 The minimum \fIlblog\fR is 0 and the maximum is 8 (default: 3)\.
 .
 .TP
-\fBldmHashEveryLog\fR=\fIlhevery\fR, \fBlhevery\fR=\fIlhevery\fR
+\fBldmHashRateLog\fR=\fIlhrlog\fR, \fBlhrlog\fR=\fIlhrlog\fR
 Specify the frequency of inserting entries into the long distance matching hash table\.
 .
 .IP

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -450,7 +450,7 @@ The list of available _options_:
 
     The minimum _lblog_ is 0 and the maximum is 8 (default: 3).
 
-- `ldmHashEveryLog`=_lhevery_, `lhevery`=_lhevery_:
+- `ldmHashRateLog`=_lhrlog_, `lhrlog`=_lhrlog_:
     Specify the frequency of inserting entries into the long distance matching
     hash table.
 

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -383,13 +383,13 @@ The list of available _options_:
 
     The minimum _slog_ is 1 and the maximum is 26.
 
-- `searchLength`=_slen_, `slen`=_slen_:
+- `minMatch`=_mml_, `mml`=_mml_:
     Specify the minimum searched length of a match in a hash table.
 
     Larger search lengths usually decrease compression ratio but improve
     decompression speed.
 
-    The minimum _slen_ is 3 and the maximum is 7.
+    The minimum _mml_ is 3 and the maximum is 7.
 
 - `targetLen`=_tlen_, `tlen`=_tlen_:
     The impact of this field vary depending on selected strategy.
@@ -420,7 +420,7 @@ The list of available _options_:
     Default _ovlog_ is 6, which means "reload `windowSize / 8`".
     Exception : the maximum compression level (22) has a default _ovlog_ of 9.
 
-- `ldmHashLog`=_ldmhlog_, `ldmhlog`=_ldmhlog_:
+- `ldmHashLog`=_lhlog_, `lhlog`=_lhlog_:
     Specify the maximum size for a hash table used for long distance matching.
 
     This option is ignored unless long distance matching is enabled.
@@ -428,18 +428,18 @@ The list of available _options_:
     Bigger hash tables usually improve compression ratio at the expense of more
     memory during compression and a decrease in compression speed.
 
-    The minimum _ldmhlog_ is 6 and the maximum is 26 (default: 20).
+    The minimum _lhlog_ is 6 and the maximum is 26 (default: 20).
 
-- `ldmSearchLength`=_ldmslen_, `ldmslen`=_ldmslen_:
+- `ldmMinMatch`=_lmml_, `lmml`=_lmml_:
     Specify the minimum searched length of a match for long distance matching.
 
     This option is ignored unless long distance matching is enabled.
 
     Larger/very small values usually decrease compression ratio.
 
-    The minimum _ldmslen_ is 4 and the maximum is 4096 (default: 64).
+    The minimum _lmml_ is 4 and the maximum is 4096 (default: 64).
 
-- `ldmBucketSizeLog`=_ldmblog_, `ldmblog`=_ldmblog_:
+- `ldmBucketSizeLog`=_lblog_, `lblog`=_lblog_:
     Specify the size of each bucket for the hash table used for long distance
     matching.
 
@@ -448,9 +448,9 @@ The list of available _options_:
     Larger bucket sizes improve collision resolution but decrease compression
     speed.
 
-    The minimum _ldmblog_ is 0 and the maximum is 8 (default: 3).
+    The minimum _lblog_ is 0 and the maximum is 8 (default: 3).
 
-- `ldmHashEveryLog`=_ldmhevery_, `ldmhevery`=_ldmhevery_:
+- `ldmHashEveryLog`=_lhevery_, `lhevery`=_lhevery_:
     Specify the frequency of inserting entries into the long distance matching
     hash table.
 
@@ -459,13 +459,13 @@ The list of available _options_:
     Larger values will improve compression speed. Deviating far from the
     default value will likely result in a decrease in compression ratio.
 
-    The default value is `wlog - ldmhlog`.
+    The default value is `wlog - lhlog`.
 
 ### Example
 The following parameters sets advanced compression options to something
 similar to predefined level 19 for files bigger than 256 KB:
 
-`--zstd`=wlog=23,clog=23,hlog=22,slog=6,slen=3,tlen=48,strat=6
+`--zstd`=wlog=23,clog=23,hlog=22,slog=6,mml=3,tlen=48,strat=6
 
 ### -B#:
 Select the size of each compression job.

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -392,7 +392,7 @@ static unsigned parseAdaptParameters(const char* stringPtr, int* adaptMinPtr, in
 
 
 /** parseCompressionParameters() :
- *  reads compression parameters from *stringPtr (e.g. "--zstd=wlog=23,clog=23,hlog=22,slog=6,slen=3,tlen=48,strat=6") into *params
+ *  reads compression parameters from *stringPtr (e.g. "--zstd=wlog=23,clog=23,hlog=22,slog=6,mml=3,tlen=48,strat=6") into *params
  *  @return 1 means that compression parameters were correct
  *  @return 0 in case of malformed parameters
  */
@@ -403,20 +403,20 @@ static unsigned parseCompressionParameters(const char* stringPtr, ZSTD_compressi
         if (longCommandWArg(&stringPtr, "chainLog=") || longCommandWArg(&stringPtr, "clog=")) { params->chainLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "hashLog=") || longCommandWArg(&stringPtr, "hlog=")) { params->hashLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "searchLog=") || longCommandWArg(&stringPtr, "slog=")) { params->searchLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
-        if (longCommandWArg(&stringPtr, "searchLength=") || longCommandWArg(&stringPtr, "slen=")) { params->searchLength = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "minMatch=") || longCommandWArg(&stringPtr, "mml=")) { params->minMatch = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "targetLength=") || longCommandWArg(&stringPtr, "tlen=")) { params->targetLength = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "strategy=") || longCommandWArg(&stringPtr, "strat=")) { params->strategy = (ZSTD_strategy)(readU32FromChar(&stringPtr)); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "overlapLog=") || longCommandWArg(&stringPtr, "ovlog=")) { g_overlapLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
-        if (longCommandWArg(&stringPtr, "ldmHashLog=") || longCommandWArg(&stringPtr, "ldmhlog=")) { g_ldmHashLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
-        if (longCommandWArg(&stringPtr, "ldmSearchLength=") || longCommandWArg(&stringPtr, "ldmslen=")) { g_ldmMinMatch = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
-        if (longCommandWArg(&stringPtr, "ldmBucketSizeLog=") || longCommandWArg(&stringPtr, "ldmblog=")) { g_ldmBucketSizeLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
-        if (longCommandWArg(&stringPtr, "ldmHashEveryLog=") || longCommandWArg(&stringPtr, "ldmhevery=")) { g_ldmHashEveryLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmHashLog=") || longCommandWArg(&stringPtr, "lhlog=")) { g_ldmHashLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmMinMatch=") || longCommandWArg(&stringPtr, "lmml=")) { g_ldmMinMatch = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmBucketSizeLog=") || longCommandWArg(&stringPtr, "lblog=")) { g_ldmBucketSizeLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmHashEveryLog=") || longCommandWArg(&stringPtr, "lhevery=")) { g_ldmHashEveryLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         DISPLAYLEVEL(4, "invalid compression parameter \n");
         return 0;
     }
 
     DISPLAYLEVEL(4, "windowLog=%d, chainLog=%d, hashLog=%d, searchLog=%d \n", params->windowLog, params->chainLog, params->hashLog, params->searchLog);
-    DISPLAYLEVEL(4, "searchLength=%d, targetLength=%d, strategy=%d \n", params->searchLength, params->targetLength, params->strategy);
+    DISPLAYLEVEL(4, "minMatch=%d, targetLength=%d, strategy=%d \n", params->minMatch, params->targetLength, params->strategy);
     if (stringPtr[0] != 0) return 0; /* check the end of string */
     return 1;
 }

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -81,7 +81,7 @@ static const unsigned g_defaultMaxWindowLog = 27;
 static U32 g_overlapLog = OVERLAP_LOG_DEFAULT;
 static U32 g_ldmHashLog = 0;
 static U32 g_ldmMinMatch = 0;
-static U32 g_ldmHashEveryLog = LDM_PARAM_DEFAULT;
+static U32 g_ldmHashRateLog = LDM_PARAM_DEFAULT;
 static U32 g_ldmBucketSizeLog = LDM_PARAM_DEFAULT;
 
 
@@ -410,7 +410,7 @@ static unsigned parseCompressionParameters(const char* stringPtr, ZSTD_compressi
         if (longCommandWArg(&stringPtr, "ldmHashLog=") || longCommandWArg(&stringPtr, "lhlog=")) { g_ldmHashLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "ldmMinMatch=") || longCommandWArg(&stringPtr, "lmml=")) { g_ldmMinMatch = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         if (longCommandWArg(&stringPtr, "ldmBucketSizeLog=") || longCommandWArg(&stringPtr, "lblog=")) { g_ldmBucketSizeLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
-        if (longCommandWArg(&stringPtr, "ldmHashEveryLog=") || longCommandWArg(&stringPtr, "lhevery=")) { g_ldmHashEveryLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
+        if (longCommandWArg(&stringPtr, "ldmHashRateLog=") || longCommandWArg(&stringPtr, "lhrlog=")) { g_ldmHashRateLog = readU32FromChar(&stringPtr); if (stringPtr[0]==',') { stringPtr++; continue; } else break; }
         DISPLAYLEVEL(4, "invalid compression parameter \n");
         return 0;
     }
@@ -940,8 +940,8 @@ int main(int argCount, const char* argv[])
         if (g_ldmBucketSizeLog != LDM_PARAM_DEFAULT) {
             benchParams.ldmBucketSizeLog = g_ldmBucketSizeLog;
         }
-        if (g_ldmHashEveryLog != LDM_PARAM_DEFAULT) {
-            benchParams.ldmHashEveryLog = g_ldmHashEveryLog;
+        if (g_ldmHashRateLog != LDM_PARAM_DEFAULT) {
+            benchParams.ldmHashRateLog = g_ldmHashRateLog;
         }
 
         if (cLevel > ZSTD_maxCLevel()) cLevel = ZSTD_maxCLevel();
@@ -1051,7 +1051,7 @@ int main(int argCount, const char* argv[])
         FIO_setLdmHashLog(g_ldmHashLog);
         FIO_setLdmMinMatch(g_ldmMinMatch);
         if (g_ldmBucketSizeLog != LDM_PARAM_DEFAULT) FIO_setLdmBucketSizeLog(g_ldmBucketSizeLog);
-        if (g_ldmHashEveryLog != LDM_PARAM_DEFAULT) FIO_setLdmHashEveryLog(g_ldmHashEveryLog);
+        if (g_ldmHashRateLog != LDM_PARAM_DEFAULT) FIO_setLdmHashRateLog(g_ldmHashRateLog);
         FIO_setAdaptiveMode(adapt);
         FIO_setAdaptMin(adaptMin);
         FIO_setAdaptMax(adaptMax);

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Additional remarks:
 The example usage with two test files, one e-mail address, and with an additional message:
 ```
 ./test-zstd-speed.py "silesia.tar calgary.tar" "email@gmail.com" --message "tested on my laptop" --sleepTime 60
-``` 
+```
 
 To run the script in background please use:
 ```
@@ -100,19 +100,19 @@ Full list of arguments
     h# - hashLog
     c# - chainLog
     s# - searchLog
-    l# - searchLength
+    l# - minMatch
     t# - targetLength
     S# - strategy
     L# - level
  --zstd=      : Single run, parameter selection syntax same as zstdcli with more parameters
-                    (Added forceAttachDictionary / fadt) 
-                    When invoked with --optimize, this represents the sample to exceed. 
+                    (Added forceAttachDictionary / fadt)
+                    When invoked with --optimize, this represents the sample to exceed.
  --optimize=  : find parameters to maximize compression ratio given parameters
                     Can use all --zstd= commands to constrain the type of solution found in addition to the following constraints
     cSpeed=   : Minimum compression speed
     dSpeed=   : Minimum decompression speed
     cMem=     : Maximum compression memory
-    lvl=      : Searches for solutions which are strictly better than that compression lvl in ratio and cSpeed, 
+    lvl=      : Searches for solutions which are strictly better than that compression lvl in ratio and cSpeed,
     stc=      : When invoked with lvl=, represents percentage slack in ratio/cSpeed allowed for a solution to be considered (Default 100%)
               : In normal operation, represents percentage slack in choosing viable starting strategy selection in choosing the default parameters
                     (Lower value will begin with stronger strategies) (Default 90%)
@@ -121,13 +121,13 @@ Full list of arguments
                     when determining overall winner (default 5 (1% ratio = 5% speed)).
     tries=    : Maximum number of random restarts on a single strategy before switching (Default 5)
                     Higher values will make optimizer run longer, more chances to find better solution.
-    memLog    : Limits the log of the size of each memotable (1 per strategy). Will use hash tables when state space is larger than max size. 
-                    Setting memLog = 0 turns off memoization 
+    memLog    : Limits the log of the size of each memotable (1 per strategy). Will use hash tables when state space is larger than max size.
+                    Setting memLog = 0 turns off memoization
  --display=   : specifiy which parameters are included in the output
-                    can use all --zstd parameter names and 'cParams' as a shorthand for all parameters used in ZSTD_compressionParameters 
+                    can use all --zstd parameter names and 'cParams' as a shorthand for all parameters used in ZSTD_compressionParameters
                     (Default: display all params available)
  -P#          : generated sample compressibility (when no file is provided)
- -t#          : Caps runtime of operation in seconds (default : 99999 seconds (about 27 hours )) 
+ -t#          : Caps runtime of operation in seconds (default : 99999 seconds (about 27 hours ))
  -v           : Prints Benchmarking output
  -D           : Next argument dictionary file
  -s           : Benchmark all files separately

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -408,16 +408,16 @@ static size_t benchMem(U32 benchNb,
     if (g_cstream==NULL) g_cstream = ZSTD_createCStream();
     if (g_dstream==NULL) g_dstream = ZSTD_createDStream();
 
-    /* DISPLAY("params: cLevel %d, wlog %d hlog %d clog %d slog %d slen %d tlen %d strat %d \n",
+    /* DISPLAY("params: cLevel %d, wlog %d hlog %d clog %d slog %d mml %d tlen %d strat %d \n",
           cLevel, cparams->windowLog, cparams->hashLog, cparams->chainLog, cparams->searchLog,
-          cparams->searchLength, cparams->targetLength, cparams->strategy); */
+          cparams->minMatch, cparams->targetLength, cparams->strategy); */
 
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_compressionLevel, cLevel);
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_windowLog, cparams.windowLog);
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_hashLog, cparams.hashLog);
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_chainLog, cparams.chainLog);
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_searchLog, cparams.searchLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_minMatch, cparams.searchLength);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_minMatch, cparams.minMatch);
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_targetLength, cparams.targetLength);
     ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_compressionStrategy, cparams.strategy);
 
@@ -427,7 +427,7 @@ static size_t benchMem(U32 benchNb,
     ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_hashLog, cparams.hashLog);
     ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_chainLog, cparams.chainLog);
     ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_searchLog, cparams.searchLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_minMatch, cparams.searchLength);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_minMatch, cparams.minMatch);
     ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_targetLength, cparams.targetLength);
     ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_compressionStrategy, cparams.strategy);
 
@@ -752,7 +752,7 @@ int main(int argc, const char** argv)
                 if (longCommandWArg(&argument, "chainLog=") || longCommandWArg(&argument, "clog=")) { cparams.chainLog = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
                 if (longCommandWArg(&argument, "hashLog=") || longCommandWArg(&argument, "hlog=")) { cparams.hashLog = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
                 if (longCommandWArg(&argument, "searchLog=") || longCommandWArg(&argument, "slog=")) { cparams.searchLog = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
-                if (longCommandWArg(&argument, "searchLength=") || longCommandWArg(&argument, "slen=")) { cparams.searchLength = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
+                if (longCommandWArg(&argument, "minMatch=") || longCommandWArg(&argument, "mml=")) { cparams.minMatch = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
                 if (longCommandWArg(&argument, "targetLength=") || longCommandWArg(&argument, "tlen=")) { cparams.targetLength = readU32FromChar(&argument); if (argument[0]==',') { argument++; continue; } else break; }
                 if (longCommandWArg(&argument, "strategy=") || longCommandWArg(&argument, "strat=")) { cparams.strategy = (ZSTD_strategy)(readU32FromChar(&argument)); if (argument[0]==',') { argument++; continue; } else break; }
                 if (longCommandWArg(&argument, "level=") || longCommandWArg(&argument, "lvl=")) { cLevel = (int)readU32FromChar(&argument); cparams = ZSTD_getCParams(cLevel, 0, 0); if (argument[0]==',') { argument++; continue; } else break; }

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -454,8 +454,8 @@ static size_t benchMem(U32 benchNb,
             ZSTD_frameHeader zfp;
             size_t frameHeaderSize, skippedSize;
             g_cSize = ZSTD_compress(dstBuff, dstBuffSize, src, srcSize, cLevel);
-            frameHeaderSize = ZSTD_getFrameHeader(&zfp, dstBuff, ZSTD_frameHeaderSize_min);
-            if (frameHeaderSize==0) frameHeaderSize = ZSTD_frameHeaderSize_min;
+            frameHeaderSize = ZSTD_getFrameHeader(&zfp, dstBuff, ZSTD_FRAMEHEADERSIZE_MIN);
+            if (frameHeaderSize==0) frameHeaderSize = ZSTD_FRAMEHEADERSIZE_MIN;
             ZSTD_getcBlockSize(dstBuff+frameHeaderSize, dstBuffSize, &bp);  /* Get 1st block type */
             if (bp.blockType != bt_compressed) {
                 DISPLAY("ZSTD_decodeLiteralsBlock : impossible to test on this sample (not compressible)\n");
@@ -475,8 +475,8 @@ static size_t benchMem(U32 benchNb,
             size_t frameHeaderSize, cBlockSize;
             ZSTD_compress(dstBuff, dstBuffSize, src, srcSize, cLevel);   /* it would be better to use direct block compression here */
             g_cSize = ZSTD_compress(dstBuff, dstBuffSize, src, srcSize, cLevel);
-            frameHeaderSize = ZSTD_getFrameHeader(&zfp, dstBuff, ZSTD_frameHeaderSize_min);
-            if (frameHeaderSize==0) frameHeaderSize = ZSTD_frameHeaderSize_min;
+            frameHeaderSize = ZSTD_getFrameHeader(&zfp, dstBuff, ZSTD_FRAMEHEADERSIZE_MIN);
+            if (frameHeaderSize==0) frameHeaderSize = ZSTD_FRAMEHEADERSIZE_MIN;
             ip += frameHeaderSize;   /* Skip frame Header */
             cBlockSize = ZSTD_getcBlockSize(ip, dstBuffSize, &bp);   /* Get 1st block type */
             if (bp.blockType != bt_compressed) {

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -200,7 +200,7 @@ local_ZSTD_compress_generic_T2_end(const void* src, size_t srcSize,
                                    void* buff2)
 {
     (void)buff2;
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_nbWorkers, 2);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_nbWorkers, 2);
     return ZSTD_compress2(g_cstream, dst, dstCapacity, src, srcSize);
 }
 
@@ -212,7 +212,7 @@ local_ZSTD_compress_generic_T2_continue(const void* src, size_t srcSize,
     ZSTD_outBuffer buffOut;
     ZSTD_inBuffer buffIn;
     (void)buff2;
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_nbWorkers, 2);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_nbWorkers, 2);
     buffOut.dst = dst;
     buffOut.size = dstCapacity;
     buffOut.pos = 0;
@@ -394,24 +394,24 @@ static size_t benchMem(U32 benchNb,
           cLevel, cparams->windowLog, cparams->hashLog, cparams->chainLog, cparams->searchLog,
           cparams->minMatch, cparams->targetLength, cparams->strategy); */
 
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_compressionLevel, cLevel);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_windowLog, cparams.windowLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_hashLog, cparams.hashLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_chainLog, cparams.chainLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_searchLog, cparams.searchLog);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_minMatch, cparams.minMatch);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_targetLength, cparams.targetLength);
-    ZSTD_CCtx_setParameter(g_zcc, ZSTD_p_compressionStrategy, cparams.strategy);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_compressionLevel, cLevel);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_windowLog, cparams.windowLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_hashLog, cparams.hashLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_chainLog, cparams.chainLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_searchLog, cparams.searchLog);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_minMatch, cparams.minMatch);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_targetLength, cparams.targetLength);
+    ZSTD_CCtx_setParameter(g_zcc, ZSTD_c_compressionStrategy, cparams.strategy);
 
 
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_compressionLevel, cLevel);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_windowLog, cparams.windowLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_hashLog, cparams.hashLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_chainLog, cparams.chainLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_searchLog, cparams.searchLog);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_minMatch, cparams.minMatch);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_targetLength, cparams.targetLength);
-    ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_compressionStrategy, cparams.strategy);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_compressionLevel, cLevel);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_windowLog, cparams.windowLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_hashLog, cparams.hashLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_chainLog, cparams.chainLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_searchLog, cparams.searchLog);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_minMatch, cparams.minMatch);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_targetLength, cparams.targetLength);
+    ZSTD_CCtx_setParameter(g_cstream, ZSTD_c_compressionStrategy, cparams.strategy);
 
     /* Preparation */
     switch(benchNb)

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -171,17 +171,8 @@ local_ZSTD_compress_generic_end(const void* src, size_t srcSize,
                                 void* dst, size_t dstCapacity,
                                 void* buff2)
 {
-    ZSTD_outBuffer buffOut;
-    ZSTD_inBuffer buffIn;
     (void)buff2;
-    buffOut.dst = dst;
-    buffOut.size = dstCapacity;
-    buffOut.pos = 0;
-    buffIn.src = src;
-    buffIn.size = srcSize;
-    buffIn.pos = 0;
-    ZSTD_compress_generic(g_cstream, &buffOut, &buffIn, ZSTD_e_end);
-    return buffOut.pos;
+    return ZSTD_compress2(g_cstream, dst, dstCapacity, src, srcSize);
 }
 
 static size_t
@@ -198,8 +189,8 @@ local_ZSTD_compress_generic_continue(const void* src, size_t srcSize,
     buffIn.src = src;
     buffIn.size = srcSize;
     buffIn.pos = 0;
-    ZSTD_compress_generic(g_cstream, &buffOut, &buffIn, ZSTD_e_continue);
-    ZSTD_compress_generic(g_cstream, &buffOut, &buffIn, ZSTD_e_end);
+    ZSTD_compressStream2(g_cstream, &buffOut, &buffIn, ZSTD_e_continue);
+    ZSTD_compressStream2(g_cstream, &buffOut, &buffIn, ZSTD_e_end);
     return buffOut.pos;
 }
 
@@ -208,18 +199,9 @@ local_ZSTD_compress_generic_T2_end(const void* src, size_t srcSize,
                                    void* dst, size_t dstCapacity,
                                    void* buff2)
 {
-    ZSTD_outBuffer buffOut;
-    ZSTD_inBuffer buffIn;
     (void)buff2;
     ZSTD_CCtx_setParameter(g_cstream, ZSTD_p_nbWorkers, 2);
-    buffOut.dst = dst;
-    buffOut.size = dstCapacity;
-    buffOut.pos = 0;
-    buffIn.src = src;
-    buffIn.size = srcSize;
-    buffIn.pos = 0;
-    while (ZSTD_compress_generic(g_cstream, &buffOut, &buffIn, ZSTD_e_end)) {}
-    return buffOut.pos;
+    return ZSTD_compress2(g_cstream, dst, dstCapacity, src, srcSize);
 }
 
 static size_t
@@ -237,8 +219,8 @@ local_ZSTD_compress_generic_T2_continue(const void* src, size_t srcSize,
     buffIn.src = src;
     buffIn.size = srcSize;
     buffIn.pos = 0;
-    ZSTD_compress_generic(g_cstream, &buffOut, &buffIn, ZSTD_e_continue);
-    while(ZSTD_compress_generic(g_cstream, &buffOut, &buffIn, ZSTD_e_end)) {}
+    ZSTD_compressStream2(g_cstream, &buffOut, &buffIn, ZSTD_e_continue);
+    while(ZSTD_compressStream2(g_cstream, &buffOut, &buffIn, ZSTD_e_end)) {}
     return buffOut.pos;
 }
 

--- a/tests/fuzz/simple_round_trip.c
+++ b/tests/fuzz/simple_round_trip.c
@@ -42,7 +42,7 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
 
         ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
         FUZZ_setRandomParameters(cctx, srcSize, &seed);
-        err = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+        err = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
         FUZZ_ZASSERT(err);
         FUZZ_ASSERT(err == 0);
         cSize = out.pos;

--- a/tests/fuzz/simple_round_trip.c
+++ b/tests/fuzz/simple_round_trip.c
@@ -40,7 +40,7 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
         ZSTD_outBuffer out = {compressed, compressedCapacity, 0};
         size_t err;
 
-        ZSTD_CCtx_reset(cctx);
+        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
         FUZZ_setRandomParameters(cctx, srcSize, &seed);
         err = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
         FUZZ_ZASSERT(err);

--- a/tests/fuzz/simple_round_trip.c
+++ b/tests/fuzz/simple_round_trip.c
@@ -40,7 +40,7 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
         ZSTD_outBuffer out = {compressed, compressedCapacity, 0};
         size_t err;
 
-        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
+        ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
         FUZZ_setRandomParameters(cctx, srcSize, &seed);
         err = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
         FUZZ_ZASSERT(err);

--- a/tests/fuzz/stream_round_trip.c
+++ b/tests/fuzz/stream_round_trip.c
@@ -56,7 +56,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
                        const uint8_t *src, size_t srcSize)
 {
     size_t dstSize = 0;
-    ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
+    ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
     FUZZ_setRandomParameters(cctx, srcSize, &seed);
 
     while (srcSize > 0) {
@@ -84,7 +84,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
                     FUZZ_ZASSERT(ret);
                     /* Reset the compressor when the frame is finished */
                     if (ret == 0) {
-                        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
+                        ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
                         if ((FUZZ_rand(&seed) & 7) == 0) {
                             size_t const remaining = in.size - in.pos;
                             FUZZ_setRandomParameters(cctx, remaining, &seed);

--- a/tests/fuzz/stream_round_trip.c
+++ b/tests/fuzz/stream_round_trip.c
@@ -56,7 +56,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
                        const uint8_t *src, size_t srcSize)
 {
     size_t dstSize = 0;
-    ZSTD_CCtx_reset(cctx);
+    ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
     FUZZ_setRandomParameters(cctx, srcSize, &seed);
 
     while (srcSize > 0) {
@@ -84,7 +84,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
                     FUZZ_ZASSERT(ret);
                     /* Reset the compressor when the frame is finished */
                     if (ret == 0) {
-                        ZSTD_CCtx_reset(cctx);
+                        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
                         if ((FUZZ_rand(&seed) & 7) == 0) {
                             size_t const remaining = in.size - in.pos;
                             FUZZ_setRandomParameters(cctx, remaining, &seed);

--- a/tests/fuzz/stream_round_trip.c
+++ b/tests/fuzz/stream_round_trip.c
@@ -72,7 +72,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
                 case 1: /* fall-though */
                 case 2: {
                     size_t const ret =
-                        ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_flush);
+                        ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_flush);
                     FUZZ_ZASSERT(ret);
                     if (ret == 0)
                         mode = -1;
@@ -80,7 +80,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
                 }
                 case 3: {
                     size_t ret =
-                        ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+                        ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
                     FUZZ_ZASSERT(ret);
                     /* Reset the compressor when the frame is finished */
                     if (ret == 0) {
@@ -95,7 +95,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
                 }
                 default: {
                     size_t const ret =
-                        ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_continue);
+                        ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_continue);
                     FUZZ_ZASSERT(ret);
                     mode = -1;
                 }
@@ -108,7 +108,7 @@ static size_t compress(uint8_t *dst, size_t capacity,
     for (;;) {
         ZSTD_inBuffer in = {NULL, 0, 0};
         ZSTD_outBuffer out = makeOutBuffer(dst, capacity);
-        size_t const ret = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+        size_t const ret = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
         FUZZ_ZASSERT(ret);
 
         dst += out.pos;

--- a/tests/fuzz/zstd_helpers.c
+++ b/tests/fuzz/zstd_helpers.c
@@ -79,6 +79,6 @@ void FUZZ_setRandomParameters(ZSTD_CCtx *cctx, size_t srcSize, uint32_t *state)
             ZSTD_LDM_MINMATCH_MAX, state);
     setRand(cctx, ZSTD_p_ldmBucketSizeLog, 0, ZSTD_LDM_BUCKETSIZELOG_MAX,
             state);
-    setRand(cctx, ZSTD_p_ldmHashEveryLog, 0,
-            ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN, state);
+    setRand(cctx, ZSTD_p_ldmHashRateLog, ZSTD_LDM_HASHRATELOG_MIN,
+            ZSTD_LDM_HASHRATELOG_MAX, state);
 }

--- a/tests/fuzz/zstd_helpers.c
+++ b/tests/fuzz/zstd_helpers.c
@@ -32,8 +32,8 @@ ZSTD_compressionParameters FUZZ_randomCParams(size_t srcSize, uint32_t *state)
     cParams.hashLog = FUZZ_rand32(state, ZSTD_HASHLOG_MIN, 15);
     cParams.chainLog = FUZZ_rand32(state, ZSTD_CHAINLOG_MIN, 16);
     cParams.searchLog = FUZZ_rand32(state, ZSTD_SEARCHLOG_MIN, 9);
-    cParams.searchLength = FUZZ_rand32(state, ZSTD_SEARCHLENGTH_MIN,
-                                              ZSTD_SEARCHLENGTH_MAX);
+    cParams.minMatch = FUZZ_rand32(state, ZSTD_MINMATCH_MIN,
+                                          ZSTD_MINMATCH_MAX);
     cParams.targetLength = FUZZ_rand32(state, 0, 512);
     cParams.strategy = FUZZ_rand32(state, ZSTD_fast, ZSTD_btultra);
     return ZSTD_adjustCParams(cParams, srcSize, 0);
@@ -64,7 +64,7 @@ void FUZZ_setRandomParameters(ZSTD_CCtx *cctx, size_t srcSize, uint32_t *state)
     set(cctx, ZSTD_p_hashLog, cParams.hashLog);
     set(cctx, ZSTD_p_chainLog, cParams.chainLog);
     set(cctx, ZSTD_p_searchLog, cParams.searchLog);
-    set(cctx, ZSTD_p_minMatch, cParams.searchLength);
+    set(cctx, ZSTD_p_minMatch, cParams.minMatch);
     set(cctx, ZSTD_p_targetLength, cParams.targetLength);
     set(cctx, ZSTD_p_compressionStrategy, cParams.strategy);
     /* Select frame parameters */

--- a/tests/fuzz/zstd_helpers.c
+++ b/tests/fuzz/zstd_helpers.c
@@ -60,25 +60,25 @@ ZSTD_parameters FUZZ_randomParams(size_t srcSize, uint32_t *state)
 void FUZZ_setRandomParameters(ZSTD_CCtx *cctx, size_t srcSize, uint32_t *state)
 {
     ZSTD_compressionParameters cParams = FUZZ_randomCParams(srcSize, state);
-    set(cctx, ZSTD_p_windowLog, cParams.windowLog);
-    set(cctx, ZSTD_p_hashLog, cParams.hashLog);
-    set(cctx, ZSTD_p_chainLog, cParams.chainLog);
-    set(cctx, ZSTD_p_searchLog, cParams.searchLog);
-    set(cctx, ZSTD_p_minMatch, cParams.minMatch);
-    set(cctx, ZSTD_p_targetLength, cParams.targetLength);
-    set(cctx, ZSTD_p_compressionStrategy, cParams.strategy);
+    set(cctx, ZSTD_c_windowLog, cParams.windowLog);
+    set(cctx, ZSTD_c_hashLog, cParams.hashLog);
+    set(cctx, ZSTD_c_chainLog, cParams.chainLog);
+    set(cctx, ZSTD_c_searchLog, cParams.searchLog);
+    set(cctx, ZSTD_c_minMatch, cParams.minMatch);
+    set(cctx, ZSTD_c_targetLength, cParams.targetLength);
+    set(cctx, ZSTD_c_compressionStrategy, cParams.strategy);
     /* Select frame parameters */
-    setRand(cctx, ZSTD_p_contentSizeFlag, 0, 1, state);
-    setRand(cctx, ZSTD_p_checksumFlag, 0, 1, state);
-    setRand(cctx, ZSTD_p_dictIDFlag, 0, 1, state);
-    setRand(cctx, ZSTD_p_forceAttachDict, 0, 2, state);
+    setRand(cctx, ZSTD_c_contentSizeFlag, 0, 1, state);
+    setRand(cctx, ZSTD_c_checksumFlag, 0, 1, state);
+    setRand(cctx, ZSTD_c_dictIDFlag, 0, 1, state);
+    setRand(cctx, ZSTD_c_forceAttachDict, 0, 2, state);
     /* Select long distance matchig parameters */
-    setRand(cctx, ZSTD_p_enableLongDistanceMatching, 0, 1, state);
-    setRand(cctx, ZSTD_p_ldmHashLog, ZSTD_HASHLOG_MIN, 16, state);
-    setRand(cctx, ZSTD_p_ldmMinMatch, ZSTD_LDM_MINMATCH_MIN,
+    setRand(cctx, ZSTD_c_enableLongDistanceMatching, 0, 1, state);
+    setRand(cctx, ZSTD_c_ldmHashLog, ZSTD_HASHLOG_MIN, 16, state);
+    setRand(cctx, ZSTD_c_ldmMinMatch, ZSTD_LDM_MINMATCH_MIN,
             ZSTD_LDM_MINMATCH_MAX, state);
-    setRand(cctx, ZSTD_p_ldmBucketSizeLog, 0, ZSTD_LDM_BUCKETSIZELOG_MAX,
+    setRand(cctx, ZSTD_c_ldmBucketSizeLog, 0, ZSTD_LDM_BUCKETSIZELOG_MAX,
             state);
-    setRand(cctx, ZSTD_p_ldmHashRateLog, ZSTD_LDM_HASHRATELOG_MIN,
+    setRand(cctx, ZSTD_c_ldmHashRateLog, ZSTD_LDM_HASHRATELOG_MIN,
             ZSTD_LDM_HASHRATELOG_MAX, state);
 }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -235,7 +235,7 @@ static int FUZ_mallocTests_internal(unsigned seed, double compressibility, unsig
                 ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
                 ZSTD_outBuffer out = { outBuffer, outSize, 0 };
                 ZSTD_inBuffer in = { inBuffer, inSize, 0 };
-                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel) );
+                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
                 CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbWorkers, nbThreads) );
                 while ( ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end) ) {}
                 ZSTD_freeCCtx(cctx);
@@ -255,7 +255,7 @@ static int FUZ_mallocTests_internal(unsigned seed, double compressibility, unsig
                 ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
                 ZSTD_outBuffer out = { outBuffer, outSize, 0 };
                 ZSTD_inBuffer in = { inBuffer, inSize, 0 };
-                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (U32)compressionLevel) );
+                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
                 CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbWorkers, nbThreads) );
                 CHECK_Z( ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_continue) );
                 while ( ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end) ) {}
@@ -1252,7 +1252,7 @@ static int basicUnitTests(U32 seed, double compressibility)
                                         params);
             if (ZSTD_isError(cSize_1pass)) goto _output_error;
 
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, (unsigned)compressionLevel) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
             {   ZSTD_inBuffer in = { CNBuffer, srcSize, 0 };
                 ZSTD_outBuffer out = { compressedBuffer, compressedBufferSize, 0 };
                 size_t const compressionResult = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1398,13 +1398,19 @@ static int basicUnitTests(U32 seed, double compressibility)
             size_t const zfhrt = ZSTD_getFrameHeader_advanced(&zfh, compressedBuffer, cSize, ZSTD_f_zstd1_magicless);
             if (zfhrt != 0) goto _output_error;
         }
+        /* one shot */
+        {   size_t const result = ZSTD_decompressDCtx(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize);
+            if (result != inputSize) goto _output_error;
+            DISPLAYLEVEL(3, "one-shot OK, ");
+        }
+        /* streaming */
         {   ZSTD_inBuffer in = { compressedBuffer, cSize, 0 };
             ZSTD_outBuffer out = { decodedBuffer, CNBuffSize, 0 };
             size_t const result = ZSTD_decompressStream(dctx, &out, &in);
             if (result != 0) goto _output_error;
             if (in.pos != in.size) goto _output_error;
             if (out.pos != inputSize) goto _output_error;
-            DISPLAYLEVEL(3, "OK : regenerated %u bytes \n", (U32)out.pos);
+            DISPLAYLEVEL(3, "streaming OK : regenerated %u bytes \n", (U32)out.pos);
         }
 
         ZSTD_freeCCtx(cctx);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -527,13 +527,13 @@ static int basicUnitTests(U32 seed, double compressibility)
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Reset the CCtx */
-        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
+        ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
         CHECK_EQ(value, 7);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Reset the parameters */
-        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_parameters);
+        ZSTD_CCtx_reset(cctx, ZSTD_reset_parameters);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
         CHECK_EQ(value, 3);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
@@ -1327,7 +1327,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         }
 
         DISPLAYLEVEL(3, "test%3i : decompress of magic-less frame : ", testNb++);
-        ZSTD_DCtx_reset(dctx);
+        ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters);
         CHECK( ZSTD_DCtx_setFormat(dctx, ZSTD_f_zstd1_magicless) );
         {   ZSTD_frameHeader zfh;
             size_t const zfhrt = ZSTD_getFrameHeader_advanced(&zfh, compressedBuffer, cSize, ZSTD_f_zstd1_magicless);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1393,7 +1393,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         DISPLAYLEVEL(3, "test%3i : decompress of magic-less frame : ", testNb++);
         ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters);
-        CHECK( ZSTD_DCtx_setFormat(dctx, ZSTD_f_zstd1_magicless) );
+        CHECK( ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1_magicless) );
         {   ZSTD_frameHeader zfh;
             size_t const zfhrt = ZSTD_getFrameHeader_advanced(&zfh, compressedBuffer, cSize, ZSTD_f_zstd1_magicless);
             if (zfhrt != 0) goto _output_error;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -381,16 +381,24 @@ static int basicUnitTests(U32 seed, double compressibility)
 
     DISPLAYLEVEL(3, "test%3i : decompress with null dict : ", testNb++);
     {   ZSTD_DCtx* const dctx = ZSTD_createDCtx(); assert(dctx != NULL);
-        size_t const r = ZSTD_decompress_usingDict(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize, NULL, 0);
-        if (r != CNBuffSize) goto _output_error;
+        {   size_t const r = ZSTD_decompress_usingDict(dctx,
+                                                    decodedBuffer, CNBuffSize,
+                                                    compressedBuffer, cSize,
+                                                    NULL, 0);
+            if (r != CNBuffSize) goto _output_error;
+        }
         ZSTD_freeDCtx(dctx);
     }
     DISPLAYLEVEL(3, "OK \n");
 
     DISPLAYLEVEL(3, "test%3i : decompress with null DDict : ", testNb++);
     {   ZSTD_DCtx* const dctx = ZSTD_createDCtx(); assert(dctx != NULL);
-        size_t const r = ZSTD_decompress_usingDDict(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize, NULL);
-        if (r != CNBuffSize) goto _output_error;
+        {   size_t const r = ZSTD_decompress_usingDDict(dctx,
+                                                    decodedBuffer, CNBuffSize,
+                                                    compressedBuffer, cSize,
+                                                    NULL);
+            if (r != CNBuffSize) goto _output_error;
+        }
         ZSTD_freeDCtx(dctx);
     }
     DISPLAYLEVEL(3, "OK \n");
@@ -1080,12 +1088,14 @@ static int basicUnitTests(U32 seed, double compressibility)
         DISPLAYLEVEL(3, "OK \n");
 
         DISPLAYLEVEL(3, "test%3i : dictionary containing only header should return error : ", testNb++);
-        {   ZSTD_DCtx* const dctx = ZSTD_createDCtx(); assert(dctx != NULL);
-            const size_t ret = ZSTD_decompress_usingDict(
+        {   ZSTD_DCtx* const dctx = ZSTD_createDCtx();
+            assert(dctx != NULL);
+            {   const size_t ret = ZSTD_decompress_usingDict(
                     dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize,
                     "\x37\xa4\x30\xec\x11\x22\x33\x44", 8);
-            if (ZSTD_getErrorCode(ret) != ZSTD_error_dictionary_corrupted)
-                goto _output_error;
+                if (ZSTD_getErrorCode(ret) != ZSTD_error_dictionary_corrupted)
+                    goto _output_error;
+            }
             ZSTD_freeDCtx(dctx);
         }
         DISPLAYLEVEL(3, "OK \n");

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -527,13 +527,13 @@ static int basicUnitTests(U32 seed, double compressibility)
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Reset the CCtx */
-        ZSTD_CCtx_reset(cctx);
+        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_session_only);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
         CHECK_EQ(value, 7);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Reset the parameters */
-        ZSTD_CCtx_resetParameters(cctx);
+        ZSTD_CCtx_reset(cctx, ZSTD_CCtx_reset_parameters);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
         CHECK_EQ(value, 3);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -233,8 +233,8 @@ static int FUZ_mallocTests_internal(unsigned seed, double compressibility, unsig
                 mallocCounter_t malcount = INIT_MALLOC_COUNTER;
                 ZSTD_customMem const cMem = { FUZ_mallocDebug, FUZ_freeDebug, &malcount };
                 ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
-                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
-                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbWorkers, nbThreads) );
+                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, compressionLevel) );
+                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, nbThreads) );
                 CHECK_Z( ZSTD_compress2(cctx, outBuffer, outSize, inBuffer, inSize) );
                 ZSTD_freeCCtx(cctx);
                 DISPLAYLEVEL(3, "compress_generic,-T%u,end level %i : ",
@@ -253,8 +253,8 @@ static int FUZ_mallocTests_internal(unsigned seed, double compressibility, unsig
                 ZSTD_CCtx* const cctx = ZSTD_createCCtx_advanced(cMem);
                 ZSTD_outBuffer out = { outBuffer, outSize, 0 };
                 ZSTD_inBuffer in = { inBuffer, inSize, 0 };
-                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
-                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbWorkers, nbThreads) );
+                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, compressionLevel) );
+                CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, nbThreads) );
                 CHECK_Z( ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_continue) );
                 while ( ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end) ) {}
                 ZSTD_freeCCtx(cctx);
@@ -517,37 +517,37 @@ static int basicUnitTests(U32 seed, double compressibility)
         ZSTD_inBuffer in = {NULL, 0, 0};
         int value;
 
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_compressionLevel, &value));
         CHECK_EQ(value, 3);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_hashLog, &value));
         CHECK_EQ(value, 0);
-        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_p_hashLog, ZSTD_HASHLOG_MIN));
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_hashLog, ZSTD_HASHLOG_MIN));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_compressionLevel, &value));
         CHECK_EQ(value, 3);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
-        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, 7));
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 7));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_compressionLevel, &value));
         CHECK_EQ(value, 7);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Start a compression job */
         ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_continue);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_compressionLevel, &value));
         CHECK_EQ(value, 7);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Reset the CCtx */
         ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_compressionLevel, &value));
         CHECK_EQ(value, 7);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Reset the parameters */
         ZSTD_CCtx_reset(cctx, ZSTD_reset_parameters);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_compressionLevel, &value));
         CHECK_EQ(value, 3);
-        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_hashLog, &value));
         CHECK_EQ(value, 0);
 
         ZSTD_freeCCtx(cctx);
@@ -1285,7 +1285,7 @@ static int basicUnitTests(U32 seed, double compressibility)
                                         params);
             if (ZSTD_isError(cSize_1pass)) goto _output_error;
 
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, compressionLevel) );
             {   size_t const compressionResult = ZSTD_compress2(cctx,
                                     compressedBuffer, compressedBufferSize,
                                     CNBuffer, srcSize);
@@ -1304,9 +1304,9 @@ static int basicUnitTests(U32 seed, double compressibility)
         {   ZSTD_CCtx* const cctx = ZSTD_createCCtx();
             DISPLAYLEVEL(3, "test%3i : parameters in order : ", testNb++);
             assert(cctx != NULL);
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, 2) );
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_enableLongDistanceMatching, 1) );
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_windowLog, 18) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 2) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 1) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog, 18) );
             {   size_t const compressedSize = ZSTD_compress2(cctx,
                                 compressedBuffer, ZSTD_compressBound(inputSize),
                                 CNBuffer, inputSize);
@@ -1320,9 +1320,9 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         {   ZSTD_CCtx* cctx = ZSTD_createCCtx();
             DISPLAYLEVEL(3, "test%3i : parameters disordered : ", testNb++);
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_windowLog, 18) );
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_enableLongDistanceMatching, 1) );
-            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, 2) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog, 18) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 1) );
+            CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 2) );
             {   size_t const result = ZSTD_compress2(cctx,
                                 compressedBuffer, ZSTD_compressBound(inputSize),
                                 CNBuffer, inputSize);
@@ -1375,7 +1375,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         /* basic block compression */
         DISPLAYLEVEL(3, "test%3i : magic-less format test : ", testNb++);
-        CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_format, ZSTD_f_zstd1_magicless) );
+        CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_c_format, ZSTD_f_zstd1_magicless) );
         {   ZSTD_inBuffer in = { CNBuffer, inputSize, 0 };
             ZSTD_outBuffer out = { compressedBuffer, ZSTD_compressBound(inputSize), 0 };
             size_t const result = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1331,7 +1331,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         }
         {   ZSTD_inBuffer in = { compressedBuffer, cSize, 0 };
             ZSTD_outBuffer out = { decodedBuffer, CNBuffSize, 0 };
-            size_t const result = ZSTD_decompress_generic(dctx, &out, &in);
+            size_t const result = ZSTD_decompressStream(dctx, &out, &in);
             if (result != 0) goto _output_error;
             if (in.pos != in.size) goto _output_error;
             if (out.pos != inputSize) goto _output_error;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -504,7 +504,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     {   ZSTD_CCtx* const cctx = ZSTD_createCCtx();
         ZSTD_outBuffer out = {NULL, 0, 0};
         ZSTD_inBuffer in = {NULL, 0, 0};
-        unsigned value;
+        int value;
 
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
         CHECK_EQ(value, 3);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -237,7 +237,7 @@ static int FUZ_mallocTests_internal(unsigned seed, double compressibility, unsig
                 ZSTD_inBuffer in = { inBuffer, inSize, 0 };
                 CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
                 CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbWorkers, nbThreads) );
-                while ( ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end) ) {}
+                while ( ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end) ) {}
                 ZSTD_freeCCtx(cctx);
                 DISPLAYLEVEL(3, "compress_generic,-T%u,end level %i : ",
                                 nbThreads, compressionLevel);
@@ -257,8 +257,8 @@ static int FUZ_mallocTests_internal(unsigned seed, double compressibility, unsig
                 ZSTD_inBuffer in = { inBuffer, inSize, 0 };
                 CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
                 CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_p_nbWorkers, nbThreads) );
-                CHECK_Z( ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_continue) );
-                while ( ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end) ) {}
+                CHECK_Z( ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_continue) );
+                while ( ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end) ) {}
                 ZSTD_freeCCtx(cctx);
                 DISPLAYLEVEL(3, "compress_generic,-T%u,continue level %i : ",
                                 nbThreads, compressionLevel);
@@ -521,7 +521,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
         CHECK_EQ(value, ZSTD_HASHLOG_MIN);
         /* Start a compression job */
-        ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_continue);
+        ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_continue);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_compressionLevel, &value));
         CHECK_EQ(value, 7);
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_p_hashLog, &value));
@@ -1255,7 +1255,7 @@ static int basicUnitTests(U32 seed, double compressibility)
             CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, compressionLevel) );
             {   ZSTD_inBuffer in = { CNBuffer, srcSize, 0 };
                 ZSTD_outBuffer out = { compressedBuffer, compressedBufferSize, 0 };
-                size_t const compressionResult = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+                size_t const compressionResult = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
                 DISPLAYLEVEL(5, "simple=%zu vs %zu=advanced : ", cSize_1pass, out.pos);
                 if (ZSTD_isError(compressionResult)) goto _output_error;
                 if (out.pos != cSize_1pass) goto _output_error;
@@ -1276,7 +1276,7 @@ static int basicUnitTests(U32 seed, double compressibility)
             CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_windowLog, 18) );
             {   ZSTD_inBuffer in = { CNBuffer, inputSize, 0 };
                 ZSTD_outBuffer out = { compressedBuffer, ZSTD_compressBound(inputSize), 0 };
-                size_t const result = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+                size_t const result = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
                 if (result != 0) goto _output_error;
                 if (in.pos != in.size) goto _output_error;
                 cSize = out.pos;
@@ -1293,7 +1293,7 @@ static int basicUnitTests(U32 seed, double compressibility)
             CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_compressionLevel, 2) );
             {   ZSTD_inBuffer in = { CNBuffer, inputSize, 0 };
                 ZSTD_outBuffer out = { compressedBuffer, ZSTD_compressBound(inputSize), 0 };
-                size_t const result = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+                size_t const result = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
                 if (result != 0) goto _output_error;
                 if (in.pos != in.size) goto _output_error;
                 if (out.pos != cSize) goto _output_error;   /* must result in same compressed result, hence same size */
@@ -1313,7 +1313,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         CHECK( ZSTD_CCtx_setParameter(cctx, ZSTD_p_format, ZSTD_f_zstd1_magicless) );
         {   ZSTD_inBuffer in = { CNBuffer, inputSize, 0 };
             ZSTD_outBuffer out = { compressedBuffer, ZSTD_compressBound(inputSize), 0 };
-            size_t const result = ZSTD_compress_generic(cctx, &out, &in, ZSTD_e_end);
+            size_t const result = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
             if (result != 0) goto _output_error;
             if (in.pos != in.size) goto _output_error;
             cSize = out.pos;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -753,7 +753,7 @@ static int basicUnitTests(U32 seed, double compressibility)
                 const U32 skipLen = 129 KB;
                 MEM_writeLE32((BYTE*)compressedBuffer + off, ZSTD_MAGIC_SKIPPABLE_START);
                 MEM_writeLE32((BYTE*)compressedBuffer + off + 4, skipLen);
-                off += skipLen + ZSTD_skippableHeaderSize;
+                off += skipLen + ZSTD_SKIPPABLEHEADERSIZE;
             }
         }
         cSize = off;
@@ -1927,7 +1927,7 @@ static int fuzzerTests(U32 seed, U32 nbTests, unsigned startTest, U32 const maxD
         DISPLAYLEVEL(5, "fuzzer t%u: Bufferless streaming decompression test \n", testNb);
         /* ensure memory requirement is good enough (should always be true) */
         {   ZSTD_frameHeader zfh;
-            CHECK( ZSTD_getFrameHeader(&zfh, cBuffer, ZSTD_frameHeaderSize_max),
+            CHECK( ZSTD_getFrameHeader(&zfh, cBuffer, ZSTD_FRAMEHEADERSIZE_MAX),
                   "ZSTD_getFrameHeader(): error retrieving frame information");
             {   size_t const roundBuffSize = ZSTD_decodingBufferSize_min(zfh.windowSize, zfh.frameContentSize);
                 CHECK_Z(roundBuffSize);

--- a/tests/longmatch.c
+++ b/tests/longmatch.c
@@ -50,7 +50,7 @@ int main(int argc, const char** argv)
   params.cParams.chainLog = 13;
   params.cParams.hashLog = 14;
   params.cParams.searchLog = 1;
-  params.cParams.searchLength = 7;
+  params.cParams.minMatch = 7;
   params.cParams.targetLength = 16;
   params.cParams.strategy = ZSTD_fast;
   windowLog = params.cParams.windowLog;

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -128,7 +128,7 @@ static const U32 rangetable[NUM_PARAMS] =
 
 /* ZSTD_cctxSetParameter() index to set */
 static const ZSTD_cParameter cctxSetParamTable[NUM_PARAMS] =
-        { ZSTD_p_windowLog, ZSTD_p_chainLog, ZSTD_p_hashLog, ZSTD_p_searchLog, ZSTD_p_minMatch, ZSTD_p_targetLength, ZSTD_p_compressionStrategy, ZSTD_p_forceAttachDict };
+        { ZSTD_c_windowLog, ZSTD_c_chainLog, ZSTD_c_hashLog, ZSTD_c_searchLog, ZSTD_c_minMatch, ZSTD_c_targetLength, ZSTD_c_compressionStrategy, ZSTD_c_forceAttachDict };
 
 /* names of parameters */
 static const char* g_paramNames[NUM_PARAMS] =
@@ -894,7 +894,7 @@ static size_t local_initCCtx(void* payload) {
     const BMK_initCCtxArgs* ag = (const BMK_initCCtxArgs*)payload;
     varInds_t i;
     ZSTD_CCtx_reset(ag->cctx, ZSTD_reset_session_and_parameters);
-    ZSTD_CCtx_setParameter(ag->cctx, ZSTD_p_compressionLevel, ag->cLevel);
+    ZSTD_CCtx_setParameter(ag->cctx, ZSTD_c_compressionLevel, ag->cLevel);
 
     for(i = 0; i < NUM_PARAMS; i++) {
         if(ag->comprParams->vals[i] != PARAM_UNSET)

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -948,7 +948,7 @@ static size_t local_defaultDecompress(
         if(out.pos == out.size) {
             return (size_t)-ZSTD_error_dstSize_tooSmall;
         }
-        moreToFlush = ZSTD_decompress_generic(dctx,
+        moreToFlush = ZSTD_decompressStream(dctx,
                             &out, &in);
         if (ZSTD_isError(moreToFlush)) {
             return moreToFlush;

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -893,8 +893,7 @@ typedef struct {
 static size_t local_initCCtx(void* payload) {
     const BMK_initCCtxArgs* ag = (const BMK_initCCtxArgs*)payload;
     varInds_t i;
-    ZSTD_CCtx_reset(ag->cctx);
-    ZSTD_CCtx_resetParameters(ag->cctx);
+    ZSTD_CCtx_reset(ag->cctx, ZSTD_CCtx_reset_session_and_parameters);
     ZSTD_CCtx_setParameter(ag->cctx, ZSTD_p_compressionLevel, ag->cLevel);
 
     for(i = 0; i < NUM_PARAMS; i++) {

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -920,30 +920,13 @@ static size_t local_initDCtx(void* payload) {
 
 /* additional argument is just the context */
 static size_t local_defaultCompress(
-    const void* srcBuffer, size_t srcSize,
-    void* dstBuffer, size_t dstSize,
-    void* addArgs) {
-    size_t moreToFlush = 1;
-    ZSTD_CCtx* ctx = (ZSTD_CCtx*)addArgs;
-    ZSTD_inBuffer in;
-    ZSTD_outBuffer out;
-    in.src = srcBuffer;
-    in.size = srcSize;
-    in.pos = 0;
-    out.dst = dstBuffer;
-    out.size = dstSize;
-    out.pos = 0;
+                            const void* srcBuffer, size_t srcSize,
+                            void* dstBuffer, size_t dstSize,
+                            void* addArgs)
+{
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)addArgs;
     assert(dstSize == ZSTD_compressBound(srcSize)); /* specific to this version, which is only used in paramgrill */
-    while (moreToFlush) {
-        if(out.pos == out.size) {
-            return (size_t)-ZSTD_error_dstSize_tooSmall;
-        }
-        moreToFlush = ZSTD_compress_generic(ctx, &out, &in, ZSTD_e_end);
-        if (ZSTD_isError(moreToFlush)) {
-            return moreToFlush;
-        }
-    }
-    return out.pos;
+    return ZSTD_compress2(cctx, dstBuffer, dstSize, srcBuffer, srcSize);
 }
 
 /* additional argument is just the context */

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -893,7 +893,7 @@ typedef struct {
 static size_t local_initCCtx(void* payload) {
     const BMK_initCCtxArgs* ag = (const BMK_initCCtxArgs*)payload;
     varInds_t i;
-    ZSTD_CCtx_reset(ag->cctx, ZSTD_CCtx_reset_session_and_parameters);
+    ZSTD_CCtx_reset(ag->cctx, ZSTD_reset_session_and_parameters);
     ZSTD_CCtx_setParameter(ag->cctx, ZSTD_p_compressionLevel, ag->cLevel);
 
     for(i = 0; i < NUM_PARAMS; i++) {
@@ -913,7 +913,7 @@ typedef struct {
 
 static size_t local_initDCtx(void* payload) {
     const BMK_initDCtxArgs* ag = (const BMK_initDCtxArgs*)payload;
-    ZSTD_DCtx_reset(ag->dctx);
+    ZSTD_DCtx_reset(ag->dctx, ZSTD_reset_session_and_parameters);
     ZSTD_DCtx_loadDictionary(ag->dctx, ag->dictBuffer, ag->dictBufferSize);
     return 0;
 }

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -242,8 +242,8 @@ roundTripTest -g512K
 roundTripTest -g512K " --zstd=mml=3,tlen=48,strat=6"
 roundTripTest -g512K " --zstd=strat=6,wlog=23,clog=23,hlog=22,slog=6"
 roundTripTest -g512K " --zstd=windowLog=23,chainLog=23,hashLog=22,searchLog=6,minMatch=3,targetLength=48,strategy=6"
-roundTripTest -g512K " --single-thread --long --zstd=ldmHashLog=20,ldmMinMatch=64,ldmBucketSizeLog=1,ldmHashEveryLog=7"
-roundTripTest -g512K " --single-thread --long --zstd=lhlog=20,lmml=64,lblog=1,lhevery=7"
+roundTripTest -g512K " --single-thread --long --zstd=ldmHashLog=20,ldmMinMatch=64,ldmBucketSizeLog=1,ldmHashRateLog=7"
+roundTripTest -g512K " --single-thread --long --zstd=lhlog=20,lmml=64,lblog=1,lhrlog=7"
 roundTripTest -g512K 19
 
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -239,11 +239,11 @@ $ECHO "Hello world!" | $ZSTD --zstd=windowLo=21        - -o tmp.zst && die "wron
 $ECHO "Hello world!" | $ZSTD --zstd=windowLog=21,slog  - -o tmp.zst && die "wrong parameters not detected!"
 test ! -f tmp.zst  # tmp.zst should not be created
 roundTripTest -g512K
-roundTripTest -g512K " --zstd=slen=3,tlen=48,strat=6"
+roundTripTest -g512K " --zstd=mml=3,tlen=48,strat=6"
 roundTripTest -g512K " --zstd=strat=6,wlog=23,clog=23,hlog=22,slog=6"
-roundTripTest -g512K " --zstd=windowLog=23,chainLog=23,hashLog=22,searchLog=6,searchLength=3,targetLength=48,strategy=6"
-roundTripTest -g512K " --single-thread --long --zstd=ldmHashLog=20,ldmSearchLength=64,ldmBucketSizeLog=1,ldmHashEveryLog=7"
-roundTripTest -g512K " --single-thread --long --zstd=ldmhlog=20,ldmslen=64,ldmblog=1,ldmhevery=7"
+roundTripTest -g512K " --zstd=windowLog=23,chainLog=23,hashLog=22,searchLog=6,minMatch=3,targetLength=48,strategy=6"
+roundTripTest -g512K " --single-thread --long --zstd=ldmHashLog=20,ldmMinMatch=64,ldmBucketSizeLog=1,ldmHashEveryLog=7"
+roundTripTest -g512K " --single-thread --long --zstd=lhlog=20,lmml=64,lblog=1,lhevery=7"
 roundTripTest -g512K 19
 
 

--- a/tests/roundTripCrash.c
+++ b/tests/roundTripCrash.c
@@ -93,9 +93,9 @@ static size_t cctxParamRoundTripTest(void* resultBuff, size_t resultBuffCapacity
     int const cLevel = h32 % maxClevel;
 
     /* Set parameters */
-    CHECK_Z( ZSTD_CCtxParam_setParameter(cctxParams, ZSTD_p_compressionLevel, cLevel) );
-    CHECK_Z( ZSTD_CCtxParam_setParameter(cctxParams, ZSTD_p_nbWorkers, 2) );
-    CHECK_Z( ZSTD_CCtxParam_setParameter(cctxParams, ZSTD_p_overlapSizeLog, 5) );
+    CHECK_Z( ZSTD_CCtxParam_setParameter(cctxParams, ZSTD_c_compressionLevel, cLevel) );
+    CHECK_Z( ZSTD_CCtxParam_setParameter(cctxParams, ZSTD_c_nbWorkers, 2) );
+    CHECK_Z( ZSTD_CCtxParam_setParameter(cctxParams, ZSTD_c_overlapSizeLog, 5) );
 
 
     /* Apply parameters */

--- a/tests/roundTripCrash.c
+++ b/tests/roundTripCrash.c
@@ -85,7 +85,7 @@ static size_t cctxParamRoundTripTest(void* resultBuff, size_t resultBuffCapacity
     ZSTD_CCtx* const cctx = ZSTD_createCCtx();
     ZSTD_CCtx_params* const cctxParams = ZSTD_createCCtxParams();
     ZSTD_inBuffer inBuffer = { srcBuff, srcBuffSize, 0 };
-    ZSTD_outBuffer outBuffer = {compressedBuff, compressedBuffCapacity, 0 };
+    ZSTD_outBuffer outBuffer = { compressedBuff, compressedBuffCapacity, 0 };
 
     static const int maxClevel = 19;
     size_t const hashLength = MIN(128, srcBuffSize);
@@ -101,7 +101,7 @@ static size_t cctxParamRoundTripTest(void* resultBuff, size_t resultBuffCapacity
     /* Apply parameters */
     CHECK_Z( ZSTD_CCtx_setParametersUsingCCtxParams(cctx, cctxParams) );
 
-    CHECK_Z (ZSTD_compress_generic(cctx, &outBuffer, &inBuffer, ZSTD_e_end) );
+    CHECK_Z (ZSTD_compressStream2(cctx, &outBuffer, &inBuffer, ZSTD_e_end) );
 
     ZSTD_freeCCtxParams(cctxParams);
     ZSTD_freeCCtx(cctx);

--- a/tests/symbols.c
+++ b/tests/symbols.c
@@ -89,7 +89,6 @@ static const void *symbols[] = {
   &ZSTD_sizeof_CStream,
   &ZSTD_createDStream_advanced,
   &ZSTD_initDStream_usingDict,
-  &ZSTD_setDStreamParameter,
   &ZSTD_initDStream_usingDDict,
   &ZSTD_resetDStream,
   &ZSTD_sizeof_DStream,

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -379,7 +379,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     inBuff2 = inBuff;
     DISPLAYLEVEL(3, "test%3i : decompress %u bytes : ", testNb++, COMPRESSIBLE_NOISE_LENGTH);
     ZSTD_initDStream_usingDict(zd, CNBuffer, dictSize);
-    CHECK_Z( ZSTD_setDStreamParameter(zd, DStream_p_maxWindowSize, 1000000000) );  /* large limit */
+    CHECK_Z( ZSTD_DCtx_setMaxWindowSize(zd, 1000000000) );  /* large limit */
     { size_t const remaining = ZSTD_decompressStream(zd, &outBuff, &inBuff);
       if (remaining != 0) goto _output_error; }  /* should reach end of frame == 0; otherwise, some data left, or an error */
     if (outBuff.pos != CNBufferSize) goto _output_error;   /* should regenerate the same amount */
@@ -649,16 +649,10 @@ static int basicUnitTests(U32 seed, double compressibility)
         DISPLAYLEVEL(3, "OK \n");
     }
 
-    /* test ZSTD_setDStreamParameter() resilience */
-    DISPLAYLEVEL(3, "test%3i : wrong parameter for ZSTD_setDStreamParameter(): ", testNb++);
-    { size_t const r = ZSTD_setDStreamParameter(zd, (ZSTD_DStreamParameter_e)999, 1);  /* large limit */
-      if (!ZSTD_isError(r)) goto _output_error; }
-    DISPLAYLEVEL(3, "OK \n");
-
     /* Memory restriction */
     DISPLAYLEVEL(3, "test%3i : maxWindowSize < frame requirement : ", testNb++);
     ZSTD_initDStream_usingDict(zd, CNBuffer, dictSize);
-    CHECK_Z( ZSTD_setDStreamParameter(zd, DStream_p_maxWindowSize, 1000) );  /* too small limit */
+    CHECK_Z( ZSTD_DCtx_setMaxWindowSize(zd, 1000) );  /* too small limit */
     outBuff.dst = decodedBuffer;
     outBuff.size = CNBufferSize;
     outBuff.pos = 0;
@@ -940,7 +934,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         ZSTD_resetDStream(zd);
         CHECK_Z(ZSTD_CCtx_refCDict(zc, cdict));
         CHECK_Z(ZSTD_initDStream_usingDDict(zd, ddict));
-        CHECK_Z(ZSTD_setDStreamParameter(zd, DStream_p_maxWindowSize, 1U << kMaxWindowLog));
+        CHECK_Z(ZSTD_DCtx_setMaxWindowSize(zd, 1U << kMaxWindowLog));
         /* Test all values < 300 */
         for (value = 0; value < 300; ++value) {
             for (type = (SEQ_gen_type)0; type < SEQ_gen_max; ++type) {

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -224,18 +224,18 @@ static size_t SEQ_generateRoundTrip(ZSTD_CCtx* cctx, ZSTD_DCtx* dctx,
 static size_t getCCtxParams(ZSTD_CCtx* zc, ZSTD_parameters* savedParams)
 {
     int value;
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_windowLog, (int*)&savedParams->cParams.windowLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_hashLog, (int*)&savedParams->cParams.hashLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_chainLog, (int*)&savedParams->cParams.chainLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_searchLog, (int*)&savedParams->cParams.searchLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_minMatch, (int*)&savedParams->cParams.minMatch));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_targetLength, (int*)&savedParams->cParams.targetLength));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_compressionStrategy, &value));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_windowLog, (int*)&savedParams->cParams.windowLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_hashLog, (int*)&savedParams->cParams.hashLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_chainLog, (int*)&savedParams->cParams.chainLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_searchLog, (int*)&savedParams->cParams.searchLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_minMatch, (int*)&savedParams->cParams.minMatch));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_targetLength, (int*)&savedParams->cParams.targetLength));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_compressionStrategy, &value));
     savedParams->cParams.strategy = value;
 
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_checksumFlag, &savedParams->fParams.checksumFlag));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_contentSizeFlag, &savedParams->fParams.contentSizeFlag));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_dictIDFlag, &value));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_checksumFlag, &savedParams->fParams.checksumFlag));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_contentSizeFlag, &savedParams->fParams.contentSizeFlag));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_dictIDFlag, &value));
     savedParams->fParams.noDictIDFlag = !value;
     return 0;
 }
@@ -868,9 +868,9 @@ static int basicUnitTests(U32 seed, double compressibility)
         const BYTE* const srcToCopy = (const BYTE*)CNBuffer + start;
         BYTE* const dst = (BYTE*)CNBuffer + start - offset;
         DISPLAYLEVEL(3, "test%3i : compress %u bytes with multiple threads + dictionary : ", testNb++, (U32)srcSize);
-        CHECK_Z( ZSTD_CCtx_setParameter(zc, ZSTD_p_compressionLevel, 3) );
-        CHECK_Z( ZSTD_CCtx_setParameter(zc, ZSTD_p_nbWorkers, nbWorkers) );
-        CHECK_Z( ZSTD_CCtx_setParameter(zc, ZSTD_p_jobSize, jobSize) );
+        CHECK_Z( ZSTD_CCtx_setParameter(zc, ZSTD_c_compressionLevel, 3) );
+        CHECK_Z( ZSTD_CCtx_setParameter(zc, ZSTD_c_nbWorkers, nbWorkers) );
+        CHECK_Z( ZSTD_CCtx_setParameter(zc, ZSTD_c_jobSize, jobSize) );
         assert(start > offset);
         assert(start + segLength < COMPRESSIBLE_NOISE_LENGTH);
         memcpy(dst, srcToCopy, segLength);   /* create a long repetition at long distance for job 2 */
@@ -964,10 +964,10 @@ static int basicUnitTests(U32 seed, double compressibility)
     DISPLAYLEVEL(3, "test%3i : ZSTD_initCStream_srcSize sets requestedParams : ", testNb++);
     {   int level;
         CHECK_Z(ZSTD_initCStream_srcSize(zc, 11, ZSTD_CONTENTSIZE_UNKNOWN));
-        CHECK_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_compressionLevel, &level));
+        CHECK_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_compressionLevel, &level));
         CHECK(level != 11, "Compression level does not match");
         ZSTD_resetCStream(zc, ZSTD_CONTENTSIZE_UNKNOWN);
-        CHECK_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_compressionLevel, &level));
+        CHECK_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_compressionLevel, &level));
         CHECK(level != 11, "Compression level does not match");
     }
     DISPLAYLEVEL(3, "OK \n");
@@ -1079,7 +1079,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         CHECK_Z(ZSTD_CCtx_reset(zc, ZSTD_reset_session_and_parameters));
         CHECK_Z(ZSTD_CCtx_refCDict(zc, cdict));
-        CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_p_checksumFlag, 1));
+        CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_c_checksumFlag, 1));
         /* Write a bunch of 6 byte blocks */
         while (remainingInput > 0) {
           char testBuffer[6] = "\xAA\xAA\xAA\xAA\xAA\xAA";
@@ -1817,7 +1817,7 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest,
             if (maxTestSize >= srcBufferSize) maxTestSize = srcBufferSize-1;
             {   int const compressionLevel = (FUZ_rand(&lseed) % 5) + 1;
                 DISPLAYLEVEL(5, "t%u : compression level : %i \n", testNb, compressionLevel);
-                CHECK_Z (setCCtxParameter(zc, cctxParams, ZSTD_p_compressionLevel, compressionLevel, opaqueAPI) );
+                CHECK_Z (setCCtxParameter(zc, cctxParams, ZSTD_c_compressionLevel, compressionLevel, opaqueAPI) );
             }
         } else {
             U32 const testLog = FUZ_rand(&lseed) % maxSrcLog;
@@ -1857,39 +1857,39 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest,
 
                 if (FUZ_rand(&lseed) & 1) {
                     DISPLAYLEVEL(5, "t%u: windowLog : %u \n", testNb, cParams.windowLog);
-                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_windowLog, cParams.windowLog, opaqueAPI) );
+                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_windowLog, cParams.windowLog, opaqueAPI) );
                     assert(cParams.windowLog >= ZSTD_WINDOWLOG_MIN);   /* guaranteed by ZSTD_adjustCParams() */
                     windowLogMalus = (cParams.windowLog - ZSTD_WINDOWLOG_MIN) / 5;
                 }
                 if (FUZ_rand(&lseed) & 1) {
                     DISPLAYLEVEL(5, "t%u: hashLog : %u \n", testNb, cParams.hashLog);
-                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_hashLog, cParams.hashLog, opaqueAPI) );
+                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_hashLog, cParams.hashLog, opaqueAPI) );
                 }
                 if (FUZ_rand(&lseed) & 1) {
                     DISPLAYLEVEL(5, "t%u: chainLog : %u \n", testNb, cParams.chainLog);
-                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_chainLog, cParams.chainLog, opaqueAPI) );
+                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_chainLog, cParams.chainLog, opaqueAPI) );
                 }
-                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_searchLog, cParams.searchLog, opaqueAPI) );
-                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_minMatch, cParams.minMatch, opaqueAPI) );
-                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_targetLength, cParams.targetLength, opaqueAPI) );
+                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_searchLog, cParams.searchLog, opaqueAPI) );
+                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_minMatch, cParams.minMatch, opaqueAPI) );
+                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_targetLength, cParams.targetLength, opaqueAPI) );
 
                 /* mess with long distance matching parameters */
                 if (bigTests) {
-                    if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_enableLongDistanceMatching, FUZ_rand(&lseed) & 63, opaqueAPI) );
-                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmHashLog, FUZ_randomClampedLength(&lseed, ZSTD_HASHLOG_MIN, 23), opaqueAPI) );
-                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmMinMatch, FUZ_randomClampedLength(&lseed, ZSTD_LDM_MINMATCH_MIN, ZSTD_LDM_MINMATCH_MAX), opaqueAPI) );
-                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmBucketSizeLog, FUZ_randomClampedLength(&lseed, ZSTD_LDM_BUCKETSIZELOG_MIN, ZSTD_LDM_BUCKETSIZELOG_MAX), opaqueAPI) );
-                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmHashRateLog, FUZ_randomClampedLength(&lseed, ZSTD_LDM_HASHRATELOG_MIN, ZSTD_LDM_HASHRATELOG_MAX), opaqueAPI) );
+                    if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_enableLongDistanceMatching, FUZ_rand(&lseed) & 63, opaqueAPI) );
+                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_ldmHashLog, FUZ_randomClampedLength(&lseed, ZSTD_HASHLOG_MIN, 23), opaqueAPI) );
+                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_ldmMinMatch, FUZ_randomClampedLength(&lseed, ZSTD_LDM_MINMATCH_MIN, ZSTD_LDM_MINMATCH_MAX), opaqueAPI) );
+                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_ldmBucketSizeLog, FUZ_randomClampedLength(&lseed, ZSTD_LDM_BUCKETSIZELOG_MIN, ZSTD_LDM_BUCKETSIZELOG_MAX), opaqueAPI) );
+                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_ldmHashRateLog, FUZ_randomClampedLength(&lseed, ZSTD_LDM_HASHRATELOG_MIN, ZSTD_LDM_HASHRATELOG_MAX), opaqueAPI) );
                 }
 
                 /* mess with frame parameters */
                 if (FUZ_rand(&lseed) & 1) {
                     U32 const checksumFlag = FUZ_rand(&lseed) & 1;
                     DISPLAYLEVEL(5, "t%u: frame checksum : %u \n", testNb, checksumFlag);
-                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_checksumFlag, checksumFlag, opaqueAPI) );
+                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_checksumFlag, checksumFlag, opaqueAPI) );
                 }
-                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_dictIDFlag, FUZ_rand(&lseed) & 1, opaqueAPI) );
-                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_contentSizeFlag, FUZ_rand(&lseed) & 1, opaqueAPI) );
+                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_dictIDFlag, FUZ_rand(&lseed) & 1, opaqueAPI) );
+                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_contentSizeFlag, FUZ_rand(&lseed) & 1, opaqueAPI) );
                 if (FUZ_rand(&lseed) & 1) {
                     DISPLAYLEVEL(5, "t%u: pledgedSrcSize : %u \n", testNb, (U32)pledgedSrcSize);
                     CHECK_Z( ZSTD_CCtx_setPledgedSrcSize(zc, pledgedSrcSize) );
@@ -1901,17 +1901,17 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest,
                     U32 const nbThreadsAdjusted = (windowLogMalus < nbThreadsCandidate) ? nbThreadsCandidate - windowLogMalus : 1;
                     U32 const nbThreads = MIN(nbThreadsAdjusted, nbThreadsMax);
                     DISPLAYLEVEL(5, "t%u: nbThreads : %u \n", testNb, nbThreads);
-                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_nbWorkers, nbThreads, opaqueAPI) );
+                    CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_nbWorkers, nbThreads, opaqueAPI) );
                     if (nbThreads > 1) {
                         U32 const jobLog = FUZ_rand(&lseed) % (testLog+1);
-                        CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_overlapSizeLog, FUZ_rand(&lseed) % 10, opaqueAPI) );
-                        CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_jobSize, (U32)FUZ_rLogLength(&lseed, jobLog), opaqueAPI) );
+                        CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_overlapSizeLog, FUZ_rand(&lseed) % 10, opaqueAPI) );
+                        CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_jobSize, (U32)FUZ_rLogLength(&lseed, jobLog), opaqueAPI) );
                     }
                 }
                 /* Enable rsyncable mode 1 in 4 times. */
-                setCCtxParameter(zc, cctxParams, ZSTD_p_rsyncable, (FUZ_rand(&lseed) % 4 == 0), opaqueAPI);
+                setCCtxParameter(zc, cctxParams, ZSTD_c_rsyncable, (FUZ_rand(&lseed) % 4 == 0), opaqueAPI);
 
-                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_forceMaxWindow, FUZ_rand(&lseed) & 1, opaqueAPI) );
+                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_c_forceMaxWindow, FUZ_rand(&lseed) & 1, opaqueAPI) );
 
                 /* Apply parameters */
                 if (opaqueAPI) {
@@ -1931,7 +1931,7 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest,
                             size_t const setError = ZSTD_CCtx_setParametersUsingCCtxParams(zc, cctxParams);
                             CHECK(!ZSTD_isError(setError), "ZSTD_CCtx_setParametersUsingCCtxParams should have failed");
                         } else {
-                            size_t const setError = ZSTD_CCtx_setParameter(zc, ZSTD_p_windowLog, cParams.windowLog-1);
+                            size_t const setError = ZSTD_CCtx_setParameter(zc, ZSTD_c_windowLog, cParams.windowLog-1);
                             CHECK(!ZSTD_isError(setError), "ZSTD_CCtx_setParameter should have failed");
                         }
                     }

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -379,7 +379,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     inBuff2 = inBuff;
     DISPLAYLEVEL(3, "test%3i : decompress %u bytes : ", testNb++, COMPRESSIBLE_NOISE_LENGTH);
     ZSTD_initDStream_usingDict(zd, CNBuffer, dictSize);
-    CHECK_Z( ZSTD_DCtx_setMaxWindowSize(zd, 1000000000) );  /* large limit */
+    CHECK_Z( ZSTD_DCtx_setParameter(zd, ZSTD_d_windowLogMax, ZSTD_WINDOWLOG_LIMIT_DEFAULT+1) );  /* large limit */
     { size_t const remaining = ZSTD_decompressStream(zd, &outBuff, &inBuff);
       if (remaining != 0) goto _output_error; }  /* should reach end of frame == 0; otherwise, some data left, or an error */
     if (outBuff.pos != CNBufferSize) goto _output_error;   /* should regenerate the same amount */
@@ -652,7 +652,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     /* Memory restriction */
     DISPLAYLEVEL(3, "test%3i : maxWindowSize < frame requirement : ", testNb++);
     ZSTD_initDStream_usingDict(zd, CNBuffer, dictSize);
-    CHECK_Z( ZSTD_DCtx_setMaxWindowSize(zd, 1000) );  /* too small limit */
+    CHECK_Z( ZSTD_DCtx_setParameter(zd, ZSTD_d_windowLogMax, 10) );  /* too small limit */
     outBuff.dst = decodedBuffer;
     outBuff.size = CNBufferSize;
     outBuff.pos = 0;
@@ -934,7 +934,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         ZSTD_resetDStream(zd);
         CHECK_Z(ZSTD_CCtx_refCDict(zc, cdict));
         CHECK_Z(ZSTD_initDStream_usingDDict(zd, ddict));
-        CHECK_Z(ZSTD_DCtx_setMaxWindowSize(zd, 1U << kMaxWindowLog));
+        CHECK_Z(ZSTD_DCtx_setParameter(zd, ZSTD_d_windowLogMax, kMaxWindowLog));
         /* Test all values < 300 */
         for (value = 0; value < 300; ++value) {
             for (type = (SEQ_gen_type)0; type < SEQ_gen_max; ++type) {

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -228,7 +228,7 @@ static size_t getCCtxParams(ZSTD_CCtx* zc, ZSTD_parameters* savedParams)
     CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_hashLog, &savedParams->cParams.hashLog));
     CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_chainLog, &savedParams->cParams.chainLog));
     CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_searchLog, &savedParams->cParams.searchLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_minMatch, &savedParams->cParams.searchLength));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_minMatch, &savedParams->cParams.minMatch));
     CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_targetLength, &savedParams->cParams.targetLength));
     CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_compressionStrategy, &value));
     savedParams->cParams.strategy = value;
@@ -248,7 +248,7 @@ static U32 badParameters(ZSTD_CCtx* zc, ZSTD_parameters const savedParams)
     CHECK_RET(2, params.cParams.hashLog != savedParams.cParams.hashLog, "hashLog");
     CHECK_RET(3, params.cParams.chainLog != savedParams.cParams.chainLog, "chainLog");
     CHECK_RET(4, params.cParams.searchLog != savedParams.cParams.searchLog, "searchLog");
-    CHECK_RET(5, params.cParams.searchLength != savedParams.cParams.searchLength, "searchLength");
+    CHECK_RET(5, params.cParams.minMatch != savedParams.cParams.minMatch, "minMatch");
     CHECK_RET(6, params.cParams.targetLength != savedParams.cParams.targetLength, "targetLength");
 
     CHECK_RET(7, params.fParams.checksumFlag != savedParams.fParams.checksumFlag, "checksumFlag");
@@ -353,7 +353,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     DISPLAYLEVEL(3, "test%3i : use bad compression parameters : ", testNb++);
     {   size_t r;
         ZSTD_parameters params = ZSTD_getParams(1, 0, 0);
-        params.cParams.searchLength = 2;
+        params.cParams.minMatch = 2;
         r = ZSTD_initCStream_advanced(zc, NULL, 0, params, 0);
         if (!ZSTD_isError(r)) goto _output_error;
         DISPLAYLEVEL(3, "init error : %s \n", ZSTD_getErrorName(r));
@@ -1851,7 +1851,7 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest,
                 cParams.chainLog += (FUZ_rand(&lseed) & 3) - 1;
                 cParams.searchLog += (FUZ_rand(&lseed) & 3) - 1;
                 cParams.searchLog = MIN(searchLogMax, cParams.searchLog);
-                cParams.searchLength += (FUZ_rand(&lseed) & 3) - 1;
+                cParams.minMatch += (FUZ_rand(&lseed) & 3) - 1;
                 cParams.targetLength = (U32)((cParams.targetLength + 1 ) * (0.5 + ((double)(FUZ_rand(&lseed) & 127) / 128)));
                 cParams = ZSTD_adjustCParams(cParams, pledgedSrcSize, dictSize);
 
@@ -1870,7 +1870,7 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest,
                     CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_chainLog, cParams.chainLog, opaqueAPI) );
                 }
                 if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_searchLog, cParams.searchLog, opaqueAPI) );
-                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_minMatch, cParams.searchLength, opaqueAPI) );
+                if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_minMatch, cParams.minMatch, opaqueAPI) );
                 if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_targetLength, cParams.targetLength, opaqueAPI) );
 
                 /* mess with long distance matching parameters */

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -223,13 +223,13 @@ static size_t SEQ_generateRoundTrip(ZSTD_CCtx* cctx, ZSTD_DCtx* dctx,
 
 static size_t getCCtxParams(ZSTD_CCtx* zc, ZSTD_parameters* savedParams)
 {
-    unsigned value;
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_windowLog, &savedParams->cParams.windowLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_hashLog, &savedParams->cParams.hashLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_chainLog, &savedParams->cParams.chainLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_searchLog, &savedParams->cParams.searchLog));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_minMatch, &savedParams->cParams.minMatch));
-    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_targetLength, &savedParams->cParams.targetLength));
+    int value;
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_windowLog, (int*)&savedParams->cParams.windowLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_hashLog, (int*)&savedParams->cParams.hashLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_chainLog, (int*)&savedParams->cParams.chainLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_searchLog, (int*)&savedParams->cParams.searchLog));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_minMatch, (int*)&savedParams->cParams.minMatch));
+    CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_targetLength, (int*)&savedParams->cParams.targetLength));
     CHECK_RET_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_compressionStrategy, &value));
     savedParams->cParams.strategy = value;
 
@@ -962,7 +962,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     DISPLAYLEVEL(3, "OK \n");
 
     DISPLAYLEVEL(3, "test%3i : ZSTD_initCStream_srcSize sets requestedParams : ", testNb++);
-    {   unsigned level;
+    {   int level;
         CHECK_Z(ZSTD_initCStream_srcSize(zc, 11, ZSTD_CONTENTSIZE_UNKNOWN));
         CHECK_Z(ZSTD_CCtx_getParameter(zc, ZSTD_p_compressionLevel, &level));
         CHECK(level != 11, "Compression level does not match");

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -662,7 +662,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     { size_t const r = ZSTD_decompressStream(zd, &outBuff, &inBuff);
       if (!ZSTD_isError(r)) goto _output_error;  /* must fail : frame requires > 100 bytes */
       DISPLAYLEVEL(3, "OK (%s)\n", ZSTD_getErrorName(r)); }
-    ZSTD_DCtx_reset(zd);   /* leave zd in good shape for next tests */
+    ZSTD_DCtx_reset(zd, ZSTD_reset_session_and_parameters);   /* leave zd in good shape for next tests */
 
     DISPLAYLEVEL(3, "test%3i : dictionary source size and level : ", testNb++);
     {   ZSTD_DCtx* const dctx = ZSTD_createDCtx();
@@ -930,7 +930,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         if (!cdict || !ddict) goto _output_error;
 
-        ZSTD_CCtx_reset(zc, ZSTD_CCtx_reset_session_only);
+        ZSTD_CCtx_reset(zc, ZSTD_reset_session_only);
         ZSTD_resetDStream(zd);
         CHECK_Z(ZSTD_CCtx_refCDict(zc, cdict));
         CHECK_Z(ZSTD_initDStream_usingDDict(zd, ddict));
@@ -1077,7 +1077,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         int remainingInput = 256 * 1024;
         int offset;
 
-        CHECK_Z(ZSTD_CCtx_reset(zc, ZSTD_CCtx_reset_session_and_parameters));
+        CHECK_Z(ZSTD_CCtx_reset(zc, ZSTD_reset_session_and_parameters));
         CHECK_Z(ZSTD_CCtx_refCDict(zc, cdict));
         CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_p_checksumFlag, 1));
         /* Write a bunch of 6 byte blocks */

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -930,7 +930,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         if (!cdict || !ddict) goto _output_error;
 
-        ZSTD_CCtx_reset(zc);
+        ZSTD_CCtx_reset(zc, ZSTD_CCtx_reset_session_only);
         ZSTD_resetDStream(zd);
         CHECK_Z(ZSTD_CCtx_refCDict(zc, cdict));
         CHECK_Z(ZSTD_initDStream_usingDDict(zd, ddict));
@@ -1077,8 +1077,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         int remainingInput = 256 * 1024;
         int offset;
 
-        ZSTD_CCtx_reset(zc);
-        CHECK_Z(ZSTD_CCtx_resetParameters(zc));
+        CHECK_Z(ZSTD_CCtx_reset(zc, ZSTD_CCtx_reset_session_and_parameters));
         CHECK_Z(ZSTD_CCtx_refCDict(zc, cdict));
         CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_p_checksumFlag, 1));
         /* Write a bunch of 6 byte blocks */

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1878,8 +1878,8 @@ static int fuzzerTests_newAPI(U32 seed, U32 nbTests, unsigned startTest,
                     if (FUZ_rand(&lseed) & 1) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_enableLongDistanceMatching, FUZ_rand(&lseed) & 63, opaqueAPI) );
                     if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmHashLog, FUZ_randomClampedLength(&lseed, ZSTD_HASHLOG_MIN, 23), opaqueAPI) );
                     if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmMinMatch, FUZ_randomClampedLength(&lseed, ZSTD_LDM_MINMATCH_MIN, ZSTD_LDM_MINMATCH_MAX), opaqueAPI) );
-                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmBucketSizeLog, FUZ_randomClampedLength(&lseed, 0, ZSTD_LDM_BUCKETSIZELOG_MAX), opaqueAPI) );
-                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmHashEveryLog, FUZ_randomClampedLength(&lseed, 0, ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN), opaqueAPI) );
+                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmBucketSizeLog, FUZ_randomClampedLength(&lseed, ZSTD_LDM_BUCKETSIZELOG_MIN, ZSTD_LDM_BUCKETSIZELOG_MAX), opaqueAPI) );
+                    if (FUZ_rand(&lseed) & 3) CHECK_Z( setCCtxParameter(zc, cctxParams, ZSTD_p_ldmHashRateLog, FUZ_randomClampedLength(&lseed, ZSTD_LDM_HASHRATELOG_MIN, ZSTD_LDM_HASHRATELOG_MAX), opaqueAPI) );
                 }
 
                 /* mess with frame parameters */

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -691,7 +691,7 @@ static int basicUnitTests(U32 seed, double compressibility)
                 if (inBuff.pos != inBuff.size) goto _output_error;
                 {   ZSTD_outBuffer decOut = {decodedBuffer, size, 0};
                     ZSTD_inBuffer decIn = {outBuff.dst, outBuff.pos, 0};
-                    CHECK_Z( ZSTD_decompress_generic(dctx, &decOut, &decIn) );
+                    CHECK_Z( ZSTD_decompressStream(dctx, &decOut, &decIn) );
                     if (decIn.pos != decIn.size) goto _output_error;
                     if (decOut.pos != size) goto _output_error;
                     {   U64 const crcDec = XXH64(decOut.dst, decOut.pos, 0);
@@ -759,7 +759,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     inBuff.src = compressedBuffer;
     inBuff.size = cSize;
     inBuff.pos = 0;
-    CHECK_Z( ZSTD_decompress_generic(zd, &outBuff, &inBuff) );
+    CHECK_Z( ZSTD_decompressStream(zd, &outBuff, &inBuff) );
     if (inBuff.pos != inBuff.size) goto _output_error;  /* entire input should be consumed */
     if (outBuff.pos != CNBufferSize) goto _output_error;  /* must regenerate whole input */
     DISPLAYLEVEL(3, "OK \n");

--- a/zlibWrapper/zstd_zlibwrapper.c
+++ b/zlibWrapper/zstd_zlibwrapper.c
@@ -31,7 +31,7 @@
 /* ===   Constants   === */
 #define Z_INFLATE_SYNC              8
 #define ZLIB_HEADERSIZE             4
-#define ZSTD_HEADERSIZE             ZSTD_frameHeaderSize_min
+#define ZSTD_HEADERSIZE             ZSTD_FRAMEHEADERSIZE_MIN
 #define ZWRAP_DEFAULT_CLEVEL        3   /* Z_DEFAULT_COMPRESSION is translated to ZWRAP_DEFAULT_CLEVEL for zstd */
 
 

--- a/zlibWrapper/zstd_zlibwrapper.c
+++ b/zlibWrapper/zstd_zlibwrapper.c
@@ -140,8 +140,8 @@ static int ZWRAP_initializeCStream(ZWRAP_CCtx* zwc, const void* dict, size_t dic
     if (!pledgedSrcSize) pledgedSrcSize = zwc->pledgedSrcSize;
     {   ZSTD_parameters const params = ZSTD_getParams(zwc->compressionLevel, pledgedSrcSize, dictSize);
         size_t initErr;
-        LOG_WRAPPERC("pledgedSrcSize=%d windowLog=%d chainLog=%d hashLog=%d searchLog=%d searchLength=%d strategy=%d\n",
-                    (int)pledgedSrcSize, params.cParams.windowLog, params.cParams.chainLog, params.cParams.hashLog, params.cParams.searchLog, params.cParams.searchLength, params.cParams.strategy);
+        LOG_WRAPPERC("pledgedSrcSize=%d windowLog=%d chainLog=%d hashLog=%d searchLog=%d minMatch=%d strategy=%d\n",
+                    (int)pledgedSrcSize, params.cParams.windowLog, params.cParams.chainLog, params.cParams.hashLog, params.cParams.searchLog, params.cParams.minMatch, params.cParams.strategy);
         initErr = ZSTD_initCStream_advanced(zwc->zbc, dict, dictSize, params, pledgedSrcSize);
         if (ZSTD_isError(initErr)) return Z_STREAM_ERROR;
     }


### PR DESCRIPTION
This patch creates a "staging area",
with experimental API designed to reach "stable" status by `v1.4.0`.
It mostly concerns a core part of the "advanced API", and necessary dependencies.

There are some questions remaining, which I believe should be addressed before merging this PR : 

- scope : The staged API has been limited to well-known advanced functionalities (sticky dictionaries, compression parameters, frame parameters, multi-threading, long distance mode) for which we have clear usage scenarios.  More advanced ones have been left into "experimental" status. But maybe it's too restrictive ?    
    + For example, there is a very new `--rsyncable` capability, it is currently labelled "experimental" : should it be part of "staging area" instead ?
- Some `enum` values in `ZSTD_cParameter` are branded "experimental", but they are still present in staging area, because an `enum` definition cannot be broken into 2 separate parts.
    + should these `enum` be moved away into "experimental" section ? For example, using `#define` instead ? Note this could cause some side-effects regarding `enum`-related checks, such as `-Wswitch-enum` and `-Wc++-compat`.
- There is no `ZSTD_DCtx_setParameter()` function which would mirror `ZSTD_CCtx_setParameter()`. A key reason is that there is only one parameter (`MaxWindowSize`) on the decompression side, hence a `ZSTD_DCtx_setParameter()` would have a single `enum` value. Moreover, even `ZSTD_CCtx_setParameter()` cannot set all parameters : several parameters require dedicated setter functions, such as dictionaries, and `pledgedSrcSize`. Still, should the list of decoder parameters increase in the future, this will either re-open the topic, or lead to 2 different logics, with decompression side using dedicated setters, rather than a single `ZSTD_DCtx_setParameter()` entry point.
- `ZSTD_?Ctx_reset()` works differently on compression and decompression sides : compression makes it possible to reset parameter and/or session, decompression resets everything only. Should their behavior converge ?
- What about `_simpleArgs()` variant ? are they relevant candidates for "stable" status ?

Some more related points, to be addressed in a separate PR : 

- #1249 : The new advanced API should have a simple one-pass function : and I guess it extends to both compression and decompression sides.
- Function naming : is `ZSTD_compress_generic` good enough ?
    + should this function be merged with `ZSTD_compressStream` instead ?

_Edit_ : 
- `ZSTD_DCtx_reset()` signature and behavior changed to match `ZSTD_CCtx_reset()`
- experimental `enum` are now pushed into experimental section of the API
- `_simpleArgs()` variants are now relegated to experimental section
- `rsyncable` is still part of experimental. We can revisit this choice after v1.3.8 (it can still be part of stable within v1.4.0 if it feels suitable).
- `ZSTD_compress_generic()` is renamed `ZSTD_compressStream2()`
- created `ZSTD_compress2()` as one-pass variant