### PR TITLE
[regression] Add more configs

### DIFF
--- a/tests/regression/Makefile
+++ b/tests/regression/Makefile
@@ -10,7 +10,7 @@
 CFLAGS ?= -O3
 
 CURL_CFLAGS := $(shell curl-config --cflags)
-CURL_LDFLAGS := $(shell curl-config --libs)
+CURL_LDFLAGS := $(shell curl-config --libs) -pthread
 
 PROGDIR := ../../programs
 LIBDIR := ../../lib
@@ -46,7 +46,7 @@ test.o: test.c data.h config.h method.h
 	$(CC) $(REGRESSION_CFLAGS) $(REGRESSION_CPPFLAGS) $< -c -o $@
 
 libzstd.a:
-	$(MAKE) -C $(LIBDIR) libzstd.a
+	$(MAKE) -C $(LIBDIR) libzstd.a-mt
 	cp $(LIBDIR)/libzstd.a .
 
 test: test.o data.o config.o util.o method.o result.o xxhash.o libzstd.a

--- a/tests/regression/config.c
+++ b/tests/regression/config.c
@@ -59,6 +59,86 @@ static config_t no_pledged_src_size = {
     .no_pledged_src_size = 1,
 };
 
+static param_value_t const ldm_param_values[] = {
+    {.param = ZSTD_c_enableLongDistanceMatching, .value = 1},
+};
+
+static config_t ldm = {
+    .name = "long distance mode",
+    .cli_args = "--long",
+    .param_values = PARAM_VALUES(ldm_param_values),
+};
+
+static param_value_t const mt_param_values[] = {
+    {.param = ZSTD_c_nbWorkers, .value = 2},
+};
+
+static config_t mt = {
+    .name = "multithreaded",
+    .cli_args = "-T2",
+    .param_values = PARAM_VALUES(mt_param_values),
+};
+
+static param_value_t const mt_ldm_param_values[] = {
+    {.param = ZSTD_c_nbWorkers, .value = 2},
+    {.param = ZSTD_c_enableLongDistanceMatching, .value = 1},
+};
+
+static config_t mt_ldm = {
+    .name = "multithreaded long distance mode",
+    .cli_args = "-T2 --long",
+    .param_values = PARAM_VALUES(mt_ldm_param_values),
+};
+
+static param_value_t const small_wlog_param_values[] = {
+    {.param = ZSTD_c_windowLog, .value = 10},
+};
+
+static config_t small_wlog = {
+    .name = "small window log",
+    .cli_args = "--zstd=wlog=10",
+    .param_values = PARAM_VALUES(small_wlog_param_values),
+};
+
+static param_value_t const small_hlog_param_values[] = {
+    {.param = ZSTD_c_hashLog, .value = 6},
+    {.param = ZSTD_c_strategy, .value = (int)ZSTD_btopt},
+};
+
+static config_t small_hlog = {
+    .name = "small hash log",
+    .cli_args = "--zstd=hlog=6,strat=7",
+    .param_values = PARAM_VALUES(small_hlog_param_values),
+};
+
+static param_value_t const small_clog_param_values[] = {
+    {.param = ZSTD_c_chainLog, .value = 6},
+    {.param = ZSTD_c_strategy, .value = (int)ZSTD_btopt},
+};
+
+static config_t small_clog = {
+    .name = "small chain log",
+    .cli_args = "--zstd=clog=6,strat=7",
+    .param_values = PARAM_VALUES(small_clog_param_values),
+};
+
+static param_value_t const explicit_params_param_values[] = {
+    {.param = ZSTD_c_checksumFlag, .value = 1},
+    {.param = ZSTD_c_contentSizeFlag, .value = 0},
+    {.param = ZSTD_c_dictIDFlag, .value = 0},
+    {.param = ZSTD_c_strategy, .value = (int)ZSTD_greedy},
+    {.param = ZSTD_c_windowLog, .value = 18},
+    {.param = ZSTD_c_hashLog, .value = 21},
+    {.param = ZSTD_c_chainLog, .value = 21},
+    {.param = ZSTD_c_targetLength, .value = 100},
+};
+
+static config_t explicit_params = {
+    .name = "explicit params",
+    .cli_args = "--no-check --no-dictID --zstd=strategy=3,wlog=18,hlog=21,clog=21,tlen=100",
+    .param_values = PARAM_VALUES(explicit_params_param_values),
+};
+
 static config_t const* g_configs[] = {
 
 #define FAST_LEVEL(x) &level_fast##x, &level_fast##x##_dict,
@@ -68,6 +148,13 @@ static config_t const* g_configs[] = {
 #undef FAST_LEVEL
 
     &no_pledged_src_size,
+    &ldm,
+    &mt,
+    &mt_ldm,
+    &small_wlog,
+    &small_hlog,
+    &small_clog,
+    &explicit_params,
     NULL,
 };
 

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -1,350 +1,448 @@
-Data,                        Config,                      Method,                      Total compressed size
-silesia.tar,                 level -5,                    compress simple,             7160438
-silesia.tar,                 level -3,                    compress simple,             6789024
-silesia.tar,                 level -1,                    compress simple,             6195462
-silesia.tar,                 level 0,                     compress simple,             4875008
-silesia.tar,                 level 1,                     compress simple,             5339697
-silesia.tar,                 level 3,                     compress simple,             4875008
-silesia.tar,                 level 4,                     compress simple,             4813507
-silesia.tar,                 level 5,                     compress simple,             4722235
-silesia.tar,                 level 6,                     compress simple,             4672194
-silesia.tar,                 level 7,                     compress simple,             4606658
-silesia.tar,                 level 9,                     compress simple,             4554098
-silesia.tar,                 level 13,                    compress simple,             4491702
-silesia.tar,                 level 16,                    compress simple,             4381277
-silesia.tar,                 level 19,                    compress simple,             4281581
-silesia,                     level -5,                    compress cctx,               7152294
-silesia,                     level -3,                    compress cctx,               6789969
-silesia,                     level -1,                    compress cctx,               6191548
-silesia,                     level 0,                     compress cctx,               4862377
-silesia,                     level 1,                     compress cctx,               5318036
-silesia,                     level 3,                     compress cctx,               4862377
-silesia,                     level 4,                     compress cctx,               4800629
-silesia,                     level 5,                     compress cctx,               4710178
-silesia,                     level 6,                     compress cctx,               4659996
-silesia,                     level 7,                     compress cctx,               4596234
-silesia,                     level 9,                     compress cctx,               4543862
-silesia,                     level 13,                    compress cctx,               4482073
-silesia,                     level 16,                    compress cctx,               4377391
-silesia,                     level 19,                    compress cctx,               4294841
-github,                      level -5,                    compress cctx,               232744
-github,                      level -5 with dict,          compress cctx,               45704
-github,                      level -3,                    compress cctx,               220611
-github,                      level -3 with dict,          compress cctx,               44510
-github,                      level -1,                    compress cctx,               176575
-github,                      level -1 with dict,          compress cctx,               41586
-github,                      level 0,                     compress cctx,               136397
-github,                      level 0 with dict,           compress cctx,               38700
-github,                      level 1,                     compress cctx,               143457
-github,                      level 1 with dict,           compress cctx,               41538
-github,                      level 3,                     compress cctx,               136397
-github,                      level 3 with dict,           compress cctx,               38700
-github,                      level 4,                     compress cctx,               136144
-github,                      level 4 with dict,           compress cctx,               38639
-github,                      level 5,                     compress cctx,               135106
-github,                      level 5 with dict,           compress cctx,               38934
-github,                      level 6,                     compress cctx,               135108
-github,                      level 6 with dict,           compress cctx,               38628
-github,                      level 7,                     compress cctx,               135108
-github,                      level 7 with dict,           compress cctx,               38741
-github,                      level 9,                     compress cctx,               135108
-github,                      level 9 with dict,           compress cctx,               39335
-github,                      level 13,                    compress cctx,               133717
-github,                      level 13 with dict,          compress cctx,               39923
-github,                      level 16,                    compress cctx,               134844
-github,                      level 16 with dict,          compress cctx,               37568
-github,                      level 19,                    compress cctx,               134675
-github,                      level 19 with dict,          compress cctx,               37567
-silesia,                     level -5,                    zstdcli,                     7152342
-silesia,                     level -3,                    zstdcli,                     6790021
-silesia,                     level -1,                    zstdcli,                     6191597
-silesia,                     level 0,                     zstdcli,                     4862425
-silesia,                     level 1,                     zstdcli,                     5318084
-silesia,                     level 3,                     zstdcli,                     4862425
-silesia,                     level 4,                     zstdcli,                     4800677
-silesia,                     level 5,                     zstdcli,                     4710226
-silesia,                     level 6,                     zstdcli,                     4660044
-silesia,                     level 7,                     zstdcli,                     4596282
-silesia,                     level 9,                     zstdcli,                     4543910
-silesia,                     level 13,                    zstdcli,                     4482121
-silesia,                     level 16,                    zstdcli,                     4377439
-silesia,                     level 19,                    zstdcli,                     4294889
-silesia.tar,                 level -5,                    zstdcli,                     7159586
-silesia.tar,                 level -3,                    zstdcli,                     6791018
-silesia.tar,                 level -1,                    zstdcli,                     6196283
-silesia.tar,                 level 0,                     zstdcli,                     4875213
-silesia.tar,                 level 1,                     zstdcli,                     5340312
-silesia.tar,                 level 3,                     zstdcli,                     4875213
-silesia.tar,                 level 4,                     zstdcli,                     4814545
-silesia.tar,                 level 5,                     zstdcli,                     4723284
-silesia.tar,                 level 6,                     zstdcli,                     4673591
-silesia.tar,                 level 7,                     zstdcli,                     4608342
-silesia.tar,                 level 9,                     zstdcli,                     4556135
-silesia.tar,                 level 13,                    zstdcli,                     4491706
-silesia.tar,                 level 16,                    zstdcli,                     4381281
-silesia.tar,                 level 19,                    zstdcli,                     4281585
-silesia.tar,                 no source size,              zstdcli,                     4875209
-github,                      level -5,                    zstdcli,                     234744
-github,                      level -5 with dict,          zstdcli,                     47528
-github,                      level -3,                    zstdcli,                     222611
-github,                      level -3 with dict,          zstdcli,                     46394
-github,                      level -1,                    zstdcli,                     178575
-github,                      level -1 with dict,          zstdcli,                     43401
-github,                      level 0,                     zstdcli,                     138397
-github,                      level 0 with dict,           zstdcli,                     40316
-github,                      level 1,                     zstdcli,                     145457
-github,                      level 1 with dict,           zstdcli,                     43242
-github,                      level 3,                     zstdcli,                     138397
-github,                      level 3 with dict,           zstdcli,                     40316
-github,                      level 4,                     zstdcli,                     138144
-github,                      level 4 with dict,           zstdcli,                     40292
-github,                      level 5,                     zstdcli,                     137106
-github,                      level 5 with dict,           zstdcli,                     40938
-github,                      level 6,                     zstdcli,                     137108
-github,                      level 6 with dict,           zstdcli,                     40632
-github,                      level 7,                     zstdcli,                     137108
-github,                      level 7 with dict,           zstdcli,                     40766
-github,                      level 9,                     zstdcli,                     137108
-github,                      level 9 with dict,           zstdcli,                     41326
-github,                      level 13,                    zstdcli,                     135717
-github,                      level 13 with dict,          zstdcli,                     41716
-github,                      level 16,                    zstdcli,                     136846
-github,                      level 16 with dict,          zstdcli,                     39577
-github,                      level 19,                    zstdcli,                     136676
-github,                      level 19 with dict,          zstdcli,                     39576
-silesia,                     level -5,                    advanced one pass,           7152294
-silesia,                     level -3,                    advanced one pass,           6789969
-silesia,                     level -1,                    advanced one pass,           6191548
-silesia,                     level 0,                     advanced one pass,           4862377
-silesia,                     level 1,                     advanced one pass,           5318036
-silesia,                     level 3,                     advanced one pass,           4862377
-silesia,                     level 4,                     advanced one pass,           4800629
-silesia,                     level 5,                     advanced one pass,           4710178
-silesia,                     level 6,                     advanced one pass,           4659996
-silesia,                     level 7,                     advanced one pass,           4596234
-silesia,                     level 9,                     advanced one pass,           4543862
-silesia,                     level 13,                    advanced one pass,           4482073
-silesia,                     level 16,                    advanced one pass,           4377391
-silesia,                     level 19,                    advanced one pass,           4294841
-silesia,                     no source size,              advanced one pass,           4862377
-silesia.tar,                 level -5,                    advanced one pass,           7160438
-silesia.tar,                 level -3,                    advanced one pass,           6789024
-silesia.tar,                 level -1,                    advanced one pass,           6195462
-silesia.tar,                 level 0,                     advanced one pass,           4875008
-silesia.tar,                 level 1,                     advanced one pass,           5339697
-silesia.tar,                 level 3,                     advanced one pass,           4875008
-silesia.tar,                 level 4,                     advanced one pass,           4813507
-silesia.tar,                 level 5,                     advanced one pass,           4722235
-silesia.tar,                 level 6,                     advanced one pass,           4672194
-silesia.tar,                 level 7,                     advanced one pass,           4606658
-silesia.tar,                 level 9,                     advanced one pass,           4554098
-silesia.tar,                 level 13,                    advanced one pass,           4491702
-silesia.tar,                 level 16,                    advanced one pass,           4381277
-silesia.tar,                 level 19,                    advanced one pass,           4281581
-silesia.tar,                 no source size,              advanced one pass,           4875008
-github,                      level -5,                    advanced one pass,           232744
-github,                      level -5 with dict,          advanced one pass,           45528
-github,                      level -3,                    advanced one pass,           220611
-github,                      level -3 with dict,          advanced one pass,           44394
-github,                      level -1,                    advanced one pass,           176575
-github,                      level -1 with dict,          advanced one pass,           41401
-github,                      level 0,                     advanced one pass,           136397
-github,                      level 0 with dict,           advanced one pass,           38316
-github,                      level 1,                     advanced one pass,           143457
-github,                      level 1 with dict,           advanced one pass,           41242
-github,                      level 3,                     advanced one pass,           136397
-github,                      level 3 with dict,           advanced one pass,           38316
-github,                      level 4,                     advanced one pass,           136144
-github,                      level 4 with dict,           advanced one pass,           38292
-github,                      level 5,                     advanced one pass,           135106
-github,                      level 5 with dict,           advanced one pass,           38938
-github,                      level 6,                     advanced one pass,           135108
-github,                      level 6 with dict,           advanced one pass,           38632
-github,                      level 7,                     advanced one pass,           135108
-github,                      level 7 with dict,           advanced one pass,           38766
-github,                      level 9,                     advanced one pass,           135108
-github,                      level 9 with dict,           advanced one pass,           39326
-github,                      level 13,                    advanced one pass,           133717
-github,                      level 13 with dict,          advanced one pass,           39716
-github,                      level 16,                    advanced one pass,           134844
-github,                      level 16 with dict,          advanced one pass,           37577
-github,                      level 19,                    advanced one pass,           134675
-github,                      level 19 with dict,          advanced one pass,           37576
-github,                      no source size,              advanced one pass,           136397
-silesia,                     level -5,                    advanced one pass small out, 7152294
-silesia,                     level -3,                    advanced one pass small out, 6789969
-silesia,                     level -1,                    advanced one pass small out, 6191548
-silesia,                     level 0,                     advanced one pass small out, 4862377
-silesia,                     level 1,                     advanced one pass small out, 5318036
-silesia,                     level 3,                     advanced one pass small out, 4862377
-silesia,                     level 4,                     advanced one pass small out, 4800629
-silesia,                     level 5,                     advanced one pass small out, 4710178
-silesia,                     level 6,                     advanced one pass small out, 4659996
-silesia,                     level 7,                     advanced one pass small out, 4596234
-silesia,                     level 9,                     advanced one pass small out, 4543862
-silesia,                     level 13,                    advanced one pass small out, 4482073
-silesia,                     level 16,                    advanced one pass small out, 4377391
-silesia,                     level 19,                    advanced one pass small out, 4294841
-silesia,                     no source size,              advanced one pass small out, 4862377
-silesia.tar,                 level -5,                    advanced one pass small out, 7160438
-silesia.tar,                 level -3,                    advanced one pass small out, 6789024
-silesia.tar,                 level -1,                    advanced one pass small out, 6195462
-silesia.tar,                 level 0,                     advanced one pass small out, 4875008
-silesia.tar,                 level 1,                     advanced one pass small out, 5339697
-silesia.tar,                 level 3,                     advanced one pass small out, 4875008
-silesia.tar,                 level 4,                     advanced one pass small out, 4813507
-silesia.tar,                 level 5,                     advanced one pass small out, 4722235
-silesia.tar,                 level 6,                     advanced one pass small out, 4672194
-silesia.tar,                 level 7,                     advanced one pass small out, 4606658
-silesia.tar,                 level 9,                     advanced one pass small out, 4554098
-silesia.tar,                 level 13,                    advanced one pass small out, 4491702
-silesia.tar,                 level 16,                    advanced one pass small out, 4381277
-silesia.tar,                 level 19,                    advanced one pass small out, 4281581
-silesia.tar,                 no source size,              advanced one pass small out, 4875008
-github,                      level -5,                    advanced one pass small out, 232744
-github,                      level -5 with dict,          advanced one pass small out, 45528
-github,                      level -3,                    advanced one pass small out, 220611
-github,                      level -3 with dict,          advanced one pass small out, 44394
-github,                      level -1,                    advanced one pass small out, 176575
-github,                      level -1 with dict,          advanced one pass small out, 41401
-github,                      level 0,                     advanced one pass small out, 136397
-github,                      level 0 with dict,           advanced one pass small out, 38316
-github,                      level 1,                     advanced one pass small out, 143457
-github,                      level 1 with dict,           advanced one pass small out, 41242
-github,                      level 3,                     advanced one pass small out, 136397
-github,                      level 3 with dict,           advanced one pass small out, 38316
-github,                      level 4,                     advanced one pass small out, 136144
-github,                      level 4 with dict,           advanced one pass small out, 38292
-github,                      level 5,                     advanced one pass small out, 135106
-github,                      level 5 with dict,           advanced one pass small out, 38938
-github,                      level 6,                     advanced one pass small out, 135108
-github,                      level 6 with dict,           advanced one pass small out, 38632
-github,                      level 7,                     advanced one pass small out, 135108
-github,                      level 7 with dict,           advanced one pass small out, 38766
-github,                      level 9,                     advanced one pass small out, 135108
-github,                      level 9 with dict,           advanced one pass small out, 39326
-github,                      level 13,                    advanced one pass small out, 133717
-github,                      level 13 with dict,          advanced one pass small out, 39716
-github,                      level 16,                    advanced one pass small out, 134844
-github,                      level 16 with dict,          advanced one pass small out, 37577
-github,                      level 19,                    advanced one pass small out, 134675
-github,                      level 19 with dict,          advanced one pass small out, 37576
-github,                      no source size,              advanced one pass small out, 136397
-silesia,                     level -5,                    advanced streaming,          7152294
-silesia,                     level -3,                    advanced streaming,          6789973
-silesia,                     level -1,                    advanced streaming,          6191549
-silesia,                     level 0,                     advanced streaming,          4862377
-silesia,                     level 1,                     advanced streaming,          5318036
-silesia,                     level 3,                     advanced streaming,          4862377
-silesia,                     level 4,                     advanced streaming,          4800629
-silesia,                     level 5,                     advanced streaming,          4710178
-silesia,                     level 6,                     advanced streaming,          4659996
-silesia,                     level 7,                     advanced streaming,          4596234
-silesia,                     level 9,                     advanced streaming,          4543862
-silesia,                     level 13,                    advanced streaming,          4482073
-silesia,                     level 16,                    advanced streaming,          4377391
-silesia,                     level 19,                    advanced streaming,          4294841
-silesia,                     no source size,              advanced streaming,          4862341
-silesia.tar,                 level -5,                    advanced streaming,          7160440
-silesia.tar,                 level -3,                    advanced streaming,          6789026
-silesia.tar,                 level -1,                    advanced streaming,          6195465
-silesia.tar,                 level 0,                     advanced streaming,          4875010
-silesia.tar,                 level 1,                     advanced streaming,          5339701
-silesia.tar,                 level 3,                     advanced streaming,          4875010
-silesia.tar,                 level 4,                     advanced streaming,          4813507
-silesia.tar,                 level 5,                     advanced streaming,          4722240
-silesia.tar,                 level 6,                     advanced streaming,          4672203
-silesia.tar,                 level 7,                     advanced streaming,          4606658
-silesia.tar,                 level 9,                     advanced streaming,          4554105
-silesia.tar,                 level 13,                    advanced streaming,          4491703
-silesia.tar,                 level 16,                    advanced streaming,          4381277
-silesia.tar,                 level 19,                    advanced streaming,          4281581
-silesia.tar,                 no source size,              advanced streaming,          4875006
-github,                      level -5,                    advanced streaming,          232744
-github,                      level -5 with dict,          advanced streaming,          45528
-github,                      level -3,                    advanced streaming,          220611
-github,                      level -3 with dict,          advanced streaming,          44394
-github,                      level -1,                    advanced streaming,          176575
-github,                      level -1 with dict,          advanced streaming,          41401
-github,                      level 0,                     advanced streaming,          136397
-github,                      level 0 with dict,           advanced streaming,          38316
-github,                      level 1,                     advanced streaming,          143457
-github,                      level 1 with dict,           advanced streaming,          41242
-github,                      level 3,                     advanced streaming,          136397
-github,                      level 3 with dict,           advanced streaming,          38316
-github,                      level 4,                     advanced streaming,          136144
-github,                      level 4 with dict,           advanced streaming,          38292
-github,                      level 5,                     advanced streaming,          135106
-github,                      level 5 with dict,           advanced streaming,          38938
-github,                      level 6,                     advanced streaming,          135108
-github,                      level 6 with dict,           advanced streaming,          38632
-github,                      level 7,                     advanced streaming,          135108
-github,                      level 7 with dict,           advanced streaming,          38766
-github,                      level 9,                     advanced streaming,          135108
-github,                      level 9 with dict,           advanced streaming,          39326
-github,                      level 13,                    advanced streaming,          133717
-github,                      level 13 with dict,          advanced streaming,          39716
-github,                      level 16,                    advanced streaming,          134844
-github,                      level 16 with dict,          advanced streaming,          37577
-github,                      level 19,                    advanced streaming,          134675
-github,                      level 19 with dict,          advanced streaming,          37576
-github,                      no source size,              advanced streaming,          136397
-silesia,                     level -5,                    old streaming,               7152294
-silesia,                     level -3,                    old streaming,               6789973
-silesia,                     level -1,                    old streaming,               6191549
-silesia,                     level 0,                     old streaming,               4862377
-silesia,                     level 1,                     old streaming,               5318036
-silesia,                     level 3,                     old streaming,               4862377
-silesia,                     level 4,                     old streaming,               4800629
-silesia,                     level 5,                     old streaming,               4710178
-silesia,                     level 6,                     old streaming,               4659996
-silesia,                     level 7,                     old streaming,               4596234
-silesia,                     level 9,                     old streaming,               4543862
-silesia,                     level 13,                    old streaming,               4482073
-silesia,                     level 16,                    old streaming,               4377391
-silesia,                     level 19,                    old streaming,               4294841
-silesia,                     no source size,              old streaming,               4862341
-silesia.tar,                 level -5,                    old streaming,               7160440
-silesia.tar,                 level -3,                    old streaming,               6789026
-silesia.tar,                 level -1,                    old streaming,               6195465
-silesia.tar,                 level 0,                     old streaming,               4875010
-silesia.tar,                 level 1,                     old streaming,               5339701
-silesia.tar,                 level 3,                     old streaming,               4875010
-silesia.tar,                 level 4,                     old streaming,               4813507
-silesia.tar,                 level 5,                     old streaming,               4722240
-silesia.tar,                 level 6,                     old streaming,               4672203
-silesia.tar,                 level 7,                     old streaming,               4606658
-silesia.tar,                 level 9,                     old streaming,               4554105
-silesia.tar,                 level 13,                    old streaming,               4491703
-silesia.tar,                 level 16,                    old streaming,               4381277
-silesia.tar,                 level 19,                    old streaming,               4281581
-silesia.tar,                 no source size,              old streaming,               4875006
-github,                      level -5,                    old streaming,               232744
-github,                      level -5 with dict,          old streaming,               45528
-github,                      level -3,                    old streaming,               220611
-github,                      level -3 with dict,          old streaming,               44394
-github,                      level -1,                    old streaming,               176575
-github,                      level -1 with dict,          old streaming,               41401
-github,                      level 0,                     old streaming,               136397
-github,                      level 0 with dict,           old streaming,               38316
-github,                      level 1,                     old streaming,               143457
-github,                      level 1 with dict,           old streaming,               41242
-github,                      level 3,                     old streaming,               136397
-github,                      level 3 with dict,           old streaming,               38316
-github,                      level 4,                     old streaming,               136144
-github,                      level 4 with dict,           old streaming,               38292
-github,                      level 5,                     old streaming,               135106
-github,                      level 5 with dict,           old streaming,               38938
-github,                      level 6,                     old streaming,               135108
-github,                      level 6 with dict,           old streaming,               38632
-github,                      level 7,                     old streaming,               135108
-github,                      level 7 with dict,           old streaming,               38766
-github,                      level 9,                     old streaming,               135108
-github,                      level 9 with dict,           old streaming,               39326
-github,                      level 13,                    old streaming,               133717
-github,                      level 13 with dict,          old streaming,               39716
-github,                      level 16,                    old streaming,               134846
-github,                      level 16 with dict,          old streaming,               37577
-github,                      level 19,                    old streaming,               134676
-github,                      level 19 with dict,          old streaming,               37576
-github,                      no source size,              old streaming,               141003
+Data,                             Config,                           Method,                           Total compressed size
+silesia.tar,                      level -5,                         compress simple,                  7160438
+silesia.tar,                      level -3,                         compress simple,                  6789024
+silesia.tar,                      level -1,                         compress simple,                  6195462
+silesia.tar,                      level 0,                          compress simple,                  4875008
+silesia.tar,                      level 1,                          compress simple,                  5339697
+silesia.tar,                      level 3,                          compress simple,                  4875008
+silesia.tar,                      level 4,                          compress simple,                  4813507
+silesia.tar,                      level 5,                          compress simple,                  4722235
+silesia.tar,                      level 6,                          compress simple,                  4672194
+silesia.tar,                      level 7,                          compress simple,                  4606658
+silesia.tar,                      level 9,                          compress simple,                  4554098
+silesia.tar,                      level 13,                         compress simple,                  4491702
+silesia.tar,                      level 16,                         compress simple,                  4381277
+silesia.tar,                      level 19,                         compress simple,                  4281514
+silesia,                          level -5,                         compress cctx,                    7152294
+silesia,                          level -3,                         compress cctx,                    6789969
+silesia,                          level -1,                         compress cctx,                    6191548
+silesia,                          level 0,                          compress cctx,                    4862377
+silesia,                          level 1,                          compress cctx,                    5318036
+silesia,                          level 3,                          compress cctx,                    4862377
+silesia,                          level 4,                          compress cctx,                    4800629
+silesia,                          level 5,                          compress cctx,                    4710178
+silesia,                          level 6,                          compress cctx,                    4659996
+silesia,                          level 7,                          compress cctx,                    4596234
+silesia,                          level 9,                          compress cctx,                    4543862
+silesia,                          level 13,                         compress cctx,                    4482073
+silesia,                          level 16,                         compress cctx,                    4377391
+silesia,                          level 19,                         compress cctx,                    4293262
+silesia,                          long distance mode,               compress cctx,                    4862377
+silesia,                          multithreaded,                    compress cctx,                    4862377
+silesia,                          multithreaded long distance mode, compress cctx,                    4862377
+silesia,                          small window log,                 compress cctx,                    7115734
+silesia,                          small hash log,                   compress cctx,                    6554898
+silesia,                          small chain log,                  compress cctx,                    4931093
+silesia,                          explicit params,                  compress cctx,                    4813352
+github,                           level -5,                         compress cctx,                    232744
+github,                           level -5 with dict,               compress cctx,                    45704
+github,                           level -3,                         compress cctx,                    220611
+github,                           level -3 with dict,               compress cctx,                    44510
+github,                           level -1,                         compress cctx,                    176575
+github,                           level -1 with dict,               compress cctx,                    41586
+github,                           level 0,                          compress cctx,                    136397
+github,                           level 0 with dict,                compress cctx,                    38700
+github,                           level 1,                          compress cctx,                    143457
+github,                           level 1 with dict,                compress cctx,                    41538
+github,                           level 3,                          compress cctx,                    136397
+github,                           level 3 with dict,                compress cctx,                    38700
+github,                           level 4,                          compress cctx,                    136144
+github,                           level 4 with dict,                compress cctx,                    38639
+github,                           level 5,                          compress cctx,                    135106
+github,                           level 5 with dict,                compress cctx,                    38934
+github,                           level 6,                          compress cctx,                    135108
+github,                           level 6 with dict,                compress cctx,                    38628
+github,                           level 7,                          compress cctx,                    135108
+github,                           level 7 with dict,                compress cctx,                    38741
+github,                           level 9,                          compress cctx,                    135108
+github,                           level 9 with dict,                compress cctx,                    39335
+github,                           level 13,                         compress cctx,                    133717
+github,                           level 13 with dict,               compress cctx,                    39923
+github,                           level 16,                         compress cctx,                    133717
+github,                           level 16 with dict,               compress cctx,                    37568
+github,                           level 19,                         compress cctx,                    133717
+github,                           level 19 with dict,               compress cctx,                    37567
+github,                           long distance mode,               compress cctx,                    decompression error
+github,                           multithreaded,                    compress cctx,                    decompression error
+github,                           multithreaded long distance mode, compress cctx,                    decompression error
+github,                           small window log,                 compress cctx,                    decompression error
+github,                           small hash log,                   compress cctx,                    decompression error
+github,                           small chain log,                  compress cctx,                    decompression error
+github,                           explicit params,                  compress cctx,                    decompression error
+silesia,                          level -5,                         zstdcli,                          7152342
+silesia,                          level -3,                         zstdcli,                          6790021
+silesia,                          level -1,                         zstdcli,                          6191597
+silesia,                          level 0,                          zstdcli,                          4862425
+silesia,                          level 1,                          zstdcli,                          5318084
+silesia,                          level 3,                          zstdcli,                          4862425
+silesia,                          level 4,                          zstdcli,                          4800677
+silesia,                          level 5,                          zstdcli,                          4710226
+silesia,                          level 6,                          zstdcli,                          4660044
+silesia,                          level 7,                          zstdcli,                          4596282
+silesia,                          level 9,                          zstdcli,                          4543910
+silesia,                          level 13,                         zstdcli,                          4482121
+silesia,                          level 16,                         zstdcli,                          4377439
+silesia,                          level 19,                         zstdcli,                          4293310
+silesia,                          long distance mode,               zstdcli,                          4853437
+silesia,                          multithreaded,                    zstdcli,                          4862425
+silesia,                          multithreaded long distance mode, zstdcli,                          4853437
+silesia,                          small window log,                 zstdcli,                          7126434
+silesia,                          small hash log,                   zstdcli,                          6554946
+silesia,                          small chain log,                  zstdcli,                          4931141
+silesia,                          explicit params,                  zstdcli,                          4815380
+silesia.tar,                      level -5,                         zstdcli,                          7159586
+silesia.tar,                      level -3,                         zstdcli,                          6791018
+silesia.tar,                      level -1,                         zstdcli,                          6196283
+silesia.tar,                      level 0,                          zstdcli,                          4875213
+silesia.tar,                      level 1,                          zstdcli,                          5340312
+silesia.tar,                      level 3,                          zstdcli,                          4875213
+silesia.tar,                      level 4,                          zstdcli,                          4814545
+silesia.tar,                      level 5,                          zstdcli,                          4723284
+silesia.tar,                      level 6,                          zstdcli,                          4673591
+silesia.tar,                      level 7,                          zstdcli,                          4608342
+silesia.tar,                      level 9,                          zstdcli,                          4554700
+silesia.tar,                      level 13,                         zstdcli,                          4491706
+silesia.tar,                      level 16,                         zstdcli,                          4381281
+silesia.tar,                      level 19,                         zstdcli,                          4281518
+silesia.tar,                      no source size,                   zstdcli,                          4875209
+silesia.tar,                      long distance mode,               zstdcli,                          4867227
+silesia.tar,                      multithreaded,                    zstdcli,                          4875213
+silesia.tar,                      multithreaded long distance mode, zstdcli,                          4867227
+silesia.tar,                      small window log,                 zstdcli,                          7130434
+silesia.tar,                      small hash log,                   zstdcli,                          6587841
+silesia.tar,                      small chain log,                  zstdcli,                          4943259
+silesia.tar,                      explicit params,                  zstdcli,                          4839202
+github,                           level -5,                         zstdcli,                          234744
+github,                           level -5 with dict,               zstdcli,                          47528
+github,                           level -3,                         zstdcli,                          222611
+github,                           level -3 with dict,               zstdcli,                          46394
+github,                           level -1,                         zstdcli,                          178575
+github,                           level -1 with dict,               zstdcli,                          43401
+github,                           level 0,                          zstdcli,                          138397
+github,                           level 0 with dict,                zstdcli,                          40316
+github,                           level 1,                          zstdcli,                          145457
+github,                           level 1 with dict,                zstdcli,                          43242
+github,                           level 3,                          zstdcli,                          138397
+github,                           level 3 with dict,                zstdcli,                          40316
+github,                           level 4,                          zstdcli,                          138144
+github,                           level 4 with dict,                zstdcli,                          40292
+github,                           level 5,                          zstdcli,                          137106
+github,                           level 5 with dict,                zstdcli,                          40938
+github,                           level 6,                          zstdcli,                          137108
+github,                           level 6 with dict,                zstdcli,                          40632
+github,                           level 7,                          zstdcli,                          137108
+github,                           level 7 with dict,                zstdcli,                          40766
+github,                           level 9,                          zstdcli,                          137108
+github,                           level 9 with dict,                zstdcli,                          41326
+github,                           level 13,                         zstdcli,                          135717
+github,                           level 13 with dict,               zstdcli,                          41716
+github,                           level 16,                         zstdcli,                          135717
+github,                           level 16 with dict,               zstdcli,                          39577
+github,                           level 19,                         zstdcli,                          135717
+github,                           level 19 with dict,               zstdcli,                          39576
+github,                           long distance mode,               zstdcli,                          138397
+github,                           multithreaded,                    zstdcli,                          138397
+github,                           multithreaded long distance mode, zstdcli,                          138397
+github,                           small window log,                 zstdcli,                          138397
+github,                           small hash log,                   zstdcli,                          137467
+github,                           small chain log,                  zstdcli,                          138314
+github,                           explicit params,                  zstdcli,                          136140
+silesia,                          level -5,                         advanced one pass,                7152294
+silesia,                          level -3,                         advanced one pass,                6789969
+silesia,                          level -1,                         advanced one pass,                6191548
+silesia,                          level 0,                          advanced one pass,                4862377
+silesia,                          level 1,                          advanced one pass,                5318036
+silesia,                          level 3,                          advanced one pass,                4862377
+silesia,                          level 4,                          advanced one pass,                4800629
+silesia,                          level 5,                          advanced one pass,                4710178
+silesia,                          level 6,                          advanced one pass,                4659996
+silesia,                          level 7,                          advanced one pass,                4596234
+silesia,                          level 9,                          advanced one pass,                4543862
+silesia,                          level 13,                         advanced one pass,                4482073
+silesia,                          level 16,                         advanced one pass,                4377391
+silesia,                          level 19,                         advanced one pass,                4293262
+silesia,                          no source size,                   advanced one pass,                4862377
+silesia,                          long distance mode,               advanced one pass,                4853389
+silesia,                          multithreaded,                    advanced one pass,                4862377
+silesia,                          multithreaded long distance mode, advanced one pass,                4853389
+silesia,                          small window log,                 advanced one pass,                7126386
+silesia,                          small hash log,                   advanced one pass,                6554898
+silesia,                          small chain log,                  advanced one pass,                4931093
+silesia,                          explicit params,                  advanced one pass,                4815369
+silesia.tar,                      level -5,                         advanced one pass,                7160438
+silesia.tar,                      level -3,                         advanced one pass,                6789024
+silesia.tar,                      level -1,                         advanced one pass,                6195462
+silesia.tar,                      level 0,                          advanced one pass,                4875008
+silesia.tar,                      level 1,                          advanced one pass,                5339697
+silesia.tar,                      level 3,                          advanced one pass,                4875008
+silesia.tar,                      level 4,                          advanced one pass,                4813507
+silesia.tar,                      level 5,                          advanced one pass,                4722235
+silesia.tar,                      level 6,                          advanced one pass,                4672194
+silesia.tar,                      level 7,                          advanced one pass,                4606658
+silesia.tar,                      level 9,                          advanced one pass,                4554098
+silesia.tar,                      level 13,                         advanced one pass,                4491702
+silesia.tar,                      level 16,                         advanced one pass,                4381277
+silesia.tar,                      level 19,                         advanced one pass,                4281514
+silesia.tar,                      no source size,                   advanced one pass,                4875008
+silesia.tar,                      long distance mode,               advanced one pass,                4861218
+silesia.tar,                      multithreaded,                    advanced one pass,                4874711
+silesia.tar,                      multithreaded long distance mode, advanced one pass,                4860608
+silesia.tar,                      small window log,                 advanced one pass,                7130394
+silesia.tar,                      small hash log,                   advanced one pass,                6587833
+silesia.tar,                      small chain log,                  advanced one pass,                4943255
+silesia.tar,                      explicit params,                  advanced one pass,                4829974
+github,                           level -5,                         advanced one pass,                232744
+github,                           level -5 with dict,               advanced one pass,                45528
+github,                           level -3,                         advanced one pass,                220611
+github,                           level -3 with dict,               advanced one pass,                44394
+github,                           level -1,                         advanced one pass,                176575
+github,                           level -1 with dict,               advanced one pass,                41401
+github,                           level 0,                          advanced one pass,                136397
+github,                           level 0 with dict,                advanced one pass,                38316
+github,                           level 1,                          advanced one pass,                143457
+github,                           level 1 with dict,                advanced one pass,                41242
+github,                           level 3,                          advanced one pass,                136397
+github,                           level 3 with dict,                advanced one pass,                38316
+github,                           level 4,                          advanced one pass,                136144
+github,                           level 4 with dict,                advanced one pass,                38292
+github,                           level 5,                          advanced one pass,                135106
+github,                           level 5 with dict,                advanced one pass,                38938
+github,                           level 6,                          advanced one pass,                135108
+github,                           level 6 with dict,                advanced one pass,                38632
+github,                           level 7,                          advanced one pass,                135108
+github,                           level 7 with dict,                advanced one pass,                38766
+github,                           level 9,                          advanced one pass,                135108
+github,                           level 9 with dict,                advanced one pass,                39326
+github,                           level 13,                         advanced one pass,                133717
+github,                           level 13 with dict,               advanced one pass,                39716
+github,                           level 16,                         advanced one pass,                133717
+github,                           level 16 with dict,               advanced one pass,                37577
+github,                           level 19,                         advanced one pass,                133717
+github,                           level 19 with dict,               advanced one pass,                37576
+github,                           no source size,                   advanced one pass,                136397
+github,                           long distance mode,               advanced one pass,                136397
+github,                           multithreaded,                    advanced one pass,                136397
+github,                           multithreaded long distance mode, advanced one pass,                136397
+github,                           small window log,                 advanced one pass,                136397
+github,                           small hash log,                   advanced one pass,                135467
+github,                           small chain log,                  advanced one pass,                136314
+github,                           explicit params,                  advanced one pass,                137670
+silesia,                          level -5,                         advanced one pass small out,      7152294
+silesia,                          level -3,                         advanced one pass small out,      6789969
+silesia,                          level -1,                         advanced one pass small out,      6191548
+silesia,                          level 0,                          advanced one pass small out,      4862377
+silesia,                          level 1,                          advanced one pass small out,      5318036
+silesia,                          level 3,                          advanced one pass small out,      4862377
+silesia,                          level 4,                          advanced one pass small out,      4800629
+silesia,                          level 5,                          advanced one pass small out,      4710178
+silesia,                          level 6,                          advanced one pass small out,      4659996
+silesia,                          level 7,                          advanced one pass small out,      4596234
+silesia,                          level 9,                          advanced one pass small out,      4543862
+silesia,                          level 13,                         advanced one pass small out,      4482073
+silesia,                          level 16,                         advanced one pass small out,      4377391
+silesia,                          level 19,                         advanced one pass small out,      4293262
+silesia,                          no source size,                   advanced one pass small out,      4862377
+silesia,                          long distance mode,               advanced one pass small out,      4853389
+silesia,                          multithreaded,                    advanced one pass small out,      4862377
+silesia,                          multithreaded long distance mode, advanced one pass small out,      4853389
+silesia,                          small window log,                 advanced one pass small out,      7126386
+silesia,                          small hash log,                   advanced one pass small out,      6554898
+silesia,                          small chain log,                  advanced one pass small out,      4931093
+silesia,                          explicit params,                  advanced one pass small out,      4815369
+silesia.tar,                      level -5,                         advanced one pass small out,      7160438
+silesia.tar,                      level -3,                         advanced one pass small out,      6789024
+silesia.tar,                      level -1,                         advanced one pass small out,      6195462
+silesia.tar,                      level 0,                          advanced one pass small out,      4875008
+silesia.tar,                      level 1,                          advanced one pass small out,      5339697
+silesia.tar,                      level 3,                          advanced one pass small out,      4875008
+silesia.tar,                      level 4,                          advanced one pass small out,      4813507
+silesia.tar,                      level 5,                          advanced one pass small out,      4722235
+silesia.tar,                      level 6,                          advanced one pass small out,      4672194
+silesia.tar,                      level 7,                          advanced one pass small out,      4606658
+silesia.tar,                      level 9,                          advanced one pass small out,      4554098
+silesia.tar,                      level 13,                         advanced one pass small out,      4491702
+silesia.tar,                      level 16,                         advanced one pass small out,      4381277
+silesia.tar,                      level 19,                         advanced one pass small out,      4281514
+silesia.tar,                      no source size,                   advanced one pass small out,      4875008
+silesia.tar,                      long distance mode,               advanced one pass small out,      4861218
+silesia.tar,                      multithreaded,                    advanced one pass small out,      4874711
+silesia.tar,                      multithreaded long distance mode, advanced one pass small out,      4860608
+silesia.tar,                      small window log,                 advanced one pass small out,      7130394
+silesia.tar,                      small hash log,                   advanced one pass small out,      6587833
+silesia.tar,                      small chain log,                  advanced one pass small out,      4943255
+silesia.tar,                      explicit params,                  advanced one pass small out,      4829974
+github,                           level -5,                         advanced one pass small out,      232744
+github,                           level -5 with dict,               advanced one pass small out,      45528
+github,                           level -3,                         advanced one pass small out,      220611
+github,                           level -3 with dict,               advanced one pass small out,      44394
+github,                           level -1,                         advanced one pass small out,      176575
+github,                           level -1 with dict,               advanced one pass small out,      41401
+github,                           level 0,                          advanced one pass small out,      136397
+github,                           level 0 with dict,                advanced one pass small out,      38316
+github,                           level 1,                          advanced one pass small out,      143457
+github,                           level 1 with dict,                advanced one pass small out,      41242
+github,                           level 3,                          advanced one pass small out,      136397
+github,                           level 3 with dict,                advanced one pass small out,      38316
+github,                           level 4,                          advanced one pass small out,      136144
+github,                           level 4 with dict,                advanced one pass small out,      38292
+github,                           level 5,                          advanced one pass small out,      135106
+github,                           level 5 with dict,                advanced one pass small out,      38938
+github,                           level 6,                          advanced one pass small out,      135108
+github,                           level 6 with dict,                advanced one pass small out,      38632
+github,                           level 7,                          advanced one pass small out,      135108
+github,                           level 7 with dict,                advanced one pass small out,      38766
+github,                           level 9,                          advanced one pass small out,      135108
+github,                           level 9 with dict,                advanced one pass small out,      39326
+github,                           level 13,                         advanced one pass small out,      133717
+github,                           level 13 with dict,               advanced one pass small out,      39716
+github,                           level 16,                         advanced one pass small out,      133717
+github,                           level 16 with dict,               advanced one pass small out,      37577
+github,                           level 19,                         advanced one pass small out,      133717
+github,                           level 19 with dict,               advanced one pass small out,      37576
+github,                           no source size,                   advanced one pass small out,      136397
+github,                           long distance mode,               advanced one pass small out,      136397
+github,                           multithreaded,                    advanced one pass small out,      136397
+github,                           multithreaded long distance mode, advanced one pass small out,      136397
+github,                           small window log,                 advanced one pass small out,      136397
+github,                           small hash log,                   advanced one pass small out,      135467
+github,                           small chain log,                  advanced one pass small out,      136314
+github,                           explicit params,                  advanced one pass small out,      137670
+silesia,                          level -5,                         advanced streaming,               7152294
+silesia,                          level -3,                         advanced streaming,               6789973
+silesia,                          level -1,                         advanced streaming,               6191549
+silesia,                          level 0,                          advanced streaming,               4862377
+silesia,                          level 1,                          advanced streaming,               5318036
+silesia,                          level 3,                          advanced streaming,               4862377
+silesia,                          level 4,                          advanced streaming,               4800629
+silesia,                          level 5,                          advanced streaming,               4710178
+silesia,                          level 6,                          advanced streaming,               4659996
+silesia,                          level 7,                          advanced streaming,               4596234
+silesia,                          level 9,                          advanced streaming,               4543862
+silesia,                          level 13,                         advanced streaming,               4482073
+silesia,                          level 16,                         advanced streaming,               4377391
+silesia,                          level 19,                         advanced streaming,               4293262
+silesia,                          no source size,                   advanced streaming,               4862341
+silesia,                          long distance mode,               advanced streaming,               4853389
+silesia,                          multithreaded,                    advanced streaming,               4862377
+silesia,                          multithreaded long distance mode, advanced streaming,               4853389
+silesia,                          small window log,                 advanced streaming,               7126389
+silesia,                          small hash log,                   advanced streaming,               6554898
+silesia,                          small chain log,                  advanced streaming,               4931093
+silesia,                          explicit params,                  advanced streaming,               4815380
+silesia.tar,                      level -5,                         advanced streaming,               7160440
+silesia.tar,                      level -3,                         advanced streaming,               6789026
+silesia.tar,                      level -1,                         advanced streaming,               6195465
+silesia.tar,                      level 0,                          advanced streaming,               4875010
+silesia.tar,                      level 1,                          advanced streaming,               5339701
+silesia.tar,                      level 3,                          advanced streaming,               4875010
+silesia.tar,                      level 4,                          advanced streaming,               4813507
+silesia.tar,                      level 5,                          advanced streaming,               4722240
+silesia.tar,                      level 6,                          advanced streaming,               4672203
+silesia.tar,                      level 7,                          advanced streaming,               4606658
+silesia.tar,                      level 9,                          advanced streaming,               4554105
+silesia.tar,                      level 13,                         advanced streaming,               4491703
+silesia.tar,                      level 16,                         advanced streaming,               4381277
+silesia.tar,                      level 19,                         advanced streaming,               4281514
+silesia.tar,                      no source size,                   advanced streaming,               4875006
+silesia.tar,                      long distance mode,               advanced streaming,               4861218
+silesia.tar,                      multithreaded,                    advanced streaming,               4875209
+silesia.tar,                      multithreaded long distance mode, advanced streaming,               4867223
+silesia.tar,                      small window log,                 advanced streaming,               7130394
+silesia.tar,                      small hash log,                   advanced streaming,               6587834
+silesia.tar,                      small chain log,                  advanced streaming,               4943260
+silesia.tar,                      explicit params,                  advanced streaming,               4830002
+github,                           level -5,                         advanced streaming,               232744
+github,                           level -5 with dict,               advanced streaming,               45528
+github,                           level -3,                         advanced streaming,               220611
+github,                           level -3 with dict,               advanced streaming,               44394
+github,                           level -1,                         advanced streaming,               176575
+github,                           level -1 with dict,               advanced streaming,               41401
+github,                           level 0,                          advanced streaming,               136397
+github,                           level 0 with dict,                advanced streaming,               38316
+github,                           level 1,                          advanced streaming,               143457
+github,                           level 1 with dict,                advanced streaming,               41242
+github,                           level 3,                          advanced streaming,               136397
+github,                           level 3 with dict,                advanced streaming,               38316
+github,                           level 4,                          advanced streaming,               136144
+github,                           level 4 with dict,                advanced streaming,               38292
+github,                           level 5,                          advanced streaming,               135106
+github,                           level 5 with dict,                advanced streaming,               38938
+github,                           level 6,                          advanced streaming,               135108
+github,                           level 6 with dict,                advanced streaming,               38632
+github,                           level 7,                          advanced streaming,               135108
+github,                           level 7 with dict,                advanced streaming,               38766
+github,                           level 9,                          advanced streaming,               135108
+github,                           level 9 with dict,                advanced streaming,               39326
+github,                           level 13,                         advanced streaming,               133717
+github,                           level 13 with dict,               advanced streaming,               39716
+github,                           level 16,                         advanced streaming,               133717
+github,                           level 16 with dict,               advanced streaming,               37577
+github,                           level 19,                         advanced streaming,               133717
+github,                           level 19 with dict,               advanced streaming,               37576
+github,                           no source size,                   advanced streaming,               136397
+github,                           long distance mode,               advanced streaming,               136397
+github,                           multithreaded,                    advanced streaming,               136397
+github,                           multithreaded long distance mode, advanced streaming,               136397
+github,                           small window log,                 advanced streaming,               136397
+github,                           small hash log,                   advanced streaming,               135467
+github,                           small chain log,                  advanced streaming,               136314
+github,                           explicit params,                  advanced streaming,               137670
+silesia,                          level -5,                         old streaming,                    7152294
+silesia,                          level -3,                         old streaming,                    6789973
+silesia,                          level -1,                         old streaming,                    6191549
+silesia,                          level 0,                          old streaming,                    4862377
+silesia,                          level 1,                          old streaming,                    5318036
+silesia,                          level 3,                          old streaming,                    4862377
+silesia,                          level 4,                          old streaming,                    4800629
+silesia,                          level 5,                          old streaming,                    4710178
+silesia,                          level 6,                          old streaming,                    4659996
+silesia,                          level 7,                          old streaming,                    4596234
+silesia,                          level 9,                          old streaming,                    4543862
+silesia,                          level 13,                         old streaming,                    4482073
+silesia,                          level 16,                         old streaming,                    4377391
+silesia,                          level 19,                         old streaming,                    4293262
+silesia,                          no source size,                   old streaming,                    4862341
+silesia.tar,                      level -5,                         old streaming,                    7160440
+silesia.tar,                      level -3,                         old streaming,                    6789026
+silesia.tar,                      level -1,                         old streaming,                    6195465
+silesia.tar,                      level 0,                          old streaming,                    4875010
+silesia.tar,                      level 1,                          old streaming,                    5339701
+silesia.tar,                      level 3,                          old streaming,                    4875010
+silesia.tar,                      level 4,                          old streaming,                    4813507
+silesia.tar,                      level 5,                          old streaming,                    4722240
+silesia.tar,                      level 6,                          old streaming,                    4672203
+silesia.tar,                      level 7,                          old streaming,                    4606658
+silesia.tar,                      level 9,                          old streaming,                    4554105
+silesia.tar,                      level 13,                         old streaming,                    4491703
+silesia.tar,                      level 16,                         old streaming,                    4381277
+silesia.tar,                      level 19,                         old streaming,                    4281514
+silesia.tar,                      no source size,                   old streaming,                    4875006
+github,                           level -5,                         old streaming,                    232744
+github,                           level -5 with dict,               old streaming,                    45528
+github,                           level -3,                         old streaming,                    220611
+github,                           level -3 with dict,               old streaming,                    44394
+github,                           level -1,                         old streaming,                    176575
+github,                           level -1 with dict,               old streaming,                    41401
+github,                           level 0,                          old streaming,                    136397
+github,                           level 0 with dict,                old streaming,                    38316
+github,                           level 1,                          old streaming,                    143457
+github,                           level 1 with dict,                old streaming,                    41242
+github,                           level 3,                          old streaming,                    136397
+github,                           level 3 with dict,                old streaming,                    38316
+github,                           level 4,                          old streaming,                    136144
+github,                           level 4 with dict,                old streaming,                    38292
+github,                           level 5,                          old streaming,                    135106
+github,                           level 5 with dict,                old streaming,                    38938
+github,                           level 6,                          old streaming,                    135108
+github,                           level 6 with dict,                old streaming,                    38632
+github,                           level 7,                          old streaming,                    135108
+github,                           level 7 with dict,                old streaming,                    38766
+github,                           level 9,                          old streaming,                    135108
+github,                           level 9 with dict,                old streaming,                    39326
+github,                           level 13,                         old streaming,                    133717
+github,                           level 13 with dict,               old streaming,                    39716
+github,                           level 16,                         old streaming,                    133717
+github,                           level 16 with dict,               old streaming,                    37577
+github,                           level 19,                         old streaming,                    133717
+github,                           level 19 with dict,               old streaming,                    37576
+github,                           no source size,                   old streaming,                    141003


### PR DESCRIPTION
* Add configs that test multithreading, LDM, and setting explicit
  parameters.
* Update the `compress cctx` method to accept `ZSTD_parameters`.
* Compile against the multithreaded `libzstd.a`.
* Update `results.csv` for the new configs.

Unless you think there are more configs/methods I should test, I think
we have a fairly wide set of configs/methods, so I'll pause adding
more for now.