### PR TITLE
Add New Seekable Compression Example to .gitignore

### DIFF
--- a/contrib/seekable_format/examples/.gitignore
+++ b/contrib/seekable_format/examples/.gitignore
@@ -1,4 +1,5 @@
 seekable_compression
 seekable_decompression
+seekable_decompression_mem
 parallel_processing
 parallel_compression


### PR DESCRIPTION
Trivial PR to reflect the existence of a new binary in
`contrib/seekable_format/examples/`.