### PR TITLE
Clean up parameter code

### DIFF
--- a/tests/regression/config.c
+++ b/tests/regression/config.c
@@ -90,6 +90,17 @@ static config_t mt_ldm = {
     .param_values = PARAM_VALUES(mt_ldm_param_values),
 };
 
+static param_value_t mt_advanced_param_values[] = {
+    {.param = ZSTD_c_nbWorkers, .value = 2},
+    {.param = ZSTD_c_literalCompressionMode, .value = ZSTD_lcm_uncompressed},
+};
+
+static config_t mt_advanced = {
+    .name = "multithreaded with advanced params",
+    .cli_args = "-T2 --no-compressed-literals",
+    .param_values = PARAM_VALUES(mt_advanced_param_values),
+};
+
 static param_value_t const small_wlog_param_values[] = {
     {.param = ZSTD_c_windowLog, .value = 10},
 };
@@ -191,6 +202,7 @@ static config_t const* g_configs[] = {
     &uncompressed_literals,
     &uncompressed_literals_opt,
     &huffman_literals,
+    &mt_advanced,
     NULL,
 };
 

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -1,502 +1,516 @@
-Data,                             Config,                           Method,                           Total compressed size
-silesia.tar,                      level -5,                         compress simple,                  7160438
-silesia.tar,                      level -3,                         compress simple,                  6789024
-silesia.tar,                      level -1,                         compress simple,                  6195462
-silesia.tar,                      level 0,                          compress simple,                  4875008
-silesia.tar,                      level 1,                          compress simple,                  5339697
-silesia.tar,                      level 3,                          compress simple,                  4875008
-silesia.tar,                      level 4,                          compress simple,                  4813507
-silesia.tar,                      level 5,                          compress simple,                  4722235
-silesia.tar,                      level 6,                          compress simple,                  4672194
-silesia.tar,                      level 7,                          compress simple,                  4606658
-silesia.tar,                      level 9,                          compress simple,                  4554098
-silesia.tar,                      level 13,                         compress simple,                  4491702
-silesia.tar,                      level 16,                         compress simple,                  4381277
-silesia.tar,                      level 19,                         compress simple,                  4281514
-silesia.tar,                      uncompressed literals,            compress simple,                  4875008
-silesia.tar,                      uncompressed literals optimal,    compress simple,                  4281514
-silesia.tar,                      huffman literals,                 compress simple,                  6195462
-silesia,                          level -5,                         compress cctx,                    7152294
-silesia,                          level -3,                         compress cctx,                    6789969
-silesia,                          level -1,                         compress cctx,                    6191548
-silesia,                          level 0,                          compress cctx,                    4862377
-silesia,                          level 1,                          compress cctx,                    5318036
-silesia,                          level 3,                          compress cctx,                    4862377
-silesia,                          level 4,                          compress cctx,                    4800629
-silesia,                          level 5,                          compress cctx,                    4710178
-silesia,                          level 6,                          compress cctx,                    4659996
-silesia,                          level 7,                          compress cctx,                    4596234
-silesia,                          level 9,                          compress cctx,                    4543862
-silesia,                          level 13,                         compress cctx,                    4482073
-silesia,                          level 16,                         compress cctx,                    4377391
-silesia,                          level 19,                         compress cctx,                    4293262
-silesia,                          long distance mode,               compress cctx,                    4862377
-silesia,                          multithreaded,                    compress cctx,                    4862377
-silesia,                          multithreaded long distance mode, compress cctx,                    4862377
-silesia,                          small window log,                 compress cctx,                    7115734
-silesia,                          small hash log,                   compress cctx,                    6554898
-silesia,                          small chain log,                  compress cctx,                    4931093
-silesia,                          explicit params,                  compress cctx,                    4813352
-silesia,                          uncompressed literals,            compress cctx,                    4862377
-silesia,                          uncompressed literals optimal,    compress cctx,                    4293262
-silesia,                          huffman literals,                 compress cctx,                    6191548
-github,                           level -5,                         compress cctx,                    232744
-github,                           level -5 with dict,               compress cctx,                    47294
-github,                           level -3,                         compress cctx,                    220611
-github,                           level -3 with dict,               compress cctx,                    48047
-github,                           level -1,                         compress cctx,                    176575
-github,                           level -1 with dict,               compress cctx,                    43527
-github,                           level 0,                          compress cctx,                    136397
-github,                           level 0 with dict,                compress cctx,                    41536
-github,                           level 1,                          compress cctx,                    143457
-github,                           level 1 with dict,                compress cctx,                    42157
-github,                           level 3,                          compress cctx,                    136397
-github,                           level 3 with dict,                compress cctx,                    41536
-github,                           level 4,                          compress cctx,                    136144
-github,                           level 4 with dict,                compress cctx,                    41721
-github,                           level 5,                          compress cctx,                    135106
-github,                           level 5 with dict,                compress cctx,                    38934
-github,                           level 6,                          compress cctx,                    135108
-github,                           level 6 with dict,                compress cctx,                    38628
-github,                           level 7,                          compress cctx,                    135108
-github,                           level 7 with dict,                compress cctx,                    38741
-github,                           level 9,                          compress cctx,                    135108
-github,                           level 9 with dict,                compress cctx,                    39335
-github,                           level 13,                         compress cctx,                    133717
-github,                           level 13 with dict,               compress cctx,                    39923
-github,                           level 16,                         compress cctx,                    133717
-github,                           level 16 with dict,               compress cctx,                    37568
-github,                           level 19,                         compress cctx,                    133717
-github,                           level 19 with dict,               compress cctx,                    37567
-github,                           long distance mode,               compress cctx,                    141473
-github,                           multithreaded,                    compress cctx,                    141473
-github,                           multithreaded long distance mode, compress cctx,                    141473
-github,                           small window log,                 compress cctx,                    141473
-github,                           small hash log,                   compress cctx,                    138943
-github,                           small chain log,                  compress cctx,                    139239
-github,                           explicit params,                  compress cctx,                    140924
-github,                           uncompressed literals,            compress cctx,                    136397
-github,                           uncompressed literals optimal,    compress cctx,                    133717
-github,                           huffman literals,                 compress cctx,                    176575
-silesia,                          level -5,                         zstdcli,                          7152342
-silesia,                          level -3,                         zstdcli,                          6790021
-silesia,                          level -1,                         zstdcli,                          6191597
-silesia,                          level 0,                          zstdcli,                          4862425
-silesia,                          level 1,                          zstdcli,                          5318084
-silesia,                          level 3,                          zstdcli,                          4862425
-silesia,                          level 4,                          zstdcli,                          4800677
-silesia,                          level 5,                          zstdcli,                          4710226
-silesia,                          level 6,                          zstdcli,                          4660044
-silesia,                          level 7,                          zstdcli,                          4596282
-silesia,                          level 9,                          zstdcli,                          4543910
-silesia,                          level 13,                         zstdcli,                          4482121
-silesia,                          level 16,                         zstdcli,                          4377439
-silesia,                          level 19,                         zstdcli,                          4293310
-silesia,                          long distance mode,               zstdcli,                          4853437
-silesia,                          multithreaded,                    zstdcli,                          4862425
-silesia,                          multithreaded long distance mode, zstdcli,                          4853437
-silesia,                          small window log,                 zstdcli,                          7126434
-silesia,                          small hash log,                   zstdcli,                          6554946
-silesia,                          small chain log,                  zstdcli,                          4931141
-silesia,                          explicit params,                  zstdcli,                          4815380
-silesia,                          uncompressed literals,            zstdcli,                          5155472
-silesia,                          uncompressed literals optimal,    zstdcli,                          4325475
-silesia,                          huffman literals,                 zstdcli,                          5341405
-silesia.tar,                      level -5,                         zstdcli,                          7161160
-silesia.tar,                      level -3,                         zstdcli,                          6789865
-silesia.tar,                      level -1,                         zstdcli,                          6196433
-silesia.tar,                      level 0,                          zstdcli,                          4875136
-silesia.tar,                      level 1,                          zstdcli,                          5340573
-silesia.tar,                      level 3,                          zstdcli,                          4875136
-silesia.tar,                      level 4,                          zstdcli,                          4814531
-silesia.tar,                      level 5,                          zstdcli,                          4723284
-silesia.tar,                      level 6,                          zstdcli,                          4673591
-silesia.tar,                      level 7,                          zstdcli,                          4608342
-silesia.tar,                      level 9,                          zstdcli,                          4554700
-silesia.tar,                      level 13,                         zstdcli,                          4491706
-silesia.tar,                      level 16,                         zstdcli,                          4381281
-silesia.tar,                      level 19,                         zstdcli,                          4281518
-silesia.tar,                      no source size,                   zstdcli,                          4875132
-silesia.tar,                      long distance mode,               zstdcli,                          4866975
-silesia.tar,                      multithreaded,                    zstdcli,                          4875136
-silesia.tar,                      multithreaded long distance mode, zstdcli,                          4866975
-silesia.tar,                      small window log,                 zstdcli,                          7130434
-silesia.tar,                      small hash log,                   zstdcli,                          6587841
-silesia.tar,                      small chain log,                  zstdcli,                          4943259
-silesia.tar,                      explicit params,                  zstdcli,                          4839202
-silesia.tar,                      uncompressed literals,            zstdcli,                          5158134
-silesia.tar,                      uncompressed literals optimal,    zstdcli,                          4321098
-silesia.tar,                      huffman literals,                 zstdcli,                          5358479
-github,                           level -5,                         zstdcli,                          234744
-github,                           level -5 with dict,               zstdcli,                          48718
-github,                           level -3,                         zstdcli,                          222611
-github,                           level -3 with dict,               zstdcli,                          47395
-github,                           level -1,                         zstdcli,                          178575
-github,                           level -1 with dict,               zstdcli,                          45170
-github,                           level 0,                          zstdcli,                          138397
-github,                           level 0 with dict,                zstdcli,                          43170
-github,                           level 1,                          zstdcli,                          145457
-github,                           level 1 with dict,                zstdcli,                          43682
-github,                           level 3,                          zstdcli,                          138397
-github,                           level 3 with dict,                zstdcli,                          43170
-github,                           level 4,                          zstdcli,                          138144
-github,                           level 4 with dict,                zstdcli,                          43306
-github,                           level 5,                          zstdcli,                          137106
-github,                           level 5 with dict,                zstdcli,                          40938
-github,                           level 6,                          zstdcli,                          137108
-github,                           level 6 with dict,                zstdcli,                          40632
-github,                           level 7,                          zstdcli,                          137108
-github,                           level 7 with dict,                zstdcli,                          40766
-github,                           level 9,                          zstdcli,                          137108
-github,                           level 9 with dict,                zstdcli,                          41326
-github,                           level 13,                         zstdcli,                          135717
-github,                           level 13 with dict,               zstdcli,                          41716
-github,                           level 16,                         zstdcli,                          135717
-github,                           level 16 with dict,               zstdcli,                          39577
-github,                           level 19,                         zstdcli,                          135717
-github,                           level 19 with dict,               zstdcli,                          39576
-github,                           long distance mode,               zstdcli,                          138397
-github,                           multithreaded,                    zstdcli,                          138397
-github,                           multithreaded long distance mode, zstdcli,                          138397
-github,                           small window log,                 zstdcli,                          138397
-github,                           small hash log,                   zstdcli,                          137467
-github,                           small chain log,                  zstdcli,                          138314
-github,                           explicit params,                  zstdcli,                          136140
-github,                           uncompressed literals,            zstdcli,                          169004
-github,                           uncompressed literals optimal,    zstdcli,                          158824
-github,                           huffman literals,                 zstdcli,                          145457
-silesia,                          level -5,                         advanced one pass,                7152294
-silesia,                          level -3,                         advanced one pass,                6789969
-silesia,                          level -1,                         advanced one pass,                6191548
-silesia,                          level 0,                          advanced one pass,                4862377
-silesia,                          level 1,                          advanced one pass,                5318036
-silesia,                          level 3,                          advanced one pass,                4862377
-silesia,                          level 4,                          advanced one pass,                4800629
-silesia,                          level 5,                          advanced one pass,                4710178
-silesia,                          level 6,                          advanced one pass,                4659996
-silesia,                          level 7,                          advanced one pass,                4596234
-silesia,                          level 9,                          advanced one pass,                4543862
-silesia,                          level 13,                         advanced one pass,                4482073
-silesia,                          level 16,                         advanced one pass,                4377391
-silesia,                          level 19,                         advanced one pass,                4293262
-silesia,                          no source size,                   advanced one pass,                4862377
-silesia,                          long distance mode,               advanced one pass,                4853389
-silesia,                          multithreaded,                    advanced one pass,                4862377
-silesia,                          multithreaded long distance mode, advanced one pass,                4853389
-silesia,                          small window log,                 advanced one pass,                7126386
-silesia,                          small hash log,                   advanced one pass,                6554898
-silesia,                          small chain log,                  advanced one pass,                4931093
-silesia,                          explicit params,                  advanced one pass,                4815369
-silesia,                          uncompressed literals,            advanced one pass,                5155424
-silesia,                          uncompressed literals optimal,    advanced one pass,                4325427
-silesia,                          huffman literals,                 advanced one pass,                5341356
-silesia.tar,                      level -5,                         advanced one pass,                7160438
-silesia.tar,                      level -3,                         advanced one pass,                6789024
-silesia.tar,                      level -1,                         advanced one pass,                6195462
-silesia.tar,                      level 0,                          advanced one pass,                4875008
-silesia.tar,                      level 1,                          advanced one pass,                5339697
-silesia.tar,                      level 3,                          advanced one pass,                4875008
-silesia.tar,                      level 4,                          advanced one pass,                4813507
-silesia.tar,                      level 5,                          advanced one pass,                4722235
-silesia.tar,                      level 6,                          advanced one pass,                4672194
-silesia.tar,                      level 7,                          advanced one pass,                4606658
-silesia.tar,                      level 9,                          advanced one pass,                4554098
-silesia.tar,                      level 13,                         advanced one pass,                4491702
-silesia.tar,                      level 16,                         advanced one pass,                4381277
-silesia.tar,                      level 19,                         advanced one pass,                4281514
-silesia.tar,                      no source size,                   advanced one pass,                4875008
-silesia.tar,                      long distance mode,               advanced one pass,                4861218
-silesia.tar,                      multithreaded,                    advanced one pass,                4874631
-silesia.tar,                      multithreaded long distance mode, advanced one pass,                4860683
-silesia.tar,                      small window log,                 advanced one pass,                7130394
-silesia.tar,                      small hash log,                   advanced one pass,                6587833
-silesia.tar,                      small chain log,                  advanced one pass,                4943255
-silesia.tar,                      explicit params,                  advanced one pass,                4829974
-silesia.tar,                      uncompressed literals,            advanced one pass,                5157992
-silesia.tar,                      uncompressed literals optimal,    advanced one pass,                4321094
-silesia.tar,                      huffman literals,                 advanced one pass,                5358079
-github,                           level -5,                         advanced one pass,                232744
-github,                           level -5 with dict,               advanced one pass,                46718
-github,                           level -3,                         advanced one pass,                220611
-github,                           level -3 with dict,               advanced one pass,                45395
-github,                           level -1,                         advanced one pass,                176575
-github,                           level -1 with dict,               advanced one pass,                43170
-github,                           level 0,                          advanced one pass,                136397
-github,                           level 0 with dict,                advanced one pass,                41170
-github,                           level 1,                          advanced one pass,                143457
-github,                           level 1 with dict,                advanced one pass,                41682
-github,                           level 3,                          advanced one pass,                136397
-github,                           level 3 with dict,                advanced one pass,                41170
-github,                           level 4,                          advanced one pass,                136144
-github,                           level 4 with dict,                advanced one pass,                41306
-github,                           level 5,                          advanced one pass,                135106
-github,                           level 5 with dict,                advanced one pass,                38938
-github,                           level 6,                          advanced one pass,                135108
-github,                           level 6 with dict,                advanced one pass,                38632
-github,                           level 7,                          advanced one pass,                135108
-github,                           level 7 with dict,                advanced one pass,                38766
-github,                           level 9,                          advanced one pass,                135108
-github,                           level 9 with dict,                advanced one pass,                39326
-github,                           level 13,                         advanced one pass,                133717
-github,                           level 13 with dict,               advanced one pass,                39716
-github,                           level 16,                         advanced one pass,                133717
-github,                           level 16 with dict,               advanced one pass,                37577
-github,                           level 19,                         advanced one pass,                133717
-github,                           level 19 with dict,               advanced one pass,                37576
-github,                           no source size,                   advanced one pass,                136397
-github,                           long distance mode,               advanced one pass,                136397
-github,                           multithreaded,                    advanced one pass,                136397
-github,                           multithreaded long distance mode, advanced one pass,                136397
-github,                           small window log,                 advanced one pass,                136397
-github,                           small hash log,                   advanced one pass,                135467
-github,                           small chain log,                  advanced one pass,                136314
-github,                           explicit params,                  advanced one pass,                137670
-github,                           uncompressed literals,            advanced one pass,                167004
-github,                           uncompressed literals optimal,    advanced one pass,                156824
-github,                           huffman literals,                 advanced one pass,                143457
-silesia,                          level -5,                         advanced one pass small out,      7152294
-silesia,                          level -3,                         advanced one pass small out,      6789969
-silesia,                          level -1,                         advanced one pass small out,      6191548
-silesia,                          level 0,                          advanced one pass small out,      4862377
-silesia,                          level 1,                          advanced one pass small out,      5318036
-silesia,                          level 3,                          advanced one pass small out,      4862377
-silesia,                          level 4,                          advanced one pass small out,      4800629
-silesia,                          level 5,                          advanced one pass small out,      4710178
-silesia,                          level 6,                          advanced one pass small out,      4659996
-silesia,                          level 7,                          advanced one pass small out,      4596234
-silesia,                          level 9,                          advanced one pass small out,      4543862
-silesia,                          level 13,                         advanced one pass small out,      4482073
-silesia,                          level 16,                         advanced one pass small out,      4377391
-silesia,                          level 19,                         advanced one pass small out,      4293262
-silesia,                          no source size,                   advanced one pass small out,      4862377
-silesia,                          long distance mode,               advanced one pass small out,      4853389
-silesia,                          multithreaded,                    advanced one pass small out,      4862377
-silesia,                          multithreaded long distance mode, advanced one pass small out,      4853389
-silesia,                          small window log,                 advanced one pass small out,      7126386
-silesia,                          small hash log,                   advanced one pass small out,      6554898
-silesia,                          small chain log,                  advanced one pass small out,      4931093
-silesia,                          explicit params,                  advanced one pass small out,      4815369
-silesia,                          uncompressed literals,            advanced one pass small out,      5155424
-silesia,                          uncompressed literals optimal,    advanced one pass small out,      4325427
-silesia,                          huffman literals,                 advanced one pass small out,      5341356
-silesia.tar,                      level -5,                         advanced one pass small out,      7160438
-silesia.tar,                      level -3,                         advanced one pass small out,      6789024
-silesia.tar,                      level -1,                         advanced one pass small out,      6195462
-silesia.tar,                      level 0,                          advanced one pass small out,      4875008
-silesia.tar,                      level 1,                          advanced one pass small out,      5339697
-silesia.tar,                      level 3,                          advanced one pass small out,      4875008
-silesia.tar,                      level 4,                          advanced one pass small out,      4813507
-silesia.tar,                      level 5,                          advanced one pass small out,      4722235
-silesia.tar,                      level 6,                          advanced one pass small out,      4672194
-silesia.tar,                      level 7,                          advanced one pass small out,      4606658
-silesia.tar,                      level 9,                          advanced one pass small out,      4554098
-silesia.tar,                      level 13,                         advanced one pass small out,      4491702
-silesia.tar,                      level 16,                         advanced one pass small out,      4381277
-silesia.tar,                      level 19,                         advanced one pass small out,      4281514
-silesia.tar,                      no source size,                   advanced one pass small out,      4875008
-silesia.tar,                      long distance mode,               advanced one pass small out,      4861218
-silesia.tar,                      multithreaded,                    advanced one pass small out,      4874631
-silesia.tar,                      multithreaded long distance mode, advanced one pass small out,      4860683
-silesia.tar,                      small window log,                 advanced one pass small out,      7130394
-silesia.tar,                      small hash log,                   advanced one pass small out,      6587833
-silesia.tar,                      small chain log,                  advanced one pass small out,      4943255
-silesia.tar,                      explicit params,                  advanced one pass small out,      4829974
-silesia.tar,                      uncompressed literals,            advanced one pass small out,      5157992
-silesia.tar,                      uncompressed literals optimal,    advanced one pass small out,      4321094
-silesia.tar,                      huffman literals,                 advanced one pass small out,      5358079
-github,                           level -5,                         advanced one pass small out,      232744
-github,                           level -5 with dict,               advanced one pass small out,      46718
-github,                           level -3,                         advanced one pass small out,      220611
-github,                           level -3 with dict,               advanced one pass small out,      45395
-github,                           level -1,                         advanced one pass small out,      176575
-github,                           level -1 with dict,               advanced one pass small out,      43170
-github,                           level 0,                          advanced one pass small out,      136397
-github,                           level 0 with dict,                advanced one pass small out,      41170
-github,                           level 1,                          advanced one pass small out,      143457
-github,                           level 1 with dict,                advanced one pass small out,      41682
-github,                           level 3,                          advanced one pass small out,      136397
-github,                           level 3 with dict,                advanced one pass small out,      41170
-github,                           level 4,                          advanced one pass small out,      136144
-github,                           level 4 with dict,                advanced one pass small out,      41306
-github,                           level 5,                          advanced one pass small out,      135106
-github,                           level 5 with dict,                advanced one pass small out,      38938
-github,                           level 6,                          advanced one pass small out,      135108
-github,                           level 6 with dict,                advanced one pass small out,      38632
-github,                           level 7,                          advanced one pass small out,      135108
-github,                           level 7 with dict,                advanced one pass small out,      38766
-github,                           level 9,                          advanced one pass small out,      135108
-github,                           level 9 with dict,                advanced one pass small out,      39326
-github,                           level 13,                         advanced one pass small out,      133717
-github,                           level 13 with dict,               advanced one pass small out,      39716
-github,                           level 16,                         advanced one pass small out,      133717
-github,                           level 16 with dict,               advanced one pass small out,      37577
-github,                           level 19,                         advanced one pass small out,      133717
-github,                           level 19 with dict,               advanced one pass small out,      37576
-github,                           no source size,                   advanced one pass small out,      136397
-github,                           long distance mode,               advanced one pass small out,      136397
-github,                           multithreaded,                    advanced one pass small out,      136397
-github,                           multithreaded long distance mode, advanced one pass small out,      136397
-github,                           small window log,                 advanced one pass small out,      136397
-github,                           small hash log,                   advanced one pass small out,      135467
-github,                           small chain log,                  advanced one pass small out,      136314
-github,                           explicit params,                  advanced one pass small out,      137670
-github,                           uncompressed literals,            advanced one pass small out,      167004
-github,                           uncompressed literals optimal,    advanced one pass small out,      156824
-github,                           huffman literals,                 advanced one pass small out,      143457
-silesia,                          level -5,                         advanced streaming,               7152294
-silesia,                          level -3,                         advanced streaming,               6789973
-silesia,                          level -1,                         advanced streaming,               6191549
-silesia,                          level 0,                          advanced streaming,               4862377
-silesia,                          level 1,                          advanced streaming,               5318036
-silesia,                          level 3,                          advanced streaming,               4862377
-silesia,                          level 4,                          advanced streaming,               4800629
-silesia,                          level 5,                          advanced streaming,               4710178
-silesia,                          level 6,                          advanced streaming,               4659996
-silesia,                          level 7,                          advanced streaming,               4596234
-silesia,                          level 9,                          advanced streaming,               4543862
-silesia,                          level 13,                         advanced streaming,               4482073
-silesia,                          level 16,                         advanced streaming,               4377391
-silesia,                          level 19,                         advanced streaming,               4293262
-silesia,                          no source size,                   advanced streaming,               4862341
-silesia,                          long distance mode,               advanced streaming,               4853389
-silesia,                          multithreaded,                    advanced streaming,               4862377
-silesia,                          multithreaded long distance mode, advanced streaming,               4853389
-silesia,                          small window log,                 advanced streaming,               7126389
-silesia,                          small hash log,                   advanced streaming,               6554898
-silesia,                          small chain log,                  advanced streaming,               4931093
-silesia,                          explicit params,                  advanced streaming,               4815380
-silesia,                          uncompressed literals,            advanced streaming,               5155424
-silesia,                          uncompressed literals optimal,    advanced streaming,               4325427
-silesia,                          huffman literals,                 advanced streaming,               5341357
-silesia.tar,                      level -5,                         advanced streaming,               7160440
-silesia.tar,                      level -3,                         advanced streaming,               6789026
-silesia.tar,                      level -1,                         advanced streaming,               6195465
-silesia.tar,                      level 0,                          advanced streaming,               4875010
-silesia.tar,                      level 1,                          advanced streaming,               5339701
-silesia.tar,                      level 3,                          advanced streaming,               4875010
-silesia.tar,                      level 4,                          advanced streaming,               4813507
-silesia.tar,                      level 5,                          advanced streaming,               4722240
-silesia.tar,                      level 6,                          advanced streaming,               4672203
-silesia.tar,                      level 7,                          advanced streaming,               4606658
-silesia.tar,                      level 9,                          advanced streaming,               4554105
-silesia.tar,                      level 13,                         advanced streaming,               4491703
-silesia.tar,                      level 16,                         advanced streaming,               4381277
-silesia.tar,                      level 19,                         advanced streaming,               4281514
-silesia.tar,                      no source size,                   advanced streaming,               4875006
-silesia.tar,                      long distance mode,               advanced streaming,               4861218
-silesia.tar,                      multithreaded,                    advanced streaming,               4875132
-silesia.tar,                      multithreaded long distance mode, advanced streaming,               4866971
-silesia.tar,                      small window log,                 advanced streaming,               7130394
-silesia.tar,                      small hash log,                   advanced streaming,               6587834
-silesia.tar,                      small chain log,                  advanced streaming,               4943260
-silesia.tar,                      explicit params,                  advanced streaming,               4830002
-silesia.tar,                      uncompressed literals,            advanced streaming,               5157995
-silesia.tar,                      uncompressed literals optimal,    advanced streaming,               4321094
-silesia.tar,                      huffman literals,                 advanced streaming,               5358083
-github,                           level -5,                         advanced streaming,               232744
-github,                           level -5 with dict,               advanced streaming,               46718
-github,                           level -3,                         advanced streaming,               220611
-github,                           level -3 with dict,               advanced streaming,               45395
-github,                           level -1,                         advanced streaming,               176575
-github,                           level -1 with dict,               advanced streaming,               43170
-github,                           level 0,                          advanced streaming,               136397
-github,                           level 0 with dict,                advanced streaming,               41170
-github,                           level 1,                          advanced streaming,               143457
-github,                           level 1 with dict,                advanced streaming,               41682
-github,                           level 3,                          advanced streaming,               136397
-github,                           level 3 with dict,                advanced streaming,               41170
-github,                           level 4,                          advanced streaming,               136144
-github,                           level 4 with dict,                advanced streaming,               41306
-github,                           level 5,                          advanced streaming,               135106
-github,                           level 5 with dict,                advanced streaming,               38938
-github,                           level 6,                          advanced streaming,               135108
-github,                           level 6 with dict,                advanced streaming,               38632
-github,                           level 7,                          advanced streaming,               135108
-github,                           level 7 with dict,                advanced streaming,               38766
-github,                           level 9,                          advanced streaming,               135108
-github,                           level 9 with dict,                advanced streaming,               39326
-github,                           level 13,                         advanced streaming,               133717
-github,                           level 13 with dict,               advanced streaming,               39716
-github,                           level 16,                         advanced streaming,               133717
-github,                           level 16 with dict,               advanced streaming,               37577
-github,                           level 19,                         advanced streaming,               133717
-github,                           level 19 with dict,               advanced streaming,               37576
-github,                           no source size,                   advanced streaming,               136397
-github,                           long distance mode,               advanced streaming,               136397
-github,                           multithreaded,                    advanced streaming,               136397
-github,                           multithreaded long distance mode, advanced streaming,               136397
-github,                           small window log,                 advanced streaming,               136397
-github,                           small hash log,                   advanced streaming,               135467
-github,                           small chain log,                  advanced streaming,               136314
-github,                           explicit params,                  advanced streaming,               137670
-github,                           uncompressed literals,            advanced streaming,               167004
-github,                           uncompressed literals optimal,    advanced streaming,               156824
-github,                           huffman literals,                 advanced streaming,               143457
-silesia,                          level -5,                         old streaming,                    7152294
-silesia,                          level -3,                         old streaming,                    6789973
-silesia,                          level -1,                         old streaming,                    6191549
-silesia,                          level 0,                          old streaming,                    4862377
-silesia,                          level 1,                          old streaming,                    5318036
-silesia,                          level 3,                          old streaming,                    4862377
-silesia,                          level 4,                          old streaming,                    4800629
-silesia,                          level 5,                          old streaming,                    4710178
-silesia,                          level 6,                          old streaming,                    4659996
-silesia,                          level 7,                          old streaming,                    4596234
-silesia,                          level 9,                          old streaming,                    4543862
-silesia,                          level 13,                         old streaming,                    4482073
-silesia,                          level 16,                         old streaming,                    4377391
-silesia,                          level 19,                         old streaming,                    4293262
-silesia,                          no source size,                   old streaming,                    4862341
-silesia,                          uncompressed literals,            old streaming,                    4862377
-silesia,                          uncompressed literals optimal,    old streaming,                    4293262
-silesia,                          huffman literals,                 old streaming,                    6191549
-silesia.tar,                      level -5,                         old streaming,                    7160440
-silesia.tar,                      level -3,                         old streaming,                    6789026
-silesia.tar,                      level -1,                         old streaming,                    6195465
-silesia.tar,                      level 0,                          old streaming,                    4875010
-silesia.tar,                      level 1,                          old streaming,                    5339701
-silesia.tar,                      level 3,                          old streaming,                    4875010
-silesia.tar,                      level 4,                          old streaming,                    4813507
-silesia.tar,                      level 5,                          old streaming,                    4722240
-silesia.tar,                      level 6,                          old streaming,                    4672203
-silesia.tar,                      level 7,                          old streaming,                    4606658
-silesia.tar,                      level 9,                          old streaming,                    4554105
-silesia.tar,                      level 13,                         old streaming,                    4491703
-silesia.tar,                      level 16,                         old streaming,                    4381277
-silesia.tar,                      level 19,                         old streaming,                    4281514
-silesia.tar,                      no source size,                   old streaming,                    4875006
-silesia.tar,                      uncompressed literals,            old streaming,                    4875010
-silesia.tar,                      uncompressed literals optimal,    old streaming,                    4281514
-silesia.tar,                      huffman literals,                 old streaming,                    6195465
-github,                           level -5,                         old streaming,                    232744
-github,                           level -5 with dict,               old streaming,                    46718
-github,                           level -3,                         old streaming,                    220611
-github,                           level -3 with dict,               old streaming,                    45395
-github,                           level -1,                         old streaming,                    176575
-github,                           level -1 with dict,               old streaming,                    43170
-github,                           level 0,                          old streaming,                    136397
-github,                           level 0 with dict,                old streaming,                    41170
-github,                           level 1,                          old streaming,                    143457
-github,                           level 1 with dict,                old streaming,                    41682
-github,                           level 3,                          old streaming,                    136397
-github,                           level 3 with dict,                old streaming,                    41170
-github,                           level 4,                          old streaming,                    136144
-github,                           level 4 with dict,                old streaming,                    41306
-github,                           level 5,                          old streaming,                    135106
-github,                           level 5 with dict,                old streaming,                    38938
-github,                           level 6,                          old streaming,                    135108
-github,                           level 6 with dict,                old streaming,                    38632
-github,                           level 7,                          old streaming,                    135108
-github,                           level 7 with dict,                old streaming,                    38766
-github,                           level 9,                          old streaming,                    135108
-github,                           level 9 with dict,                old streaming,                    39326
-github,                           level 13,                         old streaming,                    133717
-github,                           level 13 with dict,               old streaming,                    39716
-github,                           level 16,                         old streaming,                    133717
-github,                           level 16 with dict,               old streaming,                    37577
-github,                           level 19,                         old streaming,                    133717
-github,                           level 19 with dict,               old streaming,                    37576
-github,                           no source size,                   old streaming,                    141003
-github,                           uncompressed literals,            old streaming,                    136397
-github,                           uncompressed literals optimal,    old streaming,                    133717
-github,                           huffman literals,                 old streaming,                    176575
+Data,                               Config,                             Method,                             Total compressed size
+silesia.tar,                        level -5,                           compress simple,                    7160438
+silesia.tar,                        level -3,                           compress simple,                    6789024
+silesia.tar,                        level -1,                           compress simple,                    6195462
+silesia.tar,                        level 0,                            compress simple,                    4875008
+silesia.tar,                        level 1,                            compress simple,                    5339697
+silesia.tar,                        level 3,                            compress simple,                    4875008
+silesia.tar,                        level 4,                            compress simple,                    4813507
+silesia.tar,                        level 5,                            compress simple,                    4722235
+silesia.tar,                        level 6,                            compress simple,                    4672194
+silesia.tar,                        level 7,                            compress simple,                    4606658
+silesia.tar,                        level 9,                            compress simple,                    4554098
+silesia.tar,                        level 13,                           compress simple,                    4491702
+silesia.tar,                        level 16,                           compress simple,                    4381277
+silesia.tar,                        level 19,                           compress simple,                    4281514
+silesia.tar,                        uncompressed literals,              compress simple,                    4875008
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4281514
+silesia.tar,                        huffman literals,                   compress simple,                    6195462
+silesia,                            level -5,                           compress cctx,                      7152294
+silesia,                            level -3,                           compress cctx,                      6789969
+silesia,                            level -1,                           compress cctx,                      6191548
+silesia,                            level 0,                            compress cctx,                      4862377
+silesia,                            level 1,                            compress cctx,                      5318036
+silesia,                            level 3,                            compress cctx,                      4862377
+silesia,                            level 4,                            compress cctx,                      4800629
+silesia,                            level 5,                            compress cctx,                      4710178
+silesia,                            level 6,                            compress cctx,                      4659996
+silesia,                            level 7,                            compress cctx,                      4596234
+silesia,                            level 9,                            compress cctx,                      4543862
+silesia,                            level 13,                           compress cctx,                      4482073
+silesia,                            level 16,                           compress cctx,                      4377391
+silesia,                            level 19,                           compress cctx,                      4293262
+silesia,                            long distance mode,                 compress cctx,                      4862377
+silesia,                            multithreaded,                      compress cctx,                      4862377
+silesia,                            multithreaded long distance mode,   compress cctx,                      4862377
+silesia,                            small window log,                   compress cctx,                      7115734
+silesia,                            small hash log,                     compress cctx,                      6554898
+silesia,                            small chain log,                    compress cctx,                      4931093
+silesia,                            explicit params,                    compress cctx,                      4813352
+silesia,                            uncompressed literals,              compress cctx,                      4862377
+silesia,                            uncompressed literals optimal,      compress cctx,                      4293262
+silesia,                            huffman literals,                   compress cctx,                      6191548
+silesia,                            multithreaded with advanced params, compress cctx,                      4862377
+github,                             level -5,                           compress cctx,                      232744
+github,                             level -5 with dict,                 compress cctx,                      47294
+github,                             level -3,                           compress cctx,                      220611
+github,                             level -3 with dict,                 compress cctx,                      48047
+github,                             level -1,                           compress cctx,                      176575
+github,                             level -1 with dict,                 compress cctx,                      43527
+github,                             level 0,                            compress cctx,                      136397
+github,                             level 0 with dict,                  compress cctx,                      41536
+github,                             level 1,                            compress cctx,                      143457
+github,                             level 1 with dict,                  compress cctx,                      42157
+github,                             level 3,                            compress cctx,                      136397
+github,                             level 3 with dict,                  compress cctx,                      41536
+github,                             level 4,                            compress cctx,                      136144
+github,                             level 4 with dict,                  compress cctx,                      41721
+github,                             level 5,                            compress cctx,                      135106
+github,                             level 5 with dict,                  compress cctx,                      38934
+github,                             level 6,                            compress cctx,                      135108
+github,                             level 6 with dict,                  compress cctx,                      38628
+github,                             level 7,                            compress cctx,                      135108
+github,                             level 7 with dict,                  compress cctx,                      38741
+github,                             level 9,                            compress cctx,                      135108
+github,                             level 9 with dict,                  compress cctx,                      39335
+github,                             level 13,                           compress cctx,                      133717
+github,                             level 13 with dict,                 compress cctx,                      39923
+github,                             level 16,                           compress cctx,                      133717
+github,                             level 16 with dict,                 compress cctx,                      37568
+github,                             level 19,                           compress cctx,                      133717
+github,                             level 19 with dict,                 compress cctx,                      37567
+github,                             long distance mode,                 compress cctx,                      141473
+github,                             multithreaded,                      compress cctx,                      141473
+github,                             multithreaded long distance mode,   compress cctx,                      141473
+github,                             small window log,                   compress cctx,                      141473
+github,                             small hash log,                     compress cctx,                      138943
+github,                             small chain log,                    compress cctx,                      139239
+github,                             explicit params,                    compress cctx,                      140924
+github,                             uncompressed literals,              compress cctx,                      136397
+github,                             uncompressed literals optimal,      compress cctx,                      133717
+github,                             huffman literals,                   compress cctx,                      176575
+github,                             multithreaded with advanced params, compress cctx,                      141473
+silesia,                            level -5,                           zstdcli,                            7152342
+silesia,                            level -3,                           zstdcli,                            6790021
+silesia,                            level -1,                           zstdcli,                            6191597
+silesia,                            level 0,                            zstdcli,                            4862425
+silesia,                            level 1,                            zstdcli,                            5318084
+silesia,                            level 3,                            zstdcli,                            4862425
+silesia,                            level 4,                            zstdcli,                            4800677
+silesia,                            level 5,                            zstdcli,                            4710226
+silesia,                            level 6,                            zstdcli,                            4660044
+silesia,                            level 7,                            zstdcli,                            4596282
+silesia,                            level 9,                            zstdcli,                            4543910
+silesia,                            level 13,                           zstdcli,                            4482121
+silesia,                            level 16,                           zstdcli,                            4377439
+silesia,                            level 19,                           zstdcli,                            4293310
+silesia,                            long distance mode,                 zstdcli,                            4853437
+silesia,                            multithreaded,                      zstdcli,                            4862425
+silesia,                            multithreaded long distance mode,   zstdcli,                            4853437
+silesia,                            small window log,                   zstdcli,                            7126434
+silesia,                            small hash log,                     zstdcli,                            6554946
+silesia,                            small chain log,                    zstdcli,                            4931141
+silesia,                            explicit params,                    zstdcli,                            4815380
+silesia,                            uncompressed literals,              zstdcli,                            5155472
+silesia,                            uncompressed literals optimal,      zstdcli,                            4325475
+silesia,                            huffman literals,                   zstdcli,                            5341405
+silesia,                            multithreaded with advanced params, zstdcli,                            compression error
+silesia.tar,                        level -5,                           zstdcli,                            7161160
+silesia.tar,                        level -3,                           zstdcli,                            6789865
+silesia.tar,                        level -1,                           zstdcli,                            6196433
+silesia.tar,                        level 0,                            zstdcli,                            4875136
+silesia.tar,                        level 1,                            zstdcli,                            5340573
+silesia.tar,                        level 3,                            zstdcli,                            4875136
+silesia.tar,                        level 4,                            zstdcli,                            4814531
+silesia.tar,                        level 5,                            zstdcli,                            4723284
+silesia.tar,                        level 6,                            zstdcli,                            4673591
+silesia.tar,                        level 7,                            zstdcli,                            4608342
+silesia.tar,                        level 9,                            zstdcli,                            4554700
+silesia.tar,                        level 13,                           zstdcli,                            4491706
+silesia.tar,                        level 16,                           zstdcli,                            4381281
+silesia.tar,                        level 19,                           zstdcli,                            4281518
+silesia.tar,                        no source size,                     zstdcli,                            4875132
+silesia.tar,                        long distance mode,                 zstdcli,                            4866975
+silesia.tar,                        multithreaded,                      zstdcli,                            4875136
+silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4866975
+silesia.tar,                        small window log,                   zstdcli,                            7130434
+silesia.tar,                        small hash log,                     zstdcli,                            6587841
+silesia.tar,                        small chain log,                    zstdcli,                            4943259
+silesia.tar,                        explicit params,                    zstdcli,                            4839202
+silesia.tar,                        uncompressed literals,              zstdcli,                            5158134
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4321098
+silesia.tar,                        huffman literals,                   zstdcli,                            5358479
+silesia.tar,                        multithreaded with advanced params, zstdcli,                            compression error
+github,                             level -5,                           zstdcli,                            234744
+github,                             level -5 with dict,                 zstdcli,                            48718
+github,                             level -3,                           zstdcli,                            222611
+github,                             level -3 with dict,                 zstdcli,                            47395
+github,                             level -1,                           zstdcli,                            178575
+github,                             level -1 with dict,                 zstdcli,                            45170
+github,                             level 0,                            zstdcli,                            138397
+github,                             level 0 with dict,                  zstdcli,                            43170
+github,                             level 1,                            zstdcli,                            145457
+github,                             level 1 with dict,                  zstdcli,                            43682
+github,                             level 3,                            zstdcli,                            138397
+github,                             level 3 with dict,                  zstdcli,                            43170
+github,                             level 4,                            zstdcli,                            138144
+github,                             level 4 with dict,                  zstdcli,                            43306
+github,                             level 5,                            zstdcli,                            137106
+github,                             level 5 with dict,                  zstdcli,                            40938
+github,                             level 6,                            zstdcli,                            137108
+github,                             level 6 with dict,                  zstdcli,                            40632
+github,                             level 7,                            zstdcli,                            137108
+github,                             level 7 with dict,                  zstdcli,                            40766
+github,                             level 9,                            zstdcli,                            137108
+github,                             level 9 with dict,                  zstdcli,                            41326
+github,                             level 13,                           zstdcli,                            135717
+github,                             level 13 with dict,                 zstdcli,                            41716
+github,                             level 16,                           zstdcli,                            135717
+github,                             level 16 with dict,                 zstdcli,                            39577
+github,                             level 19,                           zstdcli,                            135717
+github,                             level 19 with dict,                 zstdcli,                            39576
+github,                             long distance mode,                 zstdcli,                            138397
+github,                             multithreaded,                      zstdcli,                            138397
+github,                             multithreaded long distance mode,   zstdcli,                            138397
+github,                             small window log,                   zstdcli,                            138397
+github,                             small hash log,                     zstdcli,                            137467
+github,                             small chain log,                    zstdcli,                            138314
+github,                             explicit params,                    zstdcli,                            136140
+github,                             uncompressed literals,              zstdcli,                            169004
+github,                             uncompressed literals optimal,      zstdcli,                            158824
+github,                             huffman literals,                   zstdcli,                            145457
+github,                             multithreaded with advanced params, zstdcli,                            compression error
+silesia,                            level -5,                           advanced one pass,                  7152294
+silesia,                            level -3,                           advanced one pass,                  6789969
+silesia,                            level -1,                           advanced one pass,                  6191548
+silesia,                            level 0,                            advanced one pass,                  4862377
+silesia,                            level 1,                            advanced one pass,                  5318036
+silesia,                            level 3,                            advanced one pass,                  4862377
+silesia,                            level 4,                            advanced one pass,                  4800629
+silesia,                            level 5,                            advanced one pass,                  4710178
+silesia,                            level 6,                            advanced one pass,                  4659996
+silesia,                            level 7,                            advanced one pass,                  4596234
+silesia,                            level 9,                            advanced one pass,                  4543862
+silesia,                            level 13,                           advanced one pass,                  4482073
+silesia,                            level 16,                           advanced one pass,                  4377391
+silesia,                            level 19,                           advanced one pass,                  4293262
+silesia,                            no source size,                     advanced one pass,                  4862377
+silesia,                            long distance mode,                 advanced one pass,                  4853389
+silesia,                            multithreaded,                      advanced one pass,                  4862377
+silesia,                            multithreaded long distance mode,   advanced one pass,                  4853389
+silesia,                            small window log,                   advanced one pass,                  7126386
+silesia,                            small hash log,                     advanced one pass,                  6554898
+silesia,                            small chain log,                    advanced one pass,                  4931093
+silesia,                            explicit params,                    advanced one pass,                  4815369
+silesia,                            uncompressed literals,              advanced one pass,                  5155424
+silesia,                            uncompressed literals optimal,      advanced one pass,                  4325427
+silesia,                            huffman literals,                   advanced one pass,                  5341356
+silesia,                            multithreaded with advanced params, advanced one pass,                  5155424
+silesia.tar,                        level -5,                           advanced one pass,                  7160438
+silesia.tar,                        level -3,                           advanced one pass,                  6789024
+silesia.tar,                        level -1,                           advanced one pass,                  6195462
+silesia.tar,                        level 0,                            advanced one pass,                  4875008
+silesia.tar,                        level 1,                            advanced one pass,                  5339697
+silesia.tar,                        level 3,                            advanced one pass,                  4875008
+silesia.tar,                        level 4,                            advanced one pass,                  4813507
+silesia.tar,                        level 5,                            advanced one pass,                  4722235
+silesia.tar,                        level 6,                            advanced one pass,                  4672194
+silesia.tar,                        level 7,                            advanced one pass,                  4606658
+silesia.tar,                        level 9,                            advanced one pass,                  4554098
+silesia.tar,                        level 13,                           advanced one pass,                  4491702
+silesia.tar,                        level 16,                           advanced one pass,                  4381277
+silesia.tar,                        level 19,                           advanced one pass,                  4281514
+silesia.tar,                        no source size,                     advanced one pass,                  4875008
+silesia.tar,                        long distance mode,                 advanced one pass,                  4861218
+silesia.tar,                        multithreaded,                      advanced one pass,                  4874631
+silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4860683
+silesia.tar,                        small window log,                   advanced one pass,                  7130394
+silesia.tar,                        small hash log,                     advanced one pass,                  6587833
+silesia.tar,                        small chain log,                    advanced one pass,                  4943255
+silesia.tar,                        explicit params,                    advanced one pass,                  4829974
+silesia.tar,                        uncompressed literals,              advanced one pass,                  5157992
+silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4321094
+silesia.tar,                        huffman literals,                   advanced one pass,                  5358079
+silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5158545
+github,                             level -5,                           advanced one pass,                  232744
+github,                             level -5 with dict,                 advanced one pass,                  46718
+github,                             level -3,                           advanced one pass,                  220611
+github,                             level -3 with dict,                 advanced one pass,                  45395
+github,                             level -1,                           advanced one pass,                  176575
+github,                             level -1 with dict,                 advanced one pass,                  43170
+github,                             level 0,                            advanced one pass,                  136397
+github,                             level 0 with dict,                  advanced one pass,                  41170
+github,                             level 1,                            advanced one pass,                  143457
+github,                             level 1 with dict,                  advanced one pass,                  41682
+github,                             level 3,                            advanced one pass,                  136397
+github,                             level 3 with dict,                  advanced one pass,                  41170
+github,                             level 4,                            advanced one pass,                  136144
+github,                             level 4 with dict,                  advanced one pass,                  41306
+github,                             level 5,                            advanced one pass,                  135106
+github,                             level 5 with dict,                  advanced one pass,                  38938
+github,                             level 6,                            advanced one pass,                  135108
+github,                             level 6 with dict,                  advanced one pass,                  38632
+github,                             level 7,                            advanced one pass,                  135108
+github,                             level 7 with dict,                  advanced one pass,                  38766
+github,                             level 9,                            advanced one pass,                  135108
+github,                             level 9 with dict,                  advanced one pass,                  39326
+github,                             level 13,                           advanced one pass,                  133717
+github,                             level 13 with dict,                 advanced one pass,                  39716
+github,                             level 16,                           advanced one pass,                  133717
+github,                             level 16 with dict,                 advanced one pass,                  37577
+github,                             level 19,                           advanced one pass,                  133717
+github,                             level 19 with dict,                 advanced one pass,                  37576
+github,                             no source size,                     advanced one pass,                  136397
+github,                             long distance mode,                 advanced one pass,                  136397
+github,                             multithreaded,                      advanced one pass,                  136397
+github,                             multithreaded long distance mode,   advanced one pass,                  136397
+github,                             small window log,                   advanced one pass,                  136397
+github,                             small hash log,                     advanced one pass,                  135467
+github,                             small chain log,                    advanced one pass,                  136314
+github,                             explicit params,                    advanced one pass,                  137670
+github,                             uncompressed literals,              advanced one pass,                  167004
+github,                             uncompressed literals optimal,      advanced one pass,                  156824
+github,                             huffman literals,                   advanced one pass,                  143457
+github,                             multithreaded with advanced params, advanced one pass,                  167004
+silesia,                            level -5,                           advanced one pass small out,        7152294
+silesia,                            level -3,                           advanced one pass small out,        6789969
+silesia,                            level -1,                           advanced one pass small out,        6191548
+silesia,                            level 0,                            advanced one pass small out,        4862377
+silesia,                            level 1,                            advanced one pass small out,        5318036
+silesia,                            level 3,                            advanced one pass small out,        4862377
+silesia,                            level 4,                            advanced one pass small out,        4800629
+silesia,                            level 5,                            advanced one pass small out,        4710178
+silesia,                            level 6,                            advanced one pass small out,        4659996
+silesia,                            level 7,                            advanced one pass small out,        4596234
+silesia,                            level 9,                            advanced one pass small out,        4543862
+silesia,                            level 13,                           advanced one pass small out,        4482073
+silesia,                            level 16,                           advanced one pass small out,        4377391
+silesia,                            level 19,                           advanced one pass small out,        4293262
+silesia,                            no source size,                     advanced one pass small out,        4862377
+silesia,                            long distance mode,                 advanced one pass small out,        4853389
+silesia,                            multithreaded,                      advanced one pass small out,        4862377
+silesia,                            multithreaded long distance mode,   advanced one pass small out,        4853389
+silesia,                            small window log,                   advanced one pass small out,        7126386
+silesia,                            small hash log,                     advanced one pass small out,        6554898
+silesia,                            small chain log,                    advanced one pass small out,        4931093
+silesia,                            explicit params,                    advanced one pass small out,        4815369
+silesia,                            uncompressed literals,              advanced one pass small out,        5155424
+silesia,                            uncompressed literals optimal,      advanced one pass small out,        4325427
+silesia,                            huffman literals,                   advanced one pass small out,        5341356
+silesia,                            multithreaded with advanced params, advanced one pass small out,        5155424
+silesia.tar,                        level -5,                           advanced one pass small out,        7160438
+silesia.tar,                        level -3,                           advanced one pass small out,        6789024
+silesia.tar,                        level -1,                           advanced one pass small out,        6195462
+silesia.tar,                        level 0,                            advanced one pass small out,        4875008
+silesia.tar,                        level 1,                            advanced one pass small out,        5339697
+silesia.tar,                        level 3,                            advanced one pass small out,        4875008
+silesia.tar,                        level 4,                            advanced one pass small out,        4813507
+silesia.tar,                        level 5,                            advanced one pass small out,        4722235
+silesia.tar,                        level 6,                            advanced one pass small out,        4672194
+silesia.tar,                        level 7,                            advanced one pass small out,        4606658
+silesia.tar,                        level 9,                            advanced one pass small out,        4554098
+silesia.tar,                        level 13,                           advanced one pass small out,        4491702
+silesia.tar,                        level 16,                           advanced one pass small out,        4381277
+silesia.tar,                        level 19,                           advanced one pass small out,        4281514
+silesia.tar,                        no source size,                     advanced one pass small out,        4875008
+silesia.tar,                        long distance mode,                 advanced one pass small out,        4861218
+silesia.tar,                        multithreaded,                      advanced one pass small out,        4874631
+silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4860683
+silesia.tar,                        small window log,                   advanced one pass small out,        7130394
+silesia.tar,                        small hash log,                     advanced one pass small out,        6587833
+silesia.tar,                        small chain log,                    advanced one pass small out,        4943255
+silesia.tar,                        explicit params,                    advanced one pass small out,        4829974
+silesia.tar,                        uncompressed literals,              advanced one pass small out,        5157992
+silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4321094
+silesia.tar,                        huffman literals,                   advanced one pass small out,        5358079
+silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5158545
+github,                             level -5,                           advanced one pass small out,        232744
+github,                             level -5 with dict,                 advanced one pass small out,        46718
+github,                             level -3,                           advanced one pass small out,        220611
+github,                             level -3 with dict,                 advanced one pass small out,        45395
+github,                             level -1,                           advanced one pass small out,        176575
+github,                             level -1 with dict,                 advanced one pass small out,        43170
+github,                             level 0,                            advanced one pass small out,        136397
+github,                             level 0 with dict,                  advanced one pass small out,        41170
+github,                             level 1,                            advanced one pass small out,        143457
+github,                             level 1 with dict,                  advanced one pass small out,        41682
+github,                             level 3,                            advanced one pass small out,        136397
+github,                             level 3 with dict,                  advanced one pass small out,        41170
+github,                             level 4,                            advanced one pass small out,        136144
+github,                             level 4 with dict,                  advanced one pass small out,        41306
+github,                             level 5,                            advanced one pass small out,        135106
+github,                             level 5 with dict,                  advanced one pass small out,        38938
+github,                             level 6,                            advanced one pass small out,        135108
+github,                             level 6 with dict,                  advanced one pass small out,        38632
+github,                             level 7,                            advanced one pass small out,        135108
+github,                             level 7 with dict,                  advanced one pass small out,        38766
+github,                             level 9,                            advanced one pass small out,        135108
+github,                             level 9 with dict,                  advanced one pass small out,        39326
+github,                             level 13,                           advanced one pass small out,        133717
+github,                             level 13 with dict,                 advanced one pass small out,        39716
+github,                             level 16,                           advanced one pass small out,        133717
+github,                             level 16 with dict,                 advanced one pass small out,        37577
+github,                             level 19,                           advanced one pass small out,        133717
+github,                             level 19 with dict,                 advanced one pass small out,        37576
+github,                             no source size,                     advanced one pass small out,        136397
+github,                             long distance mode,                 advanced one pass small out,        136397
+github,                             multithreaded,                      advanced one pass small out,        136397
+github,                             multithreaded long distance mode,   advanced one pass small out,        136397
+github,                             small window log,                   advanced one pass small out,        136397
+github,                             small hash log,                     advanced one pass small out,        135467
+github,                             small chain log,                    advanced one pass small out,        136314
+github,                             explicit params,                    advanced one pass small out,        137670
+github,                             uncompressed literals,              advanced one pass small out,        167004
+github,                             uncompressed literals optimal,      advanced one pass small out,        156824
+github,                             huffman literals,                   advanced one pass small out,        143457
+github,                             multithreaded with advanced params, advanced one pass small out,        167004
+silesia,                            level -5,                           advanced streaming,                 7152294
+silesia,                            level -3,                           advanced streaming,                 6789973
+silesia,                            level -1,                           advanced streaming,                 6191549
+silesia,                            level 0,                            advanced streaming,                 4862377
+silesia,                            level 1,                            advanced streaming,                 5318036
+silesia,                            level 3,                            advanced streaming,                 4862377
+silesia,                            level 4,                            advanced streaming,                 4800629
+silesia,                            level 5,                            advanced streaming,                 4710178
+silesia,                            level 6,                            advanced streaming,                 4659996
+silesia,                            level 7,                            advanced streaming,                 4596234
+silesia,                            level 9,                            advanced streaming,                 4543862
+silesia,                            level 13,                           advanced streaming,                 4482073
+silesia,                            level 16,                           advanced streaming,                 4377391
+silesia,                            level 19,                           advanced streaming,                 4293262
+silesia,                            no source size,                     advanced streaming,                 4862341
+silesia,                            long distance mode,                 advanced streaming,                 4853389
+silesia,                            multithreaded,                      advanced streaming,                 4862377
+silesia,                            multithreaded long distance mode,   advanced streaming,                 4853389
+silesia,                            small window log,                   advanced streaming,                 7126389
+silesia,                            small hash log,                     advanced streaming,                 6554898
+silesia,                            small chain log,                    advanced streaming,                 4931093
+silesia,                            explicit params,                    advanced streaming,                 4815380
+silesia,                            uncompressed literals,              advanced streaming,                 5155424
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4325427
+silesia,                            huffman literals,                   advanced streaming,                 5341357
+silesia,                            multithreaded with advanced params, advanced streaming,                 5155424
+silesia.tar,                        level -5,                           advanced streaming,                 7160440
+silesia.tar,                        level -3,                           advanced streaming,                 6789026
+silesia.tar,                        level -1,                           advanced streaming,                 6195465
+silesia.tar,                        level 0,                            advanced streaming,                 4875010
+silesia.tar,                        level 1,                            advanced streaming,                 5339701
+silesia.tar,                        level 3,                            advanced streaming,                 4875010
+silesia.tar,                        level 4,                            advanced streaming,                 4813507
+silesia.tar,                        level 5,                            advanced streaming,                 4722240
+silesia.tar,                        level 6,                            advanced streaming,                 4672203
+silesia.tar,                        level 7,                            advanced streaming,                 4606658
+silesia.tar,                        level 9,                            advanced streaming,                 4554105
+silesia.tar,                        level 13,                           advanced streaming,                 4491703
+silesia.tar,                        level 16,                           advanced streaming,                 4381277
+silesia.tar,                        level 19,                           advanced streaming,                 4281514
+silesia.tar,                        no source size,                     advanced streaming,                 4875006
+silesia.tar,                        long distance mode,                 advanced streaming,                 4861218
+silesia.tar,                        multithreaded,                      advanced streaming,                 4875132
+silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4866971
+silesia.tar,                        small window log,                   advanced streaming,                 7130394
+silesia.tar,                        small hash log,                     advanced streaming,                 6587834
+silesia.tar,                        small chain log,                    advanced streaming,                 4943260
+silesia.tar,                        explicit params,                    advanced streaming,                 4830002
+silesia.tar,                        uncompressed literals,              advanced streaming,                 5157995
+silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4321094
+silesia.tar,                        huffman literals,                   advanced streaming,                 5358083
+silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5158130
+github,                             level -5,                           advanced streaming,                 232744
+github,                             level -5 with dict,                 advanced streaming,                 46718
+github,                             level -3,                           advanced streaming,                 220611
+github,                             level -3 with dict,                 advanced streaming,                 45395
+github,                             level -1,                           advanced streaming,                 176575
+github,                             level -1 with dict,                 advanced streaming,                 43170
+github,                             level 0,                            advanced streaming,                 136397
+github,                             level 0 with dict,                  advanced streaming,                 41170
+github,                             level 1,                            advanced streaming,                 143457
+github,                             level 1 with dict,                  advanced streaming,                 41682
+github,                             level 3,                            advanced streaming,                 136397
+github,                             level 3 with dict,                  advanced streaming,                 41170
+github,                             level 4,                            advanced streaming,                 136144
+github,                             level 4 with dict,                  advanced streaming,                 41306
+github,                             level 5,                            advanced streaming,                 135106
+github,                             level 5 with dict,                  advanced streaming,                 38938
+github,                             level 6,                            advanced streaming,                 135108
+github,                             level 6 with dict,                  advanced streaming,                 38632
+github,                             level 7,                            advanced streaming,                 135108
+github,                             level 7 with dict,                  advanced streaming,                 38766
+github,                             level 9,                            advanced streaming,                 135108
+github,                             level 9 with dict,                  advanced streaming,                 39326
+github,                             level 13,                           advanced streaming,                 133717
+github,                             level 13 with dict,                 advanced streaming,                 39716
+github,                             level 16,                           advanced streaming,                 133717
+github,                             level 16 with dict,                 advanced streaming,                 37577
+github,                             level 19,                           advanced streaming,                 133717
+github,                             level 19 with dict,                 advanced streaming,                 37576
+github,                             no source size,                     advanced streaming,                 136397
+github,                             long distance mode,                 advanced streaming,                 136397
+github,                             multithreaded,                      advanced streaming,                 136397
+github,                             multithreaded long distance mode,   advanced streaming,                 136397
+github,                             small window log,                   advanced streaming,                 136397
+github,                             small hash log,                     advanced streaming,                 135467
+github,                             small chain log,                    advanced streaming,                 136314
+github,                             explicit params,                    advanced streaming,                 137670
+github,                             uncompressed literals,              advanced streaming,                 167004
+github,                             uncompressed literals optimal,      advanced streaming,                 156824
+github,                             huffman literals,                   advanced streaming,                 143457
+github,                             multithreaded with advanced params, advanced streaming,                 167004
+silesia,                            level -5,                           old streaming,                      7152294
+silesia,                            level -3,                           old streaming,                      6789973
+silesia,                            level -1,                           old streaming,                      6191549
+silesia,                            level 0,                            old streaming,                      4862377
+silesia,                            level 1,                            old streaming,                      5318036
+silesia,                            level 3,                            old streaming,                      4862377
+silesia,                            level 4,                            old streaming,                      4800629
+silesia,                            level 5,                            old streaming,                      4710178
+silesia,                            level 6,                            old streaming,                      4659996
+silesia,                            level 7,                            old streaming,                      4596234
+silesia,                            level 9,                            old streaming,                      4543862
+silesia,                            level 13,                           old streaming,                      4482073
+silesia,                            level 16,                           old streaming,                      4377391
+silesia,                            level 19,                           old streaming,                      4293262
+silesia,                            no source size,                     old streaming,                      4862341
+silesia,                            uncompressed literals,              old streaming,                      4862377
+silesia,                            uncompressed literals optimal,      old streaming,                      4293262
+silesia,                            huffman literals,                   old streaming,                      6191549
+silesia.tar,                        level -5,                           old streaming,                      7160440
+silesia.tar,                        level -3,                           old streaming,                      6789026
+silesia.tar,                        level -1,                           old streaming,                      6195465
+silesia.tar,                        level 0,                            old streaming,                      4875010
+silesia.tar,                        level 1,                            old streaming,                      5339701
+silesia.tar,                        level 3,                            old streaming,                      4875010
+silesia.tar,                        level 4,                            old streaming,                      4813507
+silesia.tar,                        level 5,                            old streaming,                      4722240
+silesia.tar,                        level 6,                            old streaming,                      4672203
+silesia.tar,                        level 7,                            old streaming,                      4606658
+silesia.tar,                        level 9,                            old streaming,                      4554105
+silesia.tar,                        level 13,                           old streaming,                      4491703
+silesia.tar,                        level 16,                           old streaming,                      4381277
+silesia.tar,                        level 19,                           old streaming,                      4281514
+silesia.tar,                        no source size,                     old streaming,                      4875006
+silesia.tar,                        uncompressed literals,              old streaming,                      4875010
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4281514
+silesia.tar,                        huffman literals,                   old streaming,                      6195465
+github,                             level -5,                           old streaming,                      232744
+github,                             level -5 with dict,                 old streaming,                      46718
+github,                             level -3,                           old streaming,                      220611
+github,                             level -3 with dict,                 old streaming,                      45395
+github,                             level -1,                           old streaming,                      176575
+github,                             level -1 with dict,                 old streaming,                      43170
+github,                             level 0,                            old streaming,                      136397
+github,                             level 0 with dict,                  old streaming,                      41170
+github,                             level 1,                            old streaming,                      143457
+github,                             level 1 with dict,                  old streaming,                      41682
+github,                             level 3,                            old streaming,                      136397
+github,                             level 3 with dict,                  old streaming,                      41170
+github,                             level 4,                            old streaming,                      136144
+github,                             level 4 with dict,                  old streaming,                      41306
+github,                             level 5,                            old streaming,                      135106
+github,                             level 5 with dict,                  old streaming,                      38938
+github,                             level 6,                            old streaming,                      135108
+github,                             level 6 with dict,                  old streaming,                      38632
+github,                             level 7,                            old streaming,                      135108
+github,                             level 7 with dict,                  old streaming,                      38766
+github,                             level 9,                            old streaming,                      135108
+github,                             level 9 with dict,                  old streaming,                      39326
+github,                             level 13,                           old streaming,                      133717
+github,                             level 13 with dict,                 old streaming,                      39716
+github,                             level 16,                           old streaming,                      133717
+github,                             level 16 with dict,                 old streaming,                      37577
+github,                             level 19,                           old streaming,                      133717
+github,                             level 19 with dict,                 old streaming,                      37576
+github,                             no source size,                     old streaming,                      141003
+github,                             uncompressed literals,              old streaming,                      136397
+github,                             uncompressed literals optimal,      old streaming,                      133717
+github,                             huffman literals,                   old streaming,                      176575


### PR DESCRIPTION
* Move all ZSTDMT parameter setting code to ZSTD_CCtxParams_*Parameter().
  ZSTDMT now calls these functions, so we can keep all the logic in the
  same place.
* Make setting `ZSTD_c_nbWorkers` not clear overlap log / job size.
* Clean up `ZSTD_CCtx_setParameter()` to only add extra checks where needed.
* Clean up `ZSTDMT_initJobCCtxParams()` by copying all parameters by default,
  and then zeroing the ones that need to be zeroed. We've missed adding several
  parameters here, and it makes more sense to only have to update it if you
  change something in ZSTDMT.
* Add `ZSTDMT_cParam_clampBounds()` to clamp a parameter into its valid
  range. Use this to keep backwards compatibility when setting ZSTDMT parameters,
  which clamp into the valid range.
* Add test cases to to cover the `ZSTD_c_nbWorkers` bug and the `ZSTDMT_initJobCCtxParams()` bug, which both fail before this patch.

Fixes #1524.