### PR TITLE
Fix #1591 - Not building on MinGW-W64

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -269,6 +269,13 @@ void FIO_addAbortHandler()
         else
             return -1;
     }
+    static __int64 LONG_TELL(FILE* file) {
+        LARGE_INTEGER off, newOff;
+        off.QuadPart = 0;
+        newOff.QuadPart = 0;
+        SetFilePointerEx((HANDLE) _get_osfhandle(_fileno(file)), off, &newOff, FILE_CURRENT);
+        return newOff.QuadPart;
+    }
 #else
 #   define LONG_SEEK fseek
 #   define LONG_TELL ftell


### PR DESCRIPTION
Add a static function `LONG_TELL` for the forth `#if` branch

It looks like the only way to invoke the edited code is through the `--list` option of the cli.
I tested it on a Windows 7 machine, for both small and large(3 GiB) files, and they worked as expected.