### PR TITLE
fix gitignore errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 
 # Executables
 zstd
+!build/VS2008/zstd
+!build/VS2010/zstd
+!contrib/VS2005/zstd
 zstdmt
 *.exe
 *.out
@@ -23,6 +26,10 @@ zstdmt
 # Test artefacts
 tmp*
 dictionary*
+!examples/dictionary_compression.c
+!examples/dictionary_decompression.c
+!tests/fuzz/dictionary_decompress.c
+!tests/fuzz/dictionary_round_trip.c
 NUL
 
 # Build artefacts

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -29,3 +29,5 @@ compile_commands.json
 CTestTestfile.cmake
 build
 lib
+!cmake/lib
+!meson/lib

--- a/programs/.gitignore
+++ b/programs/.gitignore
@@ -33,4 +33,5 @@ afl
 
 # Misc files
 *.bat
+!windres/generate_res.bat
 dirTest*

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -55,6 +55,7 @@ _*
 tmp*
 *.zst
 *.gz
+!gzip/hufts-segv.gz
 result
 out
 *.zstd

--- a/zlibWrapper/.gitignore
+++ b/zlibWrapper/.gitignore
@@ -1,11 +1,14 @@
 # Default result files
 _*
 example.*
+!examples/example.c
 example_zstd.*
 example_gz.*
 fitblk.*
+!examples/fitblk.c
 fitblk_zstd.*
 zwrapbench.*
+!examples/zwrapbench.c
 foo.gz
 
 minigzip


### PR DESCRIPTION
Some files are ignored by some .gitignore rules. These files should be exclude from gitignore

Ignored files:
`build/VS2008/zstd/`
`build/VS2010/zstd/`
`build/cmake/lib/`
`build/meson/lib/`
`contrib/VS2005/zstd/`
`examples/dictionary_compression.c`
`examples/dictionary_decompression.c`
`mygittestproject.zip`
`programs/windres/generate_res.bat`
`tests/fuzz/dictionary_decompress.c`
`tests/fuzz/dictionary_round_trip.c`
`tests/gzip/hufts-segv.gz`
`zlibWrapper/examples/example.c`
`zlibWrapper/examples/fitblk.c`
`zlibWrapper/examples/zwrapbench.c`
