### PR TITLE
[fuzz] Add a compression fuzzer with randomly sized output buffer

### DIFF
--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -72,7 +72,8 @@ FUZZ_TARGETS :=       \
 	block_decompress  \
 	dictionary_round_trip \
 	dictionary_decompress \
-	zstd_frame_info
+	zstd_frame_info \
+	simple_compress
 
 all: $(FUZZ_TARGETS)
 
@@ -102,6 +103,9 @@ dictionary_round_trip: $(FUZZ_HEADERS) $(FUZZ_OBJ) dictionary_round_trip.o
 
 dictionary_decompress: $(FUZZ_HEADERS) $(FUZZ_OBJ) dictionary_decompress.o
 	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_OBJ) dictionary_decompress.o $(LIB_FUZZING_ENGINE) -o $@
+
+simple_compress: $(FUZZ_HEADERS) $(FUZZ_OBJ) simple_compress.o
+	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_OBJ) simple_compress.o $(LIB_FUZZING_ENGINE) -o $@
 
 zstd_frame_info: $(FUZZ_HEADERS) $(FUZZ_OBJ) zstd_frame_info.o
 	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_OBJ) zstd_frame_info.o $(LIB_FUZZING_ENGINE) -o $@
@@ -139,7 +143,9 @@ clean:
 	@$(MAKE) -C $(ZSTDDIR) clean
 	@$(RM) *.a *.o
 	@$(RM) simple_round_trip stream_round_trip simple_decompress \
-           stream_decompress block_decompress block_round_trip
+           stream_decompress block_decompress block_round_trip \
+           simple_compress dictionary_round_trip dictionary_decompress \
+           zstd_frame_info
 
 cleanall:
 	@$(RM) -r Fuzzer

--- a/tests/fuzz/fuzz.py
+++ b/tests/fuzz/fuzz.py
@@ -37,6 +37,7 @@ TARGETS = [
     'dictionary_round_trip',
     'dictionary_decompress',
     'zstd_frame_info',
+    'simple_compress',
 ]
 ALL_TARGETS = TARGETS + ['all']
 FUZZ_RNG_SEED_SIZE = 4

--- a/tests/fuzz/simple_compress.c
+++ b/tests/fuzz/simple_compress.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ */
+
+/**
+ * This fuzz target attempts to comprss the fuzzed data with the simple
+ * compression function with an output buffer that may be too small to
+ * ensure that the compressor never crashes.
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "fuzz_helpers.h"
+#include "zstd.h"
+
+static ZSTD_CCtx *cctx = NULL;
+
+int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
+{
+    uint32_t seed = FUZZ_seed(&src, &size);
+    size_t const maxSize = ZSTD_compressBound(size);
+    int i;
+    if (!cctx) {
+        cctx = ZSTD_createCCtx();
+        FUZZ_ASSERT(cctx);
+    }
+    /* Run it 10 times over 10 output sizes. Reuse the context. */
+    for (i = 0; i < 10; ++i) {
+        int const level = (int)FUZZ_rand32(&seed, 0, 19 + 3) - 3; /* [-3, 19] */
+        size_t const bufSize = FUZZ_rand32(&seed, 0, maxSize);
+        void* rBuf = malloc(bufSize);
+        FUZZ_ASSERT(rBuf);
+        ZSTD_compressCCtx(cctx, rBuf, bufSize, src, size, level);
+        free(rBuf);
+    }
+
+#ifndef STATEFUL_FUZZING
+    ZSTD_freeCCtx(cctx); cctx = NULL;
+#endif
+    return 0;
+}


### PR DESCRIPTION
We were missing coverage of compression with a too-small output buffer.

This fuzzer catches the bug fixed by https://github.com/facebook/zstd/pull/1404 (with the fix removed) in an hour or two of CPU time. The same bug took the unguided `fuzzer.c` fuzzer months or years of CPU time to find.