### PR TITLE
[programs] set restrictive umask before file creation

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -533,6 +533,11 @@ static FILE* FIO_openDstFile(FIO_prefs_t* const prefs, const char* srcFileName, 
         prefs->sparseFileSupport = ZSTD_SPARSE_DEFAULT;
     }
 
+    /* set the umask so group and other permissions are not set,
+     * preventing possible security leaks when compressing or
+     * uncompressing */
+    umask(0077);
+
     if (UTIL_isRegularFile(dstFileName)) {
         /* Check if destination file already exists */
         FILE* const fCheck = fopen( dstFileName, "rb" );


### PR DESCRIPTION
This resolves a condition where zstd or unzstd may expose read
permissions beyond what the original file allowed.  umask 077
blocks out all permissions for group and other while the file
is being written to by zstd, and gets reset to the source file’s
mode afterward.

As suggested by @felixhandte in PR #1644, I think this solution is cleaner and removes the chance of reading the file before a chmod() call could be done. That PR should be closed if this one is accepted instead (one or the other).