### PR TITLE
[regression] Update results for ZSTD_double_fast update

### DIFF
--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -2,10 +2,10 @@ Data,                               Config,                             Method, 
 silesia.tar,                        level -5,                           compress simple,                    6738558
 silesia.tar,                        level -3,                           compress simple,                    6446362
 silesia.tar,                        level -1,                           compress simple,                    6186038
-silesia.tar,                        level 0,                            compress simple,                    4875008
+silesia.tar,                        level 0,                            compress simple,                    4861374
 silesia.tar,                        level 1,                            compress simple,                    5334825
-silesia.tar,                        level 3,                            compress simple,                    4875008
-silesia.tar,                        level 4,                            compress simple,                    4813507
+silesia.tar,                        level 3,                            compress simple,                    4861374
+silesia.tar,                        level 4,                            compress simple,                    4799583
 silesia.tar,                        level 5,                            compress simple,                    4722271
 silesia.tar,                        level 6,                            compress simple,                    4672231
 silesia.tar,                        level 7,                            compress simple,                    4606657
@@ -13,16 +13,16 @@ silesia.tar,                        level 9,                            compress
 silesia.tar,                        level 13,                           compress simple,                    4491706
 silesia.tar,                        level 16,                           compress simple,                    4381265
 silesia.tar,                        level 19,                           compress simple,                    4281551
-silesia.tar,                        uncompressed literals,              compress simple,                    4875008
+silesia.tar,                        uncompressed literals,              compress simple,                    4861374
 silesia.tar,                        uncompressed literals optimal,      compress simple,                    4281551
 silesia.tar,                        huffman literals,                   compress simple,                    6186038
 silesia,                            level -5,                           compress cctx,                      6737567
 silesia,                            level -3,                           compress cctx,                      6444663
 silesia,                            level -1,                           compress cctx,                      6178442
-silesia,                            level 0,                            compress cctx,                      4862377
+silesia,                            level 0,                            compress cctx,                      4849491
 silesia,                            level 1,                            compress cctx,                      5313144
-silesia,                            level 3,                            compress cctx,                      4862377
-silesia,                            level 4,                            compress cctx,                      4800629
+silesia,                            level 3,                            compress cctx,                      4849491
+silesia,                            level 4,                            compress cctx,                      4786913
 silesia,                            level 5,                            compress cctx,                      4710178
 silesia,                            level 6,                            compress cctx,                      4659996
 silesia,                            level 7,                            compress cctx,                      4596234
@@ -30,31 +30,31 @@ silesia,                            level 9,                            compress
 silesia,                            level 13,                           compress cctx,                      4482073
 silesia,                            level 16,                           compress cctx,                      4377389
 silesia,                            level 19,                           compress cctx,                      4293262
-silesia,                            long distance mode,                 compress cctx,                      4862377
-silesia,                            multithreaded,                      compress cctx,                      4862377
-silesia,                            multithreaded long distance mode,   compress cctx,                      4862377
-silesia,                            small window log,                   compress cctx,                      7115734
+silesia,                            long distance mode,                 compress cctx,                      4849491
+silesia,                            multithreaded,                      compress cctx,                      4849491
+silesia,                            multithreaded long distance mode,   compress cctx,                      4849491
+silesia,                            small window log,                   compress cctx,                      7112784
 silesia,                            small hash log,                     compress cctx,                      6554898
 silesia,                            small chain log,                    compress cctx,                      4931093
 silesia,                            explicit params,                    compress cctx,                      4794609
-silesia,                            uncompressed literals,              compress cctx,                      4862377
+silesia,                            uncompressed literals,              compress cctx,                      4849491
 silesia,                            uncompressed literals optimal,      compress cctx,                      4293262
 silesia,                            huffman literals,                   compress cctx,                      6178442
-silesia,                            multithreaded with advanced params, compress cctx,                      4862377
+silesia,                            multithreaded with advanced params, compress cctx,                      4849491
 github,                             level -5,                           compress cctx,                      205285
 github,                             level -5 with dict,                 compress cctx,                      47294
 github,                             level -3,                           compress cctx,                      190643
 github,                             level -3 with dict,                 compress cctx,                      48047
 github,                             level -1,                           compress cctx,                      175568
 github,                             level -1 with dict,                 compress cctx,                      43527
-github,                             level 0,                            compress cctx,                      136397
-github,                             level 0 with dict,                  compress cctx,                      41536
+github,                             level 0,                            compress cctx,                      136311
+github,                             level 0 with dict,                  compress cctx,                      41534
 github,                             level 1,                            compress cctx,                      142450
 github,                             level 1 with dict,                  compress cctx,                      42157
-github,                             level 3,                            compress cctx,                      136397
-github,                             level 3 with dict,                  compress cctx,                      41536
+github,                             level 3,                            compress cctx,                      136311
+github,                             level 3 with dict,                  compress cctx,                      41534
 github,                             level 4,                            compress cctx,                      136144
-github,                             level 4 with dict,                  compress cctx,                      41721
+github,                             level 4 with dict,                  compress cctx,                      41725
 github,                             level 5,                            compress cctx,                      135106
 github,                             level 5 with dict,                  compress cctx,                      38934
 github,                             level 6,                            compress cctx,                      135108
@@ -69,24 +69,24 @@ github,                             level 16,                           compress
 github,                             level 16 with dict,                 compress cctx,                      37568
 github,                             level 19,                           compress cctx,                      133717
 github,                             level 19 with dict,                 compress cctx,                      37567
-github,                             long distance mode,                 compress cctx,                      141473
-github,                             multithreaded,                      compress cctx,                      141473
-github,                             multithreaded long distance mode,   compress cctx,                      141473
-github,                             small window log,                   compress cctx,                      141473
+github,                             long distance mode,                 compress cctx,                      141101
+github,                             multithreaded,                      compress cctx,                      141101
+github,                             multithreaded long distance mode,   compress cctx,                      141101
+github,                             small window log,                   compress cctx,                      141101
 github,                             small hash log,                     compress cctx,                      138943
 github,                             small chain log,                    compress cctx,                      139239
 github,                             explicit params,                    compress cctx,                      140924
-github,                             uncompressed literals,              compress cctx,                      136397
+github,                             uncompressed literals,              compress cctx,                      136311
 github,                             uncompressed literals optimal,      compress cctx,                      133717
 github,                             huffman literals,                   compress cctx,                      175568
-github,                             multithreaded with advanced params, compress cctx,                      141473
+github,                             multithreaded with advanced params, compress cctx,                      141101
 silesia,                            level -5,                           zstdcli,                            6882514
 silesia,                            level -3,                           zstdcli,                            6568406
 silesia,                            level -1,                           zstdcli,                            6183433
-silesia,                            level 0,                            zstdcli,                            4862425
+silesia,                            level 0,                            zstdcli,                            4849539
 silesia,                            level 1,                            zstdcli,                            5314157
-silesia,                            level 3,                            zstdcli,                            4862425
-silesia,                            level 4,                            zstdcli,                            4800677
+silesia,                            level 3,                            zstdcli,                            4849539
+silesia,                            level 4,                            zstdcli,                            4786961
 silesia,                            level 5,                            zstdcli,                            4710226
 silesia,                            level 6,                            zstdcli,                            4660044
 silesia,                            level 7,                            zstdcli,                            4596282
@@ -94,24 +94,24 @@ silesia,                            level 9,                            zstdcli,
 silesia,                            level 13,                           zstdcli,                            4482121
 silesia,                            level 16,                           zstdcli,                            4377437
 silesia,                            level 19,                           zstdcli,                            4293310
-silesia,                            long distance mode,                 zstdcli,                            4853437
-silesia,                            multithreaded,                      zstdcli,                            4862425
-silesia,                            multithreaded long distance mode,   zstdcli,                            4853437
-silesia,                            small window log,                   zstdcli,                            7126434
+silesia,                            long distance mode,                 zstdcli,                            4839698
+silesia,                            multithreaded,                      zstdcli,                            4849539
+silesia,                            multithreaded long distance mode,   zstdcli,                            4839698
+silesia,                            small window log,                   zstdcli,                            7123892
 silesia,                            small hash log,                     zstdcli,                            6554946
 silesia,                            small chain log,                    zstdcli,                            4931141
 silesia,                            explicit params,                    zstdcli,                            4797048
-silesia,                            uncompressed literals,              zstdcli,                            5155472
+silesia,                            uncompressed literals,              zstdcli,                            5128008
 silesia,                            uncompressed literals optimal,      zstdcli,                            4325482
 silesia,                            huffman literals,                   zstdcli,                            5331158
-silesia,                            multithreaded with advanced params, zstdcli,                            5155472
+silesia,                            multithreaded with advanced params, zstdcli,                            5128008
 silesia.tar,                        level -5,                           zstdcli,                            6738906
 silesia.tar,                        level -3,                           zstdcli,                            6448409
 silesia.tar,                        level -1,                           zstdcli,                            6186908
-silesia.tar,                        level 0,                            zstdcli,                            4875136
+silesia.tar,                        level 0,                            zstdcli,                            4861462
 silesia.tar,                        level 1,                            zstdcli,                            5336255
-silesia.tar,                        level 3,                            zstdcli,                            4875136
-silesia.tar,                        level 4,                            zstdcli,                            4814531
+silesia.tar,                        level 3,                            zstdcli,                            4861462
+silesia.tar,                        level 4,                            zstdcli,                            4800482
 silesia.tar,                        level 5,                            zstdcli,                            4723312
 silesia.tar,                        level 6,                            zstdcli,                            4673616
 silesia.tar,                        level 7,                            zstdcli,                            4608346
@@ -119,32 +119,32 @@ silesia.tar,                        level 9,                            zstdcli,
 silesia.tar,                        level 13,                           zstdcli,                            4491710
 silesia.tar,                        level 16,                           zstdcli,                            4381269
 silesia.tar,                        level 19,                           zstdcli,                            4281555
-silesia.tar,                        no source size,                     zstdcli,                            4875132
-silesia.tar,                        long distance mode,                 zstdcli,                            4866975
-silesia.tar,                        multithreaded,                      zstdcli,                            4875136
-silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4866975
-silesia.tar,                        small window log,                   zstdcli,                            7130434
+silesia.tar,                        no source size,                     zstdcli,                            4861458
+silesia.tar,                        long distance mode,                 zstdcli,                            4853140
+silesia.tar,                        multithreaded,                      zstdcli,                            4861462
+silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4853140
+silesia.tar,                        small window log,                   zstdcli,                            7127964
 silesia.tar,                        small hash log,                     zstdcli,                            6587841
 silesia.tar,                        small chain log,                    zstdcli,                            4943269
 silesia.tar,                        explicit params,                    zstdcli,                            4822318
-silesia.tar,                        uncompressed literals,              zstdcli,                            5158134
+silesia.tar,                        uncompressed literals,              zstdcli,                            5129548
 silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4320914
 silesia.tar,                        huffman literals,                   zstdcli,                            5347560
-silesia.tar,                        multithreaded with advanced params, zstdcli,                            5158134
+silesia.tar,                        multithreaded with advanced params, zstdcli,                            5129548
 github,                             level -5,                           zstdcli,                            207285
 github,                             level -5 with dict,                 zstdcli,                            48718
 github,                             level -3,                           zstdcli,                            192643
 github,                             level -3 with dict,                 zstdcli,                            47395
 github,                             level -1,                           zstdcli,                            177568
 github,                             level -1 with dict,                 zstdcli,                            45170
-github,                             level 0,                            zstdcli,                            138397
-github,                             level 0 with dict,                  zstdcli,                            43170
+github,                             level 0,                            zstdcli,                            138311
+github,                             level 0 with dict,                  zstdcli,                            43148
 github,                             level 1,                            zstdcli,                            144450
 github,                             level 1 with dict,                  zstdcli,                            43682
-github,                             level 3,                            zstdcli,                            138397
-github,                             level 3 with dict,                  zstdcli,                            43170
+github,                             level 3,                            zstdcli,                            138311
+github,                             level 3 with dict,                  zstdcli,                            43148
 github,                             level 4,                            zstdcli,                            138144
-github,                             level 4 with dict,                  zstdcli,                            43306
+github,                             level 4 with dict,                  zstdcli,                            43251
 github,                             level 5,                            zstdcli,                            137106
 github,                             level 5 with dict,                  zstdcli,                            40938
 github,                             level 6,                            zstdcli,                            137108
@@ -159,24 +159,24 @@ github,                             level 16,                           zstdcli,
 github,                             level 16 with dict,                 zstdcli,                            39577
 github,                             level 19,                           zstdcli,                            135717
 github,                             level 19 with dict,                 zstdcli,                            39576
-github,                             long distance mode,                 zstdcli,                            138397
-github,                             multithreaded,                      zstdcli,                            138397
-github,                             multithreaded long distance mode,   zstdcli,                            138397
-github,                             small window log,                   zstdcli,                            138397
+github,                             long distance mode,                 zstdcli,                            138311
+github,                             multithreaded,                      zstdcli,                            138311
+github,                             multithreaded long distance mode,   zstdcli,                            138311
+github,                             small window log,                   zstdcli,                            138311
 github,                             small hash log,                     zstdcli,                            137467
 github,                             small chain log,                    zstdcli,                            138314
 github,                             explicit params,                    zstdcli,                            136140
-github,                             uncompressed literals,              zstdcli,                            169004
+github,                             uncompressed literals,              zstdcli,                            167915
 github,                             uncompressed literals optimal,      zstdcli,                            158824
 github,                             huffman literals,                   zstdcli,                            144450
-github,                             multithreaded with advanced params, zstdcli,                            169004
+github,                             multithreaded with advanced params, zstdcli,                            167915
 silesia,                            level -5,                           advanced one pass,                  6737567
 silesia,                            level -3,                           advanced one pass,                  6444663
 silesia,                            level -1,                           advanced one pass,                  6178442
-silesia,                            level 0,                            advanced one pass,                  4862377
+silesia,                            level 0,                            advanced one pass,                  4849491
 silesia,                            level 1,                            advanced one pass,                  5313144
-silesia,                            level 3,                            advanced one pass,                  4862377
-silesia,                            level 4,                            advanced one pass,                  4800629
+silesia,                            level 3,                            advanced one pass,                  4849491
+silesia,                            level 4,                            advanced one pass,                  4786913
 silesia,                            level 5,                            advanced one pass,                  4710178
 silesia,                            level 6,                            advanced one pass,                  4659996
 silesia,                            level 7,                            advanced one pass,                  4596234
@@ -184,25 +184,25 @@ silesia,                            level 9,                            advanced
 silesia,                            level 13,                           advanced one pass,                  4482073
 silesia,                            level 16,                           advanced one pass,                  4377389
 silesia,                            level 19,                           advanced one pass,                  4293262
-silesia,                            no source size,                     advanced one pass,                  4862377
-silesia,                            long distance mode,                 advanced one pass,                  4853389
-silesia,                            multithreaded,                      advanced one pass,                  4862377
-silesia,                            multithreaded long distance mode,   advanced one pass,                  4853389
-silesia,                            small window log,                   advanced one pass,                  7126386
+silesia,                            no source size,                     advanced one pass,                  4849491
+silesia,                            long distance mode,                 advanced one pass,                  4839650
+silesia,                            multithreaded,                      advanced one pass,                  4849491
+silesia,                            multithreaded long distance mode,   advanced one pass,                  4839650
+silesia,                            small window log,                   advanced one pass,                  7123844
 silesia,                            small hash log,                     advanced one pass,                  6554898
 silesia,                            small chain log,                    advanced one pass,                  4931093
 silesia,                            explicit params,                    advanced one pass,                  4797035
-silesia,                            uncompressed literals,              advanced one pass,                  5155424
+silesia,                            uncompressed literals,              advanced one pass,                  5127960
 silesia,                            uncompressed literals optimal,      advanced one pass,                  4325434
 silesia,                            huffman literals,                   advanced one pass,                  5326210
-silesia,                            multithreaded with advanced params, advanced one pass,                  5155424
+silesia,                            multithreaded with advanced params, advanced one pass,                  5127960
 silesia.tar,                        level -5,                           advanced one pass,                  6738558
 silesia.tar,                        level -3,                           advanced one pass,                  6446362
 silesia.tar,                        level -1,                           advanced one pass,                  6186038
-silesia.tar,                        level 0,                            advanced one pass,                  4875008
+silesia.tar,                        level 0,                            advanced one pass,                  4861374
 silesia.tar,                        level 1,                            advanced one pass,                  5334825
-silesia.tar,                        level 3,                            advanced one pass,                  4875008
-silesia.tar,                        level 4,                            advanced one pass,                  4813507
+silesia.tar,                        level 3,                            advanced one pass,                  4861374
+silesia.tar,                        level 4,                            advanced one pass,                  4799583
 silesia.tar,                        level 5,                            advanced one pass,                  4722271
 silesia.tar,                        level 6,                            advanced one pass,                  4672231
 silesia.tar,                        level 7,                            advanced one pass,                  4606657
@@ -210,32 +210,32 @@ silesia.tar,                        level 9,                            advanced
 silesia.tar,                        level 13,                           advanced one pass,                  4491706
 silesia.tar,                        level 16,                           advanced one pass,                  4381265
 silesia.tar,                        level 19,                           advanced one pass,                  4281551
-silesia.tar,                        no source size,                     advanced one pass,                  4875008
-silesia.tar,                        long distance mode,                 advanced one pass,                  4861218
-silesia.tar,                        multithreaded,                      advanced one pass,                  4874631
-silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4860683
-silesia.tar,                        small window log,                   advanced one pass,                  7130394
+silesia.tar,                        no source size,                     advanced one pass,                  4861374
+silesia.tar,                        long distance mode,                 advanced one pass,                  4848046
+silesia.tar,                        multithreaded,                      advanced one pass,                  4860726
+silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4847343
+silesia.tar,                        small window log,                   advanced one pass,                  7127924
 silesia.tar,                        small hash log,                     advanced one pass,                  6587833
 silesia.tar,                        small chain log,                    advanced one pass,                  4943266
 silesia.tar,                        explicit params,                    advanced one pass,                  4808543
-silesia.tar,                        uncompressed literals,              advanced one pass,                  5157992
+silesia.tar,                        uncompressed literals,              advanced one pass,                  5129447
 silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4320910
 silesia.tar,                        huffman literals,                   advanced one pass,                  5347283
-silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5158545
+silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5129766
 github,                             level -5,                           advanced one pass,                  205285
 github,                             level -5 with dict,                 advanced one pass,                  46718
 github,                             level -3,                           advanced one pass,                  190643
 github,                             level -3 with dict,                 advanced one pass,                  45395
 github,                             level -1,                           advanced one pass,                  175568
 github,                             level -1 with dict,                 advanced one pass,                  43170
-github,                             level 0,                            advanced one pass,                  136397
-github,                             level 0 with dict,                  advanced one pass,                  41170
+github,                             level 0,                            advanced one pass,                  136311
+github,                             level 0 with dict,                  advanced one pass,                  41148
 github,                             level 1,                            advanced one pass,                  142450
 github,                             level 1 with dict,                  advanced one pass,                  41682
-github,                             level 3,                            advanced one pass,                  136397
-github,                             level 3 with dict,                  advanced one pass,                  41170
+github,                             level 3,                            advanced one pass,                  136311
+github,                             level 3 with dict,                  advanced one pass,                  41148
 github,                             level 4,                            advanced one pass,                  136144
-github,                             level 4 with dict,                  advanced one pass,                  41306
+github,                             level 4 with dict,                  advanced one pass,                  41251
 github,                             level 5,                            advanced one pass,                  135106
 github,                             level 5 with dict,                  advanced one pass,                  38938
 github,                             level 6,                            advanced one pass,                  135108
@@ -250,25 +250,25 @@ github,                             level 16,                           advanced
 github,                             level 16 with dict,                 advanced one pass,                  37577
 github,                             level 19,                           advanced one pass,                  133717
 github,                             level 19 with dict,                 advanced one pass,                  37576
-github,                             no source size,                     advanced one pass,                  136397
-github,                             long distance mode,                 advanced one pass,                  136397
-github,                             multithreaded,                      advanced one pass,                  136397
-github,                             multithreaded long distance mode,   advanced one pass,                  136397
-github,                             small window log,                   advanced one pass,                  136397
+github,                             no source size,                     advanced one pass,                  136311
+github,                             long distance mode,                 advanced one pass,                  136311
+github,                             multithreaded,                      advanced one pass,                  136311
+github,                             multithreaded long distance mode,   advanced one pass,                  136311
+github,                             small window log,                   advanced one pass,                  136311
 github,                             small hash log,                     advanced one pass,                  135467
 github,                             small chain log,                    advanced one pass,                  136314
 github,                             explicit params,                    advanced one pass,                  137670
-github,                             uncompressed literals,              advanced one pass,                  167004
+github,                             uncompressed literals,              advanced one pass,                  165915
 github,                             uncompressed literals optimal,      advanced one pass,                  156824
 github,                             huffman literals,                   advanced one pass,                  142450
-github,                             multithreaded with advanced params, advanced one pass,                  167004
+github,                             multithreaded with advanced params, advanced one pass,                  165915
 silesia,                            level -5,                           advanced one pass small out,        6737567
 silesia,                            level -3,                           advanced one pass small out,        6444663
 silesia,                            level -1,                           advanced one pass small out,        6178442
-silesia,                            level 0,                            advanced one pass small out,        4862377
+silesia,                            level 0,                            advanced one pass small out,        4849491
 silesia,                            level 1,                            advanced one pass small out,        5313144
-silesia,                            level 3,                            advanced one pass small out,        4862377
-silesia,                            level 4,                            advanced one pass small out,        4800629
+silesia,                            level 3,                            advanced one pass small out,        4849491
+silesia,                            level 4,                            advanced one pass small out,        4786913
 silesia,                            level 5,                            advanced one pass small out,        4710178
 silesia,                            level 6,                            advanced one pass small out,        4659996
 silesia,                            level 7,                            advanced one pass small out,        4596234
@@ -276,25 +276,25 @@ silesia,                            level 9,                            advanced
 silesia,                            level 13,                           advanced one pass small out,        4482073
 silesia,                            level 16,                           advanced one pass small out,        4377389
 silesia,                            level 19,                           advanced one pass small out,        4293262
-silesia,                            no source size,                     advanced one pass small out,        4862377
-silesia,                            long distance mode,                 advanced one pass small out,        4853389
-silesia,                            multithreaded,                      advanced one pass small out,        4862377
-silesia,                            multithreaded long distance mode,   advanced one pass small out,        4853389
-silesia,                            small window log,                   advanced one pass small out,        7126386
+silesia,                            no source size,                     advanced one pass small out,        4849491
+silesia,                            long distance mode,                 advanced one pass small out,        4839650
+silesia,                            multithreaded,                      advanced one pass small out,        4849491
+silesia,                            multithreaded long distance mode,   advanced one pass small out,        4839650
+silesia,                            small window log,                   advanced one pass small out,        7123844
 silesia,                            small hash log,                     advanced one pass small out,        6554898
 silesia,                            small chain log,                    advanced one pass small out,        4931093
 silesia,                            explicit params,                    advanced one pass small out,        4797035
-silesia,                            uncompressed literals,              advanced one pass small out,        5155424
+silesia,                            uncompressed literals,              advanced one pass small out,        5127960
 silesia,                            uncompressed literals optimal,      advanced one pass small out,        4325434
 silesia,                            huffman literals,                   advanced one pass small out,        5326210
-silesia,                            multithreaded with advanced params, advanced one pass small out,        5155424
+silesia,                            multithreaded with advanced params, advanced one pass small out,        5127960
 silesia.tar,                        level -5,                           advanced one pass small out,        6738558
 silesia.tar,                        level -3,                           advanced one pass small out,        6446362
 silesia.tar,                        level -1,                           advanced one pass small out,        6186038
-silesia.tar,                        level 0,                            advanced one pass small out,        4875008
+silesia.tar,                        level 0,                            advanced one pass small out,        4861374
 silesia.tar,                        level 1,                            advanced one pass small out,        5334825
-silesia.tar,                        level 3,                            advanced one pass small out,        4875008
-silesia.tar,                        level 4,                            advanced one pass small out,        4813507
+silesia.tar,                        level 3,                            advanced one pass small out,        4861374
+silesia.tar,                        level 4,                            advanced one pass small out,        4799583
 silesia.tar,                        level 5,                            advanced one pass small out,        4722271
 silesia.tar,                        level 6,                            advanced one pass small out,        4672231
 silesia.tar,                        level 7,                            advanced one pass small out,        4606657
@@ -302,32 +302,32 @@ silesia.tar,                        level 9,                            advanced
 silesia.tar,                        level 13,                           advanced one pass small out,        4491706
 silesia.tar,                        level 16,                           advanced one pass small out,        4381265
 silesia.tar,                        level 19,                           advanced one pass small out,        4281551
-silesia.tar,                        no source size,                     advanced one pass small out,        4875008
-silesia.tar,                        long distance mode,                 advanced one pass small out,        4861218
-silesia.tar,                        multithreaded,                      advanced one pass small out,        4874631
-silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4860683
-silesia.tar,                        small window log,                   advanced one pass small out,        7130394
+silesia.tar,                        no source size,                     advanced one pass small out,        4861374
+silesia.tar,                        long distance mode,                 advanced one pass small out,        4848046
+silesia.tar,                        multithreaded,                      advanced one pass small out,        4860726
+silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4847343
+silesia.tar,                        small window log,                   advanced one pass small out,        7127924
 silesia.tar,                        small hash log,                     advanced one pass small out,        6587833
 silesia.tar,                        small chain log,                    advanced one pass small out,        4943266
 silesia.tar,                        explicit params,                    advanced one pass small out,        4808543
-silesia.tar,                        uncompressed literals,              advanced one pass small out,        5157992
+silesia.tar,                        uncompressed literals,              advanced one pass small out,        5129447
 silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4320910
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5347283
-silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5158545
+silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5129766
 github,                             level -5,                           advanced one pass small out,        205285
 github,                             level -5 with dict,                 advanced one pass small out,        46718
 github,                             level -3,                           advanced one pass small out,        190643
 github,                             level -3 with dict,                 advanced one pass small out,        45395
 github,                             level -1,                           advanced one pass small out,        175568
 github,                             level -1 with dict,                 advanced one pass small out,        43170
-github,                             level 0,                            advanced one pass small out,        136397
-github,                             level 0 with dict,                  advanced one pass small out,        41170
+github,                             level 0,                            advanced one pass small out,        136311
+github,                             level 0 with dict,                  advanced one pass small out,        41148
 github,                             level 1,                            advanced one pass small out,        142450
 github,                             level 1 with dict,                  advanced one pass small out,        41682
-github,                             level 3,                            advanced one pass small out,        136397
-github,                             level 3 with dict,                  advanced one pass small out,        41170
+github,                             level 3,                            advanced one pass small out,        136311
+github,                             level 3 with dict,                  advanced one pass small out,        41148
 github,                             level 4,                            advanced one pass small out,        136144
-github,                             level 4 with dict,                  advanced one pass small out,        41306
+github,                             level 4 with dict,                  advanced one pass small out,        41251
 github,                             level 5,                            advanced one pass small out,        135106
 github,                             level 5 with dict,                  advanced one pass small out,        38938
 github,                             level 6,                            advanced one pass small out,        135108
@@ -342,25 +342,25 @@ github,                             level 16,                           advanced
 github,                             level 16 with dict,                 advanced one pass small out,        37577
 github,                             level 19,                           advanced one pass small out,        133717
 github,                             level 19 with dict,                 advanced one pass small out,        37576
-github,                             no source size,                     advanced one pass small out,        136397
-github,                             long distance mode,                 advanced one pass small out,        136397
-github,                             multithreaded,                      advanced one pass small out,        136397
-github,                             multithreaded long distance mode,   advanced one pass small out,        136397
-github,                             small window log,                   advanced one pass small out,        136397
+github,                             no source size,                     advanced one pass small out,        136311
+github,                             long distance mode,                 advanced one pass small out,        136311
+github,                             multithreaded,                      advanced one pass small out,        136311
+github,                             multithreaded long distance mode,   advanced one pass small out,        136311
+github,                             small window log,                   advanced one pass small out,        136311
 github,                             small hash log,                     advanced one pass small out,        135467
 github,                             small chain log,                    advanced one pass small out,        136314
 github,                             explicit params,                    advanced one pass small out,        137670
-github,                             uncompressed literals,              advanced one pass small out,        167004
+github,                             uncompressed literals,              advanced one pass small out,        165915
 github,                             uncompressed literals optimal,      advanced one pass small out,        156824
 github,                             huffman literals,                   advanced one pass small out,        142450
-github,                             multithreaded with advanced params, advanced one pass small out,        167004
+github,                             multithreaded with advanced params, advanced one pass small out,        165915
 silesia,                            level -5,                           advanced streaming,                 6882466
 silesia,                            level -3,                           advanced streaming,                 6568358
 silesia,                            level -1,                           advanced streaming,                 6183385
-silesia,                            level 0,                            advanced streaming,                 4862377
+silesia,                            level 0,                            advanced streaming,                 4849491
 silesia,                            level 1,                            advanced streaming,                 5314109
-silesia,                            level 3,                            advanced streaming,                 4862377
-silesia,                            level 4,                            advanced streaming,                 4800629
+silesia,                            level 3,                            advanced streaming,                 4849491
+silesia,                            level 4,                            advanced streaming,                 4786913
 silesia,                            level 5,                            advanced streaming,                 4710178
 silesia,                            level 6,                            advanced streaming,                 4659996
 silesia,                            level 7,                            advanced streaming,                 4596234
@@ -368,25 +368,25 @@ silesia,                            level 9,                            advanced
 silesia,                            level 13,                           advanced streaming,                 4482073
 silesia,                            level 16,                           advanced streaming,                 4377389
 silesia,                            level 19,                           advanced streaming,                 4293262
-silesia,                            no source size,                     advanced streaming,                 4862341
-silesia,                            long distance mode,                 advanced streaming,                 4853389
-silesia,                            multithreaded,                      advanced streaming,                 4862377
-silesia,                            multithreaded long distance mode,   advanced streaming,                 4853389
-silesia,                            small window log,                   advanced streaming,                 7126389
+silesia,                            no source size,                     advanced streaming,                 4849455
+silesia,                            long distance mode,                 advanced streaming,                 4839650
+silesia,                            multithreaded,                      advanced streaming,                 4849491
+silesia,                            multithreaded long distance mode,   advanced streaming,                 4839650
+silesia,                            small window log,                   advanced streaming,                 7123846
 silesia,                            small hash log,                     advanced streaming,                 6554898
 silesia,                            small chain log,                    advanced streaming,                 4931093
 silesia,                            explicit params,                    advanced streaming,                 4797048
-silesia,                            uncompressed literals,              advanced streaming,                 5155424
+silesia,                            uncompressed literals,              advanced streaming,                 5127960
 silesia,                            uncompressed literals optimal,      advanced streaming,                 4325434
 silesia,                            huffman literals,                   advanced streaming,                 5331110
-silesia,                            multithreaded with advanced params, advanced streaming,                 5155424
+silesia,                            multithreaded with advanced params, advanced streaming,                 5127960
 silesia.tar,                        level -5,                           advanced streaming,                 6982738
 silesia.tar,                        level -3,                           advanced streaming,                 6641264
 silesia.tar,                        level -1,                           advanced streaming,                 6190789
-silesia.tar,                        level 0,                            advanced streaming,                 4875010
+silesia.tar,                        level 0,                            advanced streaming,                 4861376
 silesia.tar,                        level 1,                            advanced streaming,                 5336879
-silesia.tar,                        level 3,                            advanced streaming,                 4875010
-silesia.tar,                        level 4,                            advanced streaming,                 4813507
+silesia.tar,                        level 3,                            advanced streaming,                 4861376
+silesia.tar,                        level 4,                            advanced streaming,                 4799583
 silesia.tar,                        level 5,                            advanced streaming,                 4722276
 silesia.tar,                        level 6,                            advanced streaming,                 4672240
 silesia.tar,                        level 7,                            advanced streaming,                 4606657
@@ -394,32 +394,32 @@ silesia.tar,                        level 9,                            advanced
 silesia.tar,                        level 13,                           advanced streaming,                 4491707
 silesia.tar,                        level 16,                           advanced streaming,                 4381284
 silesia.tar,                        level 19,                           advanced streaming,                 4281511
-silesia.tar,                        no source size,                     advanced streaming,                 4875006
-silesia.tar,                        long distance mode,                 advanced streaming,                 4861218
-silesia.tar,                        multithreaded,                      advanced streaming,                 4875132
-silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4866971
-silesia.tar,                        small window log,                   advanced streaming,                 7130394
+silesia.tar,                        no source size,                     advanced streaming,                 4861372
+silesia.tar,                        long distance mode,                 advanced streaming,                 4848046
+silesia.tar,                        multithreaded,                      advanced streaming,                 4861458
+silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4853136
+silesia.tar,                        small window log,                   advanced streaming,                 7127924
 silesia.tar,                        small hash log,                     advanced streaming,                 6587834
 silesia.tar,                        small chain log,                    advanced streaming,                 4943271
 silesia.tar,                        explicit params,                    advanced streaming,                 4808570
-silesia.tar,                        uncompressed literals,              advanced streaming,                 5157995
+silesia.tar,                        uncompressed literals,              advanced streaming,                 5129450
 silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4320841
 silesia.tar,                        huffman literals,                   advanced streaming,                 5352306
-silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5158130
+silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5129544
 github,                             level -5,                           advanced streaming,                 205285
 github,                             level -5 with dict,                 advanced streaming,                 46718
 github,                             level -3,                           advanced streaming,                 190643
 github,                             level -3 with dict,                 advanced streaming,                 45395
 github,                             level -1,                           advanced streaming,                 175568
 github,                             level -1 with dict,                 advanced streaming,                 43170
-github,                             level 0,                            advanced streaming,                 136397
-github,                             level 0 with dict,                  advanced streaming,                 41170
+github,                             level 0,                            advanced streaming,                 136311
+github,                             level 0 with dict,                  advanced streaming,                 41148
 github,                             level 1,                            advanced streaming,                 142450
 github,                             level 1 with dict,                  advanced streaming,                 41682
-github,                             level 3,                            advanced streaming,                 136397
-github,                             level 3 with dict,                  advanced streaming,                 41170
+github,                             level 3,                            advanced streaming,                 136311
+github,                             level 3 with dict,                  advanced streaming,                 41148
 github,                             level 4,                            advanced streaming,                 136144
-github,                             level 4 with dict,                  advanced streaming,                 41306
+github,                             level 4 with dict,                  advanced streaming,                 41251
 github,                             level 5,                            advanced streaming,                 135106
 github,                             level 5 with dict,                  advanced streaming,                 38938
 github,                             level 6,                            advanced streaming,                 135108
@@ -434,25 +434,25 @@ github,                             level 16,                           advanced
 github,                             level 16 with dict,                 advanced streaming,                 37577
 github,                             level 19,                           advanced streaming,                 133717
 github,                             level 19 with dict,                 advanced streaming,                 37576
-github,                             no source size,                     advanced streaming,                 136397
-github,                             long distance mode,                 advanced streaming,                 136397
-github,                             multithreaded,                      advanced streaming,                 136397
-github,                             multithreaded long distance mode,   advanced streaming,                 136397
-github,                             small window log,                   advanced streaming,                 136397
+github,                             no source size,                     advanced streaming,                 136311
+github,                             long distance mode,                 advanced streaming,                 136311
+github,                             multithreaded,                      advanced streaming,                 136311
+github,                             multithreaded long distance mode,   advanced streaming,                 136311
+github,                             small window log,                   advanced streaming,                 136311
 github,                             small hash log,                     advanced streaming,                 135467
 github,                             small chain log,                    advanced streaming,                 136314
 github,                             explicit params,                    advanced streaming,                 137670
-github,                             uncompressed literals,              advanced streaming,                 167004
+github,                             uncompressed literals,              advanced streaming,                 165915
 github,                             uncompressed literals optimal,      advanced streaming,                 156824
 github,                             huffman literals,                   advanced streaming,                 142450
-github,                             multithreaded with advanced params, advanced streaming,                 167004
+github,                             multithreaded with advanced params, advanced streaming,                 165915
 silesia,                            level -5,                           old streaming,                      6882466
 silesia,                            level -3,                           old streaming,                      6568358
 silesia,                            level -1,                           old streaming,                      6183385
-silesia,                            level 0,                            old streaming,                      4862377
+silesia,                            level 0,                            old streaming,                      4849491
 silesia,                            level 1,                            old streaming,                      5314109
-silesia,                            level 3,                            old streaming,                      4862377
-silesia,                            level 4,                            old streaming,                      4800629
+silesia,                            level 3,                            old streaming,                      4849491
+silesia,                            level 4,                            old streaming,                      4786913
 silesia,                            level 5,                            old streaming,                      4710178
 silesia,                            level 6,                            old streaming,                      4659996
 silesia,                            level 7,                            old streaming,                      4596234
@@ -460,7 +460,7 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming,                      4482073
 silesia,                            level 16,                           old streaming,                      4377389
 silesia,                            level 19,                           old streaming,                      4293262
-silesia,                            no source size,                     old streaming,                      4862341
+silesia,                            no source size,                     old streaming,                      4849455
 silesia,                            long distance mode,                 old streaming,                      12000408
 silesia,                            multithreaded,                      old streaming,                      12000408
 silesia,                            multithreaded long distance mode,   old streaming,                      12000408
@@ -468,17 +468,17 @@ silesia,                            small window log,                   old stre
 silesia,                            small hash log,                     old streaming,                      12000408
 silesia,                            small chain log,                    old streaming,                      12000408
 silesia,                            explicit params,                    old streaming,                      12000408
-silesia,                            uncompressed literals,              old streaming,                      4862377
+silesia,                            uncompressed literals,              old streaming,                      4849491
 silesia,                            uncompressed literals optimal,      old streaming,                      4293262
 silesia,                            huffman literals,                   old streaming,                      6183385
 silesia,                            multithreaded with advanced params, old streaming,                      12000408
 silesia.tar,                        level -5,                           old streaming,                      6982738
 silesia.tar,                        level -3,                           old streaming,                      6641264
 silesia.tar,                        level -1,                           old streaming,                      6190789
-silesia.tar,                        level 0,                            old streaming,                      4875010
+silesia.tar,                        level 0,                            old streaming,                      4861376
 silesia.tar,                        level 1,                            old streaming,                      5336879
-silesia.tar,                        level 3,                            old streaming,                      4875010
-silesia.tar,                        level 4,                            old streaming,                      4813507
+silesia.tar,                        level 3,                            old streaming,                      4861376
+silesia.tar,                        level 4,                            old streaming,                      4799583
 silesia.tar,                        level 5,                            old streaming,                      4722276
 silesia.tar,                        level 6,                            old streaming,                      4672240
 silesia.tar,                        level 7,                            old streaming,                      4606657
@@ -486,7 +486,7 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming,                      4491707
 silesia.tar,                        level 16,                           old streaming,                      4381284
 silesia.tar,                        level 19,                           old streaming,                      4281511
-silesia.tar,                        no source size,                     old streaming,                      4875006
+silesia.tar,                        no source size,                     old streaming,                      4861372
 silesia.tar,                        long distance mode,                 old streaming,                      12022046
 silesia.tar,                        multithreaded,                      old streaming,                      12022046
 silesia.tar,                        multithreaded long distance mode,   old streaming,                      12022046
@@ -494,7 +494,7 @@ silesia.tar,                        small window log,                   old stre
 silesia.tar,                        small hash log,                     old streaming,                      12022046
 silesia.tar,                        small chain log,                    old streaming,                      12022046
 silesia.tar,                        explicit params,                    old streaming,                      12022046
-silesia.tar,                        uncompressed literals,              old streaming,                      4875010
+silesia.tar,                        uncompressed literals,              old streaming,                      4861376
 silesia.tar,                        uncompressed literals optimal,      old streaming,                      4281511
 silesia.tar,                        huffman literals,                   old streaming,                      6190789
 silesia.tar,                        multithreaded with advanced params, old streaming,                      12022046
@@ -504,14 +504,14 @@ github,                             level -3,                           old stre
 github,                             level -3 with dict,                 old streaming,                      45395
 github,                             level -1,                           old streaming,                      175568
 github,                             level -1 with dict,                 old streaming,                      43170
-github,                             level 0,                            old streaming,                      136397
-github,                             level 0 with dict,                  old streaming,                      41170
+github,                             level 0,                            old streaming,                      136311
+github,                             level 0 with dict,                  old streaming,                      41148
 github,                             level 1,                            old streaming,                      142450
 github,                             level 1 with dict,                  old streaming,                      41682
-github,                             level 3,                            old streaming,                      136397
-github,                             level 3 with dict,                  old streaming,                      41170
+github,                             level 3,                            old streaming,                      136311
+github,                             level 3 with dict,                  old streaming,                      41148
 github,                             level 4,                            old streaming,                      136144
-github,                             level 4 with dict,                  old streaming,                      41306
+github,                             level 4 with dict,                  old streaming,                      41251
 github,                             level 5,                            old streaming,                      135106
 github,                             level 5 with dict,                  old streaming,                      38938
 github,                             level 6,                            old streaming,                      135108
@@ -526,7 +526,7 @@ github,                             level 16,                           old stre
 github,                             level 16 with dict,                 old streaming,                      37577
 github,                             level 19,                           old streaming,                      133717
 github,                             level 19 with dict,                 old streaming,                      37576
-github,                             no source size,                     old streaming,                      141003
+github,                             no source size,                     old streaming,                      140631
 github,                             long distance mode,                 old streaming,                      412933
 github,                             multithreaded,                      old streaming,                      412933
 github,                             multithreaded long distance mode,   old streaming,                      412933
@@ -534,17 +534,17 @@ github,                             small window log,                   old stre
 github,                             small hash log,                     old streaming,                      412933
 github,                             small chain log,                    old streaming,                      412933
 github,                             explicit params,                    old streaming,                      412933
-github,                             uncompressed literals,              old streaming,                      136397
+github,                             uncompressed literals,              old streaming,                      136311
 github,                             uncompressed literals optimal,      old streaming,                      133717
 github,                             huffman literals,                   old streaming,                      175568
 github,                             multithreaded with advanced params, old streaming,                      412933
 silesia,                            level -5,                           old streaming advanced,             6882466
 silesia,                            level -3,                           old streaming advanced,             6568358
 silesia,                            level -1,                           old streaming advanced,             6183385
-silesia,                            level 0,                            old streaming advanced,             4862377
+silesia,                            level 0,                            old streaming advanced,             4849491
 silesia,                            level 1,                            old streaming advanced,             5314109
-silesia,                            level 3,                            old streaming advanced,             4862377
-silesia,                            level 4,                            old streaming advanced,             4800629
+silesia,                            level 3,                            old streaming advanced,             4849491
+silesia,                            level 4,                            old streaming advanced,             4786913
 silesia,                            level 5,                            old streaming advanced,             4710178
 silesia,                            level 6,                            old streaming advanced,             4659996
 silesia,                            level 7,                            old streaming advanced,             4596234
@@ -552,7 +552,7 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming advanced,             4482073
 silesia,                            level 16,                           old streaming advanced,             4377389
 silesia,                            level 19,                           old streaming advanced,             4293262
-silesia,                            no source size,                     old streaming advanced,             4862341
+silesia,                            no source size,                     old streaming advanced,             4849455
 silesia,                            long distance mode,                 old streaming advanced,             12000408
 silesia,                            multithreaded,                      old streaming advanced,             12000408
 silesia,                            multithreaded long distance mode,   old streaming advanced,             12000408
@@ -560,17 +560,17 @@ silesia,                            small window log,                   old stre
 silesia,                            small hash log,                     old streaming advanced,             12000408
 silesia,                            small chain log,                    old streaming advanced,             12000408
 silesia,                            explicit params,                    old streaming advanced,             12000408
-silesia,                            uncompressed literals,              old streaming advanced,             4862377
+silesia,                            uncompressed literals,              old streaming advanced,             4849491
 silesia,                            uncompressed literals optimal,      old streaming advanced,             4293262
 silesia,                            huffman literals,                   old streaming advanced,             6183385
 silesia,                            multithreaded with advanced params, old streaming advanced,             12000408
 silesia.tar,                        level -5,                           old streaming advanced,             6982738
 silesia.tar,                        level -3,                           old streaming advanced,             6641264
 silesia.tar,                        level -1,                           old streaming advanced,             6190789
-silesia.tar,                        level 0,                            old streaming advanced,             4875010
+silesia.tar,                        level 0,                            old streaming advanced,             4861376
 silesia.tar,                        level 1,                            old streaming advanced,             5336879
-silesia.tar,                        level 3,                            old streaming advanced,             4875010
-silesia.tar,                        level 4,                            old streaming advanced,             4813507
+silesia.tar,                        level 3,                            old streaming advanced,             4861376
+silesia.tar,                        level 4,                            old streaming advanced,             4799583
 silesia.tar,                        level 5,                            old streaming advanced,             4722276
 silesia.tar,                        level 6,                            old streaming advanced,             4672240
 silesia.tar,                        level 7,                            old streaming advanced,             4606657
@@ -578,7 +578,7 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming advanced,             4491707
 silesia.tar,                        level 16,                           old streaming advanced,             4381284
 silesia.tar,                        level 19,                           old streaming advanced,             4281511
-silesia.tar,                        no source size,                     old streaming advanced,             4875006
+silesia.tar,                        no source size,                     old streaming advanced,             4861372
 silesia.tar,                        long distance mode,                 old streaming advanced,             12022046
 silesia.tar,                        multithreaded,                      old streaming advanced,             12022046
 silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             12022046
@@ -586,7 +586,7 @@ silesia.tar,                        small window log,                   old stre
 silesia.tar,                        small hash log,                     old streaming advanced,             12022046
 silesia.tar,                        small chain log,                    old streaming advanced,             12022046
 silesia.tar,                        explicit params,                    old streaming advanced,             12022046
-silesia.tar,                        uncompressed literals,              old streaming advanced,             4875010
+silesia.tar,                        uncompressed literals,              old streaming advanced,             4861376
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4281511
 silesia.tar,                        huffman literals,                   old streaming advanced,             6190789
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             12022046
@@ -596,14 +596,14 @@ github,                             level -3,                           old stre
 github,                             level -3 with dict,                 old streaming advanced,             45395
 github,                             level -1,                           old streaming advanced,             175568
 github,                             level -1 with dict,                 old streaming advanced,             43170
-github,                             level 0,                            old streaming advanced,             136397
-github,                             level 0 with dict,                  old streaming advanced,             41170
+github,                             level 0,                            old streaming advanced,             136311
+github,                             level 0 with dict,                  old streaming advanced,             41148
 github,                             level 1,                            old streaming advanced,             142450
 github,                             level 1 with dict,                  old streaming advanced,             41682
-github,                             level 3,                            old streaming advanced,             136397
-github,                             level 3 with dict,                  old streaming advanced,             41170
+github,                             level 3,                            old streaming advanced,             136311
+github,                             level 3 with dict,                  old streaming advanced,             41148
 github,                             level 4,                            old streaming advanced,             136144
-github,                             level 4 with dict,                  old streaming advanced,             41306
+github,                             level 4 with dict,                  old streaming advanced,             41251
 github,                             level 5,                            old streaming advanced,             135106
 github,                             level 5 with dict,                  old streaming advanced,             38938
 github,                             level 6,                            old streaming advanced,             135108
@@ -618,7 +618,7 @@ github,                             level 16,                           old stre
 github,                             level 16 with dict,                 old streaming advanced,             37577
 github,                             level 19,                           old streaming advanced,             133717
 github,                             level 19 with dict,                 old streaming advanced,             37576
-github,                             no source size,                     old streaming advanced,             141003
+github,                             no source size,                     old streaming advanced,             140631
 github,                             long distance mode,                 old streaming advanced,             412933
 github,                             multithreaded,                      old streaming advanced,             412933
 github,                             multithreaded long distance mode,   old streaming advanced,             412933
@@ -626,17 +626,17 @@ github,                             small window log,                   old stre
 github,                             small hash log,                     old streaming advanced,             412933
 github,                             small chain log,                    old streaming advanced,             412933
 github,                             explicit params,                    old streaming advanced,             412933
-github,                             uncompressed literals,              old streaming advanced,             136397
+github,                             uncompressed literals,              old streaming advanced,             136311
 github,                             uncompressed literals optimal,      old streaming advanced,             133717
 github,                             huffman literals,                   old streaming advanced,             175568
 github,                             multithreaded with advanced params, old streaming advanced,             412933
 silesia,                            level -5,                           old streaming cdcit,                6882466
 silesia,                            level -3,                           old streaming cdcit,                6568358
 silesia,                            level -1,                           old streaming cdcit,                6183385
-silesia,                            level 0,                            old streaming cdcit,                4862377
+silesia,                            level 0,                            old streaming cdcit,                4849491
 silesia,                            level 1,                            old streaming cdcit,                5314109
-silesia,                            level 3,                            old streaming cdcit,                4862377
-silesia,                            level 4,                            old streaming cdcit,                4800629
+silesia,                            level 3,                            old streaming cdcit,                4849491
+silesia,                            level 4,                            old streaming cdcit,                4786913
 silesia,                            level 5,                            old streaming cdcit,                4710178
 silesia,                            level 6,                            old streaming cdcit,                4659996
 silesia,                            level 7,                            old streaming cdcit,                4596234
@@ -644,7 +644,7 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming cdcit,                4482073
 silesia,                            level 16,                           old streaming cdcit,                4377389
 silesia,                            level 19,                           old streaming cdcit,                4293262
-silesia,                            no source size,                     old streaming cdcit,                4862341
+silesia,                            no source size,                     old streaming cdcit,                4849455
 silesia,                            long distance mode,                 old streaming cdcit,                12000408
 silesia,                            multithreaded,                      old streaming cdcit,                12000408
 silesia,                            multithreaded long distance mode,   old streaming cdcit,                12000408
@@ -652,17 +652,17 @@ silesia,                            small window log,                   old stre
 silesia,                            small hash log,                     old streaming cdcit,                12000408
 silesia,                            small chain log,                    old streaming cdcit,                12000408
 silesia,                            explicit params,                    old streaming cdcit,                12000408
-silesia,                            uncompressed literals,              old streaming cdcit,                4862377
+silesia,                            uncompressed literals,              old streaming cdcit,                4849491
 silesia,                            uncompressed literals optimal,      old streaming cdcit,                4293262
 silesia,                            huffman literals,                   old streaming cdcit,                6183385
 silesia,                            multithreaded with advanced params, old streaming cdcit,                12000408
 silesia.tar,                        level -5,                           old streaming cdcit,                6982738
 silesia.tar,                        level -3,                           old streaming cdcit,                6641264
 silesia.tar,                        level -1,                           old streaming cdcit,                6190789
-silesia.tar,                        level 0,                            old streaming cdcit,                4875010
+silesia.tar,                        level 0,                            old streaming cdcit,                4861376
 silesia.tar,                        level 1,                            old streaming cdcit,                5336879
-silesia.tar,                        level 3,                            old streaming cdcit,                4875010
-silesia.tar,                        level 4,                            old streaming cdcit,                4813507
+silesia.tar,                        level 3,                            old streaming cdcit,                4861376
+silesia.tar,                        level 4,                            old streaming cdcit,                4799583
 silesia.tar,                        level 5,                            old streaming cdcit,                4722276
 silesia.tar,                        level 6,                            old streaming cdcit,                4672240
 silesia.tar,                        level 7,                            old streaming cdcit,                4606657
@@ -670,7 +670,7 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming cdcit,                4491707
 silesia.tar,                        level 16,                           old streaming cdcit,                4381284
 silesia.tar,                        level 19,                           old streaming cdcit,                4281511
-silesia.tar,                        no source size,                     old streaming cdcit,                4875006
+silesia.tar,                        no source size,                     old streaming cdcit,                4861372
 silesia.tar,                        long distance mode,                 old streaming cdcit,                12022046
 silesia.tar,                        multithreaded,                      old streaming cdcit,                12022046
 silesia.tar,                        multithreaded long distance mode,   old streaming cdcit,                12022046
@@ -678,7 +678,7 @@ silesia.tar,                        small window log,                   old stre
 silesia.tar,                        small hash log,                     old streaming cdcit,                12022046
 silesia.tar,                        small chain log,                    old streaming cdcit,                12022046
 silesia.tar,                        explicit params,                    old streaming cdcit,                12022046
-silesia.tar,                        uncompressed literals,              old streaming cdcit,                4875010
+silesia.tar,                        uncompressed literals,              old streaming cdcit,                4861376
 silesia.tar,                        uncompressed literals optimal,      old streaming cdcit,                4281511
 silesia.tar,                        huffman literals,                   old streaming cdcit,                6190789
 silesia.tar,                        multithreaded with advanced params, old streaming cdcit,                12022046
@@ -688,14 +688,14 @@ github,                             level -3,                           old stre
 github,                             level -3 with dict,                 old streaming cdcit,                45395
 github,                             level -1,                           old streaming cdcit,                175568
 github,                             level -1 with dict,                 old streaming cdcit,                43170
-github,                             level 0,                            old streaming cdcit,                136397
-github,                             level 0 with dict,                  old streaming cdcit,                41170
+github,                             level 0,                            old streaming cdcit,                136311
+github,                             level 0 with dict,                  old streaming cdcit,                41148
 github,                             level 1,                            old streaming cdcit,                142450
 github,                             level 1 with dict,                  old streaming cdcit,                41682
-github,                             level 3,                            old streaming cdcit,                136397
-github,                             level 3 with dict,                  old streaming cdcit,                41170
+github,                             level 3,                            old streaming cdcit,                136311
+github,                             level 3 with dict,                  old streaming cdcit,                41148
 github,                             level 4,                            old streaming cdcit,                136144
-github,                             level 4 with dict,                  old streaming cdcit,                41306
+github,                             level 4 with dict,                  old streaming cdcit,                41251
 github,                             level 5,                            old streaming cdcit,                135106
 github,                             level 5 with dict,                  old streaming cdcit,                38938
 github,                             level 6,                            old streaming cdcit,                135108
@@ -710,7 +710,7 @@ github,                             level 16,                           old stre
 github,                             level 16 with dict,                 old streaming cdcit,                37577
 github,                             level 19,                           old streaming cdcit,                133717
 github,                             level 19 with dict,                 old streaming cdcit,                37576
-github,                             no source size,                     old streaming cdcit,                141003
+github,                             no source size,                     old streaming cdcit,                140631
 github,                             long distance mode,                 old streaming cdcit,                412933
 github,                             multithreaded,                      old streaming cdcit,                412933
 github,                             multithreaded long distance mode,   old streaming cdcit,                412933
@@ -718,17 +718,17 @@ github,                             small window log,                   old stre
 github,                             small hash log,                     old streaming cdcit,                412933
 github,                             small chain log,                    old streaming cdcit,                412933
 github,                             explicit params,                    old streaming cdcit,                412933
-github,                             uncompressed literals,              old streaming cdcit,                136397
+github,                             uncompressed literals,              old streaming cdcit,                136311
 github,                             uncompressed literals optimal,      old streaming cdcit,                133717
 github,                             huffman literals,                   old streaming cdcit,                175568
 github,                             multithreaded with advanced params, old streaming cdcit,                412933
 silesia,                            level -5,                           old streaming advanced cdict,       6882466
 silesia,                            level -3,                           old streaming advanced cdict,       6568358
 silesia,                            level -1,                           old streaming advanced cdict,       6183385
-silesia,                            level 0,                            old streaming advanced cdict,       4862377
+silesia,                            level 0,                            old streaming advanced cdict,       4849491
 silesia,                            level 1,                            old streaming advanced cdict,       5314109
-silesia,                            level 3,                            old streaming advanced cdict,       4862377
-silesia,                            level 4,                            old streaming advanced cdict,       4800629
+silesia,                            level 3,                            old streaming advanced cdict,       4849491
+silesia,                            level 4,                            old streaming advanced cdict,       4786913
 silesia,                            level 5,                            old streaming advanced cdict,       4710178
 silesia,                            level 6,                            old streaming advanced cdict,       4659996
 silesia,                            level 7,                            old streaming advanced cdict,       4596234
@@ -736,7 +736,7 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming advanced cdict,       4482073
 silesia,                            level 16,                           old streaming advanced cdict,       4377389
 silesia,                            level 19,                           old streaming advanced cdict,       4293262
-silesia,                            no source size,                     old streaming advanced cdict,       4862341
+silesia,                            no source size,                     old streaming advanced cdict,       4849455
 silesia,                            long distance mode,                 old streaming advanced cdict,       12000408
 silesia,                            multithreaded,                      old streaming advanced cdict,       12000408
 silesia,                            multithreaded long distance mode,   old streaming advanced cdict,       12000408
@@ -744,17 +744,17 @@ silesia,                            small window log,                   old stre
 silesia,                            small hash log,                     old streaming advanced cdict,       12000408
 silesia,                            small chain log,                    old streaming advanced cdict,       12000408
 silesia,                            explicit params,                    old streaming advanced cdict,       12000408
-silesia,                            uncompressed literals,              old streaming advanced cdict,       4862377
+silesia,                            uncompressed literals,              old streaming advanced cdict,       4849491
 silesia,                            uncompressed literals optimal,      old streaming advanced cdict,       4293262
 silesia,                            huffman literals,                   old streaming advanced cdict,       6183385
 silesia,                            multithreaded with advanced params, old streaming advanced cdict,       12000408
 silesia.tar,                        level -5,                           old streaming advanced cdict,       6982738
 silesia.tar,                        level -3,                           old streaming advanced cdict,       6641264
 silesia.tar,                        level -1,                           old streaming advanced cdict,       6190789
-silesia.tar,                        level 0,                            old streaming advanced cdict,       4875010
+silesia.tar,                        level 0,                            old streaming advanced cdict,       4861376
 silesia.tar,                        level 1,                            old streaming advanced cdict,       5336879
-silesia.tar,                        level 3,                            old streaming advanced cdict,       4875010
-silesia.tar,                        level 4,                            old streaming advanced cdict,       4813507
+silesia.tar,                        level 3,                            old streaming advanced cdict,       4861376
+silesia.tar,                        level 4,                            old streaming advanced cdict,       4799583
 silesia.tar,                        level 5,                            old streaming advanced cdict,       4722276
 silesia.tar,                        level 6,                            old streaming advanced cdict,       4672240
 silesia.tar,                        level 7,                            old streaming advanced cdict,       4606657
@@ -762,7 +762,7 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming advanced cdict,       4491707
 silesia.tar,                        level 16,                           old streaming advanced cdict,       4381284
 silesia.tar,                        level 19,                           old streaming advanced cdict,       4281511
-silesia.tar,                        no source size,                     old streaming advanced cdict,       4875006
+silesia.tar,                        no source size,                     old streaming advanced cdict,       4861372
 silesia.tar,                        long distance mode,                 old streaming advanced cdict,       12022046
 silesia.tar,                        multithreaded,                      old streaming advanced cdict,       12022046
 silesia.tar,                        multithreaded long distance mode,   old streaming advanced cdict,       12022046
@@ -770,7 +770,7 @@ silesia.tar,                        small window log,                   old stre
 silesia.tar,                        small hash log,                     old streaming advanced cdict,       12022046
 silesia.tar,                        small chain log,                    old streaming advanced cdict,       12022046
 silesia.tar,                        explicit params,                    old streaming advanced cdict,       12022046
-silesia.tar,                        uncompressed literals,              old streaming advanced cdict,       4875010
+silesia.tar,                        uncompressed literals,              old streaming advanced cdict,       4861376
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced cdict,       4281511
 silesia.tar,                        huffman literals,                   old streaming advanced cdict,       6190789
 silesia.tar,                        multithreaded with advanced params, old streaming advanced cdict,       12022046
@@ -780,14 +780,14 @@ github,                             level -3,                           old stre
 github,                             level -3 with dict,                 old streaming advanced cdict,       45395
 github,                             level -1,                           old streaming advanced cdict,       175568
 github,                             level -1 with dict,                 old streaming advanced cdict,       43170
-github,                             level 0,                            old streaming advanced cdict,       136397
-github,                             level 0 with dict,                  old streaming advanced cdict,       41170
+github,                             level 0,                            old streaming advanced cdict,       136311
+github,                             level 0 with dict,                  old streaming advanced cdict,       41148
 github,                             level 1,                            old streaming advanced cdict,       142450
 github,                             level 1 with dict,                  old streaming advanced cdict,       41682
-github,                             level 3,                            old streaming advanced cdict,       136397
-github,                             level 3 with dict,                  old streaming advanced cdict,       41170
+github,                             level 3,                            old streaming advanced cdict,       136311
+github,                             level 3 with dict,                  old streaming advanced cdict,       41148
 github,                             level 4,                            old streaming advanced cdict,       136144
-github,                             level 4 with dict,                  old streaming advanced cdict,       41306
+github,                             level 4 with dict,                  old streaming advanced cdict,       41251
 github,                             level 5,                            old streaming advanced cdict,       135106
 github,                             level 5 with dict,                  old streaming advanced cdict,       38938
 github,                             level 6,                            old streaming advanced cdict,       135108
@@ -802,7 +802,7 @@ github,                             level 16,                           old stre
 github,                             level 16 with dict,                 old streaming advanced cdict,       37577
 github,                             level 19,                           old streaming advanced cdict,       133717
 github,                             level 19 with dict,                 old streaming advanced cdict,       37576
-github,                             no source size,                     old streaming advanced cdict,       141003
+github,                             no source size,                     old streaming advanced cdict,       140631
 github,                             long distance mode,                 old streaming advanced cdict,       412933
 github,                             multithreaded,                      old streaming advanced cdict,       412933
 github,                             multithreaded long distance mode,   old streaming advanced cdict,       412933
@@ -810,7 +810,7 @@ github,                             small window log,                   old stre
 github,                             small hash log,                     old streaming advanced cdict,       412933
 github,                             small chain log,                    old streaming advanced cdict,       412933
 github,                             explicit params,                    old streaming advanced cdict,       412933
-github,                             uncompressed literals,              old streaming advanced cdict,       136397
+github,                             uncompressed literals,              old streaming advanced cdict,       136311
 github,                             uncompressed literals optimal,      old streaming advanced cdict,       133717
 github,                             huffman literals,                   old streaming advanced cdict,       175568
 github,                             multithreaded with advanced params, old streaming advanced cdict,       412933


### PR DESCRIPTION
Results look positive across the board. There are a few cases where it gets ~10 bytes worse, but that is noise.