### PR TITLE
[libzstd] Optimize ZSTD_insertBt1() for repetitive data

### DIFF
--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -506,9 +506,11 @@ static U32 ZSTD_insertBt1(
     }   }
 
     *smallerPtr = *largerPtr = 0;
-    if (bestLength > 384) return MIN(192, (U32)(bestLength - 384));   /* speed optimization */
-    assert(matchEndIdx > current + 8);
-    return matchEndIdx - (current + 8);
+    {   U32 positions = 0;
+        if (bestLength > 384) positions = MIN(192, (U32)(bestLength - 384));   /* speed optimization */
+        assert(matchEndIdx > current + 8);
+        return MAX(positions, matchEndIdx - (current + 8));
+    }
 }
 
 FORCE_INLINE_TEMPLATE

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -11,10 +11,10 @@ silesia.tar,                        level 6,                            compress
 silesia.tar,                        level 7,                            compress simple,                    4606658
 silesia.tar,                        level 9,                            compress simple,                    4554098
 silesia.tar,                        level 13,                           compress simple,                    4491702
-silesia.tar,                        level 16,                           compress simple,                    4381277
-silesia.tar,                        level 19,                           compress simple,                    4281514
+silesia.tar,                        level 16,                           compress simple,                    4381284
+silesia.tar,                        level 19,                           compress simple,                    4281512
 silesia.tar,                        uncompressed literals,              compress simple,                    4875008
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4281514
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4281512
 silesia.tar,                        huffman literals,                   compress simple,                    6186038
 silesia,                            level -5,                           compress cctx,                      6737567
 silesia,                            level -3,                           compress cctx,                      6444663
@@ -28,7 +28,7 @@ silesia,                            level 6,                            compress
 silesia,                            level 7,                            compress cctx,                      4596234
 silesia,                            level 9,                            compress cctx,                      4543862
 silesia,                            level 13,                           compress cctx,                      4482073
-silesia,                            level 16,                           compress cctx,                      4377391
+silesia,                            level 16,                           compress cctx,                      4377389
 silesia,                            level 19,                           compress cctx,                      4293262
 silesia,                            long distance mode,                 compress cctx,                      4862377
 silesia,                            multithreaded,                      compress cctx,                      4862377
@@ -92,7 +92,7 @@ silesia,                            level 6,                            zstdcli,
 silesia,                            level 7,                            zstdcli,                            4596282
 silesia,                            level 9,                            zstdcli,                            4543910
 silesia,                            level 13,                           zstdcli,                            4482121
-silesia,                            level 16,                           zstdcli,                            4377439
+silesia,                            level 16,                           zstdcli,                            4377437
 silesia,                            level 19,                           zstdcli,                            4293310
 silesia,                            long distance mode,                 zstdcli,                            4853437
 silesia,                            multithreaded,                      zstdcli,                            4862425
@@ -102,7 +102,7 @@ silesia,                            small hash log,                     zstdcli,
 silesia,                            small chain log,                    zstdcli,                            4931141
 silesia,                            explicit params,                    zstdcli,                            4815380
 silesia,                            uncompressed literals,              zstdcli,                            5155472
-silesia,                            uncompressed literals optimal,      zstdcli,                            4325475
+silesia,                            uncompressed literals optimal,      zstdcli,                            4325482
 silesia,                            huffman literals,                   zstdcli,                            5331158
 silesia,                            multithreaded with advanced params, zstdcli,                            5155472
 silesia.tar,                        level -5,                           zstdcli,                            6738906
@@ -117,8 +117,8 @@ silesia.tar,                        level 6,                            zstdcli,
 silesia.tar,                        level 7,                            zstdcli,                            4608342
 silesia.tar,                        level 9,                            zstdcli,                            4554700
 silesia.tar,                        level 13,                           zstdcli,                            4491706
-silesia.tar,                        level 16,                           zstdcli,                            4381281
-silesia.tar,                        level 19,                           zstdcli,                            4281518
+silesia.tar,                        level 16,                           zstdcli,                            4381288
+silesia.tar,                        level 19,                           zstdcli,                            4281516
 silesia.tar,                        no source size,                     zstdcli,                            4875132
 silesia.tar,                        long distance mode,                 zstdcli,                            4866975
 silesia.tar,                        multithreaded,                      zstdcli,                            4875136
@@ -128,7 +128,7 @@ silesia.tar,                        small hash log,                     zstdcli,
 silesia.tar,                        small chain log,                    zstdcli,                            4943259
 silesia.tar,                        explicit params,                    zstdcli,                            4839202
 silesia.tar,                        uncompressed literals,              zstdcli,                            5158134
-silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4321098
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4321099
 silesia.tar,                        huffman literals,                   zstdcli,                            5347560
 silesia.tar,                        multithreaded with advanced params, zstdcli,                            5158134
 github,                             level -5,                           zstdcli,                            207285
@@ -182,7 +182,7 @@ silesia,                            level 6,                            advanced
 silesia,                            level 7,                            advanced one pass,                  4596234
 silesia,                            level 9,                            advanced one pass,                  4543862
 silesia,                            level 13,                           advanced one pass,                  4482073
-silesia,                            level 16,                           advanced one pass,                  4377391
+silesia,                            level 16,                           advanced one pass,                  4377389
 silesia,                            level 19,                           advanced one pass,                  4293262
 silesia,                            no source size,                     advanced one pass,                  4862377
 silesia,                            long distance mode,                 advanced one pass,                  4853389
@@ -193,7 +193,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass,                  4931093
 silesia,                            explicit params,                    advanced one pass,                  4815369
 silesia,                            uncompressed literals,              advanced one pass,                  5155424
-silesia,                            uncompressed literals optimal,      advanced one pass,                  4325427
+silesia,                            uncompressed literals optimal,      advanced one pass,                  4325434
 silesia,                            huffman literals,                   advanced one pass,                  5326210
 silesia,                            multithreaded with advanced params, advanced one pass,                  5155424
 silesia.tar,                        level -5,                           advanced one pass,                  6738558
@@ -208,8 +208,8 @@ silesia.tar,                        level 6,                            advanced
 silesia.tar,                        level 7,                            advanced one pass,                  4606658
 silesia.tar,                        level 9,                            advanced one pass,                  4554098
 silesia.tar,                        level 13,                           advanced one pass,                  4491702
-silesia.tar,                        level 16,                           advanced one pass,                  4381277
-silesia.tar,                        level 19,                           advanced one pass,                  4281514
+silesia.tar,                        level 16,                           advanced one pass,                  4381284
+silesia.tar,                        level 19,                           advanced one pass,                  4281512
 silesia.tar,                        no source size,                     advanced one pass,                  4875008
 silesia.tar,                        long distance mode,                 advanced one pass,                  4861218
 silesia.tar,                        multithreaded,                      advanced one pass,                  4874631
@@ -219,7 +219,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced one pass,                  4943255
 silesia.tar,                        explicit params,                    advanced one pass,                  4829974
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5157992
-silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4321094
+silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4321095
 silesia.tar,                        huffman literals,                   advanced one pass,                  5347283
 silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5158545
 github,                             level -5,                           advanced one pass,                  205285
@@ -274,7 +274,7 @@ silesia,                            level 6,                            advanced
 silesia,                            level 7,                            advanced one pass small out,        4596234
 silesia,                            level 9,                            advanced one pass small out,        4543862
 silesia,                            level 13,                           advanced one pass small out,        4482073
-silesia,                            level 16,                           advanced one pass small out,        4377391
+silesia,                            level 16,                           advanced one pass small out,        4377389
 silesia,                            level 19,                           advanced one pass small out,        4293262
 silesia,                            no source size,                     advanced one pass small out,        4862377
 silesia,                            long distance mode,                 advanced one pass small out,        4853389
@@ -285,7 +285,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass small out,        4931093
 silesia,                            explicit params,                    advanced one pass small out,        4815369
 silesia,                            uncompressed literals,              advanced one pass small out,        5155424
-silesia,                            uncompressed literals optimal,      advanced one pass small out,        4325427
+silesia,                            uncompressed literals optimal,      advanced one pass small out,        4325434
 silesia,                            huffman literals,                   advanced one pass small out,        5326210
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5155424
 silesia.tar,                        level -5,                           advanced one pass small out,        6738558
@@ -300,8 +300,8 @@ silesia.tar,                        level 6,                            advanced
 silesia.tar,                        level 7,                            advanced one pass small out,        4606658
 silesia.tar,                        level 9,                            advanced one pass small out,        4554098
 silesia.tar,                        level 13,                           advanced one pass small out,        4491702
-silesia.tar,                        level 16,                           advanced one pass small out,        4381277
-silesia.tar,                        level 19,                           advanced one pass small out,        4281514
+silesia.tar,                        level 16,                           advanced one pass small out,        4381284
+silesia.tar,                        level 19,                           advanced one pass small out,        4281512
 silesia.tar,                        no source size,                     advanced one pass small out,        4875008
 silesia.tar,                        long distance mode,                 advanced one pass small out,        4861218
 silesia.tar,                        multithreaded,                      advanced one pass small out,        4874631
@@ -311,7 +311,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced one pass small out,        4943255
 silesia.tar,                        explicit params,                    advanced one pass small out,        4829974
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5157992
-silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4321094
+silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4321095
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5347283
 silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5158545
 github,                             level -5,                           advanced one pass small out,        205285
@@ -366,7 +366,7 @@ silesia,                            level 6,                            advanced
 silesia,                            level 7,                            advanced streaming,                 4596234
 silesia,                            level 9,                            advanced streaming,                 4543862
 silesia,                            level 13,                           advanced streaming,                 4482073
-silesia,                            level 16,                           advanced streaming,                 4377391
+silesia,                            level 16,                           advanced streaming,                 4377389
 silesia,                            level 19,                           advanced streaming,                 4293262
 silesia,                            no source size,                     advanced streaming,                 4862341
 silesia,                            long distance mode,                 advanced streaming,                 4853389
@@ -377,7 +377,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced streaming,                 4931093
 silesia,                            explicit params,                    advanced streaming,                 4815380
 silesia,                            uncompressed literals,              advanced streaming,                 5155424
-silesia,                            uncompressed literals optimal,      advanced streaming,                 4325427
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4325434
 silesia,                            huffman literals,                   advanced streaming,                 5331110
 silesia,                            multithreaded with advanced params, advanced streaming,                 5155424
 silesia.tar,                        level -5,                           advanced streaming,                 6982738
@@ -392,8 +392,8 @@ silesia.tar,                        level 6,                            advanced
 silesia.tar,                        level 7,                            advanced streaming,                 4606658
 silesia.tar,                        level 9,                            advanced streaming,                 4554105
 silesia.tar,                        level 13,                           advanced streaming,                 4491703
-silesia.tar,                        level 16,                           advanced streaming,                 4381277
-silesia.tar,                        level 19,                           advanced streaming,                 4281514
+silesia.tar,                        level 16,                           advanced streaming,                 4381284
+silesia.tar,                        level 19,                           advanced streaming,                 4281512
 silesia.tar,                        no source size,                     advanced streaming,                 4875006
 silesia.tar,                        long distance mode,                 advanced streaming,                 4861218
 silesia.tar,                        multithreaded,                      advanced streaming,                 4875132
@@ -403,7 +403,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced streaming,                 4943260
 silesia.tar,                        explicit params,                    advanced streaming,                 4830002
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5157995
-silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4321094
+silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4321095
 silesia.tar,                        huffman literals,                   advanced streaming,                 5352306
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5158130
 github,                             level -5,                           advanced streaming,                 205285
@@ -458,7 +458,7 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming,                      4596234
 silesia,                            level 9,                            old streaming,                      4543862
 silesia,                            level 13,                           old streaming,                      4482073
-silesia,                            level 16,                           old streaming,                      4377391
+silesia,                            level 16,                           old streaming,                      4377389
 silesia,                            level 19,                           old streaming,                      4293262
 silesia,                            no source size,                     old streaming,                      4862341
 silesia,                            long distance mode,                 old streaming,                      12000408
@@ -484,8 +484,8 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming,                      4606658
 silesia.tar,                        level 9,                            old streaming,                      4554105
 silesia.tar,                        level 13,                           old streaming,                      4491703
-silesia.tar,                        level 16,                           old streaming,                      4381277
-silesia.tar,                        level 19,                           old streaming,                      4281514
+silesia.tar,                        level 16,                           old streaming,                      4381284
+silesia.tar,                        level 19,                           old streaming,                      4281512
 silesia.tar,                        no source size,                     old streaming,                      4875006
 silesia.tar,                        long distance mode,                 old streaming,                      12022046
 silesia.tar,                        multithreaded,                      old streaming,                      12022046
@@ -495,7 +495,7 @@ silesia.tar,                        small hash log,                     old stre
 silesia.tar,                        small chain log,                    old streaming,                      12022046
 silesia.tar,                        explicit params,                    old streaming,                      12022046
 silesia.tar,                        uncompressed literals,              old streaming,                      4875010
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4281514
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4281512
 silesia.tar,                        huffman literals,                   old streaming,                      6190789
 silesia.tar,                        multithreaded with advanced params, old streaming,                      12022046
 github,                             level -5,                           old streaming,                      205285
@@ -550,7 +550,7 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming advanced,             4596234
 silesia,                            level 9,                            old streaming advanced,             4543862
 silesia,                            level 13,                           old streaming advanced,             4482073
-silesia,                            level 16,                           old streaming advanced,             4377391
+silesia,                            level 16,                           old streaming advanced,             4377389
 silesia,                            level 19,                           old streaming advanced,             4293262
 silesia,                            no source size,                     old streaming advanced,             4862341
 silesia,                            long distance mode,                 old streaming advanced,             12000408
@@ -576,8 +576,8 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming advanced,             4606658
 silesia.tar,                        level 9,                            old streaming advanced,             4554105
 silesia.tar,                        level 13,                           old streaming advanced,             4491703
-silesia.tar,                        level 16,                           old streaming advanced,             4381277
-silesia.tar,                        level 19,                           old streaming advanced,             4281514
+silesia.tar,                        level 16,                           old streaming advanced,             4381284
+silesia.tar,                        level 19,                           old streaming advanced,             4281512
 silesia.tar,                        no source size,                     old streaming advanced,             4875006
 silesia.tar,                        long distance mode,                 old streaming advanced,             12022046
 silesia.tar,                        multithreaded,                      old streaming advanced,             12022046
@@ -587,7 +587,7 @@ silesia.tar,                        small hash log,                     old stre
 silesia.tar,                        small chain log,                    old streaming advanced,             12022046
 silesia.tar,                        explicit params,                    old streaming advanced,             12022046
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4875010
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4281514
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4281512
 silesia.tar,                        huffman literals,                   old streaming advanced,             6190789
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             12022046
 github,                             level -5,                           old streaming advanced,             205285
@@ -642,7 +642,7 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming cdcit,                4596234
 silesia,                            level 9,                            old streaming cdcit,                4543862
 silesia,                            level 13,                           old streaming cdcit,                4482073
-silesia,                            level 16,                           old streaming cdcit,                4377391
+silesia,                            level 16,                           old streaming cdcit,                4377389
 silesia,                            level 19,                           old streaming cdcit,                4293262
 silesia,                            no source size,                     old streaming cdcit,                4862341
 silesia,                            long distance mode,                 old streaming cdcit,                12000408
@@ -668,8 +668,8 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming cdcit,                4606658
 silesia.tar,                        level 9,                            old streaming cdcit,                4554105
 silesia.tar,                        level 13,                           old streaming cdcit,                4491703
-silesia.tar,                        level 16,                           old streaming cdcit,                4381277
-silesia.tar,                        level 19,                           old streaming cdcit,                4281514
+silesia.tar,                        level 16,                           old streaming cdcit,                4381284
+silesia.tar,                        level 19,                           old streaming cdcit,                4281512
 silesia.tar,                        no source size,                     old streaming cdcit,                4875006
 silesia.tar,                        long distance mode,                 old streaming cdcit,                12022046
 silesia.tar,                        multithreaded,                      old streaming cdcit,                12022046
@@ -679,7 +679,7 @@ silesia.tar,                        small hash log,                     old stre
 silesia.tar,                        small chain log,                    old streaming cdcit,                12022046
 silesia.tar,                        explicit params,                    old streaming cdcit,                12022046
 silesia.tar,                        uncompressed literals,              old streaming cdcit,                4875010
-silesia.tar,                        uncompressed literals optimal,      old streaming cdcit,                4281514
+silesia.tar,                        uncompressed literals optimal,      old streaming cdcit,                4281512
 silesia.tar,                        huffman literals,                   old streaming cdcit,                6190789
 silesia.tar,                        multithreaded with advanced params, old streaming cdcit,                12022046
 github,                             level -5,                           old streaming cdcit,                205285
@@ -734,7 +734,7 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming advanced cdict,       4596234
 silesia,                            level 9,                            old streaming advanced cdict,       4543862
 silesia,                            level 13,                           old streaming advanced cdict,       4482073
-silesia,                            level 16,                           old streaming advanced cdict,       4377391
+silesia,                            level 16,                           old streaming advanced cdict,       4377389
 silesia,                            level 19,                           old streaming advanced cdict,       4293262
 silesia,                            no source size,                     old streaming advanced cdict,       4862341
 silesia,                            long distance mode,                 old streaming advanced cdict,       12000408
@@ -760,8 +760,8 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming advanced cdict,       4606658
 silesia.tar,                        level 9,                            old streaming advanced cdict,       4554105
 silesia.tar,                        level 13,                           old streaming advanced cdict,       4491703
-silesia.tar,                        level 16,                           old streaming advanced cdict,       4381277
-silesia.tar,                        level 19,                           old streaming advanced cdict,       4281514
+silesia.tar,                        level 16,                           old streaming advanced cdict,       4381284
+silesia.tar,                        level 19,                           old streaming advanced cdict,       4281512
 silesia.tar,                        no source size,                     old streaming advanced cdict,       4875006
 silesia.tar,                        long distance mode,                 old streaming advanced cdict,       12022046
 silesia.tar,                        multithreaded,                      old streaming advanced cdict,       12022046
@@ -771,7 +771,7 @@ silesia.tar,                        small hash log,                     old stre
 silesia.tar,                        small chain log,                    old streaming advanced cdict,       12022046
 silesia.tar,                        explicit params,                    old streaming advanced cdict,       12022046
 silesia.tar,                        uncompressed literals,              old streaming advanced cdict,       4875010
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced cdict,       4281514
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced cdict,       4281512
 silesia.tar,                        huffman literals,                   old streaming advanced cdict,       6190789
 silesia.tar,                        multithreaded with advanced params, old streaming advanced cdict,       12022046
 github,                             level -5,                           old streaming advanced cdict,       205285


### PR DESCRIPTION
We would only skip at most 192 bytes at a time before this diff.
This was added to optimize long matches and skip the middle of the
match. However, it doesn't handle the case of repetitive data.

This patch keeps the optimization, but also handles repetitive data
by taking the max of the two return values.

**Before:**
```
> for n in $(seq 9); do echo strategy=$n; dd status=none if=/dev/zero bs=1024k count=1000 | command time -f %U zstd --zstd=strategy=$n >/dev/null; done
strategy=1
0.34
strategy=2
0.36
strategy=3
0.41
strategy=4
0.93
strategy=5
1.33
strategy=6
8.41
strategy=7
31.03
strategy=8
31.13
strategy=9
123.05
```

**After:**
```
> for n in $(seq 9); do echo strategy=$n; dd status=none if=/dev/zero bs=1024k count=1000 | command time -f %U ./zstd --zstd=strategy=$n >/dev/null; done
strategy=1
0.27
strategy=2
0.23
strategy=3
0.27
strategy=4
0.43
strategy=5
0.56
strategy=6
0.43
strategy=7
0.34
strategy=8
0.34
strategy=9
0.35
```

At level 19 with multithreading the compressed size of `silesia.tar` regresses 300 bytes, and `enwik8` regresses 100 bytes. In single threaded mode `enwik8` is also within 100 bytes, and I didn't test `silesia.tar`. The compression speed is not significantly effected.

The regression tests show changes in the order of single digit number of bytes.

Fixes Issue #1634.