### PR TITLE
[libzstd] Fix infinite loop in decompression

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -353,6 +353,14 @@ static int basicUnitTests(U32 seed, double compressibility)
         ZSTD_freeCCtx(cctx);
     }
 
+    DISPLAYLEVEL(3, "test%3i : decompress skippable frame -8 size : ", testNb++);
+    {
+       char const skippable8[] = "\x50\x2a\x4d\x18\xf8\xff\xff\xff";
+       size_t const size = ZSTD_decompress(NULL, 0, skippable8, 8);
+       if (!ZSTD_isError(size)) goto _output_error;
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
 
     DISPLAYLEVEL(3, "test%3i : ZSTD_getFrameContentSize test : ", testNb++);
     {   unsigned long long const rSize = ZSTD_getFrameContentSize(compressedBuffer, cSize);


### PR DESCRIPTION
When we switched `ZSTD_SKIPPABLEHEADERSIZE` to a macro, the places where we do:

    MEM_readLE32(ptr) + ZSTD_SKIPPABLEHEADERSIZE

can now overflow `(unsigned)-8` to `0` and we infinite loop. The fix is to make
the variable an `unsigned long long`, so it is always 64-bits. I've also made
the other related variables `unsigned long long` to mitigate similar potential
issues.

Note that this bug never made it into a release, and was only in the dev branch
for a few days.

Credit to OSS-Fuzz