### PR TITLE
fixed : better error message

### DIFF
--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -27,18 +27,18 @@ void ZSTD_fillHashTable(ZSTD_matchState_t* ms,
     /* Always insert every fastHashFillStep position into the hash table.
      * Insert the other positions if their hash entry is empty.
      */
-    for (; ip + fastHashFillStep - 1 <= iend; ip += fastHashFillStep) {
+    for ( ; ip + fastHashFillStep < iend + 2; ip += fastHashFillStep) {
         U32 const current = (U32)(ip - base);
-        U32 i;
-        for (i = 0; i < fastHashFillStep; ++i) {
-            size_t const hash = ZSTD_hashPtr(ip + i, hBits, mls);
-            if (i == 0 || hashTable[hash] == 0)
-                hashTable[hash] = current + i;
-            /* Only load extra positions for ZSTD_dtlm_full */
-            if (dtlm == ZSTD_dtlm_fast)
-                break;
-        }
-    }
+        size_t const hash0 = ZSTD_hashPtr(ip, hBits, mls);
+        hashTable[hash0] = current;
+        if (dtlm == ZSTD_dtlm_fast) continue;
+        /* Only load extra positions for ZSTD_dtlm_full */
+        {   U32 p;
+            for (p = 1; p < fastHashFillStep; ++p) {
+                size_t const hash = ZSTD_hashPtr(ip + p, hBits, mls);
+                if (hashTable[hash] == 0) {  /* not yet filled */
+                    hashTable[hash] = current + p;
+    }   }   }   }
 }
 
 FORCE_INLINE_TEMPLATE

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>      /* malloc, free */
 #include <string.h>      /* memset */
 #include <stdio.h>       /* fprintf, fopen */
+#include <errno.h>
 #include <assert.h>      /* assert */
 
 #include "benchfn.h"
@@ -799,6 +800,11 @@ BMK_benchOutcome_t BMK_benchFilesAdvanced(
     /* Load dictionary */
     if (dictFileName != NULL) {
         U64 const dictFileSize = UTIL_getFileSize(dictFileName);
+        if (dictFileSize == UTIL_FILESIZE_UNKNOWN) {
+            DISPLAYLEVEL(1, "error loading %s : %s \n", dictFileName, strerror(errno));
+            free(fileSizes);
+            RETURN_ERROR(9, BMK_benchOutcome_t, "benchmark aborted");
+        }
         if (dictFileSize > 64 MB) {
             free(fileSizes);
             RETURN_ERROR(10, BMK_benchOutcome_t, "dictionary file %s too large", dictFileName);

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -23,7 +23,7 @@
 #include "platform.h"    /* Large Files support */
 #include "util.h"        /* UTIL_getFileSize, UTIL_sleep */
 #include <stdlib.h>      /* malloc, free */
-#include <string.h>      /* memset */
+#include <string.h>      /* memset, strerror */
 #include <stdio.h>       /* fprintf, fopen */
 #include <errno.h>
 #include <assert.h>      /* assert */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -487,6 +487,7 @@ static size_t FIO_createDictBuffer(void** bufferPtr, const char* fileName)
     DISPLAYLEVEL(4,"Loading %s as dictionary \n", fileName);
     fileHandle = fopen(fileName, "rb");
     if (fileHandle==NULL) EXM_THROW(31, "%s: %s", fileName, strerror(errno));
+
     fileSize = UTIL_getFileSize(fileName);
     if (fileSize > DICTSIZE_MAX) {
         EXM_THROW(32, "Dictionary file %s is too large (> %u MB)",
@@ -495,7 +496,7 @@ static size_t FIO_createDictBuffer(void** bufferPtr, const char* fileName)
     *bufferPtr = malloc((size_t)fileSize);
     if (*bufferPtr==NULL) EXM_THROW(34, "%s", strerror(errno));
     {   size_t const readSize = fread(*bufferPtr, 1, (size_t)fileSize, fileHandle);
-        if (readSize!=fileSize)
+        if (readSize != fileSize)
             EXM_THROW(35, "Error reading dictionary file %s : %s",
                     fileName, strerror(errno));
     }


### PR DESCRIPTION
when dictionary missing during benchmark.

Also : refactored `ZSTD_fillHashTable()`,
just for readability (it does the same thing)