### PR TITLE
[programs] set chmod 600 after opening destination file

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -564,9 +564,11 @@ static FILE* FIO_openDstFile(FIO_prefs_t* const prefs, const char* srcFileName, 
     }   }
 
     {   FILE* const f = fopen( dstFileName, "wb" );
-        if (f == NULL)
+        if (f == NULL) {
             DISPLAYLEVEL(1, "zstd: %s: %s\n", dstFileName, strerror(errno));
-        chmod(dstFileName, 00600);
+        } else {
+            chmod(dstFileName, 00600);
+        }
         return f;
     }
 }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -566,6 +566,7 @@ static FILE* FIO_openDstFile(FIO_prefs_t* const prefs, const char* srcFileName, 
     {   FILE* const f = fopen( dstFileName, "wb" );
         if (f == NULL)
             DISPLAYLEVEL(1, "zstd: %s: %s\n", dstFileName, strerror(errno));
+        chmod(dstFileName, 00600);
         return f;
     }
 }


### PR DESCRIPTION
This resolves a race condition where zstd or unzstd may expose read
permissions beyond the original file allowed.  Mode 600 is used
temporarily during the compression and decompression write stage
and the new file inherits the original file’s mode at the end.

Fixes #1630

chmod() should silently fail in situations where it isn't possible to set mode 600, such as on FAT file systems. I'm also not really able to tell if this builds okay on Windows. mingw-w64 seems to build it fine (as long as I changed timefn.h to have `<windows.h>` instead of `<Windows.h>`), but i don't know if chmod() has any effect on that OS -- it's well possible that someone should make a Windows-specific equivalent to this.