### PR TITLE
decodecorpus 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,9 @@ jobs:
     # TODO: Create a small custom docker image with all the dependencies we need
     #       preinstalled to reduce installation time.
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     steps:
       - checkout
-      - *install-dependencies
       - run:
           name: Test
           command: |
@@ -41,10 +40,9 @@ jobs:
   # the second half of the jobs are in this test
   short-tests-1:
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     steps:
       - checkout
-      - *install-dependencies
       - run:
           name: Test
           command: |
@@ -61,12 +59,11 @@ jobs:
   # tagged release.
   publish-github-release:
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
     steps:
       - checkout
-      - *install-dependencies
       - run:
           name: Publish
           command: |
@@ -86,12 +83,11 @@ jobs:
   # This step should only be run in a cron job
   regression-test:
     docker:
-      - image: circleci/buildpack-deps:bionic
+      - image: fbopensource/zstd-circleci-primary:0.0.1
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
     steps:
       - checkout
-      - *install-dependencies
       # Restore the cached resources.
       - restore_cache:
           # We try our best to bust the cache when the data changes by hashing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,5 @@
 version: 2
 
-references:
-  # Install the dependencies required for tests.
-  # Add the step "- *install-dependencies" to the beginning of your job to run
-  # this command.
-  install-dependencies: &install-dependencies
-    run:
-      name: Install dependencies
-      # TODO: We can split these dependencies up by job to reduce installation
-      # time.
-      command: |
-        sudo dpkg --add-architecture i386
-        sudo apt-get -y -qq update
-        sudo apt-get -y install \
-            gcc-multilib-powerpc-linux-gnu gcc-arm-linux-gnueabi \
-            libc6-dev-armel-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
-            libc6-dev-ppc64-powerpc-cross zstd gzip coreutils \
-            libcurl4-openssl-dev
-
 jobs:
   # the first half of the jobs are in this test
   short-tests-0:

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -1,0 +1,9 @@
+FROM circleci/buildpack-deps:bionic
+
+RUN sudo dpkg --add-architecture i386
+RUN sudo apt-get -y -qq update
+RUN sudo apt-get -y install \
+    gcc-multilib-powerpc-linux-gnu gcc-arm-linux-gnueabi \
+    libc6-dev-armel-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+    libc6-dev-ppc64-powerpc-cross zstd gzip coreutils \
+    libcurl4-openssl-dev


### PR DESCRIPTION
Decoder was enforcing a constraint that is more strict than the spec. Sequence section for a compressed block can be less than the constraint that was enforced by decoder. When a block with rle mode for all (literal length, match length, and offset) is followed by another block with repeat mode for all (literal length, match length, and offset), the second block's sequence section can be 2 bytes (1 byte for number of sequences and 1 byte for compression mode for each field). 

This pull request includes 2 changes. 
1. fixing the decoder code to remove the constraint. 
2. Updating decodecorpus code to generate repeat after rle mode. 

Run `./decodecorpus -ptestfiles -otestfiles -n1 -s1236947365 -v` to generate an input that has an issue before the fix.