### PR TITLE
Fix #1682 Maybe there is a redundant command when execute the make test command. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,7 @@ zlibwrapper: lib
 
 ## test: run long-duration tests
 .PHONY: test
-DEBUGLEVEL ?= 1
-test: MOREFLAGS += -g -DDEBUGLEVEL=$(DEBUGLEVEL) -Werror
 test:
-	MOREFLAGS="$(MOREFLAGS)" $(MAKE) -j -C $(PRGDIR) allVariants
 	$(MAKE) -C $(TESTDIR) $@
 
 ## shortest: same as `make check`


### PR DESCRIPTION
When execute the make test command,will generate twice of the following targets:zstdcli.o、util.o、timefn.o、fileio.o、benchfn.o、benchzstd.o、datagen.o、dibio.o、zstd. 

When  add -fprofile-arcs -ftest-coverage compile option to count code coverage，execute the make test and collect coverage data will report errors like
```
Processing xxx.gcda
xxx.gcda:stamp mismatch with graph file
geninfo: WARNING: gcov did not create any files for xxx.gcda!
```
So remove the redundant  command to fix it.