### PR TITLE
add NULL pointer check in util.c

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -494,7 +494,7 @@ int UTIL_countPhysicalCores(void)
             if (fgets(buff, BUF_SIZE, cpuinfo) != NULL) {
                 if (strncmp(buff, "siblings", 8) == 0) {
                     const char* const sep = strchr(buff, ':');
-                    if (*sep == '\0') {
+                    if (sep == NULL || *sep == '\0') {
                         /* formatting was broken? */
                         goto failed;
                     }
@@ -503,7 +503,7 @@ int UTIL_countPhysicalCores(void)
                 }
                 if (strncmp(buff, "cpu cores", 9) == 0) {
                     const char* const sep = strchr(buff, ':');
-                    if (*sep == '\0') {
+                    if (sep == NULL || *sep == '\0') {
                         /* formatting was broken? */
                         goto failed;
                     }


### PR DESCRIPTION
I believe the original code was meant to deal with case that `/proc/cpuinfo` has come across a error: the formatting of `/proc/cpuinfo` was broken. In that way, the `sep` could also be `NULL` because it's the return of `strchr`.
I think adding a `NULL` check is better here.