### PR TITLE
 fixed : detection of non-existing file 

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -751,10 +751,10 @@ MEM_STATIC double ZSTD_fWeight(U32 rawStat)
 {
     U32 const fp_accuracy = 8;
     U32 const fp_multiplier = (1 << fp_accuracy);
-    U32 const stat = rawStat + 1;
-    U32 const hb = ZSTD_highbit32(stat);
+    U32 const newStat = rawStat + 1;
+    U32 const hb = ZSTD_highbit32(newStat);
     U32 const BWeight = hb * fp_multiplier;
-    U32 const FWeight = (stat << fp_accuracy) >> hb;
+    U32 const FWeight = (newStat << fp_accuracy) >> hb;
     U32 const weight = BWeight + FWeight;
     assert(hb + fp_accuracy < 31);
     return (double)weight / fp_multiplier;

--- a/lib/dictBuilder/fastcover.c
+++ b/lib/dictBuilder/fastcover.c
@@ -159,15 +159,15 @@ static COVER_segment_t FASTCOVER_selectSegment(const FASTCOVER_ctx_t *ctx,
    */
   while (activeSegment.end < end) {
     /* Get hash value of current dmer */
-    const size_t index = FASTCOVER_hashPtrToIndex(ctx->samples + activeSegment.end, f, d);
+    const size_t idx = FASTCOVER_hashPtrToIndex(ctx->samples + activeSegment.end, f, d);
 
     /* Add frequency of this index to score if this is the first occurence of index in active segment */
-    if (segmentFreqs[index] == 0) {
-      activeSegment.score += freqs[index];
+    if (segmentFreqs[idx] == 0) {
+      activeSegment.score += freqs[idx];
     }
     /* Increment end of segment and segmentFreqs*/
     activeSegment.end += 1;
-    segmentFreqs[index] += 1;
+    segmentFreqs[idx] += 1;
     /* If the window is now too large, drop the first position */
     if (activeSegment.end - activeSegment.begin == dmersInK + 1) {
       /* Get hash value of the dmer to be eliminated from active segment */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2334,7 +2334,7 @@ FIO_listFile(fileInfo_t* total, const char* inFileName, int displayLevel)
         }
         displayInfo(inFileName, &info, displayLevel);
         *total = FIO_addFInfo(*total, info);
-        assert(error>=0 || error<=1);
+        assert(error == info_success || error == info_frame_error);
         return error;
     }
 }

--- a/programs/util.c
+++ b/programs/util.c
@@ -24,8 +24,12 @@ extern "C" {
 int UTIL_fileExist(const char* filename)
 {
     stat_t statbuf;
-    int const stat_success = stat(filename, &statbuf);
-    return !stat_success;
+#if defined(_MSC_VER)
+    int const stat_error = _stat64(filename, &statbuf);
+#else
+    int const stat_error = stat(filename, &statbuf);
+#endif
+    return !stat_error;
 }
 
 int UTIL_isRegularFile(const char* infilename)

--- a/programs/util.c
+++ b/programs/util.c
@@ -444,8 +444,6 @@ U64 UTIL_getSpanTimeNano(UTIL_time_t begin, UTIL_time_t end)
 
 #else   /* relies on standard C (note : clock_t measurements can be wrong when using multi-threading) */
 
-typedef clock_t UTIL_time_t;
-#define UTIL_TIME_INITIALIZER 0
 UTIL_time_t UTIL_getTime(void) { return clock(); }
 U64 UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }
 U64 UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd) { return 1000000000ULL * (clockEnd - clockStart) / CLOCKS_PER_SEC; }

--- a/programs/util.c
+++ b/programs/util.c
@@ -16,11 +16,10 @@ extern "C" {
 /*-****************************************
 *  Dependencies
 ******************************************/
-#include <string.h>       /* strncmp */
+#include "util.h"       /* note : ensure that platform.h is included first ! */
 #include <errno.h>
 #include <assert.h>
 
-#include "util.h"
 
 int UTIL_fileExist(const char* filename)
 {

--- a/programs/util.c
+++ b/programs/util.c
@@ -16,7 +16,17 @@ extern "C" {
 /*-****************************************
 *  Dependencies
 ******************************************/
+#include <string.h>       /* strncmp */
+#include <errno.h>
+
 #include "util.h"
+
+int UTIL_fileExist(const char* filename)
+{
+    stat_t statbuf;
+    int const stat_success = stat(filename, &statbuf);
+    return !stat_success;
+}
 
 int UTIL_isRegularFile(const char* infilename)
 {
@@ -651,4 +661,3 @@ int UTIL_countPhysicalCores(void)
 #if defined (__cplusplus)
 }
 #endif
-

--- a/programs/util.h
+++ b/programs/util.h
@@ -116,12 +116,16 @@ extern int g_utilDisplayLevel;
 *  Time functions
 ******************************************/
 #if defined(_WIN32)   /* Windows */
+
     #define UTIL_TIME_INITIALIZER { { 0, 0 } }
     typedef LARGE_INTEGER UTIL_time_t;
+
 #elif defined(__APPLE__) && defined(__MACH__)
+
     #include <mach/mach_time.h>
     #define UTIL_TIME_INITIALIZER 0
     typedef U64 UTIL_time_t;
+
 #elif (PLATFORM_POSIX_VERSION >= 200112L) \
    && (defined(__UCLIBC__)                \
       || (defined(__GLIBC__)              \
@@ -133,10 +137,14 @@ extern int g_utilDisplayLevel;
     typedef struct timespec UTIL_time_t;
 
     UTIL_time_t UTIL_getSpanTime(UTIL_time_t begin, UTIL_time_t end);
+
 #else   /* relies on standard C (note : clock_t measurements can be wrong when using multi-threading) */
+
     typedef clock_t UTIL_time_t;
     #define UTIL_TIME_INITIALIZER 0
+
 #endif
+
 UTIL_time_t UTIL_getTime(void);
 U64 UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd);
 U64 UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd);

--- a/programs/util.h
+++ b/programs/util.h
@@ -20,10 +20,9 @@ extern "C" {
 *  Dependencies
 ******************************************/
 #include "platform.h"     /* PLATFORM_POSIX_VERSION, ZSTD_NANOSLEEP_SUPPORT, ZSTD_SETPRIORITY_SUPPORT */
-#include <stdlib.h>       /* malloc */
+#include <stdlib.h>       /* malloc, realloc, free */
 #include <stddef.h>       /* size_t, ptrdiff_t */
 #include <stdio.h>        /* fprintf */
-#include <string.h>       /* strncmp */
 #include <sys/types.h>    /* stat, utime */
 #include <sys/stat.h>     /* stat, chmod */
 #if defined(_MSC_VER)
@@ -34,7 +33,6 @@ extern "C" {
 #  include <utime.h>      /* utime */
 #endif
 #include <time.h>         /* clock_t, clock, CLOCKS_PER_SEC, nanosleep */
-#include <errno.h>
 #include "mem.h"          /* U32, U64 */
 
 
@@ -163,10 +161,11 @@ void UTIL_waitForNextTick(void);
 #endif
 
 
+int UTIL_fileExist(const char* filename);
 int UTIL_isRegularFile(const char* infilename);
-int UTIL_setFileStat(const char *filename, stat_t *statbuf);
+int UTIL_setFileStat(const char* filename, stat_t* statbuf);
 U32 UTIL_isDirectory(const char* infilename);
-int UTIL_getFileStat(const char* infilename, stat_t *statbuf);
+int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
 
 U32 UTIL_isLink(const char* infilename);
 #define UTIL_FILESIZE_UNKNOWN  ((U64)(-1))
@@ -178,7 +177,7 @@ U64 UTIL_getTotalFileSize(const char* const * const fileNamesTable, unsigned nbF
  * A modified version of realloc().
  * If UTIL_realloc() fails the original block is freed.
 */
-UTIL_STATIC void *UTIL_realloc(void *ptr, size_t size)
+UTIL_STATIC void* UTIL_realloc(void *ptr, size_t size)
 {
     void *newptr = realloc(ptr, size);
     if (newptr) return newptr;
@@ -186,7 +185,7 @@ UTIL_STATIC void *UTIL_realloc(void *ptr, size_t size)
     return NULL;
 }
 
-int UTIL_prepareFileList(const char *dirName, char** bufStart, size_t* pos, char** bufEnd, int followLinks);
+int UTIL_prepareFileList(const char* dirName, char** bufStart, size_t* pos, char** bufEnd, int followLinks);
 #ifdef _WIN32
 #  define UTIL_HAS_CREATEFILELIST
 #elif defined(__linux__) || (PLATFORM_POSIX_VERSION >= 200112L)  /* opendir, readdir require POSIX.1-2001 */

--- a/tests/paramgrill.c
+++ b/tests/paramgrill.c
@@ -12,7 +12,7 @@
 /*-************************************
 *  Dependencies
 **************************************/
-#include "util.h"      /* Compiler options, UTIL_GetFileSize */
+#include "util.h"      /* Ensure platform.h is compiled first; also : compiler options, UTIL_GetFileSize */
 #include <stdlib.h>    /* malloc */
 #include <stdio.h>     /* fprintf, fopen, ftello64 */
 #include <string.h>    /* strcmp */
@@ -24,7 +24,6 @@
 #include "zstd.h"
 #include "datagen.h"
 #include "xxhash.h"
-#include "util.h"
 #include "benchfn.h"
 #include "benchzstd.h"
 #include "zstd_errors.h"
@@ -879,12 +878,12 @@ BMK_printWinner(FILE* f, const int cLevel, const BMK_benchResult_t result, const
 
     if(TIMED) {
         const U64 mn_in_ns = 60ULL * TIMELOOP_NANOSEC;
-        const U64 time = UTIL_clockSpanNano(g_time);
-        const U64 minutes = time / mn_in_ns;
+        const U64 time_ns = UTIL_clockSpanNano(g_time);
+        const U64 minutes = time_ns / mn_in_ns;
         fprintf(f, "%1lu:%2lu:%05.2f - ",
                 (unsigned long) minutes / 60,
                 (unsigned long) minutes % 60,
-                (double)(time - (minutes * mn_in_ns)) / TIMELOOP_NANOSEC );
+                (double)(time_ns - (minutes * mn_in_ns)) / TIMELOOP_NANOSEC );
     }
 
     fprintf(f, "/* %s */   ", lvlstr);

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -186,7 +186,8 @@ rm -f tmpro tmpro.zst
 $ECHO "test: overwrite input file (must fail)"
 $ZSTD tmp -fo tmp && die "zstd overwrote the input file"
 $ZSTD tmp.zst -dfo tmp.zst && die "zstd overwrote the input file"
-
+$ECHO "test: properly detect input file does not exist"
+$ZSTD nothere 2>&1 | grep "o such file"
 
 $ECHO "test : file removal"
 $ZSTD -f --rm tmp

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -184,9 +184,9 @@ $ZSTD tmpro -c --no-progress | $ZSTD -d -o "$INTOVOID" --no-progress
 $ZSTD tmpro -cv --no-progress | $ZSTD -dv -o "$INTOVOID" --no-progress
 rm -f tmpro tmpro.zst
 $ECHO "test: overwrite input file (must fail)"
-$ZSTD tmp -fo tmp && die "zstd overwrote the input file"
-$ZSTD tmp.zst -dfo tmp.zst && die "zstd overwrote the input file"
-$ECHO "test: properly detect input file does not exist"
+$ZSTD tmp -fo tmp && die "zstd compression overwrote the input file"
+$ZSTD tmp.zst -dfo tmp.zst && die "zstd decompression overwrote the input file"
+$ECHO "test: detect that input file does not exist"
 $ZSTD nothere && die "zstd hasn't detected that input file does not exist"
 
 $ECHO "test : file removal"

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -187,7 +187,7 @@ $ECHO "test: overwrite input file (must fail)"
 $ZSTD tmp -fo tmp && die "zstd overwrote the input file"
 $ZSTD tmp.zst -dfo tmp.zst && die "zstd overwrote the input file"
 $ECHO "test: properly detect input file does not exist"
-$ZSTD nothere 2>&1 | grep "o such file"
+$ZSTD nothere && die "zstd hasn't detected that input file does not exist"
 
 $ECHO "test : file removal"
 $ZSTD -f --rm tmp

--- a/zlibWrapper/Makefile
+++ b/zlibWrapper/Makefile
@@ -71,25 +71,25 @@ valgrindTest: clean example fitblk example_zstd fitblk_zstd zwrapbench
 #	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
 minigzip: $(EXAMPLE_PATH)/minigzip.o $(ZLIBWRAPPER_PATH)/zstd_zlibwrapper.o $(GZFILES) $(ZSTDLIBRARY)
-	$(CC) $(LDFLAGS) $^ $(ZSTDLIBRARY) $(ZLIB_LIBRARY) -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ $(ZSTDLIBRARY) $(ZLIB_LIBRARY) -o $@
 
 minigzip_zstd: $(EXAMPLE_PATH)/minigzip.o $(ZLIBWRAPPER_PATH)/zstdTurnedOn_zlibwrapper.o $(GZFILES) $(ZSTDLIBRARY)
-	$(CC) $(LDFLAGS) $^ $(ZSTDLIBRARY) $(ZLIB_LIBRARY) -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ $(ZSTDLIBRARY) $(ZLIB_LIBRARY) -o $@
 
 example: $(EXAMPLE_PATH)/example.o $(ZLIBWRAPPER_PATH)/zstd_zlibwrapper.o $(GZFILES) $(ZSTDLIBRARY)
-	$(CC) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
 
 example_zstd: $(EXAMPLE_PATH)/example.o $(ZLIBWRAPPER_PATH)/zstdTurnedOn_zlibwrapper.o $(GZFILES) $(ZSTDLIBRARY)
-	$(CC) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
 
 fitblk: $(EXAMPLE_PATH)/fitblk.o $(ZLIBWRAPPER_PATH)/zstd_zlibwrapper.o $(ZSTDLIBRARY)
-	$(CC) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
 
 fitblk_zstd: $(EXAMPLE_PATH)/fitblk.o $(ZLIBWRAPPER_PATH)/zstdTurnedOn_zlibwrapper.o $(ZSTDLIBRARY)
-	$(CC) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
 
 zwrapbench: $(EXAMPLE_PATH)/zwrapbench.o $(ZLIBWRAPPER_PATH)/zstd_zlibwrapper.o $(PROGRAMS_PATH)/util.o $(PROGRAMS_PATH)/datagen.o $(ZSTDLIBRARY)
-	$(CC) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ $(ZLIB_LIBRARY) -o $@
 
 
 $(ZLIBWRAPPER_PATH)/zstd_zlibwrapper.o: $(ZLIBWRAPPER_PATH)/zstd_zlibwrapper.c $(ZLIBWRAPPER_PATH)/zstd_zlibwrapper.h

--- a/zlibWrapper/examples/zwrapbench.c
+++ b/zlibWrapper/examples/zwrapbench.c
@@ -17,6 +17,7 @@
 #include <stdio.h>       /* fprintf, fopen, ftello64 */
 #include <time.h>        /* clock_t, clock, CLOCKS_PER_SEC */
 #include <ctype.h>       /* toupper */
+#include <errno.h>       /* errno */
 
 #include "mem.h"
 #define ZSTD_STATIC_LINKING_ONLY


### PR DESCRIPTION
provides a better error message, consistent with `gzip` one