### PR TITLE
updated double_fast complementary insertion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 *.dylib
 
 # Executables
-zstd.
+/zstd
 zstdmt
 *.exe
 *.out

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -254,11 +254,23 @@ _match_stored:
         anchor = ip;
 
         if (ip <= ilimit) {
-            /* Fill Table */
-            hashLong[ZSTD_hashPtr(base+current+2, hBitsL, 8)] =
-                hashSmall[ZSTD_hashPtr(base+current+2, hBitsS, mls)] = current+2;  /* here because current+2 could be > iend-8 */
-            hashLong[ZSTD_hashPtr(ip-2, hBitsL, 8)] =
-                hashSmall[ZSTD_hashPtr(ip-2, hBitsS, mls)] = (U32)(ip-2-base);
+            /* Complementary insertion */
+            /* done after iLimit test, as candidates could be > iend-8 */
+            {   U32 const indexToInsert = current+2;
+                hashLong[ZSTD_hashPtr(base+indexToInsert, hBitsL, 8)] =
+                    hashSmall[ZSTD_hashPtr(base+indexToInsert, hBitsS, mls)] =
+                        indexToInsert;
+            }
+            {   const BYTE* const ipToInsert = ip - 2;
+                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
+                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
+                        (U32)(ipToInsert-base);
+            }
+            {   const BYTE* const ipToInsert = ip - 1;
+                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
+                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
+                        (U32)(ipToInsert-base);
+            }
 
             /* check immediate repcode */
             if (dictMode == ZSTD_dictMatchState) {
@@ -452,16 +464,28 @@ static size_t ZSTD_compressBlock_doubleFast_extDict_generic(
                 continue;
         }   }
 
-        /* found a match : store it */
+        /* move to next sequence start */
         ip += mLength;
         anchor = ip;
 
         if (ip <= ilimit) {
-            /* Fill Table */
-            hashSmall[ZSTD_hashPtr(base+current+2, hBitsS, mls)] = current+2;
-            hashLong[ZSTD_hashPtr(base+current+2, hBitsL, 8)] = current+2;
-            hashSmall[ZSTD_hashPtr(ip-2, hBitsS, mls)] = (U32)(ip-2-base);
-            hashLong[ZSTD_hashPtr(ip-2, hBitsL, 8)] = (U32)(ip-2-base);
+            /* Complementary insertion */
+            /* done after iLimit test, as candidates could be > iend-8 */
+            {   U32 const indexToInsert = current+2;
+                hashLong[ZSTD_hashPtr(base+indexToInsert, hBitsL, 8)] =
+                    hashSmall[ZSTD_hashPtr(base+indexToInsert, hBitsS, mls)] =
+                        indexToInsert;
+            }
+            {   const BYTE* const ipToInsert = ip - 2;
+                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
+                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
+                        (U32)(ipToInsert-base);
+            }
+            {   const BYTE* const ipToInsert = ip - 1;
+                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
+                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
+                        (U32)(ipToInsert-base);
+            }
             /* check immediate repcode */
             while (ip <= ilimit) {
                 U32 const current2 = (U32)(ip-base);

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -257,19 +257,10 @@ _match_stored:
             /* Complementary insertion */
             /* done after iLimit test, as candidates could be > iend-8 */
             {   U32 const indexToInsert = current+2;
-                hashLong[ZSTD_hashPtr(base+indexToInsert, hBitsL, 8)] =
-                    hashSmall[ZSTD_hashPtr(base+indexToInsert, hBitsS, mls)] =
-                        indexToInsert;
-            }
-            {   const BYTE* const ipToInsert = ip - 2;
-                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
-                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
-                        (U32)(ipToInsert-base);
-            }
-            {   const BYTE* const ipToInsert = ip - 1;
-                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
-                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
-                        (U32)(ipToInsert-base);
+                hashLong[ZSTD_hashPtr(base+indexToInsert, hBitsL, 8)] = indexToInsert;
+                hashLong[ZSTD_hashPtr(ip-2, hBitsL, 8)] = (U32)(ip-2-base);
+                hashSmall[ZSTD_hashPtr(base+indexToInsert, hBitsS, mls)] = indexToInsert;
+                hashSmall[ZSTD_hashPtr(ip-1, hBitsS, mls)] = (U32)(ip-1-base);
             }
 
             /* check immediate repcode */

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -463,20 +463,12 @@ static size_t ZSTD_compressBlock_doubleFast_extDict_generic(
             /* Complementary insertion */
             /* done after iLimit test, as candidates could be > iend-8 */
             {   U32 const indexToInsert = current+2;
-                hashLong[ZSTD_hashPtr(base+indexToInsert, hBitsL, 8)] =
-                    hashSmall[ZSTD_hashPtr(base+indexToInsert, hBitsS, mls)] =
-                        indexToInsert;
+                hashLong[ZSTD_hashPtr(base+indexToInsert, hBitsL, 8)] = indexToInsert;
+                hashLong[ZSTD_hashPtr(ip-2, hBitsL, 8)] = (U32)(ip-2-base);
+                hashSmall[ZSTD_hashPtr(base+indexToInsert, hBitsS, mls)] = indexToInsert;
+                hashSmall[ZSTD_hashPtr(ip-1, hBitsS, mls)] = (U32)(ip-1-base);
             }
-            {   const BYTE* const ipToInsert = ip - 2;
-                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
-                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
-                        (U32)(ipToInsert-base);
-            }
-            {   const BYTE* const ipToInsert = ip - 1;
-                hashLong[ZSTD_hashPtr(ipToInsert, hBitsL, 8)] =
-                    hashSmall[ZSTD_hashPtr(ipToInsert, hBitsS, mls)] =
-                        (U32)(ipToInsert-base);
-            }
+
             /* check immediate repcode */
             while (ip <= ilimit) {
                 U32 const current2 = (U32)(ip-base);


### PR DESCRIPTION
in a way which is more favorable to compression ratio, though slightly slower.

Detailed benchmark :
core i7-9700k (disabled turboboost), Ubuntu x64 19.04, `gcc` v8.3.0 : 

| filename | `dev` ratio | this patch | improv | c.speed | d.speed |
| --- | --- | --- | --- | --- | --- |
| silesia.tar | 3.173 | 3.188 | +0.47% |  -1.9% | +0.28% |
| calgary.tar | 3.075 | 3.098  | +0.75% | -1.5% | +0.60% |
| dickens | 2.767 | 2.789 | +0.79% | -2.2% | +1.13% |
| mozilla | 2.767 | 2.768 | +0.04% | -2.5% | +0.02% |
| xml | 8.364 | 8.407 | +0.51% | -2.1% | +0.01% |
| book2 | 2.976 | 3.008 | +1.08 % | -1.5% | +0.00% |
| progc | 2.785 | 2.804 | +0.68% | -2.6% | +0.32% |
| enwik8 | 2.806 | 2.826 | +0.71% | -1.5% | +0.80% |

Note : I must re-run speed tests, as it seems there is enough difference between cores to deserve pinning all measurements to the same core, for proper comparison.

_edit_ : completed speed measurements.
