### PR TITLE
fileio: Disable BACKTRACE under uClibc

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -175,7 +175,7 @@ static void clearHandler(void)
 
 #if !defined(BACKTRACE_ENABLE)
 /* automatic detector : backtrace enabled by default on linux+glibc and osx */
-#  if (defined(__linux__) && defined(__GLIBC__)) \
+#  if (defined(__linux__) && (defined(__GLIBC__) && !defined(__UCLIBC__))) \
      || (defined(__APPLE__) && defined(__MACH__))
 #    define BACKTRACE_ENABLE 1
 #  else


### PR DESCRIPTION
uClibc does not support BACKTRACE. It also defines __GLIBC__ and minor as both 2.
This fixes compilation under such a setup.

Example: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/zstd/compile.txt

