### PR TITLE
add cmake lz4 support

### DIFF
--- a/build/cmake/CMakeModules/FindLibLZ4.cmake
+++ b/build/cmake/CMakeModules/FindLibLZ4.cmake
@@ -1,0 +1,49 @@
+# Find LibLZ4
+#
+# Find LibLZ4 headers and library
+#
+#   Result Variables
+#
+#   LIBLZ4_FOUND             - True if lz4 is found
+#   LIBLZ4_INCLUDE_DIRS      - lz4 headers directories
+#   LIBLZ4_LIBRARIES         - lz4 libraries
+#   LIBLZ4_VERSION_MAJOR     - The major version of lz4
+#   LIBLZ4_VERSION_MINOR     - The minor version of lz4
+#   LIBLZ4_VERSION_RELEASE   - The release version of lz4
+#   LIBLZ4_VERSION_STRING    - version number string (e.g. 1.8.3)
+#
+#   Hints
+#
+#   Set ``LZ4_ROOT_DIR`` to the directory of lz4.h and lz4 library
+
+set(_LIBLZ4_ROOT_HINTS
+    ENV LZ4_ROOT_DIR)
+
+find_path(  LIBLZ4_INCLUDE_DIR lz4.h
+            HINTS ${_LIBLZ4_ROOT_HINTS})
+find_library(   LIBLZ4_LIBRARY NAMES lz4 liblz4 liblz4_static
+                HINTS ${_LIBLZ4_ROOT_HINTS})
+
+if(LIBLZ4_INCLUDE_DIR)
+    file(STRINGS "${LIBLZ4_INCLUDE_DIR}/lz4.h" LIBLZ4_HEADER_CONTENT REGEX "#define LZ4_VERSION_[A-Z]+ +[0-9]+")
+
+    string(REGEX REPLACE ".*#define LZ4_VERSION_MAJOR +([0-9]+).*" "\\1" LIBLZ4_VERSION_MAJOR "${LIBLZ4_HEADER_CONTENT}")
+    string(REGEX REPLACE ".*#define LZ4_VERSION_MINOR +([0-9]+).*" "\\1" LIBLZ4_VERSION_MINOR "${LIBLZ4_HEADER_CONTENT}")
+    string(REGEX REPLACE ".*#define LZ4_VERSION_RELEASE +([0-9]+).*" "\\1" LIBLZ4_VERSION_RELEASE "${LIBLZ4_HEADER_CONTENT}")
+
+    set(LIBLZ4_VERSION_STRING "${LIBLZ4_VERSION_MAJOR}.${LIBLZ4_VERSION_MINOR}.${LIBLZ4_VERSION_RELEASE}")
+    unset(LIBLZ4_HEADER_CONTENT)
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibLZ4    REQUIRED_VARS   LIBLZ4_INCLUDE_DIR
+                                                            LIBLZ4_LIBRARY
+                                            VERSION_VAR     LIBLZ4_VERSION_STRING
+                                            FAIL_MESSAGE    "Could NOT find LZ4, try to set the paths to lz4.h and lz4 library in environment variable LZ4_ROOT_DIR")
+
+if (LIBLZ4_FOUND)
+    set(LIBLZ4_LIBRARIES ${LIBLZ4_LIBRARY})
+    set(LIBLZ4_INCLUDE_DIRS ${LIBLZ4_INCLUDE_DIR})
+endif ()
+
+mark_as_advanced( LIBLZ4_INCLUDE_DIR LIBLZ4_LIBRARY )

--- a/build/cmake/README.md
+++ b/build/cmake/README.md
@@ -5,6 +5,45 @@ use case sensitivity that matches modern (ie. cmake version 2.6 and above)
 conventions of using lower-case for commands, and upper-case for
 variables.
 
+# How to build
+
+As cmake doesn't support command like `cmake clean`, it's recommanded to perform a "out of source build".
+To do this, you can create a new directory and build in it:
+```sh
+cd build/cmake
+mkdir builddir
+cd builddir
+cmake ..
+make
+```
+Then you can clean all cmake caches by simpily delete the new directory:
+```sh
+rm -rf build/cmake/builddir
+```
+
+And of course, you can directly build in build/cmake:
+```sh
+cd build/cmake
+cmake
+make
+```
+
+To show cmake build options, you can:
+```sh
+cd build/cmake/builddir
+cmake -LH ..
+```
+
+Bool options can be set to ON/OFF with -D\[option\]=\[ON/OFF\]. You can configure cmake options like this:
+```sh
+cd build/cmake/builddir
+cmake -DZSTD_BUILD_TESTS=ON -DZSTD_LEGACY_SUPPORT=ON ..
+make
+```
+
+## referring
+[Looking for a 'cmake clean' command to clear up CMake output](https://stackoverflow.com/questions/9680420/looking-for-a-cmake-clean-command-to-clear-up-cmake-output)
+
 # CMake Style Recommendations
 
 ## Indent all code correctly, i.e. the body of

--- a/build/cmake/programs/CMakeLists.txt
+++ b/build/cmake/programs/CMakeLists.txt
@@ -83,7 +83,9 @@ endif ()
 
 option(ZSTD_ZLIB_SUPPORT "ZLIB SUPPORT" OFF)
 option(ZSTD_LZMA_SUPPORT "LZMA SUPPORT" OFF)
+option(ZSTD_LZ4_SUPPORT "LZ4 SUPPORT" OFF)
 
+# Add gzip support
 if (ZSTD_ZLIB_SUPPORT)
     find_package(ZLIB REQUIRED)
 
@@ -96,6 +98,7 @@ if (ZSTD_ZLIB_SUPPORT)
     endif ()
 endif ()
 
+# Add lzma support
 if (ZSTD_LZMA_SUPPORT)
     find_package(LibLZMA REQUIRED)
 
@@ -105,5 +108,18 @@ if (ZSTD_LZMA_SUPPORT)
         set_property(TARGET zstd APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_LZMACOMPRESS;ZSTD_LZMADECOMPRESS")
     else ()
         message(SEND_ERROR "lzma library is missing")
+    endif ()
+endif ()
+
+# Add lz4 support
+if (ZSTD_LZ4_SUPPORT)
+    find_package(LibLZ4 REQUIRED)
+
+    if (LIBLZ4_FOUND)
+        include_directories(${LIBLZ4_INCLUDE_DIRS})
+        target_link_libraries(zstd ${LIBLZ4_LIBRARIES})
+        set_property(TARGET zstd APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_LZ4COMPRESS;ZSTD_LZ4DECOMPRESS")
+    else ()
+        message(SEND_ERROR "lz4 library is missing")
     endif ()
 endif ()


### PR DESCRIPTION
Add some instructions in build/cmake/README.md for guys not familiar with cmake. Show them how to build with options
Yes, I saw there is a cmake support, but it can be improved using a CMakeLists.txt file and have a flag for each thing we want to build or not.

Add lz4 format support for zstd program, with a new cmake module FindLibLZ4.cmake added to find lz4 library.
This has been test on:
suse12sp2 cmake 3.12.1 lz4 1.8.3
windows10 cmake 3.12.1 lz4 1.8.3
ubuntu12.04 cmake 3.0.2 lz4 1.8.3
centos7.4 cmake 2.8.12 lz4 1.8.3
redhat7.2 cmake 3.0.2 lz4 1.8.3
with tests like:
lz4 compressed file->zstd decompress file->diff files
zstd compressed file->lz4 decompress file->diff files
[Issue#715](https://github.com/facebook/zstd/issues/715)


I rebased my last pull request and restart a new pull request again