### PR TITLE
Refactor examples to avoid code duplication

### DIFF
--- a/examples/dictionary_compression.c
+++ b/examples/dictionary_compression.c
@@ -7,71 +7,13 @@
  * in the COPYING file in the root directory of this source tree).
  * You may select, at your option, one of the above-listed licenses.
  */
-
-
 #include <stdlib.h>    // malloc, exit
 #include <stdio.h>     // printf
 #include <string.h>    // strerror
 #include <errno.h>     // errno
 #include <sys/stat.h>  // stat
 #include <zstd.h>      // presumes zstd library is installed
-
-
-static off_t fsize_orDie(const char *filename)
-{
-    struct stat st;
-    if (stat(filename, &st) == 0) return st.st_size;
-    /* error */
-    perror(filename);
-    exit(1);
-}
-
-static FILE* fopen_orDie(const char *filename, const char *instruction)
-{
-    FILE* const inFile = fopen(filename, instruction);
-    if (inFile) return inFile;
-    /* error */
-    perror(filename);
-    exit(2);
-}
-
-static void* malloc_orDie(size_t size)
-{
-    void* const buff = malloc(size);
-    if (buff) return buff;
-    /* error */
-    perror("malloc");
-    exit(3);
-}
-
-static void* loadFile_orDie(const char* fileName, size_t* size)
-{
-    off_t const buffSize = fsize_orDie(fileName);
-    FILE* const inFile = fopen_orDie(fileName, "rb");
-    void* const buffer = malloc_orDie(buffSize);
-    size_t const readSize = fread(buffer, 1, buffSize, inFile);
-    if (readSize != (size_t)buffSize) {
-        fprintf(stderr, "fread: %s : %s \n", fileName, strerror(errno));
-        exit(4);
-    }
-    fclose(inFile);
-    *size = buffSize;
-    return buffer;
-}
-
-static void saveFile_orDie(const char* fileName, const void* buff, size_t buffSize)
-{
-    FILE* const oFile = fopen_orDie(fileName, "wb");
-    size_t const wSize = fwrite(buff, 1, buffSize, oFile);
-    if (wSize != (size_t)buffSize) {
-        fprintf(stderr, "fwrite: %s : %s \n", fileName, strerror(errno));
-        exit(5);
-    }
-    if (fclose(oFile)) {
-        perror(fileName);
-        exit(6);
-    }
-}
+#include "utils.h"
 
 /* createDict() :
    `dictFileName` is supposed to have been created using `zstd --train` */

--- a/examples/dictionary_decompression.c
+++ b/examples/dictionary_decompression.c
@@ -17,49 +17,7 @@
 #include <sys/stat.h>  // stat
 #define ZSTD_STATIC_LINKING_ONLY   // ZSTD_findDecompressedSize
 #include <zstd.h>      // presumes zstd library is installed
-
-
-static off_t fsize_orDie(const char *filename)
-{
-    struct stat st;
-    if (stat(filename, &st) == 0) return st.st_size;
-    /* error */
-    perror(filename);
-    exit(1);
-}
-
-static FILE* fopen_orDie(const char *filename, const char *instruction)
-{
-    FILE* const inFile = fopen(filename, instruction);
-    if (inFile) return inFile;
-    /* error */
-    perror(filename);
-    exit(2);
-}
-
-static void* malloc_orDie(size_t size)
-{
-    void* const buff = malloc(size);
-    if (buff) return buff;
-    /* error */
-    perror("malloc");
-    exit(3);
-}
-
-static void* loadFile_orDie(const char* fileName, size_t* size)
-{
-    off_t const buffSize = fsize_orDie(fileName);
-    FILE* const inFile = fopen_orDie(fileName, "rb");
-    void* const buffer = malloc_orDie(buffSize);
-    size_t const readSize = fread(buffer, 1, buffSize, inFile);
-    if (readSize != (size_t)buffSize) {
-        fprintf(stderr, "fread: %s : %s \n", fileName, strerror(errno));
-        exit(4);
-    }
-    fclose(inFile);
-    *size = buffSize;
-    return buffer;
-}
+#include "utils.h"
 
 /* createDict() :
    `dictFileName` is supposed to have been created using `zstd --train` */
@@ -73,7 +31,6 @@ static ZSTD_DDict* createDict_orDie(const char* dictFileName)
     free(dictBuffer);
     return ddict;
 }
-
 
 static void decompress(const char* fname, const ZSTD_DDict* ddict)
 {

--- a/examples/multiple_streaming_compression.c
+++ b/examples/multiple_streaming_compression.c
@@ -20,53 +20,7 @@
 #include <errno.h>     // errno
 #define ZSTD_STATIC_LINKING_ONLY  // streaming API defined as "experimental" for the time being
 #include <zstd.h>      // presumes zstd library is installed
-
-
-static void* malloc_orDie(size_t size)
-{
-    void* const buff = malloc(size);
-    if (buff) return buff;
-    /* error */
-    perror("malloc:");
-    exit(1);
-}
-
-static FILE* fopen_orDie(const char *filename, const char *instruction)
-{
-    FILE* const inFile = fopen(filename, instruction);
-    if (inFile) return inFile;
-    /* error */
-    perror(filename);
-    exit(3);
-}
-
-static size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
-{
-    size_t const readSize = fread(buffer, 1, sizeToRead, file);
-    if (readSize == sizeToRead) return readSize;   /* good */
-    if (feof(file)) return readSize;   /* good, reached end of file */
-    /* error */
-    perror("fread");
-    exit(4);
-}
-
-static size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
-{
-    size_t const writtenSize = fwrite(buffer, 1, sizeToWrite, file);
-    if (writtenSize == sizeToWrite) return sizeToWrite;   /* good */
-    /* error */
-    perror("fwrite");
-    exit(5);
-}
-
-static size_t fclose_orDie(FILE* file)
-{
-    if (!fclose(file)) return 0;
-    /* error */
-    perror("fclose");
-    exit(6);
-}
-
+#include "utils.h"
 
 typedef struct {
     void* buffIn;
@@ -94,7 +48,6 @@ static void freeResources(resources ress)
     free(ress.buffIn);
     free(ress.buffOut);
 }
-
 
 static void compressFile_orDie(resources ress, const char* fname, const char* outName, int cLevel)
 {
@@ -124,7 +77,6 @@ static void compressFile_orDie(resources ress, const char* fname, const char* ou
     fclose_orDie(fout);
     fclose_orDie(fin);
 }
-
 
 int main(int argc, const char** argv)
 {

--- a/examples/simple_compression.c
+++ b/examples/simple_compression.c
@@ -8,78 +8,13 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
-
-
 #include <stdlib.h>    // malloc, free, exit
 #include <stdio.h>     // fprintf, perror, fopen, etc.
 #include <string.h>    // strlen, strcat, memset, strerror
 #include <errno.h>     // errno
 #include <sys/stat.h>  // stat
 #include <zstd.h>      // presumes zstd library is installed
-
-
-static off_t fsize_orDie(const char *filename)
-{
-    struct stat st;
-    if (stat(filename, &st) == 0) return st.st_size;
-    /* error */
-    perror(filename);
-    exit(1);
-}
-
-static FILE* fopen_orDie(const char *filename, const char *instruction)
-{
-    FILE* const inFile = fopen(filename, instruction);
-    if (inFile) return inFile;
-    /* error */
-    perror(filename);
-    exit(2);
-}
-
-static void* malloc_orDie(size_t size)
-{
-    void* const buff = malloc(size);
-    if (buff) return buff;
-    /* error */
-    perror(NULL);
-    exit(3);
-}
-
-static void* loadFile_orDie(const char* fileName, size_t* size)
-{
-    off_t const fileSize = fsize_orDie(fileName);
-    size_t const buffSize = (size_t)fileSize;
-    if ((off_t)buffSize < fileSize) {   /* narrowcast overflow */
-        fprintf(stderr, "%s : filesize too large \n", fileName);
-        exit(4);
-    }
-    FILE* const inFile = fopen_orDie(fileName, "rb");
-    void* const buffer = malloc_orDie(buffSize);
-    size_t const readSize = fread(buffer, 1, buffSize, inFile);
-    if (readSize != (size_t)buffSize) {
-        fprintf(stderr, "fread: %s : %s \n", fileName, strerror(errno));
-        exit(5);
-    }
-    fclose(inFile);  /* can't fail, read only */
-    *size = buffSize;
-    return buffer;
-}
-
-
-static void saveFile_orDie(const char* fileName, const void* buff, size_t buffSize)
-{
-    FILE* const oFile = fopen_orDie(fileName, "wb");
-    size_t const wSize = fwrite(buff, 1, buffSize, oFile);
-    if (wSize != (size_t)buffSize) {
-        fprintf(stderr, "fwrite: %s : %s \n", fileName, strerror(errno));
-        exit(6);
-    }
-    if (fclose(oFile)) {
-        perror(fileName);
-        exit(7);
-    }
-}
-
+#include "utils.h"
 
 static void compress_orDie(const char* fname, const char* oname)
 {
@@ -102,7 +37,6 @@ static void compress_orDie(const char* fname, const char* oname)
     free(fBuff);
     free(cBuff);
 }
-
 
 static char* createOutFilename_orDie(const char* filename)
 {

--- a/examples/simple_decompression.c
+++ b/examples/simple_decompression.c
@@ -15,50 +15,7 @@
 #include <sys/stat.h>  // stat
 #define ZSTD_STATIC_LINKING_ONLY   // ZSTD_findDecompressedSize
 #include <zstd.h>      // presumes zstd library is installed
-
-
-static off_t fsize_orDie(const char *filename)
-{
-    struct stat st;
-    if (stat(filename, &st) == 0) return st.st_size;
-    /* error */
-    fprintf(stderr, "stat: %s : %s \n", filename, strerror(errno));
-    exit(1);
-}
-
-static FILE* fopen_orDie(const char *filename, const char *instruction)
-{
-    FILE* const inFile = fopen(filename, instruction);
-    if (inFile) return inFile;
-    /* error */
-    fprintf(stderr, "fopen: %s : %s \n", filename, strerror(errno));
-    exit(2);
-}
-
-static void* malloc_orDie(size_t size)
-{
-    void* const buff = malloc(size + !size);   /* avoid allocating size of 0 : may return NULL (implementation dependent) */
-    if (buff) return buff;
-    /* error */
-    fprintf(stderr, "malloc: %s \n", strerror(errno));
-    exit(3);
-}
-
-static void* loadFile_orDie(const char* fileName, size_t* size)
-{
-    off_t const buffSize = fsize_orDie(fileName);
-    FILE* const inFile = fopen_orDie(fileName, "rb");
-    void* const buffer = malloc_orDie(buffSize);
-    size_t const readSize = fread(buffer, 1, buffSize, inFile);
-    if (readSize != (size_t)buffSize) {
-        fprintf(stderr, "fread: %s : %s \n", fileName, strerror(errno));
-        exit(4);
-    }
-    fclose(inFile);   /* can't fail (read only) */
-    *size = buffSize;
-    return buffer;
-}
-
+#include "utils.h"
 
 static void decompress(const char* fname)
 {
@@ -89,7 +46,6 @@ static void decompress(const char* fname)
     free(rBuff);
     free(cBuff);
 }
-
 
 int main(int argc, const char** argv)
 {

--- a/examples/streaming_compression.c
+++ b/examples/streaming_compression.c
@@ -13,53 +13,7 @@
 #include <stdio.h>     // fprintf, perror, feof, fopen, etc.
 #include <string.h>    // strlen, memset, strcat
 #include <zstd.h>      // presumes zstd library is installed
-
-
-static void* malloc_orDie(size_t size)
-{
-    void* const buff = malloc(size);
-    if (buff) return buff;
-    /* error */
-    perror("malloc:");
-    exit(1);
-}
-
-static FILE* fopen_orDie(const char *filename, const char *instruction)
-{
-    FILE* const inFile = fopen(filename, instruction);
-    if (inFile) return inFile;
-    /* error */
-    perror(filename);
-    exit(3);
-}
-
-static size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
-{
-    size_t const readSize = fread(buffer, 1, sizeToRead, file);
-    if (readSize == sizeToRead) return readSize;   /* good */
-    if (feof(file)) return readSize;   /* good, reached end of file */
-    /* error */
-    perror("fread");
-    exit(4);
-}
-
-static size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
-{
-    size_t const writtenSize = fwrite(buffer, 1, sizeToWrite, file);
-    if (writtenSize == sizeToWrite) return sizeToWrite;   /* good */
-    /* error */
-    perror("fwrite");
-    exit(5);
-}
-
-static size_t fclose_orDie(FILE* file)
-{
-    if (!fclose(file)) return 0;
-    /* error */
-    perror("fclose");
-    exit(6);
-}
-
+#include "utils.h"
 
 static void compressFile_orDie(const char* fname, const char* outName, int cLevel)
 {

--- a/examples/streaming_decompression.c
+++ b/examples/streaming_decompression.c
@@ -14,53 +14,7 @@
 #include <string.h>    // strerror
 #include <errno.h>     // errno
 #include <zstd.h>      // presumes zstd library is installed
-
-
-static void* malloc_orDie(size_t size)
-{
-    void* const buff = malloc(size);
-    if (buff) return buff;
-    /* error */
-    perror("malloc:");
-    exit(1);
-}
-
-static FILE* fopen_orDie(const char *filename, const char *instruction)
-{
-    FILE* const inFile = fopen(filename, instruction);
-    if (inFile) return inFile;
-    /* error */
-    perror(filename);
-    exit(3);
-}
-
-static size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
-{
-    size_t const readSize = fread(buffer, 1, sizeToRead, file);
-    if (readSize == sizeToRead) return readSize;   /* good */
-    if (feof(file)) return readSize;   /* good, reached end of file */
-    /* error */
-    perror("fread");
-    exit(4);
-}
-
-static size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
-{
-    size_t const writtenSize = fwrite(buffer, 1, sizeToWrite, file);
-    if (writtenSize == sizeToWrite) return sizeToWrite;   /* good */
-    /* error */
-    perror("fwrite");
-    exit(5);
-}
-
-static size_t fclose_orDie(FILE* file)
-{
-    if (!fclose(file)) return 0;
-    /* error */
-    perror("fclose");
-    exit(6);
-}
-
+#include "utils.h"
 
 static void decompressFile_orDie(const char* fname)
 {

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <stdlib.h>    // malloc, free, exit
+#include <stdio.h>     // fprintf, perror, fopen, etc.
+#include <string.h>    // strlen, strcat, memset, strerror
+#include <errno.h>     // errno
+#include <sys/stat.h>  // stat
+
+typedef enum {
+    ERROR_fsize = 1,
+    ERROR_fopen = 2,
+    ERROR_fclose = 3,
+    ERROR_fread = 4,
+    ERROR_fwrite = 5,
+    ERROR_loadFile = 6,
+    ERROR_saveFile = 7,
+    ERROR_malloc = 8,
+    ERROR_largeFile = 9,
+} UTILS_ErrorCode;
+
+off_t fsize_orDie(const char *filename)
+{
+    struct stat st;
+    if (stat(filename, &st) == 0) return st.st_size;
+    /* error */
+    perror(filename);
+    exit(ERROR_fsize);
+}
+
+FILE* fopen_orDie(const char *filename, const char *instruction)
+{
+    FILE* const inFile = fopen(filename, instruction);
+    if (inFile) return inFile;
+    /* error */
+    perror(filename);
+    exit(ERROR_fopen);
+}
+
+size_t fclose_orDie(FILE* file)
+{
+    if (!fclose(file)) return 0;
+    /* error */
+    perror("fclose");
+    exit(ERROR_fclose);
+}
+
+size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
+{
+    size_t const readSize = fread(buffer, 1, sizeToRead, file);
+    if (readSize == sizeToRead) return readSize;   /* good */
+    if (feof(file)) return readSize;   /* good, reached end of file */
+    /* error */
+    perror("fread");
+    exit(ERROR_fread);
+}
+
+size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
+{
+    size_t const writtenSize = fwrite(buffer, 1, sizeToWrite, file);
+    if (writtenSize == sizeToWrite) return sizeToWrite;   /* good */
+    /* error */
+    perror("fwrite");
+    exit(ERROR_fwrite);
+}
+
+void* malloc_orDie(size_t size)
+{
+    void* const buff = malloc(size);
+    if (buff) return buff;
+    /* error */
+    perror("malloc");
+    exit(ERROR_malloc);
+}
+
+void* loadFile_orDie(const char* fileName, size_t* size)
+{
+    off_t const fileSize = fsize_orDie(fileName);
+    size_t const buffSize = (size_t)fileSize;
+    if ((off_t)buffSize < fileSize) {   /* narrowcast overflow */
+        fprintf(stderr, "%s : filesize too large \n", fileName);
+        exit(ERROR_largeFile);
+    }
+    FILE* const inFile = fopen_orDie(fileName, "rb");
+    void* const buffer = malloc_orDie(buffSize);
+    size_t const readSize = fread(buffer, 1, buffSize, inFile);
+    if (readSize != (size_t)buffSize) {
+        fprintf(stderr, "fread: %s : %s \n", fileName, strerror(errno));
+        exit(ERROR_fread);
+    }
+    fclose(inFile);  /* can't fail, read only */
+    *size = buffSize;
+    return buffer;
+}
+
+void saveFile_orDie(const char* fileName, const void* buff, size_t buffSize)
+{
+    FILE* const oFile = fopen_orDie(fileName, "wb");
+    size_t const wSize = fwrite(buff, 1, buffSize, oFile);
+    if (wSize != (size_t)buffSize) {
+        fprintf(stderr, "fwrite: %s : %s \n", fileName, strerror(errno));
+        exit(ERROR_fwrite);
+    }
+    if (fclose(oFile)) {
+        perror(fileName);
+        exit(ERROR_fclose);
+    }
+}

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+/*
+ * This header file has common utility functions used in examples. 
+ */
 #pragma once
 
 #include <stdlib.h>    // malloc, free, exit
@@ -6,6 +19,9 @@
 #include <errno.h>     // errno
 #include <sys/stat.h>  // stat
 
+/*
+ * Define the returned error code from utility functions. 
+ */
 typedef enum {
     ERROR_fsize = 1,
     ERROR_fopen = 2,
@@ -18,6 +34,11 @@ typedef enum {
     ERROR_largeFile = 9,
 } UTILS_ErrorCode;
 
+/*! fsize_orDie() : 
+ * Get the size of a given file path.
+ * 
+ * @return The size of a given file path.
+ */
 off_t fsize_orDie(const char *filename)
 {
     struct stat st;
@@ -27,6 +48,12 @@ off_t fsize_orDie(const char *filename)
     exit(ERROR_fsize);
 }
 
+/*! fopen_orDie() : 
+ * Open a file using given file path and open option.
+ *
+ * @return If successful this function will return a FILE pointer to an
+ * opened file otherwise it sends an error to stderr and exits.
+ */
 FILE* fopen_orDie(const char *filename, const char *instruction)
 {
     FILE* const inFile = fopen(filename, instruction);
@@ -36,14 +63,24 @@ FILE* fopen_orDie(const char *filename, const char *instruction)
     exit(ERROR_fopen);
 }
 
-size_t fclose_orDie(FILE* file)
+/*! fclose_orDie() : 
+ * Close an opened file using given FILE pointer.
+ */
+void fclose_orDie(FILE* file)
 {
-    if (!fclose(file)) return 0;
+    if (!fclose(file)) { return; };
     /* error */
     perror("fclose");
     exit(ERROR_fclose);
 }
 
+/*! fread_orDie() : 
+ * 
+ * Read sizeToRead bytes from a given file, storing them at the
+ * location given by buffer.
+ * 
+ * @return The number of bytes read.
+ */
 size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
 {
     size_t const readSize = fread(buffer, 1, sizeToRead, file);
@@ -54,6 +91,16 @@ size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
     exit(ERROR_fread);
 }
 
+/*! fwrite_orDie() :
+ *  
+ * Write sizeToWrite bytes to a file pointed to by file, obtaining
+ * them from a location given by buffer.
+ *
+ * Note: This function will send an error to stderr and exit if it
+ * cannot write data to the given file pointer. 
+ *
+ * @return The number of bytes written.
+ */
 size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
 {
     size_t const writtenSize = fwrite(buffer, 1, sizeToWrite, file);
@@ -63,6 +110,13 @@ size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
     exit(ERROR_fwrite);
 }
 
+/*! malloc_orDie() :
+ * Allocate memory.
+ * 
+ * @return If successful this function returns a pointer to allo-
+ * cated memory.  If there is an error, this function will send that
+ * error to stderr and exit.
+ */
 void* malloc_orDie(size_t size)
 {
     void* const buff = malloc(size);
@@ -72,6 +126,15 @@ void* malloc_orDie(size_t size)
     exit(ERROR_malloc);
 }
 
+/*! loadFile_orDie() :
+ * Read size bytes from a file.
+ * 
+ * Note: This function will send an error to stderr and exit if it
+ * cannot read data from the given file path.
+ * 
+ * @return If successful this function will return a pointer to read
+ * data otherwise it will printout an error to stderr and exit.
+ */
 void* loadFile_orDie(const char* fileName, size_t* size)
 {
     off_t const fileSize = fsize_orDie(fileName);
@@ -92,6 +155,14 @@ void* loadFile_orDie(const char* fileName, size_t* size)
     return buffer;
 }
 
+/*! saveFile_orDie() :
+ *  
+ * Save buffSize bytes to a given file path, obtaining them from a location pointed
+ * to by buff.
+ * 
+ * Note: This function will send an error to stderr and exit if it
+ * cannot write to a given file.
+ */
 void saveFile_orDie(const char* fileName, const void* buff, size_t buffSize)
 {
     FILE* const oFile = fopen_orDie(fileName, "wb");

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -11,7 +11,8 @@
 /*
  * This header file has common utility functions used in examples. 
  */
-#pragma once
+#ifndef UTILS_H
+#define UTILS_H
 
 #include <stdlib.h>    // malloc, free, exit
 #include <stdio.h>     // fprintf, perror, fopen, etc.
@@ -39,7 +40,7 @@ typedef enum {
  * 
  * @return The size of a given file path.
  */
-off_t fsize_orDie(const char *filename)
+static off_t fsize_orDie(const char *filename)
 {
     struct stat st;
     if (stat(filename, &st) == 0) return st.st_size;
@@ -54,7 +55,7 @@ off_t fsize_orDie(const char *filename)
  * @return If successful this function will return a FILE pointer to an
  * opened file otherwise it sends an error to stderr and exits.
  */
-FILE* fopen_orDie(const char *filename, const char *instruction)
+static FILE* fopen_orDie(const char *filename, const char *instruction)
 {
     FILE* const inFile = fopen(filename, instruction);
     if (inFile) return inFile;
@@ -66,7 +67,7 @@ FILE* fopen_orDie(const char *filename, const char *instruction)
 /*! fclose_orDie() : 
  * Close an opened file using given FILE pointer.
  */
-void fclose_orDie(FILE* file)
+static void fclose_orDie(FILE* file)
 {
     if (!fclose(file)) { return; };
     /* error */
@@ -81,7 +82,7 @@ void fclose_orDie(FILE* file)
  * 
  * @return The number of bytes read.
  */
-size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
+static size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
 {
     size_t const readSize = fread(buffer, 1, sizeToRead, file);
     if (readSize == sizeToRead) return readSize;   /* good */
@@ -101,7 +102,7 @@ size_t fread_orDie(void* buffer, size_t sizeToRead, FILE* file)
  *
  * @return The number of bytes written.
  */
-size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
+static size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
 {
     size_t const writtenSize = fwrite(buffer, 1, sizeToWrite, file);
     if (writtenSize == sizeToWrite) return sizeToWrite;   /* good */
@@ -117,7 +118,7 @@ size_t fwrite_orDie(const void* buffer, size_t sizeToWrite, FILE* file)
  * cated memory.  If there is an error, this function will send that
  * error to stderr and exit.
  */
-void* malloc_orDie(size_t size)
+static void* malloc_orDie(size_t size)
 {
     void* const buff = malloc(size);
     if (buff) return buff;
@@ -176,3 +177,5 @@ void saveFile_orDie(const char* fileName, const void* buff, size_t buffSize)
         exit(ERROR_fclose);
     }
 }
+
+#endif


### PR DESCRIPTION
Below are changes that I have made:
1. Move common functions into a shared header file to avoid code duplication
2. Replace hard coded exit values with enums to improve readability of example code.