### PR TITLE
zstdcli : expose cpu load indicator for each file on -vv mode

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1236,6 +1236,9 @@ static int FIO_compressFilename_dstFile(FIO_prefs_t* const prefs,
                                         const char* srcFileName,
                                         int compressionLevel)
 {
+    UTIL_time_t timeStart;
+    clock_t cpuStart;
+
     int closeDstFile = 0;
     int result;
     stat_t statbuf;
@@ -1259,8 +1262,8 @@ static int FIO_compressFilename_dstFile(FIO_prefs_t* const prefs,
             transfer_permissions = 1;
     }
 
-    UTIL_time_t const timeStart = UTIL_getTime();
-    clock_t const cpuStart = clock();
+    timeStart = UTIL_getTime();
+    cpuStart = clock();
 
     result = FIO_compressFilename_internal(prefs, ress, dstFileName, srcFileName, compressionLevel);
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1225,7 +1225,7 @@ FIO_compressFilename_internal(FIO_prefs_t* const prefs,
         U64 const timeLength_ns = UTIL_clockSpanNano(timeStart);
         double const timeLength_s = (double)timeLength_ns / 1000000000;
         double const cpuLoad_pct = (cpuLoad_s / timeLength_s) * 100;
-        DISPLAYLEVEL(4, "%s: Completed in %.2f sec  (cpu load : %.0f%%)\n",
+        DISPLAYLEVEL(4, "%-20s : Completed in %.2f sec  (cpu load : %.0f%%)\n",
                         srcFileName, timeLength_s, cpuLoad_pct);
     }
     return 0;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1236,9 +1236,6 @@ static int FIO_compressFilename_dstFile(FIO_prefs_t* const prefs,
                                         const char* srcFileName,
                                         int compressionLevel)
 {
-    UTIL_time_t const timeStart = UTIL_getTime();
-    clock_t const cpuStart = clock();
-
     int closeDstFile = 0;
     int result;
     stat_t statbuf;
@@ -1261,6 +1258,9 @@ static int FIO_compressFilename_dstFile(FIO_prefs_t* const prefs,
           && UTIL_getFileStat(srcFileName, &statbuf))
             transfer_permissions = 1;
     }
+
+    UTIL_time_t const timeStart = UTIL_getTime();
+    clock_t const cpuStart = clock();
 
     result = FIO_compressFilename_internal(prefs, ress, dstFileName, srcFileName, compressionLevel);
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1167,7 +1167,6 @@ FIO_compressFilename_internal(FIO_prefs_t* const prefs,
 {
     UTIL_time_t const timeStart = UTIL_getTime();;
     clock_t const cpuStart = clock();
-
     U64 readsize = 0;
     U64 compressedfilesize = 0;
     U64 const fileSize = UTIL_getFileSize(srcFileName);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1165,7 +1165,7 @@ FIO_compressFilename_internal(FIO_prefs_t* const prefs,
                               const char* dstFileName, const char* srcFileName,
                               int compressionLevel)
 {
-    UTIL_time_t const timeStart = UTIL_getTime();;
+    UTIL_time_t const timeStart = UTIL_getTime();
     clock_t const cpuStart = clock();
     U64 readsize = 0;
     U64 compressedfilesize = 0;


### PR DESCRIPTION
Moved the logic to measure elapsed time and cpu load from FIO_compressFilename to FIO_compressFilename_internal.

1. FIO_compressFilename is only used for single file case. If we want to show elapsed time and cpu load for each file in multiple file scenario, the measurement needs to be done in FIO_compressFilename_internal, which is called by both single and multiple file scenarios. 
2. I could have added the logic to FIO_compressFilename_internal, FIO_compressFilename_dstFile, or FIO_compressFilename_srcFile. I thought FIO_compressFilename_internal is a good fit since it already has logic to print stats about compression (compression ratio). I see elapsed time and cpu load as the extension to the stats. 