### PR TITLE
meson: Fix deprecated build warnings on build options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,18 +190,23 @@ matrix:
       compiler: clang
       install:
         - sudo apt-get install -qq liblz4-dev valgrind tree
-        - travis_retry curl -o ~/ninja.zip -L 'https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip'
-            && unzip ~/ninja.zip -d ~/.local/bin
-        - travis_retry curl -o ~/get-pip.py -L 'https://bootstrap.pypa.io/get-pip.py'
-            && python3 ~/get-pip.py --user
-            && pip3 install --user meson
+        - |
+          travis_retry curl -o ~/ninja.zip -L 'https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip' &&
+          unzip ~/ninja.zip -d ~/.local/bin
+        - |
+          travis_retry curl -o ~/get-pip.py -L 'https://bootstrap.pypa.io/get-pip.py' &&
+          python3 ~/get-pip.py --user &&
+          pip3 install --user meson
       script:
-        - meson setup
-            --buildtype=debugoptimized
-            -Db_lundef=false
-            -Dauto_features=enabled
-            -Dbuild_{programs,tests,contrib}=true
-            -Ddefault_library=both
+        - |
+          meson setup \
+            --buildtype=debugoptimized \
+            -Db_lundef=false \
+            -Dauto_features=enabled \
+            -Dbuild_programs=true \
+            -Dbuild_tests=true \
+            -Dbuild_contrib=true \
+            -Ddefault_library=both \
              build/meson builddir
         - pushd builddir
         - ninja

--- a/.travis.yml
+++ b/.travis.yml
@@ -203,9 +203,9 @@ matrix:
             --buildtype=debugoptimized \
             -Db_lundef=false \
             -Dauto_features=enabled \
-            -Dbuild_programs=true \
-            -Dbuild_tests=true \
-            -Dbuild_contrib=true \
+            -Dbin_programs=true \
+            -Dbin_tests=true \
+            -Dbin_contrib=true \
             -Ddefault_library=both \
              build/meson builddir
         - pushd builddir

--- a/build/meson/README.md
+++ b/build/meson/README.md
@@ -17,7 +17,7 @@ It outputs one `libzstd`, either shared or static, depending on
 `cd` to this meson directory (`build/meson`)
 
 ```sh
-meson --buildtype=release -Dbuild_{programs,contrib}=true builddir
+meson setup -Dbin_programs=true -Dbin_contrib=true builddir
 cd builddir
 ninja             # to build
 ninja install     # to install

--- a/build/meson/contrib/gen_html/meson.build
+++ b/build/meson/contrib/gen_html/meson.build
@@ -17,6 +17,7 @@ gen_html_includes = include_directories(join_paths(zstd_rootdir, 'programs'),
 gen_html = executable('gen_html',
   join_paths(zstd_rootdir, 'contrib/gen_html/gen_html.cpp'),
   include_directories: gen_html_includes,
+  native: true,
   install: false)
 
 # Update zstd manual

--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -75,9 +75,9 @@ legacy_level = get_option('legacy_level')
 use_backtrace = get_option('backtrace')
 use_static_runtime = get_option('static_runtime')
 
-build_programs = get_option('build_programs')
-build_contrib = get_option('build_contrib')
-build_tests = get_option('build_tests')
+bin_programs = get_option('bin_programs')
+bin_contrib = get_option('bin_contrib')
+bin_tests = get_option('bin_tests')
 
 feature_multi_thread = get_option('multi_thread')
 feature_zlib = get_option('zlib')
@@ -88,7 +88,7 @@ feature_lz4 = get_option('lz4')
 # Dependencies
 # =============================================================================
 
-libm_dep = cc.find_library('m', required: build_tests)
+libm_dep = cc.find_library('m', required: bin_tests)
 thread_dep = dependency('threads', required: feature_multi_thread)
 use_multi_thread = thread_dep.found()
 # Arguments in dependency should be equivalent to those passed to pkg-config
@@ -133,14 +133,14 @@ endif
 
 subdir('lib')
 
-if build_programs
+if bin_programs
   subdir('programs')
 endif
 
-if build_tests
+if bin_tests
   subdir('tests')
 endif
 
-if build_contrib
+if bin_contrib
   subdir('contrib')
 endif

--- a/build/meson/meson_options.txt
+++ b/build/meson/meson_options.txt
@@ -19,11 +19,11 @@ option('backtrace', type: 'boolean', value: false,
 option('static_runtime', type: 'boolean', value: false,
   description: 'Link to static run-time libraries on MSVC')
 
-option('build_programs', type: 'boolean', value: true,
+option('bin_programs', type: 'boolean', value: true,
   description: 'Enable programs build')
-option('build_tests', type: 'boolean', value: false,
+option('bin_tests', type: 'boolean', value: false,
   description: 'Enable tests build')
-option('build_contrib', type: 'boolean', value: false,
+option('bin_contrib', type: 'boolean', value: false,
   description: 'Enable contrib build')
 
 option('multi_thread', type: 'feature', value: 'enabled',


### PR DESCRIPTION
Meson now reserves the `build_` prefix for options.