### PR TITLE
Stabilize the advanced API

### DIFF
--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -70,8 +70,8 @@ extern "C" {
 
 /*------   Version   ------*/
 #define ZSTD_VERSION_MAJOR    1
-#define ZSTD_VERSION_MINOR    3
-#define ZSTD_VERSION_RELEASE  8
+#define ZSTD_VERSION_MINOR    4
+#define ZSTD_VERSION_RELEASE  0
 
 #define ZSTD_VERSION_NUMBER  (ZSTD_VERSION_MAJOR *100*100 + ZSTD_VERSION_MINOR *100 + ZSTD_VERSION_RELEASE)
 ZSTDLIB_API unsigned ZSTD_versionNumber(void);   /**< to check runtime library version */


### PR DESCRIPTION
* Bump the library version to 1.4.0
* Move the candidate advanced API to the stable section.
It makes some minor whitespace changes, but it doesn't change any
of the wording of the documentation.

The biggest thing to review in this PR is the order of the functions.
Also, if there are any documentation changes you want to see, let me know.
I'm planning on updating the streaming documentation block to mention
`ZSTD_compressStream2()`.

I'll put up a separate PR that tweaks some of the documentation
once this lands, so that it is easier to review.

NOTE: Even though these functions are now in stable, they aren't
stable until the next release (in under 1 month). It is possible
that they change until then.