### PR TITLE
Detection of symbolic links on OpenBSD

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -92,6 +92,7 @@ U32 UTIL_isLink(const char* infilename)
 /* macro guards, as defined in : https://linux.die.net/man/2/lstat */
 #ifndef __STRICT_ANSI__
 #if defined(_BSD_SOURCE) \
+    || defined(__OpenBSD__) \
     || (defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500)) \
     || (defined(_XOPEN_SOURCE) && defined(_XOPEN_SOURCE_EXTENDED)) \
     || (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L)) \

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -951,6 +951,8 @@ int main(int argCount, const char* argv[])
                 filenameTable[fileNamesNb++] = filenameTable[u];
             }
         }
+        if (fileNamesNb == 0 && filenameIdx > 0)
+            CLEAN_RETURN(1);
         filenameIdx = fileNamesNb;
     }
     if (recursive) {  /* at this stage, filenameTable is a list of paths, which can contain both files and directories */

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -314,18 +314,28 @@ $ECHO foo | $ZSTD > /dev/full && die "write error not detected!"
 $ECHO "$ECHO foo | $ZSTD | $ZSTD -d > /dev/full"
 $ECHO foo | $ZSTD | $ZSTD -d > /dev/full && die "write error not detected!"
 
+fi
+
+
+if [ "$isWindows" = false ] && [ "$UNAME" != 'SunOS' ] ; then
 
 $ECHO "\n===>  symbolic link test "
 
-rm -f hello.tmp world.tmp hello.tmp.zst world.tmp.zst
+rm -f hello.tmp world.tmp world2.tmp hello.tmp.zst world.tmp.zst
 $ECHO "hello world" > hello.tmp
 ln -s hello.tmp world.tmp
-$ZSTD world.tmp hello.tmp
+ln -s hello.tmp world2.tmp
+$ZSTD world.tmp hello.tmp || true
 test -f hello.tmp.zst  # regular file should have been compressed!
 test ! -f world.tmp.zst  # symbolic link should not have been compressed!
+$ZSTD world.tmp || true
+test ! -f world.tmp.zst  # symbolic link should not have been compressed!
+$ZSTD world.tmp world2.tmp || true
+test ! -f world.tmp.zst  # symbolic link should not have been compressed!
+test ! -f world2.tmp.zst  # symbolic link should not have been compressed!
 $ZSTD world.tmp hello.tmp -f
 test -f world.tmp.zst  # symbolic link should have been compressed with --force
-rm -f hello.tmp world.tmp hello.tmp.zst world.tmp.zst
+rm -f hello.tmp world.tmp world2.tmp hello.tmp.zst world.tmp.zst
 
 fi
 


### PR DESCRIPTION
In #1520 it is described that FreeBSD doesn't detect symbolic links. The same is true for OpenBSD. This diff fixes this issue for OpenBSD. I'm guessing that something similar works for FreeBSD as well. However, I'm unable to test this.

While working on the above I noticed some inconsistent behaviour:

```
$ echo hello > hello
$ ln -s hello world
$ zstd hello world
Warning : world is a symbolic link, ignoring
hello                :316.67%   (     6 =>     19 bytes, hello.zst
$ ls *.zst
hello.zst
$ zstd world
world                :316.67%   (     6 =>     19 bytes, world.zst)
$ ls *.zst
hello.zst world.zst

```
I'm guessing that the latter is not OpenBSD specific?