### PR TITLE
fullbench minor improvements

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -930,12 +930,12 @@ size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_ResetDirective reset)
     @return : 0, or an error code if one value is beyond authorized range */
 size_t ZSTD_checkCParams(ZSTD_compressionParameters cParams)
 {
-    BOUNDCHECK(ZSTD_c_windowLog, cParams.windowLog);
-    BOUNDCHECK(ZSTD_c_chainLog,  cParams.chainLog);
-    BOUNDCHECK(ZSTD_c_hashLog,   cParams.hashLog);
-    BOUNDCHECK(ZSTD_c_searchLog, cParams.searchLog);
-    BOUNDCHECK(ZSTD_c_minMatch,  cParams.minMatch);
-    BOUNDCHECK(ZSTD_c_targetLength,cParams.targetLength);
+    BOUNDCHECK(ZSTD_c_windowLog, (int)cParams.windowLog);
+    BOUNDCHECK(ZSTD_c_chainLog,  (int)cParams.chainLog);
+    BOUNDCHECK(ZSTD_c_hashLog,   (int)cParams.hashLog);
+    BOUNDCHECK(ZSTD_c_searchLog, (int)cParams.searchLog);
+    BOUNDCHECK(ZSTD_c_minMatch,  (int)cParams.minMatch);
+    BOUNDCHECK(ZSTD_c_targetLength,(int)cParams.targetLength);
     BOUNDCHECK(ZSTD_c_strategy,  cParams.strategy);
     return 0;
 }
@@ -951,7 +951,7 @@ ZSTD_clampCParams(ZSTD_compressionParameters cParams)
         if ((int)val<bounds.lowerBound) val=(type)bounds.lowerBound;      \
         else if ((int)val>bounds.upperBound) val=(type)bounds.upperBound; \
     }
-#   define CLAMP(cParam, val) CLAMP_TYPE(cParam, val, int)
+#   define CLAMP(cParam, val) CLAMP_TYPE(cParam, val, unsigned)
     CLAMP(ZSTD_c_windowLog, cParams.windowLog);
     CLAMP(ZSTD_c_chainLog,  cParams.chainLog);
     CLAMP(ZSTD_c_hashLog,   cParams.hashLog);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -1094,7 +1094,7 @@ _shortestPath:   /* cur, last_pos, best_mlen, best_off have to be set */
     }   /* while (ip < ilimit) */
 
     /* Return the last literals size */
-    return iend - anchor;
+    return (size_t)(iend - anchor);
 }
 
 

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -499,6 +499,9 @@ static int benchMem(unsigned benchNb,
     case 42 :
         g_cSize = ZSTD_compress(buff2, dstBuffSize, src, srcSize, cLevel);
         break;
+    case 43 :
+        buff2 = &cparams;
+        break;
 
     /* test functions */
     /* convention: test functions have ID > 100 */

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -166,11 +166,14 @@ local_ZSTD_compressStream_freshCCtx(const void* src, size_t srcSize,
                           void* buff2)
 {
     ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+    size_t r;
     assert(cctx != NULL);
 
-    return local_ZSTD_compressStream(src, srcSize, dst, dstCapacity, buff2);
+    r = local_ZSTD_compressStream(src, srcSize, dst, dstCapacity, buff2);
 
     ZSTD_freeCCtx(cctx);
+
+    return r;
 }
 
 static size_t

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -15,6 +15,7 @@
 #include "util.h"        /* Compiler options, UTIL_GetFileSize */
 #include <stdlib.h>      /* malloc */
 #include <stdio.h>       /* fprintf, fopen, ftello64 */
+#include <assert.h>
 
 #include "timefn.h"      /* UTIL_clockSpanNano, UTIL_getTime */
 #include "mem.h"         /* U32 */
@@ -30,8 +31,8 @@
 #include "zstd.h"        /* ZSTD_versionString */
 #include "util.h"        /* time functions */
 #include "datagen.h"
-#include "benchfn.h"       /* CustomBench*/
-#include "benchzstd.h"     /* MB_UNIT */
+#include "benchfn.h"     /* CustomBench */
+#include "benchzstd.h"   /* MB_UNIT */
 
 
 /*_************************************
@@ -50,7 +51,7 @@
 #define DEFAULT_CLEVEL 1
 
 #define COMPRESSIBILITY_DEFAULT 0.50
-static const size_t k_sampleSize_default = 10000000;
+static const size_t kSampleSizeDefault = 10000000;
 
 #define TIMELOOP_NANOSEC      (1*1000000000ULL) /* 1 second */
 
@@ -723,7 +724,7 @@ static int usage_advanced(const char* exename)
     DISPLAY( " -l#    : benchmark functions at that compression level (default : %i)\n", DEFAULT_CLEVEL);
     DISPLAY( " --zstd : custom parameter selection. Format same as zstdcli \n");
     DISPLAY( " -P#    : sample compressibility (default : %.1f%%)\n", COMPRESSIBILITY_DEFAULT * 100);
-    DISPLAY( " -B#    : sample size (default : %u)\n", (unsigned)k_sampleSize_default);
+    DISPLAY( " -B#    : sample size (default : %u)\n", (unsigned)kSampleSizeDefault);
     DISPLAY( " -i#    : iteration loops [1-9](default : %i)\n", NBLOOPS);
     return 0;
 }
@@ -743,7 +744,7 @@ int main(int argc, const char** argv)
     U32 benchNb = 0, main_pause = 0;
     int cLevel = DEFAULT_CLEVEL;
     ZSTD_compressionParameters cparams = ZSTD_getCParams(cLevel, 0, 0);
-    size_t sampleSize = k_sampleSize_default;
+    size_t sampleSize = kSampleSizeDefault;
     double compressibility = COMPRESSIBILITY_DEFAULT;
 
     DISPLAY(WELCOME_MESSAGE);

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -161,6 +161,19 @@ local_ZSTD_compressStream(const void* src, size_t srcSize,
 }
 
 static size_t
+local_ZSTD_compressStream_freshCCtx(const void* src, size_t srcSize,
+                          void* dst, size_t dstCapacity,
+                          void* buff2)
+{
+    ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+    assert(cctx != NULL);
+
+    return local_ZSTD_compressStream(src, srcSize, dst, dstCapacity, buff2);
+
+    ZSTD_freeCCtx(cctx);
+}
+
+static size_t
 local_ZSTD_compress_generic_end(const void* src, size_t srcSize,
                                 void* dst, size_t dstCapacity,
                                 void* buff2)
@@ -353,6 +366,9 @@ static int benchMem(unsigned benchNb,
         break;
     case 42:
         benchFunction = local_ZSTD_decompressStream; benchName = "decompressStream";
+        break;
+    case 43:
+        benchFunction = local_ZSTD_compressStream_freshCCtx; benchName = "compressStream_freshCCtx";
         break;
     case 51:
         benchFunction = local_ZSTD_compress_generic_continue; benchName = "compress_generic, continue";

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2464,7 +2464,7 @@ static unsigned readU32FromChar(const char** stringPtr)
  *  If yes, @return 1 and advances *stringPtr to the position which immediately follows longCommand.
  *  @return 0 and doesn't modify *stringPtr otherwise.
  */
-static unsigned longCommandWArg(const char** stringPtr, const char* longCommand)
+static int longCommandWArg(const char** stringPtr, const char* longCommand)
 {
     size_t const comSize = strlen(longCommand);
     int const result = !strncmp(*stringPtr, longCommand, comSize);
@@ -2524,7 +2524,7 @@ int main(int argc, const char** argv)
 
                 case 'i':
                     argument++; maxDuration = 0;
-                    nbTests = readU32FromChar(&argument);
+                    nbTests = (int)readU32FromChar(&argument);
                     break;
 
                 case 'T':
@@ -2544,12 +2544,12 @@ int main(int argc, const char** argv)
 
                 case 't':
                     argument++;
-                    testNb = readU32FromChar(&argument);
+                    testNb = (int)readU32FromChar(&argument);
                     break;
 
                 case 'P':   /* compressibility % */
                     argument++;
-                    proba = readU32FromChar(&argument);
+                    proba = (int)readU32FromChar(&argument);
                     if (proba>100) proba = 100;
                     break;
 


### PR DESCRIPTION
`fullbench` can now benchmark speed on sample of any size, thanks to `-B#` command.

new : scenario 43, streaming compression with a new context allocated and freed every time, and initialization not knowing source size (`ZSTD_CONTENTSIZE_UNKNOWN`).