### PR TITLE
Refactor old stream API to completely wrap the advanced API

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -808,13 +808,6 @@ size_t ZSTD_initCStream_internal(ZSTD_CStream* zcs,
 
 void ZSTD_resetSeqStore(seqStore_t* ssPtr);
 
-/*! ZSTD_compressStream_generic() :
- *  Private use only. To be called from zstdmt_compress.c in single-thread mode. */
-size_t ZSTD_compressStream_generic(ZSTD_CStream* zcs,
-                                   ZSTD_outBuffer* output,
-                                   ZSTD_inBuffer* input,
-                                   ZSTD_EndDirective const flushMode);
-
 /*! ZSTD_getCParamsFromCDict() :
  *  as the name implies */
 ZSTD_compressionParameters ZSTD_getCParamsFromCDict(const ZSTD_CDict* cdict);

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1967,7 +1967,7 @@ size_t ZSTDMT_compressStream_generic(ZSTDMT_CCtx* mtctx,
     assert(input->pos  <= input->size);
 
     if (mtctx->singleBlockingThread) {  /* delegate to single-thread (synchronous) */
-        return ZSTD_compressStream_generic(mtctx->cctxPool->cctx[0], output, input, endOp);
+        return ZSTD_compressStream2(mtctx->cctxPool->cctx[0], output, input, endOp);
     }
 
     if ((mtctx->frameEnded) && (endOp==ZSTD_e_continue)) {

--- a/tests/regression/config.c
+++ b/tests/regression/config.c
@@ -97,7 +97,7 @@ static param_value_t mt_advanced_param_values[] = {
 
 static config_t mt_advanced = {
     .name = "multithreaded with advanced params",
-    .cli_args = "-T2 --no-compressed-literals",
+    .cli_args = "-T2 --no-compress-literals",
     .param_values = PARAM_VALUES(mt_advanced_param_values),
 };
 

--- a/tests/regression/method.c
+++ b/tests/regression/method.c
@@ -432,75 +432,156 @@ out:
     return result;
 }
 
-static result_t old_streaming_compress(
-    method_state_t* base,
-    config_t const* config) {
-    buffer_state_t* state = container_of(base, buffer_state_t, base);
-
-    if (buffer_state_bad(state, config))
-        return result_error(result_error_system_error);
-
-    int const level = config_get_level(config);
-    if (level == CONFIG_NO_LEVEL)
-        return result_error(result_error_skip);
-
-    ZSTD_CStream* zcs = ZSTD_createCStream();
-    result_t result;
-    if (zcs == NULL) {
-        result = result_error(result_error_compression_error);
-        goto out;
-    }
+static int init_cstream(
+    buffer_state_t* state,
+    ZSTD_CStream* zcs,
+    config_t const* config,
+    int const advanced,
+    ZSTD_CDict** cdict)
+{
     size_t zret;
-    if (config->use_dictionary) {
-        zret = ZSTD_initCStream_usingDict(
-            zcs, state->dictionary.data, state->dictionary.size, level);
+    if (advanced) {
+        ZSTD_parameters const params = config_get_zstd_params(config, 0, 0);
+        ZSTD_CDict* dict = NULL;
+        if (cdict) {
+            *cdict = ZSTD_createCDict_advanced(
+                state->dictionary.data,
+                state->dictionary.size,
+                ZSTD_dlm_byRef,
+                ZSTD_dct_auto,
+                params.cParams,
+                ZSTD_defaultCMem);
+            if (!*cdict) {
+                return 1;
+            }
+            zret = ZSTD_initCStream_usingCDict_advanced(
+                zcs, *cdict, params.fParams, ZSTD_CONTENTSIZE_UNKNOWN);
+        } else {
+            zret = ZSTD_initCStream_advanced(
+                zcs,
+                state->dictionary.data,
+                state->dictionary.size,
+                params,
+                ZSTD_CONTENTSIZE_UNKNOWN);
+        }
     } else {
-        zret = ZSTD_initCStream(zcs, level);
+        int const level = config_get_level(config);
+        if (cdict) {
+            *cdict = ZSTD_createCDict(
+                state->dictionary.data,
+                state->dictionary.size,
+                level);
+            if (!*cdict) {
+                return 1;
+            }
+            zret = ZSTD_initCStream_usingCDict(zcs, *cdict);
+        } else if (config->use_dictionary) {
+            zret = ZSTD_initCStream_usingDict(
+                zcs, state->dictionary.data, state->dictionary.size, level);
+        } else {
+            zret = ZSTD_initCStream(zcs, level);
+        }
     }
     if (ZSTD_isError(zret)) {
-        result = result_error(result_error_compression_error);
-        goto out;
+        return 1;
+    }
+    return 0;
+}
+
+static result_t old_streaming_compress_internal(
+    method_state_t* base,
+    config_t const* config,
+    int const advanced,
+    int const cdict) {
+  buffer_state_t* state = container_of(base, buffer_state_t, base);
+
+  if (buffer_state_bad(state, config))
+    return result_error(result_error_system_error);
+
+
+  ZSTD_CStream* zcs = ZSTD_createCStream();
+  ZSTD_CDict* cd = NULL;
+  result_t result;
+  if (zcs == NULL) {
+    result = result_error(result_error_compression_error);
+    goto out;
+  }
+  if (init_cstream(state, zcs, config, advanced, cdict ? &cd : NULL)) {
+      result = result_error(result_error_compression_error);
+      goto out;
+  }
+
+  result_data_t data = {.total_size = 0};
+  for (size_t i = 0; i < state->inputs.size; ++i) {
+    data_buffer_t input = state->inputs.buffers[i];
+    size_t zret = ZSTD_resetCStream(
+        zcs,
+        config->no_pledged_src_size ? ZSTD_CONTENTSIZE_UNKNOWN : input.size);
+    if (ZSTD_isError(zret)) {
+      result = result_error(result_error_compression_error);
+      goto out;
     }
 
-    result_data_t data = {.total_size = 0};
-    for (size_t i = 0; i < state->inputs.size; ++i) {
-        data_buffer_t input = state->inputs.buffers[i];
-        zret = ZSTD_resetCStream(
-            zcs,
-            config->no_pledged_src_size ? ZSTD_CONTENTSIZE_UNKNOWN
-                                        : input.size);
+    while (input.size > 0) {
+      ZSTD_inBuffer in = {input.data, MIN(input.size, 4096)};
+      input.data += in.size;
+      input.size -= in.size;
+      ZSTD_EndDirective const op =
+          input.size > 0 ? ZSTD_e_continue : ZSTD_e_end;
+      zret = 0;
+      while (in.pos < in.size || (op == ZSTD_e_end && zret != 0)) {
+        ZSTD_outBuffer out = {state->compressed.data,
+                              MIN(state->compressed.capacity, 1024)};
+        if (op == ZSTD_e_continue || in.pos < in.size)
+          zret = ZSTD_compressStream(zcs, &out, &in);
+        else
+          zret = ZSTD_endStream(zcs, &out);
         if (ZSTD_isError(zret)) {
-            result = result_error(result_error_compression_error);
-            goto out;
+          result = result_error(result_error_compression_error);
+          goto out;
         }
-
-        while (input.size > 0) {
-            ZSTD_inBuffer in = {input.data, MIN(input.size, 4096)};
-            input.data += in.size;
-            input.size -= in.size;
-            ZSTD_EndDirective const op =
-                input.size > 0 ? ZSTD_e_continue : ZSTD_e_end;
-            zret = 0;
-            while (in.pos < in.size || (op == ZSTD_e_end && zret != 0)) {
-                ZSTD_outBuffer out = {state->compressed.data,
-                                      MIN(state->compressed.capacity, 1024)};
-                if (op == ZSTD_e_continue || in.pos < in.size)
-                    zret = ZSTD_compressStream(zcs, &out, &in);
-                else
-                    zret = ZSTD_endStream(zcs, &out);
-                if (ZSTD_isError(zret)) {
-                    result = result_error(result_error_compression_error);
-                    goto out;
-                }
-                data.total_size += out.pos;
-            }
-        }
+        data.total_size += out.pos;
+      }
     }
+  }
 
-    result = result_data(data);
+  result = result_data(data);
 out:
     ZSTD_freeCStream(zcs);
+    ZSTD_freeCDict(cd);
     return result;
+}
+
+static result_t old_streaming_compress(
+    method_state_t* base,
+    config_t const* config)
+{
+    return old_streaming_compress_internal(
+        base, config, /* advanced */ 0, /* cdict */ 0);
+}
+
+static result_t old_streaming_compress_advanced(
+    method_state_t* base,
+    config_t const* config)
+{
+    return old_streaming_compress_internal(
+        base, config, /* advanced */ 1, /* cdict */ 0);
+}
+
+static result_t old_streaming_compress_cdict(
+    method_state_t* base,
+    config_t const* config)
+{
+    return old_streaming_compress_internal(
+        base, config, /* advanced */ 0, /* cdict */ 1);
+}
+
+static result_t old_streaming_compress_cdict_advanced(
+    method_state_t* base,
+    config_t const* config)
+{
+    return old_streaming_compress_internal(
+        base, config, /* advanced */ 1, /* cdict */ 1);
 }
 
 method_t const simple = {
@@ -545,6 +626,27 @@ method_t const old_streaming = {
     .destroy = buffer_state_destroy,
 };
 
+method_t const old_streaming_advanced = {
+    .name = "old streaming advanced",
+    .create = buffer_state_create,
+    .compress = old_streaming_compress,
+    .destroy = buffer_state_destroy,
+};
+
+method_t const old_streaming_cdict = {
+    .name = "old streaming cdcit",
+    .create = buffer_state_create,
+    .compress = old_streaming_compress,
+    .destroy = buffer_state_destroy,
+};
+
+method_t const old_streaming_advanced_cdict = {
+    .name = "old streaming advanced cdict",
+    .create = buffer_state_create,
+    .compress = old_streaming_compress,
+    .destroy = buffer_state_destroy,
+};
+
 method_t const cli = {
     .name = "zstdcli",
     .create = method_state_create,
@@ -560,6 +662,9 @@ static method_t const* g_methods[] = {
     &advanced_one_pass_small_out,
     &advanced_streaming,
     &old_streaming,
+    &old_streaming_advanced,
+    &old_streaming_cdict,
+    &old_streaming_advanced_cdict,
     NULL,
 };
 

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -104,7 +104,7 @@ silesia,                            explicit params,                    zstdcli,
 silesia,                            uncompressed literals,              zstdcli,                            5155472
 silesia,                            uncompressed literals optimal,      zstdcli,                            4325475
 silesia,                            huffman literals,                   zstdcli,                            5341405
-silesia,                            multithreaded with advanced params, zstdcli,                            compression error
+silesia,                            multithreaded with advanced params, zstdcli,                            5155472
 silesia.tar,                        level -5,                           zstdcli,                            7161160
 silesia.tar,                        level -3,                           zstdcli,                            6789865
 silesia.tar,                        level -1,                           zstdcli,                            6196433
@@ -130,7 +130,7 @@ silesia.tar,                        explicit params,                    zstdcli,
 silesia.tar,                        uncompressed literals,              zstdcli,                            5158134
 silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4321098
 silesia.tar,                        huffman literals,                   zstdcli,                            5358479
-silesia.tar,                        multithreaded with advanced params, zstdcli,                            compression error
+silesia.tar,                        multithreaded with advanced params, zstdcli,                            5158134
 github,                             level -5,                           zstdcli,                            234744
 github,                             level -5 with dict,                 zstdcli,                            48718
 github,                             level -3,                           zstdcli,                            222611
@@ -169,7 +169,7 @@ github,                             explicit params,                    zstdcli,
 github,                             uncompressed literals,              zstdcli,                            169004
 github,                             uncompressed literals optimal,      zstdcli,                            158824
 github,                             huffman literals,                   zstdcli,                            145457
-github,                             multithreaded with advanced params, zstdcli,                            compression error
+github,                             multithreaded with advanced params, zstdcli,                            169004
 silesia,                            level -5,                           advanced one pass,                  7152294
 silesia,                            level -3,                           advanced one pass,                  6789969
 silesia,                            level -1,                           advanced one pass,                  6191548
@@ -461,9 +461,17 @@ silesia,                            level 13,                           old stre
 silesia,                            level 16,                           old streaming,                      4377391
 silesia,                            level 19,                           old streaming,                      4293262
 silesia,                            no source size,                     old streaming,                      4862341
+silesia,                            long distance mode,                 old streaming,                      12000408
+silesia,                            multithreaded,                      old streaming,                      12000408
+silesia,                            multithreaded long distance mode,   old streaming,                      12000408
+silesia,                            small window log,                   old streaming,                      12000408
+silesia,                            small hash log,                     old streaming,                      12000408
+silesia,                            small chain log,                    old streaming,                      12000408
+silesia,                            explicit params,                    old streaming,                      12000408
 silesia,                            uncompressed literals,              old streaming,                      4862377
 silesia,                            uncompressed literals optimal,      old streaming,                      4293262
 silesia,                            huffman literals,                   old streaming,                      6191549
+silesia,                            multithreaded with advanced params, old streaming,                      12000408
 silesia.tar,                        level -5,                           old streaming,                      7160440
 silesia.tar,                        level -3,                           old streaming,                      6789026
 silesia.tar,                        level -1,                           old streaming,                      6195465
@@ -479,9 +487,17 @@ silesia.tar,                        level 13,                           old stre
 silesia.tar,                        level 16,                           old streaming,                      4381277
 silesia.tar,                        level 19,                           old streaming,                      4281514
 silesia.tar,                        no source size,                     old streaming,                      4875006
+silesia.tar,                        long distance mode,                 old streaming,                      12022046
+silesia.tar,                        multithreaded,                      old streaming,                      12022046
+silesia.tar,                        multithreaded long distance mode,   old streaming,                      12022046
+silesia.tar,                        small window log,                   old streaming,                      12022046
+silesia.tar,                        small hash log,                     old streaming,                      12022046
+silesia.tar,                        small chain log,                    old streaming,                      12022046
+silesia.tar,                        explicit params,                    old streaming,                      12022046
 silesia.tar,                        uncompressed literals,              old streaming,                      4875010
 silesia.tar,                        uncompressed literals optimal,      old streaming,                      4281514
 silesia.tar,                        huffman literals,                   old streaming,                      6195465
+silesia.tar,                        multithreaded with advanced params, old streaming,                      12022046
 github,                             level -5,                           old streaming,                      232744
 github,                             level -5 with dict,                 old streaming,                      46718
 github,                             level -3,                           old streaming,                      220611
@@ -511,6 +527,290 @@ github,                             level 16 with dict,                 old stre
 github,                             level 19,                           old streaming,                      133717
 github,                             level 19 with dict,                 old streaming,                      37576
 github,                             no source size,                     old streaming,                      141003
+github,                             long distance mode,                 old streaming,                      412933
+github,                             multithreaded,                      old streaming,                      412933
+github,                             multithreaded long distance mode,   old streaming,                      412933
+github,                             small window log,                   old streaming,                      412933
+github,                             small hash log,                     old streaming,                      412933
+github,                             small chain log,                    old streaming,                      412933
+github,                             explicit params,                    old streaming,                      412933
 github,                             uncompressed literals,              old streaming,                      136397
 github,                             uncompressed literals optimal,      old streaming,                      133717
 github,                             huffman literals,                   old streaming,                      176575
+github,                             multithreaded with advanced params, old streaming,                      412933
+silesia,                            level -5,                           old streaming advanced,             7152294
+silesia,                            level -3,                           old streaming advanced,             6789973
+silesia,                            level -1,                           old streaming advanced,             6191549
+silesia,                            level 0,                            old streaming advanced,             4862377
+silesia,                            level 1,                            old streaming advanced,             5318036
+silesia,                            level 3,                            old streaming advanced,             4862377
+silesia,                            level 4,                            old streaming advanced,             4800629
+silesia,                            level 5,                            old streaming advanced,             4710178
+silesia,                            level 6,                            old streaming advanced,             4659996
+silesia,                            level 7,                            old streaming advanced,             4596234
+silesia,                            level 9,                            old streaming advanced,             4543862
+silesia,                            level 13,                           old streaming advanced,             4482073
+silesia,                            level 16,                           old streaming advanced,             4377391
+silesia,                            level 19,                           old streaming advanced,             4293262
+silesia,                            no source size,                     old streaming advanced,             4862341
+silesia,                            long distance mode,                 old streaming advanced,             12000408
+silesia,                            multithreaded,                      old streaming advanced,             12000408
+silesia,                            multithreaded long distance mode,   old streaming advanced,             12000408
+silesia,                            small window log,                   old streaming advanced,             12000408
+silesia,                            small hash log,                     old streaming advanced,             12000408
+silesia,                            small chain log,                    old streaming advanced,             12000408
+silesia,                            explicit params,                    old streaming advanced,             12000408
+silesia,                            uncompressed literals,              old streaming advanced,             4862377
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4293262
+silesia,                            huffman literals,                   old streaming advanced,             6191549
+silesia,                            multithreaded with advanced params, old streaming advanced,             12000408
+silesia.tar,                        level -5,                           old streaming advanced,             7160440
+silesia.tar,                        level -3,                           old streaming advanced,             6789026
+silesia.tar,                        level -1,                           old streaming advanced,             6195465
+silesia.tar,                        level 0,                            old streaming advanced,             4875010
+silesia.tar,                        level 1,                            old streaming advanced,             5339701
+silesia.tar,                        level 3,                            old streaming advanced,             4875010
+silesia.tar,                        level 4,                            old streaming advanced,             4813507
+silesia.tar,                        level 5,                            old streaming advanced,             4722240
+silesia.tar,                        level 6,                            old streaming advanced,             4672203
+silesia.tar,                        level 7,                            old streaming advanced,             4606658
+silesia.tar,                        level 9,                            old streaming advanced,             4554105
+silesia.tar,                        level 13,                           old streaming advanced,             4491703
+silesia.tar,                        level 16,                           old streaming advanced,             4381277
+silesia.tar,                        level 19,                           old streaming advanced,             4281514
+silesia.tar,                        no source size,                     old streaming advanced,             4875006
+silesia.tar,                        long distance mode,                 old streaming advanced,             12022046
+silesia.tar,                        multithreaded,                      old streaming advanced,             12022046
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             12022046
+silesia.tar,                        small window log,                   old streaming advanced,             12022046
+silesia.tar,                        small hash log,                     old streaming advanced,             12022046
+silesia.tar,                        small chain log,                    old streaming advanced,             12022046
+silesia.tar,                        explicit params,                    old streaming advanced,             12022046
+silesia.tar,                        uncompressed literals,              old streaming advanced,             4875010
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4281514
+silesia.tar,                        huffman literals,                   old streaming advanced,             6195465
+silesia.tar,                        multithreaded with advanced params, old streaming advanced,             12022046
+github,                             level -5,                           old streaming advanced,             232744
+github,                             level -5 with dict,                 old streaming advanced,             46718
+github,                             level -3,                           old streaming advanced,             220611
+github,                             level -3 with dict,                 old streaming advanced,             45395
+github,                             level -1,                           old streaming advanced,             176575
+github,                             level -1 with dict,                 old streaming advanced,             43170
+github,                             level 0,                            old streaming advanced,             136397
+github,                             level 0 with dict,                  old streaming advanced,             41170
+github,                             level 1,                            old streaming advanced,             143457
+github,                             level 1 with dict,                  old streaming advanced,             41682
+github,                             level 3,                            old streaming advanced,             136397
+github,                             level 3 with dict,                  old streaming advanced,             41170
+github,                             level 4,                            old streaming advanced,             136144
+github,                             level 4 with dict,                  old streaming advanced,             41306
+github,                             level 5,                            old streaming advanced,             135106
+github,                             level 5 with dict,                  old streaming advanced,             38938
+github,                             level 6,                            old streaming advanced,             135108
+github,                             level 6 with dict,                  old streaming advanced,             38632
+github,                             level 7,                            old streaming advanced,             135108
+github,                             level 7 with dict,                  old streaming advanced,             38766
+github,                             level 9,                            old streaming advanced,             135108
+github,                             level 9 with dict,                  old streaming advanced,             39326
+github,                             level 13,                           old streaming advanced,             133717
+github,                             level 13 with dict,                 old streaming advanced,             39716
+github,                             level 16,                           old streaming advanced,             133717
+github,                             level 16 with dict,                 old streaming advanced,             37577
+github,                             level 19,                           old streaming advanced,             133717
+github,                             level 19 with dict,                 old streaming advanced,             37576
+github,                             no source size,                     old streaming advanced,             141003
+github,                             long distance mode,                 old streaming advanced,             412933
+github,                             multithreaded,                      old streaming advanced,             412933
+github,                             multithreaded long distance mode,   old streaming advanced,             412933
+github,                             small window log,                   old streaming advanced,             412933
+github,                             small hash log,                     old streaming advanced,             412933
+github,                             small chain log,                    old streaming advanced,             412933
+github,                             explicit params,                    old streaming advanced,             412933
+github,                             uncompressed literals,              old streaming advanced,             136397
+github,                             uncompressed literals optimal,      old streaming advanced,             133717
+github,                             huffman literals,                   old streaming advanced,             176575
+github,                             multithreaded with advanced params, old streaming advanced,             412933
+silesia,                            level -5,                           old streaming cdcit,                7152294
+silesia,                            level -3,                           old streaming cdcit,                6789973
+silesia,                            level -1,                           old streaming cdcit,                6191549
+silesia,                            level 0,                            old streaming cdcit,                4862377
+silesia,                            level 1,                            old streaming cdcit,                5318036
+silesia,                            level 3,                            old streaming cdcit,                4862377
+silesia,                            level 4,                            old streaming cdcit,                4800629
+silesia,                            level 5,                            old streaming cdcit,                4710178
+silesia,                            level 6,                            old streaming cdcit,                4659996
+silesia,                            level 7,                            old streaming cdcit,                4596234
+silesia,                            level 9,                            old streaming cdcit,                4543862
+silesia,                            level 13,                           old streaming cdcit,                4482073
+silesia,                            level 16,                           old streaming cdcit,                4377391
+silesia,                            level 19,                           old streaming cdcit,                4293262
+silesia,                            no source size,                     old streaming cdcit,                4862341
+silesia,                            long distance mode,                 old streaming cdcit,                12000408
+silesia,                            multithreaded,                      old streaming cdcit,                12000408
+silesia,                            multithreaded long distance mode,   old streaming cdcit,                12000408
+silesia,                            small window log,                   old streaming cdcit,                12000408
+silesia,                            small hash log,                     old streaming cdcit,                12000408
+silesia,                            small chain log,                    old streaming cdcit,                12000408
+silesia,                            explicit params,                    old streaming cdcit,                12000408
+silesia,                            uncompressed literals,              old streaming cdcit,                4862377
+silesia,                            uncompressed literals optimal,      old streaming cdcit,                4293262
+silesia,                            huffman literals,                   old streaming cdcit,                6191549
+silesia,                            multithreaded with advanced params, old streaming cdcit,                12000408
+silesia.tar,                        level -5,                           old streaming cdcit,                7160440
+silesia.tar,                        level -3,                           old streaming cdcit,                6789026
+silesia.tar,                        level -1,                           old streaming cdcit,                6195465
+silesia.tar,                        level 0,                            old streaming cdcit,                4875010
+silesia.tar,                        level 1,                            old streaming cdcit,                5339701
+silesia.tar,                        level 3,                            old streaming cdcit,                4875010
+silesia.tar,                        level 4,                            old streaming cdcit,                4813507
+silesia.tar,                        level 5,                            old streaming cdcit,                4722240
+silesia.tar,                        level 6,                            old streaming cdcit,                4672203
+silesia.tar,                        level 7,                            old streaming cdcit,                4606658
+silesia.tar,                        level 9,                            old streaming cdcit,                4554105
+silesia.tar,                        level 13,                           old streaming cdcit,                4491703
+silesia.tar,                        level 16,                           old streaming cdcit,                4381277
+silesia.tar,                        level 19,                           old streaming cdcit,                4281514
+silesia.tar,                        no source size,                     old streaming cdcit,                4875006
+silesia.tar,                        long distance mode,                 old streaming cdcit,                12022046
+silesia.tar,                        multithreaded,                      old streaming cdcit,                12022046
+silesia.tar,                        multithreaded long distance mode,   old streaming cdcit,                12022046
+silesia.tar,                        small window log,                   old streaming cdcit,                12022046
+silesia.tar,                        small hash log,                     old streaming cdcit,                12022046
+silesia.tar,                        small chain log,                    old streaming cdcit,                12022046
+silesia.tar,                        explicit params,                    old streaming cdcit,                12022046
+silesia.tar,                        uncompressed literals,              old streaming cdcit,                4875010
+silesia.tar,                        uncompressed literals optimal,      old streaming cdcit,                4281514
+silesia.tar,                        huffman literals,                   old streaming cdcit,                6195465
+silesia.tar,                        multithreaded with advanced params, old streaming cdcit,                12022046
+github,                             level -5,                           old streaming cdcit,                232744
+github,                             level -5 with dict,                 old streaming cdcit,                46718
+github,                             level -3,                           old streaming cdcit,                220611
+github,                             level -3 with dict,                 old streaming cdcit,                45395
+github,                             level -1,                           old streaming cdcit,                176575
+github,                             level -1 with dict,                 old streaming cdcit,                43170
+github,                             level 0,                            old streaming cdcit,                136397
+github,                             level 0 with dict,                  old streaming cdcit,                41170
+github,                             level 1,                            old streaming cdcit,                143457
+github,                             level 1 with dict,                  old streaming cdcit,                41682
+github,                             level 3,                            old streaming cdcit,                136397
+github,                             level 3 with dict,                  old streaming cdcit,                41170
+github,                             level 4,                            old streaming cdcit,                136144
+github,                             level 4 with dict,                  old streaming cdcit,                41306
+github,                             level 5,                            old streaming cdcit,                135106
+github,                             level 5 with dict,                  old streaming cdcit,                38938
+github,                             level 6,                            old streaming cdcit,                135108
+github,                             level 6 with dict,                  old streaming cdcit,                38632
+github,                             level 7,                            old streaming cdcit,                135108
+github,                             level 7 with dict,                  old streaming cdcit,                38766
+github,                             level 9,                            old streaming cdcit,                135108
+github,                             level 9 with dict,                  old streaming cdcit,                39326
+github,                             level 13,                           old streaming cdcit,                133717
+github,                             level 13 with dict,                 old streaming cdcit,                39716
+github,                             level 16,                           old streaming cdcit,                133717
+github,                             level 16 with dict,                 old streaming cdcit,                37577
+github,                             level 19,                           old streaming cdcit,                133717
+github,                             level 19 with dict,                 old streaming cdcit,                37576
+github,                             no source size,                     old streaming cdcit,                141003
+github,                             long distance mode,                 old streaming cdcit,                412933
+github,                             multithreaded,                      old streaming cdcit,                412933
+github,                             multithreaded long distance mode,   old streaming cdcit,                412933
+github,                             small window log,                   old streaming cdcit,                412933
+github,                             small hash log,                     old streaming cdcit,                412933
+github,                             small chain log,                    old streaming cdcit,                412933
+github,                             explicit params,                    old streaming cdcit,                412933
+github,                             uncompressed literals,              old streaming cdcit,                136397
+github,                             uncompressed literals optimal,      old streaming cdcit,                133717
+github,                             huffman literals,                   old streaming cdcit,                176575
+github,                             multithreaded with advanced params, old streaming cdcit,                412933
+silesia,                            level -5,                           old streaming advanced cdict,       7152294
+silesia,                            level -3,                           old streaming advanced cdict,       6789973
+silesia,                            level -1,                           old streaming advanced cdict,       6191549
+silesia,                            level 0,                            old streaming advanced cdict,       4862377
+silesia,                            level 1,                            old streaming advanced cdict,       5318036
+silesia,                            level 3,                            old streaming advanced cdict,       4862377
+silesia,                            level 4,                            old streaming advanced cdict,       4800629
+silesia,                            level 5,                            old streaming advanced cdict,       4710178
+silesia,                            level 6,                            old streaming advanced cdict,       4659996
+silesia,                            level 7,                            old streaming advanced cdict,       4596234
+silesia,                            level 9,                            old streaming advanced cdict,       4543862
+silesia,                            level 13,                           old streaming advanced cdict,       4482073
+silesia,                            level 16,                           old streaming advanced cdict,       4377391
+silesia,                            level 19,                           old streaming advanced cdict,       4293262
+silesia,                            no source size,                     old streaming advanced cdict,       4862341
+silesia,                            long distance mode,                 old streaming advanced cdict,       12000408
+silesia,                            multithreaded,                      old streaming advanced cdict,       12000408
+silesia,                            multithreaded long distance mode,   old streaming advanced cdict,       12000408
+silesia,                            small window log,                   old streaming advanced cdict,       12000408
+silesia,                            small hash log,                     old streaming advanced cdict,       12000408
+silesia,                            small chain log,                    old streaming advanced cdict,       12000408
+silesia,                            explicit params,                    old streaming advanced cdict,       12000408
+silesia,                            uncompressed literals,              old streaming advanced cdict,       4862377
+silesia,                            uncompressed literals optimal,      old streaming advanced cdict,       4293262
+silesia,                            huffman literals,                   old streaming advanced cdict,       6191549
+silesia,                            multithreaded with advanced params, old streaming advanced cdict,       12000408
+silesia.tar,                        level -5,                           old streaming advanced cdict,       7160440
+silesia.tar,                        level -3,                           old streaming advanced cdict,       6789026
+silesia.tar,                        level -1,                           old streaming advanced cdict,       6195465
+silesia.tar,                        level 0,                            old streaming advanced cdict,       4875010
+silesia.tar,                        level 1,                            old streaming advanced cdict,       5339701
+silesia.tar,                        level 3,                            old streaming advanced cdict,       4875010
+silesia.tar,                        level 4,                            old streaming advanced cdict,       4813507
+silesia.tar,                        level 5,                            old streaming advanced cdict,       4722240
+silesia.tar,                        level 6,                            old streaming advanced cdict,       4672203
+silesia.tar,                        level 7,                            old streaming advanced cdict,       4606658
+silesia.tar,                        level 9,                            old streaming advanced cdict,       4554105
+silesia.tar,                        level 13,                           old streaming advanced cdict,       4491703
+silesia.tar,                        level 16,                           old streaming advanced cdict,       4381277
+silesia.tar,                        level 19,                           old streaming advanced cdict,       4281514
+silesia.tar,                        no source size,                     old streaming advanced cdict,       4875006
+silesia.tar,                        long distance mode,                 old streaming advanced cdict,       12022046
+silesia.tar,                        multithreaded,                      old streaming advanced cdict,       12022046
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced cdict,       12022046
+silesia.tar,                        small window log,                   old streaming advanced cdict,       12022046
+silesia.tar,                        small hash log,                     old streaming advanced cdict,       12022046
+silesia.tar,                        small chain log,                    old streaming advanced cdict,       12022046
+silesia.tar,                        explicit params,                    old streaming advanced cdict,       12022046
+silesia.tar,                        uncompressed literals,              old streaming advanced cdict,       4875010
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced cdict,       4281514
+silesia.tar,                        huffman literals,                   old streaming advanced cdict,       6195465
+silesia.tar,                        multithreaded with advanced params, old streaming advanced cdict,       12022046
+github,                             level -5,                           old streaming advanced cdict,       232744
+github,                             level -5 with dict,                 old streaming advanced cdict,       46718
+github,                             level -3,                           old streaming advanced cdict,       220611
+github,                             level -3 with dict,                 old streaming advanced cdict,       45395
+github,                             level -1,                           old streaming advanced cdict,       176575
+github,                             level -1 with dict,                 old streaming advanced cdict,       43170
+github,                             level 0,                            old streaming advanced cdict,       136397
+github,                             level 0 with dict,                  old streaming advanced cdict,       41170
+github,                             level 1,                            old streaming advanced cdict,       143457
+github,                             level 1 with dict,                  old streaming advanced cdict,       41682
+github,                             level 3,                            old streaming advanced cdict,       136397
+github,                             level 3 with dict,                  old streaming advanced cdict,       41170
+github,                             level 4,                            old streaming advanced cdict,       136144
+github,                             level 4 with dict,                  old streaming advanced cdict,       41306
+github,                             level 5,                            old streaming advanced cdict,       135106
+github,                             level 5 with dict,                  old streaming advanced cdict,       38938
+github,                             level 6,                            old streaming advanced cdict,       135108
+github,                             level 6 with dict,                  old streaming advanced cdict,       38632
+github,                             level 7,                            old streaming advanced cdict,       135108
+github,                             level 7 with dict,                  old streaming advanced cdict,       38766
+github,                             level 9,                            old streaming advanced cdict,       135108
+github,                             level 9 with dict,                  old streaming advanced cdict,       39326
+github,                             level 13,                           old streaming advanced cdict,       133717
+github,                             level 13 with dict,                 old streaming advanced cdict,       39716
+github,                             level 16,                           old streaming advanced cdict,       133717
+github,                             level 16 with dict,                 old streaming advanced cdict,       37577
+github,                             level 19,                           old streaming advanced cdict,       133717
+github,                             level 19 with dict,                 old streaming advanced cdict,       37576
+github,                             no source size,                     old streaming advanced cdict,       141003
+github,                             long distance mode,                 old streaming advanced cdict,       412933
+github,                             multithreaded,                      old streaming advanced cdict,       412933
+github,                             multithreaded long distance mode,   old streaming advanced cdict,       412933
+github,                             small window log,                   old streaming advanced cdict,       412933
+github,                             small hash log,                     old streaming advanced cdict,       412933
+github,                             small chain log,                    old streaming advanced cdict,       412933
+github,                             explicit params,                    old streaming advanced cdict,       412933
+github,                             uncompressed literals,              old streaming advanced cdict,       136397
+github,                             uncompressed literals optimal,      old streaming advanced cdict,       133717
+github,                             huffman literals,                   old streaming advanced cdict,       176575
+github,                             multithreaded with advanced params, old streaming advanced cdict,       412933


### PR DESCRIPTION
Refactor the `ZSTD_initCStream*()` functions and `ZSTD_resetCStream()` to call:

```c
ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
// Set the pledged src size if known
// Set parameters
// Set or clear the dictionary
```

This is a small difference in behavior when you mix the two APIs, since the parameters are now sticky.

The biggest advantages of this change are that it reduces the maintenance of the old streaming API, since it is now just a small wrapper, and we can point users to the implementation to help them switch to the new API. We can document these functions in terms of what they do in the new API.

The disadvantages are a small change in behavior, and users will end up mixing the two APIs.