### PR TITLE
Conversion warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,12 @@ matrix:
       script:
         - make test
 
-    - name: clang + gcc-6 + gcc-7 compilation
+    - name: gcc-6 + gcc-7 compilation
       script:
         - make gcc6install gcc7install
         - CC=gcc-6 CFLAGS=-Werror make -j all
         - make clean
         - CC=gcc-7 CFLAGS=-Werror make -j all
-        - make clean
-        - CXX=clang++ CC=clang CFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation" make all
 
     - name: gcc-8 + ASan + UBSan + Test Zstd
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,14 @@ matrix:
       script:
         - make test
 
-    - name: gcc-6 + gcc-7 compilation
+    - name: clang + gcc-6 + gcc-7 compilation
       script:
         - make gcc6install gcc7install
         - CC=gcc-6 CFLAGS=-Werror make -j all
         - make clean
         - CC=gcc-7 CFLAGS=-Werror make -j all
+        - make clean
+        - CXX=clang++ CC=clang CFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation" make all
 
     - name: gcc-8 + ASan + UBSan + Test Zstd
       script:

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ list:
 	    done \
 	} | column -t -s $$'\t'
 
-.PHONY: install clangtest armtest usan asan uasan
+.PHONY: install armtest usan asan uasan
 install:
 	@$(MAKE) -C $(ZSTDDIR) $@
 	@$(MAKE) -C $(PRGDIR) $@
@@ -188,7 +188,7 @@ gcc7build: clean
 .PHONY: clangbuild
 clangbuild: clean
 	clang -v
-	CXX=clang++ CC=clang $(MAKE) all MOREFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation"
+	CXX=clang++ CC=clang CFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation" $(MAKE) all
 
 m32build: clean
 	gcc -v
@@ -231,10 +231,6 @@ gcc5test: clean
 gcc6test: clean
 	gcc-6 -v
 	$(MAKE) all CC=gcc-6 MOREFLAGS="-Werror"
-
-clangtest: clean
-	clang -v
-	$(MAKE) all CXX=clang++ CC=clang MOREFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation"
 
 armtest: clean
 	$(MAKE) -C $(TESTDIR) datagen   # use native, faster

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -1011,22 +1011,26 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
 </p></pre><BR>
 
 <pre><b>ZSTD_compressionParameters ZSTD_getCParams(int compressionLevel, unsigned long long estimatedSrcSize, size_t dictSize);
-</b><p>   @return ZSTD_compressionParameters structure for a selected compression level and estimated srcSize.
-   `estimatedSrcSize` value is optional, select 0 if not known 
+</b><p> @return ZSTD_compressionParameters structure for a selected compression level and estimated srcSize.
+ `estimatedSrcSize` value is optional, select 0 if not known 
 </p></pre><BR>
 
 <pre><b>ZSTD_parameters ZSTD_getParams(int compressionLevel, unsigned long long estimatedSrcSize, size_t dictSize);
-</b><p>   same as ZSTD_getCParams(), but @return a full `ZSTD_parameters` object instead of sub-component `ZSTD_compressionParameters`.
-   All fields of `ZSTD_frameParameters` are set to default : contentSize=1, checksum=0, noDictID=0 
+</b><p>  same as ZSTD_getCParams(), but @return a full `ZSTD_parameters` object instead of sub-component `ZSTD_compressionParameters`.
+  All fields of `ZSTD_frameParameters` are set to default : contentSize=1, checksum=0, noDictID=0 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_checkCParams(ZSTD_compressionParameters params);
-</b><p>   Ensure param values remain within authorized range 
+</b><p>  Ensure param values remain within authorized range.
+ @return 0 on success, or an error code (can be checked with ZSTD_isError()) 
 </p></pre><BR>
 
 <pre><b>ZSTD_compressionParameters ZSTD_adjustCParams(ZSTD_compressionParameters cPar, unsigned long long srcSize, size_t dictSize);
 </b><p>  optimize params for a given `srcSize` and `dictSize`.
-  both values are optional, select `0` if unknown. 
+ `srcSize` can be unknown, in which case use ZSTD_CONTENTSIZE_UNKNOWN.
+ `dictSize` must be `0` when there is no dictionary.
+  cPar can be invalid : all parameters will be clamped within valid range in the @return struct.
+  This function never fails (wide contract) 
 </p></pre><BR>
 
 <pre><b>size_t ZSTD_compress_advanced(ZSTD_CCtx* cctx,

--- a/examples/multiple_simple_compression.c
+++ b/examples/multiple_simple_compression.c
@@ -28,7 +28,7 @@ typedef struct {
  * allocate memory for buffers big enough to compress all files
  * as well as memory for output file name (ofn)
  */
-static resources createResources_orDie(int argc, const char** argv, char **ofn, int* ofnBufferLen)
+static resources createResources_orDie(int argc, const char** argv, char **ofn, size_t* ofnBufferLen)
 {
     size_t maxFilenameLength=0;
     size_t maxFileSize = 0;
@@ -94,14 +94,14 @@ int main(int argc, const char** argv)
 
     /* memory allocation for outFilename and resources */
     char* outFilename;
-    int outFilenameBufferLen;
-    resources const ress = createResources_orDie(argc, argv, &outFilename, &outFilenameBufferLen); 
+    size_t outFilenameBufferLen;
+    resources const ress = createResources_orDie(argc, argv, &outFilename, &outFilenameBufferLen);
 
     /* compress files with shared context, input and output buffers */
     int argNb;
     for (argNb = 1; argNb < argc; argNb++) {
         const char* const inFilename = argv[argNb];
-        int inFilenameLen = strlen(inFilename);
+        size_t const inFilenameLen = strlen(inFilename);
         assert(inFilenameLen + 5 <= outFilenameBufferLen);
         memcpy(outFilename, inFilename, inFilenameLen);
         memcpy(outFilename+inFilenameLen, ".zst", 5);

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -56,7 +56,7 @@ static size_t fsize_orDie(const char *filename)
      * 2. if off_t -> size_t type conversion results in discrepancy,
      *    the file size is too large for type size_t.
      */
-    if ((fileSize < 0) || (fileSize != (off_t)size)) { 
+    if ((fileSize < 0) || (fileSize != (off_t)size)) {
         fprintf(stderr, "%s : filesize too large \n", filename);
         exit(ERROR_largeFile);
     }
@@ -150,7 +150,7 @@ static void* malloc_orDie(size_t size)
  * @return If successful this function will load file into buffer and
  * return file size, otherwise it will printout an error to stderr and exit.
  */
-static size_t loadFile_orDie(const char* fileName, void* buffer, int bufferSize)
+static size_t loadFile_orDie(const char* fileName, void* buffer, size_t bufferSize)
 {
     size_t const fileSize = fsize_orDie(fileName);
     assert(fileSize <= bufferSize);


### PR DESCRIPTION
updated `clang` tests on travis CI
fixed associated minor conversion warnings in `examples/` 
