### PR TITLE
[zstdcli] Add --no-progress flag

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -88,10 +88,10 @@ void FIO_setNotificationLevel(unsigned level) { g_displayLevel=level; }
 static const U64 g_refreshRate = SEC_TO_MICRO / 6;
 static UTIL_time_t g_displayClock = UTIL_TIME_INITIALIZER;
 
-#define READY_FOR_UPDATE() (UTIL_clockSpanMicro(g_displayClock) > g_refreshRate)
+#define READY_FOR_UPDATE() (!g_noProgress && UTIL_clockSpanMicro(g_displayClock) > g_refreshRate)
 #define DELAY_NEXT_UPDATE() { g_displayClock = UTIL_getTime(); }
 #define DISPLAYUPDATE(l, ...) {                              \
-        if (g_displayLevel>=l) {                             \
+        if (g_displayLevel>=l && !g_noProgress) {            \
             if (READY_FOR_UPDATE() || (g_displayLevel>=4)) { \
                 DELAY_NEXT_UPDATE();                         \
                 DISPLAY(__VA_ARGS__);                        \
@@ -349,6 +349,10 @@ void FIO_setLdmBucketSizeLog(unsigned ldmBucketSizeLog) {
 static U32 g_ldmHashRateLog = FIO_LDM_PARAM_NOTSET;
 void FIO_setLdmHashRateLog(unsigned ldmHashRateLog) {
     g_ldmHashRateLog = ldmHashRateLog;
+}
+static U32 g_noProgress = 0;
+void FIO_setNoProgress(unsigned noProgress) {
+    g_noProgress = noProgress;
 }
 
 

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -66,6 +66,7 @@ void FIO_setOverlapLog(unsigned overlapLog);
 void FIO_setRemoveSrcFile(unsigned flag);
 void FIO_setSparseWrite(unsigned sparse);  /**< 0: no sparse; 1: disable on stdout; 2: always enabled */
 void FIO_setRsyncable(unsigned rsyncable);
+void FIO_setNoProgress(unsigned noProgress);
 
 
 /*-*************************************

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -195,6 +195,8 @@ the last one takes effect.
 * `-q`, `--quiet`:
     suppress warnings, interactivity, and notifications.
     specify twice to suppress errors too.
+* `--no-progress`:
+    do not display the progress bar, but keep all other messages.
 * `-C`, `--[no-]check`:
     add integrity check computed from uncompressed data (default: enabled)
 * `--`:

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -171,6 +171,7 @@ static int usage_advanced(const char* programName)
 #endif
 #endif
     DISPLAY( " -M#    : Set a memory usage limit for decompression \n");
+    DISPLAY( "--no-progress : do not display the progress bar \n");
     DISPLAY( "--      : All arguments after \"--\" are treated as files \n");
 #ifndef ZSTD_NODICT
     DISPLAY( "\n");
@@ -610,6 +611,7 @@ int main(int argCount, const char* argv[])
                     if (!strcmp(argument, "--format=lz4")) { suffix = LZ4_EXTENSION; FIO_setCompressionType(FIO_lz4Compression);  continue; }
 #endif
                     if (!strcmp(argument, "--rsyncable")) { rsyncable = 1; continue; }
+                    if (!strcmp(argument, "--no-progress")) { FIO_setNoProgress(1); continue; }
 
                     /* long commands with arguments */
 #ifndef ZSTD_NODICT

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -179,6 +179,9 @@ $ECHO foo > tmpro
 chmod 400 tmpro.zst
 $ZSTD -q tmpro && die "should have refused to overwrite read-only file"
 $ZSTD -q -f tmpro
+$ECHO "test: --no-progress flag"
+$ZSTD tmpro -c --no-progress | $ZSTD -d -o "$INTOVOID" --no-progress
+$ZSTD tmpro -cv --no-progress | $ZSTD -dv -o "$INTOVOID" --no-progress
 rm -f tmpro tmpro.zst
 
 


### PR DESCRIPTION
The `--no-progress` flag disables zstd's progress bars, but leaves
the summary.

I've added simple tests to `playTests.sh` to make sure the parsing
works.

Closes #1371 