### PR TITLE
Include unistd.h on unix platforms for explicit function declaration

### DIFF
--- a/zlibWrapper/gzguts.h
+++ b/zlibWrapper/gzguts.h
@@ -38,6 +38,8 @@
 
 #ifdef _WIN32
 #  include <stddef.h>
+#else
+#  include <unistd.h>
 #endif
 
 #if defined(__TURBOC__) || defined(_MSC_VER) || defined(_WIN32)


### PR DESCRIPTION
This fixes building under FreeBSD with Clang 6.0.1.