### PR TITLE
fixed a typo

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -151,7 +151,7 @@ static int usage_advanced(const char* programName)
 #ifdef UTIL_HAS_CREATEFILELIST
     DISPLAY( " -r     : operate recursively on directories \n");
 #endif
-    DISPLAY( "--format=zstd : compress files to the .zstd format (default) \n");
+    DISPLAY( "--format=zstd : compress files to the .zst format (default) \n");
 #ifdef ZSTD_GZCOMPRESS
     DISPLAY( "--format=gzip : compress files to the .gz format \n");
 #endif


### PR DESCRIPTION
Since zstd is generating files with the ending .zst I corrected the help output.