### PR TITLE
Add support for environment variable ZSTD_CLEVEL in CLI

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -176,6 +176,7 @@ Benchmark arguments :
 Using environment variables to set compression/decompression parameters has security implications. Therefore,
 we intentionally restrict its usage. Currently, only `ZSTD_CLEVEL` is supported for setting compression level.
 If the value of `ZSTD_CLEVEL` is not a valid integer, it will be ignored with a warning message.
+Note that command line options will override corresponding environment variable settings.
 
 #### Long distance matching mode
 The long distance matching mode, enabled with `--long`, is designed to improve

--- a/programs/README.md
+++ b/programs/README.md
@@ -172,6 +172,10 @@ Benchmark arguments :
 --priority=rt : set process priority to real-time
 ```
 
+#### Restricted usage of Environment Variables
+Using environment variables to set compression/decompression parameters has security implications. Therefore,
+we intentionally restrict its usage. Currently, only `ZSTD_CLEVEL` is supported for setting compression level.
+If the value of `ZSTD_CLEVEL` is not a valid integer, it will be ignored with a warning message.
 
 #### Long distance matching mode
 The long distance matching mode, enabled with `--long`, is designed to improve

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -234,12 +234,12 @@ static void errorOut(const char* msg)
     DISPLAY("%s \n", msg); exit(1);
 }
 
-/*! _readU32FromChar() :
+/*! readU32FromCharChecked() :
  * @return 0 if success, and store the result in *value.
  *  allows and interprets K, KB, KiB, M, MB and MiB suffix.
  *  Will also modify `*stringPtr`, advancing it to position where it stopped reading.
  * @return 1 if an overflow error occurs */
-static int _readU32FromChar(const char** stringPtr, unsigned* value)
+static int readU32FromCharChecked(const char** stringPtr, unsigned* value)
 {
     static unsigned const max = (((unsigned)(-1)) / 10) - 1;
     unsigned result = 0;
@@ -271,7 +271,7 @@ static int _readU32FromChar(const char** stringPtr, unsigned* value)
 static unsigned readU32FromChar(const char** stringPtr) {
     static const char errorMsg[] = "error: numeric value too large";
     unsigned result;
-    if (_readU32FromChar(stringPtr, &result)) { errorOut(errorMsg); }
+    if (readU32FromCharChecked(stringPtr, &result)) { errorOut(errorMsg); }
     return result;
 }
 
@@ -483,15 +483,15 @@ static int init_cLevel(void) {
 
         if ((*ptr>='0') && (*ptr<='9')) {
             unsigned absLevel;
-            if (_readU32FromChar(&ptr, &absLevel)) { 
-                DISPLAYLEVEL(2, "Ignore environment variable %s=%s: numeric value too large\n", ENV_CLEVEL, env);
+            if (readU32FromCharChecked(&ptr, &absLevel)) { 
+                DISPLAYLEVEL(2, "Ignore environment variable setting %s=%s: numeric value too large\n", ENV_CLEVEL, env);
                 return ZSTDCLI_CLEVEL_DEFAULT;
             } else if (*ptr == 0) {
                 return sign * absLevel;
             }
         }
 
-        DISPLAYLEVEL(2, "Ignore environment variable %s=%s: not a valid integer value\n", ENV_CLEVEL, env);
+        DISPLAYLEVEL(2, "Ignore environment variable setting %s=%s: not a valid integer value\n", ENV_CLEVEL, env);
     }
 
     return ZSTDCLI_CLEVEL_DEFAULT;

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -469,7 +469,7 @@ static void printVersion(void)
 #define ENV_CLEVEL "ZSTD_CLEVEL"
 
 /* functions that pick up environment variables */
-int init_cLevel() {
+int init_cLevel(void) {
     const char* const env = getenv(ENV_CLEVEL);
     if (env) {
         const char *ptr = env;
@@ -541,6 +541,7 @@ int main(int argCount, const char* argv[])
     zstd_operation_mode operation = zom_compress;
     ZSTD_compressionParameters compressionParams;
     int cLevel = init_cLevel();
+    printf("init cLevel = %d\n", cLevel);
     int cLevelLast = -1000000000;
     unsigned recursive = 0;
     unsigned memLimit = 0;
@@ -1107,6 +1108,7 @@ int main(int argCount, const char* argv[])
         if (adaptMin > cLevel) cLevel = adaptMin;
         if (adaptMax < cLevel) cLevel = adaptMax;
 
+    printf("final cLevel = %d\n", cLevel);
         if ((filenameIdx==1) && outFileName)
           operationResult = FIO_compressFilename(outFileName, filenameTable[0], dictFileName, cLevel, compressionParams);
         else

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -512,8 +512,6 @@ typedef enum { zom_compress, zom_decompress, zom_test, zom_bench, zom_train, zom
 
 int main(int argCount, const char* argv[])
 {
-    g_displayOut = stderr;
-
     int argNb,
         followLinks = 0,
         forceStdout = 0,
@@ -540,8 +538,7 @@ int main(int argCount, const char* argv[])
     size_t blockSize = 0;
     zstd_operation_mode operation = zom_compress;
     ZSTD_compressionParameters compressionParams;
-    int cLevel = init_cLevel();
-    printf("init cLevel = %d\n", cLevel);
+    int cLevel;
     int cLevelLast = -1000000000;
     unsigned recursive = 0;
     unsigned memLimit = 0;
@@ -575,6 +572,8 @@ int main(int argCount, const char* argv[])
     (void)memLimit;   /* not used when ZSTD_NODECOMPRESS set */
     if (filenameTable==NULL) { DISPLAY("zstd: %s \n", strerror(errno)); exit(1); }
     filenameTable[0] = stdinmark;
+    g_displayOut = stderr;
+    cLevel = init_cLevel();
     programName = lastNameFromPath(programName);
 #ifdef ZSTD_MULTITHREAD
     nbWorkers = 1;
@@ -1108,7 +1107,6 @@ int main(int argCount, const char* argv[])
         if (adaptMin > cLevel) cLevel = adaptMin;
         if (adaptMax < cLevel) cLevel = adaptMax;
 
-    printf("final cLevel = %d\n", cLevel);
         if ((filenameIdx==1) && outFileName)
           operationResult = FIO_compressFilename(outFileName, filenameTable[0], dictFileName, cLevel, compressionParams);
         else

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -469,7 +469,7 @@ static void printVersion(void)
 #define ENV_CLEVEL "ZSTD_CLEVEL"
 
 /* functions that pick up environment variables */
-int init_cLevel(void) {
+static int init_cLevel(void) {
     const char* const env = getenv(ENV_CLEVEL);
     if (env) {
         const char *ptr = env;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -122,6 +122,18 @@ $ZSTD --fast=5000000000 -f tmp && die "too large numeric value : must fail"
 $ZSTD -c --fast=0 tmp > $INTOVOID && die "--fast must not accept value 0"
 $ECHO "test : too large numeric argument"
 $ZSTD --fast=9999999999 -f tmp  && die "should have refused numeric value"
+$ECHO "test : set compression level with environment variable ZSTD_CLEVEL"
+ZSTD_CLEVEL=12  $ZSTD -f tmp # positive compression level
+ZSTD_CLEVEL=-12 $ZSTD -f tmp # negative compression level
+ZSTD_CLEVEL=+12 $ZSTD -f tmp # valid: verbose '+' sign 
+ZSTD_CLEVEL=    $ZSTD -f tmp # empty env var, warn and revert to default setting
+ZSTD_CLEVEL=-   $ZSTD -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=a   $ZSTD -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=+a  $ZSTD -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=3a7 $ZSTD -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=50000000000  $ZSTD -f tmp # numeric value too large, warn and revert to default setting
+$ECHO "test : override ZSTD_CLEVEL with command line option"
+ZSTD_CLEVEL=12  $ZSTD --fast=3 -f tmp # overridden by command line option 
 $ECHO "test : compress to stdout"
 $ZSTD tmp -c > tmpCompressed
 $ZSTD tmp --stdout > tmpCompressed       # long command format


### PR DESCRIPTION
1. Add support for environment variable ZSTD_CLEVEL in CLI, both positive and negative values are allowed.
2. refactor readU32FromChar(...)
3. Add test cases and update documentation.