### PR TITLE
Fix incorrect error code in ZSTD_errorFrameSizeInfo

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -437,7 +437,7 @@ static size_t ZSTD_decodeFrameHeader(ZSTD_DCtx* dctx, const void* src, size_t he
  * Contains the compressed frame size and an upper-bound for the decompressed frame size.
  * Note: before using `compressedSize` you must check for errors using ZSTD_isError().
  *       similarly, before using `decompressedBound`, you must check for errors using:
- *          `decompressedBound` != ZSTD_CONTENTSIZE_UNKNOWN
+ *          `decompressedBound` != ZSTD_CONTENTSIZE_ERROR
  */
 typedef struct {
     size_t compressedSize;
@@ -448,7 +448,7 @@ static ZSTD_frameSizeInfo ZSTD_errorFrameSizeInfo(size_t ret)
 {
     ZSTD_frameSizeInfo frameSizeInfo;
     frameSizeInfo.compressedSize = ret;
-    frameSizeInfo.decompressedBound = ZSTD_CONTENTSIZE_UNKNOWN;
+    frameSizeInfo.decompressedBound = ZSTD_CONTENTSIZE_ERROR;
     return frameSizeInfo;
 }
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -383,6 +383,13 @@ static int basicUnitTests(U32 seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : ZSTD_decompressBound test with invalid srcSize : ", testNb++);
+    {
+        unsigned long long bound = ZSTD_decompressBound(compressedBuffer, cSize - 1);
+        if (bound != ZSTD_CONTENTSIZE_ERROR) goto _output_error;
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     DISPLAYLEVEL(3, "test%3i : decompress %u bytes : ", testNb++, (unsigned)CNBuffSize);
     { size_t const r = ZSTD_decompress(decodedBuffer, CNBuffSize, compressedBuffer, cSize);
       if (r != CNBuffSize) goto _output_error; }

--- a/tests/legacy.c
+++ b/tests/legacy.c
@@ -130,11 +130,27 @@ static int testStreamingAPI(void)
     return error_code;
 }
 
+static int testFrameDecoding(void)
+{
+    if (ZSTD_decompressBound(COMPRESSED, COMPRESSED_SIZE) != ZSTD_CONTENTSIZE_ERROR) {
+        DISPLAY("ERROR: ZSTD_decompressBound: Expected to receive ZSTD_CONTENTSIZE_ERROR\n");
+        return 1;
+    }
+    if (ZSTD_findFrameCompressedSize(COMPRESSED) != COMPRESSED_SIZE) {
+        DISPLAY("ERROR: ZSTD_findFrameCompressedSize: Expected to receive %d\n", COMPRESSED_SIZE);
+        return 1;
+    }
+    DISPLAY("Frame Decoding OK\n");
+    return 0;
+}
+
 int main(void)
 {
     {   int const ret = testSimpleAPI();
         if (ret) return ret; }
     {   int const ret = testStreamingAPI();
+        if (ret) return ret; }
+    {   int const ret = testFrameDecoding();
         if (ret) return ret; }
 
     DISPLAY("OK\n");

--- a/tests/legacy.c
+++ b/tests/legacy.c
@@ -16,10 +16,11 @@
 /*===========================================
 *   Dependencies
 *==========================================*/
-#include <stddef.h>     /* size_t */
-#include <stdlib.h>     /* malloc, free */
-#include <stdio.h>      /* fprintf */
-#include <string.h>     /* strlen */
+#include <stddef.h>              /* size_t */
+#include <stdlib.h>              /* malloc, free */
+#include <stdio.h>               /* fprintf */
+#include <string.h>              /* strlen */
+#define ZSTD_STATIC_LINKING_ONLY /* ZSTD_decompressBound */
 #include "zstd.h"
 #include "zstd_errors.h"
 
@@ -134,10 +135,6 @@ static int testFrameDecoding(void)
 {
     if (ZSTD_decompressBound(COMPRESSED, COMPRESSED_SIZE) != ZSTD_CONTENTSIZE_ERROR) {
         DISPLAY("ERROR: ZSTD_decompressBound: Expected to receive ZSTD_CONTENTSIZE_ERROR\n");
-        return 1;
-    }
-    if (ZSTD_findFrameCompressedSize(COMPRESSED) != COMPRESSED_SIZE) {
-        DISPLAY("ERROR: ZSTD_findFrameCompressedSize: Expected to receive %d\n", COMPRESSED_SIZE);
         return 1;
     }
     DISPLAY("Frame Decoding OK\n");


### PR DESCRIPTION
While reading through the code to implement legacy compatibility, I noticed that `decompressBound` was assigned to the wrong error code in `ZSTD_errorFrameSizeInfo`.

In `ZSTD_decompressBound`, we check if `decompressedBound` equals `ZSTD_CONTENTSIZE_ERROR`, not `ZSTD_CONTENTSIZE_UNKNOWN` [1].

[1] https://github.com/facebook/zstd/blob/dev/lib/decompress/zstd_decompress.c#L545