### PR TITLE
memory leak fix

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -245,6 +245,7 @@ int UTIL_prepareFileList(const char *dirName, char** bufStart, size_t* pos, char
 
         if (!followLinks && UTIL_isLink(path)) {
             UTIL_DISPLAYLEVEL(2, "Warning : %s is a symbolic link, ignoring\n", path);
+            free(path);
             continue;
         }
 


### PR DESCRIPTION
Pointer `path` points to a memory which is malloced in the `while` loop, but it's not freed before `continue`