### PR TITLE
[regression] Add dictionary support

### DIFF
--- a/tests/regression/config.c
+++ b/tests/regression/config.c
@@ -19,6 +19,12 @@
         .name = "level -" #x,                                       \
         .cli_args = "--fast=" #x,                                   \
         .param_values = PARAM_VALUES(level_fast##x##_param_values), \
+    };                                                              \
+    config_t const level_fast##x##_dict = {                         \
+        .name = "level -" #x " with dict",                          \
+        .cli_args = "--fast=" #x,                                   \
+        .param_values = PARAM_VALUES(level_fast##x##_param_values), \
+        .use_dictionary = 1,                                        \
     };
 
 /* Define a config for each level we want to test with. */
@@ -30,6 +36,12 @@
         .name = "level " #x,                                      \
         .cli_args = "-" #x,                                       \
         .param_values = PARAM_VALUES(level_##x##_param_values),   \
+    };                                                            \
+    config_t const level_##x##_dict = {                           \
+        .name = "level " #x " with dict",                         \
+        .cli_args = "-" #x,                                       \
+        .param_values = PARAM_VALUES(level_##x##_param_values),   \
+        .use_dictionary = 1,                                      \
     };
 
 
@@ -41,16 +53,30 @@
 #undef LEVEL
 #undef FAST_LEVEL
 
+static config_t no_pledged_src_size = {
+    .name = "no source size",
+    .cli_args = "",
+    .param_values = {.data = NULL, .size = 0},
+    .no_pledged_src_size = 1,
+};
+
 static config_t const* g_configs[] = {
-#define FAST_LEVEL(x) &level_fast##x,
-#define LEVEL(x) &level_##x,
+
+#define FAST_LEVEL(x) &level_fast##x, &level_fast##x##_dict,
+#define LEVEL(x) &level_##x, &level_##x##_dict,
 #include "levels.h"
 #undef LEVEL
 #undef FAST_LEVEL
+
+    &no_pledged_src_size,
     NULL,
 };
 
 config_t const* const* configs = g_configs;
+
+int config_skip_data(config_t const* config, data_t const* data) {
+    return config->use_dictionary && !data_has_dict(data);
+}
 
 int config_get_level(config_t const* config) {
     param_values_t const params = config->param_values;

--- a/tests/regression/config.h
+++ b/tests/regression/config.h
@@ -16,6 +16,8 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 
+#include "data.h"
+
 typedef struct {
     ZSTD_cParameter param;
     unsigned value;
@@ -41,7 +43,24 @@ typedef struct {
      * the parameters will be derived from these.
      */
     param_values_t param_values;
+    /**
+     * Boolean parameter that says if we should use a dictionary. If the data
+     * doesn't have a dictionary, this config is skipped. Defaults to no.
+     */
+    int use_dictionary;
+    /**
+     * Boolean parameter that says if we should pass the pledged source size
+     * when the method allows it. Defaults to yes.
+     */
+    int no_pledged_src_size;
 } config_t;
+
+/**
+ * Returns true if the config should skip this data.
+ * For instance, if the config requires a dictionary but the data doesn't have
+ * one.
+ */
+int config_skip_data(config_t const* config, data_t const* data);
 
 #define CONFIG_NO_LEVEL (-ZSTD_TARGETLENGTH_MAX - 1)
 /**

--- a/tests/regression/data.h
+++ b/tests/regression/data.h
@@ -22,16 +22,23 @@ typedef enum {
 typedef struct {
     char const* url;   /**< Where to get this resource. */
     uint64_t xxhash64; /**< Hash of the url contents. */
-    char const* name;  /**< The logical name of the resource (no extension). */
-    data_type_t type;  /**< The type of this resource. */
     char const* path;  /**< The path of the unpacked resource (derived). */
-    size_t size;
+} data_resource_t;
+
+typedef struct {
+    data_resource_t data;
+    data_resource_t dict;
+    data_type_t type;  /**< The type of the data. */
+    char const* name;  /**< The logical name of the data (no extension). */
 } data_t;
 
 /**
  * The NULL-terminated list of data objects.
  */
 extern data_t const* const* data;
+
+
+int data_has_dict(data_t const* data);
 
 /**
  * Initializes the data module and downloads the data necessary.
@@ -62,7 +69,14 @@ typedef struct {
  *
  * @returns The buffer, which is NULL on failure.
  */
-data_buffer_t data_buffer_get(data_t const* data);
+data_buffer_t data_buffer_get_data(data_t const* data);
+
+/**
+ * Read the dictionary that the data points to into a buffer.
+ *
+ * @returns The buffer, which is NULL on failure.
+ */
+data_buffer_t data_buffer_get_dict(data_t const* data);
 
 /**
  * Read the contents of filename into a buffer.
@@ -88,5 +102,39 @@ int data_buffer_compare(data_buffer_t buffer1, data_buffer_t buffer2);
  */
 void data_buffer_free(data_buffer_t buffer);
 
+typedef struct {
+    char* buffer;
+    char const** filenames;
+    unsigned size;
+} data_filenames_t;
+
+/**
+ * Get a recursive list of filenames in the data object. If it is a file, it
+ * will only contain one entry. If it is a directory, it will recursively walk
+ * the directory.
+ *
+ * @returns The list of filenames, which has size 0 and NULL pointers on error.
+ */
+data_filenames_t data_filenames_get(data_t const* data);
+
+/**
+ * Frees the filenames table.
+ */
+void data_filenames_free(data_filenames_t filenames);
+
+typedef struct {
+    data_buffer_t const* buffers;
+    size_t size;
+} data_buffers_t;
+
+/**
+ * @returns a list of buffers for every file in data. It is zero sized on error.
+ */
+data_buffers_t data_buffers_get(data_t const* data);
+
+/**
+ * Frees the data buffers.
+ */
+void data_buffers_free(data_buffers_t buffers);
 
 #endif

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -1,43 +1,101 @@
-Data,	Config,	Method,	Total compressed size
-silesia.tar,	level -5,	simple,	106176430
-silesia.tar,	level -3,	simple,	98476550
-silesia.tar,	level -1,	simple,	87206767
-silesia.tar,	level 0,	simple,	66996953
-silesia.tar,	level 1,	simple,	73658303
-silesia.tar,	level 3,	simple,	66996953
-silesia.tar,	level 4,	simple,	65996020
-silesia.tar,	level 5,	simple,	64421326
-silesia.tar,	level 6,	simple,	62388673
-silesia.tar,	level 7,	simple,	61159525
-silesia.tar,	level 9,	simple,	60214921
-silesia.tar,	level 13,	simple,	58428642
-silesia.tar,	level 16,	simple,	56363759
-silesia.tar,	level 19,	simple,	53274173
-silesia,	level -5,	cli file,	106202112
-silesia,	level -3,	cli file,	98518660
-silesia,	level -1,	cli file,	87226203
-silesia,	level 0,	cli file,	67049190
-silesia,	level 1,	cli file,	73676282
-silesia,	level 3,	cli file,	67049190
-silesia,	level 4,	cli file,	66090040
-silesia,	level 5,	cli file,	64503721
-silesia,	level 6,	cli file,	62446177
-silesia,	level 7,	cli file,	61217029
-silesia,	level 9,	cli file,	60282841
-silesia,	level 13,	cli file,	58480658
-silesia,	level 16,	cli file,	56414170
-silesia,	level 19,	cli file,	53365292
-silesia.tar,	level -5,	cli file,	106250113
-silesia.tar,	level -3,	cli file,	98550747
-silesia.tar,	level -1,	cli file,	87227322
-silesia.tar,	level 0,	cli file,	67111168
-silesia.tar,	level 1,	cli file,	73694374
-silesia.tar,	level 3,	cli file,	67111168
-silesia.tar,	level 4,	cli file,	66154079
-silesia.tar,	level 5,	cli file,	64546998
-silesia.tar,	level 6,	cli file,	62458454
-silesia.tar,	level 7,	cli file,	61231085
-silesia.tar,	level 9,	cli file,	60310313
-silesia.tar,	level 13,	cli file,	58517476
-silesia.tar,	level 16,	cli file,	56448694
-silesia.tar,	level 19,	cli file,	53444920
+Data,               Config,             Method,             Total compressed size
+This line is intentionally added to see how the nightly job reports failures
+silesia.tar,        level -5,           ZSTD_compress,      7160438
+silesia.tar,        level -3,           ZSTD_compress,      6789024
+silesia.tar,        level -1,           ZSTD_compress,      6195462
+silesia.tar,        level 0,            ZSTD_compress,      4875071
+silesia.tar,        level 1,            ZSTD_compress,      5339697
+silesia.tar,        level 3,            ZSTD_compress,      4875071
+silesia.tar,        level 4,            ZSTD_compress,      4813104
+silesia.tar,        level 5,            ZSTD_compress,      4726961
+silesia.tar,        level 6,            ZSTD_compress,      4654401
+silesia.tar,        level 7,            ZSTD_compress,      4591933
+silesia.tar,        level 9,            ZSTD_compress,      4554098
+silesia.tar,        level 13,           ZSTD_compress,      4503496
+silesia.tar,        level 16,           ZSTD_compress,      4387233
+silesia.tar,        level 19,           ZSTD_compress,      4283123
+silesia,            level -5,           ZSTD_compressCCtx,  7152294
+silesia,            level -3,           ZSTD_compressCCtx,  6789969
+silesia,            level -1,           ZSTD_compressCCtx,  6191548
+silesia,            level 0,            ZSTD_compressCCtx,  4862377
+silesia,            level 1,            ZSTD_compressCCtx,  5318036
+silesia,            level 3,            ZSTD_compressCCtx,  4862377
+silesia,            level 4,            ZSTD_compressCCtx,  4800629
+silesia,            level 5,            ZSTD_compressCCtx,  4715005
+silesia,            level 6,            ZSTD_compressCCtx,  4644055
+silesia,            level 7,            ZSTD_compressCCtx,  4581559
+silesia,            level 9,            ZSTD_compressCCtx,  4543862
+silesia,            level 13,           ZSTD_compressCCtx,  4493931
+silesia,            level 16,           ZSTD_compressCCtx,  4381885
+silesia,            level 19,           ZSTD_compressCCtx,  4296899
+github,             level -5,           ZSTD_compressCCtx,  232744
+github,             level -3,           ZSTD_compressCCtx,  220611
+github,             level -1,           ZSTD_compressCCtx,  176575
+github,             level 0,            ZSTD_compressCCtx,  136397
+github,             level 1,            ZSTD_compressCCtx,  143457
+github,             level 3,            ZSTD_compressCCtx,  136397
+github,             level 4,            ZSTD_compressCCtx,  136144
+github,             level 5,            ZSTD_compressCCtx,  135106
+github,             level 6,            ZSTD_compressCCtx,  135108
+github,             level 7,            ZSTD_compressCCtx,  135108
+github,             level 9,            ZSTD_compressCCtx,  135108
+github,             level 13,           ZSTD_compressCCtx,  133741
+github,             level 16,           ZSTD_compressCCtx,  133741
+github,             level 19,           ZSTD_compressCCtx,  133717
+silesia,            level -5,           zstdcli,            7152342
+silesia,            level -3,           zstdcli,            6790021
+silesia,            level -1,           zstdcli,            6191597
+silesia,            level 0,            zstdcli,            4862425
+silesia,            level 1,            zstdcli,            5318084
+silesia,            level 3,            zstdcli,            4862425
+silesia,            level 4,            zstdcli,            4800677
+silesia,            level 5,            zstdcli,            4715053
+silesia,            level 6,            zstdcli,            4644103
+silesia,            level 7,            zstdcli,            4581607
+silesia,            level 9,            zstdcli,            4543910
+silesia,            level 13,           zstdcli,            4493979
+silesia,            level 16,           zstdcli,            4381933
+silesia,            level 19,           zstdcli,            4296947
+silesia.tar,        level -5,           zstdcli,            7159586
+silesia.tar,        level -3,           zstdcli,            6791018
+silesia.tar,        level -1,           zstdcli,            6196283
+silesia.tar,        level 0,            zstdcli,            4876730
+silesia.tar,        level 1,            zstdcli,            5340312
+silesia.tar,        level 3,            zstdcli,            4876730
+silesia.tar,        level 4,            zstdcli,            4817723
+silesia.tar,        level 5,            zstdcli,            4730389
+silesia.tar,        level 6,            zstdcli,            4655708
+silesia.tar,        level 7,            zstdcli,            4593407
+silesia.tar,        level 9,            zstdcli,            4556135
+silesia.tar,        level 13,           zstdcli,            4503500
+silesia.tar,        level 16,           zstdcli,            4387237
+silesia.tar,        level 19,           zstdcli,            4283127
+silesia.tar,        no source size,     zstdcli,            4876726
+github,             level -5,           zstdcli,            234744
+github,             level -5 with dict, zstdcli,            47528
+github,             level -3,           zstdcli,            222611
+github,             level -3 with dict, zstdcli,            46394
+github,             level -1,           zstdcli,            178575
+github,             level -1 with dict, zstdcli,            43401
+github,             level 0,            zstdcli,            138397
+github,             level 0 with dict,  zstdcli,            40316
+github,             level 1,            zstdcli,            145457
+github,             level 1 with dict,  zstdcli,            43242
+github,             level 3,            zstdcli,            138397
+github,             level 3 with dict,  zstdcli,            40316
+github,             level 4,            zstdcli,            138144
+github,             level 4 with dict,  zstdcli,            40292
+github,             level 5,            zstdcli,            137106
+github,             level 5 with dict,  zstdcli,            40938
+github,             level 6,            zstdcli,            137108
+github,             level 6 with dict,  zstdcli,            40632
+github,             level 7,            zstdcli,            137108
+github,             level 7 with dict,  zstdcli,            40766
+github,             level 9,            zstdcli,            137108
+github,             level 9 with dict,  zstdcli,            41326
+github,             level 13,           zstdcli,            135741
+github,             level 13 with dict, zstdcli,            41670
+github,             level 16,           zstdcli,            135741
+github,             level 16 with dict, zstdcli,            39940
+github,             level 19,           zstdcli,            135717
+github,             level 19 with dict, zstdcli,            39576


### PR DESCRIPTION
Dictionaries are prebuilt and saved as part of the data object.
The config decides whether or not to use the dictionary if it is
available. Configs that require dictionaries are only run with
data that have dictionaries. The method will skip configs that are
irrelevant, so for example ZSTD_compress() will skip configs with
dictionaries.

I've also trimmed the silesia source to 1MB per file (12 MB total),
and added 500 samples from the github data set with a dictionary.

I've intentionally added an extra line to the `results.csv` to make
the nightly build fail, so that we can see how CircleCI reports it.

Full list of changes:

* Add pre-built dictionaries to the data.
* Add `use_dictionary` and `no_pledged_src_size` flags to the config.
* Add a config using a dictionary for every level.
* Add a config that specifies no pledged source size.
* Support dictionaries and streaming in the `zstdcli` method.
* Add a context-reuse method using `ZSTD_compressCCtx()`.
* Clean up the formatting of the `results.csv` file to align columns.
* Add `--data`, `--config`, and `--method` flags to constrain each
  to a particular value. This is useful for debugging a failure
  or debugging a particular config/method/data.