### PR TITLE
[libzstd] Fix estimate with negative levels

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1013,7 +1013,7 @@ size_t ZSTD_estimateCCtxSize(int compressionLevel)
 {
     int level;
     size_t memBudget = 0;
-    for (level=1; level<=compressionLevel; level++) {
+    for (level=MIN(compressionLevel, 1); level<=compressionLevel; level++) {
         size_t const newMB = ZSTD_estimateCCtxSize_internal(level);
         if (newMB > memBudget) memBudget = newMB;
     }
@@ -1049,7 +1049,7 @@ size_t ZSTD_estimateCStreamSize(int compressionLevel)
 {
     int level;
     size_t memBudget = 0;
-    for (level=1; level<=compressionLevel; level++) {
+    for (level=MIN(compressionLevel, 1); level<=compressionLevel; level++) {
         size_t const newMB = ZSTD_estimateCStreamSize_internal(level);
         if (newMB > memBudget) memBudget = newMB;
     }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -694,6 +694,17 @@ static int basicUnitTests(U32 seed, double compressibility)
         free(staticDCtxBuffer);
     }
 
+    DISPLAYLEVEL(3, "test%3i : Static negative levels : ", testNb++);
+    {   size_t const cctxSizeN1 = ZSTD_estimateCCtxSize(-1);
+        size_t const cctxSizeP1 = ZSTD_estimateCCtxSize(1);
+        size_t const cstreamSizeN1 = ZSTD_estimateCStreamSize(-1);
+        size_t const cstreamSizeP1 = ZSTD_estimateCStreamSize(1);
+
+        if (!(0 < cctxSizeN1 && cctxSizeN1 <= cctxSizeP1)) goto _output_error;
+        if (!(0 < cstreamSizeN1 && cstreamSizeN1 <= cstreamSizeP1)) goto _output_error;
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
 
     /* ZSTDMT simple MT compression test */
     DISPLAYLEVEL(3, "test%3i : create ZSTDMT CCtx : ", testNb++);


### PR DESCRIPTION
* Fix `ZSTD_estimateCCtxSize()` with negative levels.
* Fix `ZSTD_estimateCStreamSize()` with negative levels.
* Add a unit test to test for this error.

Fixes #1424 