### PR TITLE
Fix i386 build failure "Junk character 13"

### DIFF
--- a/lib/common/cpu.h
+++ b/lib/common/cpu.h
@@ -78,7 +78,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
       __asm__(
           "pushl %%ebx\n\t"
           "cpuid\n\t"
-          "movl %%ebx, %%eax\n\r"
+          "movl %%ebx, %%eax\n\t"
           "popl %%ebx"
           : "=a"(f7b), "=c"(f7c)
           : "a"(7), "c"(0)


### PR DESCRIPTION
This fixes a build failure on i386 with gcc-4.2 on Mac OS X 10.6 and earlier:

```
.tmp/cc).co70.s:899:Junk character 13 (
.tmp/cc8Vco70.s:899:Rest of line ignored. 1st junk character valued 112 (p).
.tmp/cc).co70.s:2502:Junk character 13 (
.tmp/cc8Vco70.s:2502:Rest of line ignored. 1st junk character valued 112 (p).
```

Thanks to @rmottola.