### PR TITLE
fails to "make test" in examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -77,7 +77,6 @@ test: all
 	@echo -- Edge cases detection
 	! ./streaming_decompression tmp    # invalid input, must fail
 	! ./simple_decompression tmp       # invalid input, must fail
-	! ./simple_decompression tmp.zst   # unknown input size, must fail
 	touch tmpNull                      # create 0-size file
 	./simple_compression tmpNull
 	./simple_decompression tmpNull.zst # 0-size frame : must work


### PR DESCRIPTION
fixes "make test" fail in example directory

````
$ make test
...
! ./simple_decompression tmp.zst   # unknown input size, must fail
                  tmp.zst :    617 ->    1891 
tmp.zst correctly decoded (in memory). 
make: *** [Makefile:80: test] Error 1
````