### PR TITLE
Fix tests and meson build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ matrix:
 
     # meson dedicated test
     - name: Xenial (Meson + clang)
-      env: ALLOW_FAILURES=true
+      # env: ALLOW_FAILURES=true
       dist: xenial
       language: cpp
       compiler: clang

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -12,6 +12,7 @@ zstd_rootdir = '../../..'
 
 zstd_programs_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'programs/fileio.c'),
   join_paths(zstd_rootdir, 'programs/benchfn.c'),
   join_paths(zstd_rootdir, 'programs/benchzstd.c'),
@@ -63,6 +64,7 @@ zstd = executable('zstd',
   install: true)
 
 zstd_frugal_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
   join_paths(zstd_rootdir, 'programs/fileio.c')]
 

--- a/build/meson/tests/meson.build
+++ b/build/meson/tests/meson.build
@@ -40,6 +40,7 @@ datagen = executable('datagen',
 
 fullbench_sources = [join_paths(zstd_rootdir, 'programs/datagen.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'programs/benchfn.c'),
   join_paths(zstd_rootdir, 'programs/benchzstd.c'),
   join_paths(zstd_rootdir, 'tests/fullbench.c')]
@@ -51,6 +52,7 @@ fullbench = executable('fullbench',
 
 fuzzer_sources = [join_paths(zstd_rootdir, 'programs/datagen.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'tests/fuzzer.c')]
 fuzzer = executable('fuzzer',
   fuzzer_sources,
@@ -60,6 +62,7 @@ fuzzer = executable('fuzzer',
 
 zbufftest_sources = [join_paths(zstd_rootdir, 'programs/datagen.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'tests/zbufftest.c')]
 zbufftest = executable('zbufftest',
   zbufftest_sources,
@@ -70,6 +73,7 @@ zbufftest = executable('zbufftest',
 
 zstreamtest_sources = [join_paths(zstd_rootdir, 'programs/datagen.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'tests/seqgen.c'),
   join_paths(zstd_rootdir, 'tests/zstreamtest.c')]
 zstreamtest = executable('zstreamtest',
@@ -79,6 +83,7 @@ zstreamtest = executable('zstreamtest',
   install: false)
 
 paramgrill_sources = [join_paths(zstd_rootdir, 'programs/benchfn.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'programs/benchzstd.c'),
   join_paths(zstd_rootdir, 'programs/datagen.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
@@ -116,6 +121,7 @@ legacy = executable('legacy',
   install: false)
 
 decodecorpus_sources = [join_paths(zstd_rootdir, 'programs/util.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'tests/decodecorpus.c')]
 decodecorpus = executable('decodecorpus',
   decodecorpus_sources,
@@ -132,6 +138,7 @@ symbols = executable('symbols',
   install: false)
 
 poolTests_sources = [join_paths(zstd_rootdir, 'programs/util.c'),
+  join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'tests/poolTests.c'),
   join_paths(zstd_rootdir, 'lib/common/pool.c'),
   join_paths(zstd_rootdir, 'lib/common/threading.c'),

--- a/tests/zbufftest.c
+++ b/tests/zbufftest.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>       /* free */
 #include <stdio.h>        /* fgets, sscanf */
 #include <string.h>       /* strcmp */
+#include "timefn.h"       /* UTIL_time_t */
 #include "mem.h"
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_maxCLevel */
 #include "zstd.h"         /* ZSTD_compressBound */

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -26,6 +26,7 @@
 #include <stdio.h>        /* fgets, sscanf */
 #include <string.h>       /* strcmp */
 #include <assert.h>       /* assert */
+#include "timefn.h"       /* UTIL_time_t, UTIL_getTime */
 #include "mem.h"
 #define ZSTD_STATIC_LINKING_ONLY  /* ZSTD_maxCLevel, ZSTD_customMem, ZSTD_getDictID_fromFrame */
 #include "zstd.h"         /* ZSTD_compressBound */


### PR DESCRIPTION
I [tried to set Travis notification](https://travis-ci.com/lzutao/zstd/builds/108152136) for meson job only but 
Travis didn't mail me when I tested the build failed.

So could we make mesonbuild non-optional? You could
ping me when meson build failed or just comment out
the `env: ALLOW_FAILURES=true` line.
