### PR TITLE
[ldm] Fix bug in overflow correction with large job size

### DIFF
--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -447,7 +447,7 @@ size_t ZSTD_ldm_generateSequences(
         if (ZSTD_window_needOverflowCorrection(ldmState->window, chunkEnd)) {
             U32 const ldmHSize = 1U << params->hashLog;
             U32 const correction = ZSTD_window_correctOverflow(
-                &ldmState->window, /* cycleLog */ 0, maxDist, src);
+                &ldmState->window, /* cycleLog */ 0, maxDist, chunkStart);
             ZSTD_ldm_reduceTable(ldmState->hashTable, ldmHSize, correction);
         }
         /* 2. We enforce the maximum offset allowed.

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -50,6 +50,7 @@
 #ifndef ZSTDMT_JOBSIZE_MIN
 #  define ZSTDMT_JOBSIZE_MIN (1 MB)
 #endif
+#define ZSTDMT_JOBLOG_MAX   (MEM_32bits() ? 29 : 30)
 #define ZSTDMT_JOBSIZE_MAX  (MEM_32bits() ? (512 MB) : (1024 MB))
 
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -974,6 +974,10 @@ then
     roundTripTest -g500000000 -P97 "1 -T999" " "
     fileRoundTripTest -g4103M -P98 " -T0" " "
     roundTripTest -g400000000 -P97 "1 --long=24 -T2" " "
+    # Exposes the bug in https://github.com/facebook/zstd/pull/1678
+    # This test fails on 4 different travis builds at the time of writing
+    # because it needs to allocate 8 GB of memory.
+    # roundTripTest -g10G -P99 "1 -T1 --long=31 --zstd=clog=27 --fast=1000"
 else
     println "\n**** no multithreading, skipping zstdmt tests **** "
 fi


### PR DESCRIPTION
`src` is the wrong pointer here. When the job size is 2GB the second job does overflow correction, but `src - base == 2 GB` for every chunk. When we do overflow correction we get `current & cycleLog + maxDist == 2 GB & 2^26 + 2 GB == 2 GB`, meaning we effectively never do overflow correction that job. Then the next job we overflow, and things go terribly wrong.

Instead, we need to pass the beginning of the current chunk, which is only 1 MB large and is well under the maximum chunk size of 512 MB.

There are asserts that failed before this change, and don't fail after, but I accidentally defined the wrong macro during the build for my initial tests.

The test I added to `playTests.sh` has assertion failures and produces corrupted data before this change. The test I added to `zstreamtest.c` doesn't fail before the change, but exercises the max job size and window log which is useful.

Fixes #1672.