### PR TITLE
CMake bug fix: didn't install zstdless and zstdgrep.

### DIFF
--- a/build/cmake/programs/CMakeLists.txt
+++ b/build/cmake/programs/CMakeLists.txt
@@ -38,6 +38,8 @@ if (UNIX)
     add_custom_target(unzstd ALL ${CMAKE_COMMAND} -E create_symlink zstd unzstd DEPENDS zstd COMMENT "Creating unzstd symlink")
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zstdcat DESTINATION "bin")
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unzstd DESTINATION "bin")
+    install(PROGRAMS ${PROGRAMS_DIR}/zstdgrep DESTINATION "bin")
+    install(PROGRAMS ${PROGRAMS_DIR}/zstdless DESTINATION "bin")
 
     add_custom_target(zstd.1 ALL
         ${CMAKE_COMMAND} -E copy ${PROGRAMS_DIR}/zstd.1 .


### PR DESCRIPTION
CMake bug fix: CMake didn't install zstdless and zstdgrep.

I mess up the last PR[#1625](https://github.com/facebook/zstd/pull/1625) and create a new PR here.
Really sorry about this. @felixhandte 