### PR TITLE
[fullbench] Fix speed measurements

### DIFF
--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -497,7 +497,7 @@ static int benchMem(unsigned benchNb,
         BMK_benchParams_t bp;
         BMK_runTime_t bestResult;
         bestResult.sumOfReturn = 0;
-        bestResult.nanoSecPerRun = (double)(-1);
+        bestResult.nanoSecPerRun = (double)TIMELOOP_NANOSEC * 2000000000;  /* hopefully large enough : must be larger than any potential measurement */
         assert(tfs != NULL);
 
         bp.benchFn = benchFunction;


### PR DESCRIPTION
We were getting bad speed measurements introduced by 9703a5912173982f9e9f14681f428afe18a4d828. Use the same max as used in `benchfn.c`.

Test by running `fullBench` and making sure we are getting real measurements, not `-10000000000.0 MB/s`.