### PR TITLE
[zstdcli] Refuse to overwrite input file

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -420,7 +420,7 @@ static FILE* FIO_openDstFile(const char* srcFileName, const char* dstFileName)
         stat_t srcStat;
         stat_t dstStat;
         if (UTIL_getFileStat(srcFileName, &srcStat) && UTIL_getFileStat(dstFileName, &dstStat)) {
-            if (srcStat.st_ino == dstStat.st_ino) {
+            if (srcStat.st_dev == dstStat.st_dev && srcStat.st_ino == dstStat.st_ino) {
                 DISPLAYLEVEL(1, "zstd: Refusing to open a output file which will overwrite the input file \n");
                 return NULL;
             }

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -183,6 +183,9 @@ $ECHO "test: --no-progress flag"
 $ZSTD tmpro -c --no-progress | $ZSTD -d -o "$INTOVOID" --no-progress
 $ZSTD tmpro -cv --no-progress | $ZSTD -dv -o "$INTOVOID" --no-progress
 rm -f tmpro tmpro.zst
+$ECHO "test: overwrite input file (must fail)"
+$ZSTD tmp -fo tmp && die "zstd overwrote the input file"
+$ZSTD tmp.zst -dfo tmp.zst && die "zstd overwrote the input file"
 
 
 $ECHO "test : file removal"


### PR DESCRIPTION
Compare the input and output files by their inode number and
refuse to open the output file if the input file is the same.

This doesn't work when (de)compressing multiple files to a single
file, but that is a very uncommon use case, mostly used for
benchmarking by me.

Fixes #1422.