### PR TITLE
BUG: list sub-command REMOVE_DUPLICATES requires list to be present

### DIFF
--- a/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
+++ b/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
@@ -50,9 +50,11 @@ macro(ADD_ZSTD_COMPILATION_FLAGS)
              CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
              CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
              CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        separate_arguments(${flag_var})
-        list(REMOVE_DUPLICATES ${flag_var})
-        string(REPLACE ";" " " ${flag_var} "${${flag_var}}")
+        if( ${flag_var} )
+            separate_arguments(${flag_var})
+            list(REMOVE_DUPLICATES ${flag_var})
+            string(REPLACE ";" " " ${flag_var} "${${flag_var}}")
+        endif()
     endforeach ()
 
     if (MSVC AND ZSTD_USE_STATIC_RUNTIME)
@@ -60,7 +62,9 @@ macro(ADD_ZSTD_COMPILATION_FLAGS)
                  CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
                  CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
                  CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+            if ( ${flag_var} )
+                string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+            endif()
         endforeach ()
     endif ()
 


### PR DESCRIPTION
When compiling without c++ enabled, some variables are not present.
This is a check enforced in recent Cmake versions.

CMake Error at CMakeModules/AddZstdCompilationFlags.cmake:54 (list):
  list sub-command REMOVE_DUPLICATES requires list to be present.
Call Stack (most recent call first):
  CMakeLists.txt:53 (ADD_ZSTD_COMPILATION_FLAGS)