### PR TITLE
Reduce stack usage of HUF_sort()

### DIFF
--- a/lib/compress/huf_compress.c
+++ b/lib/compress/huf_compress.c
@@ -311,8 +311,8 @@ static U32 HUF_setMaxHeight(nodeElt* huffNode, U32 lastNonNull, U32 maxNbBits)
 
 
 typedef struct {
-    U32 base;
-    U32 current;
+    U16 base;
+    U16 current;
 } rankPos;
 
 static void HUF_sort(nodeElt* huffNode, const unsigned* count, U32 maxSymbolValue)


### PR DESCRIPTION
Issue in focus: #1636 
Changes in Linux Kernel: <https://lkml.org/lkml/2019/5/10/89>

Description:
* Using `U16` instead of `U32` cuts stack usage in half for `rankPos`