### PR TITLE
Tweaks to create a single-file decoder

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -127,9 +127,14 @@
     }                                     \
 }
 
-/* vectorization */
+/* vectorization
+ * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax */
 #if !defined(__clang__) && defined(__GNUC__)
-#  define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
+#  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
+#    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
+#  else
+#    define DONT_VECTORIZE _Pragma("GCC optimize(\"no-tree-vectorize\")")
+#  endif
 #else
 #  define DONT_VECTORIZE
 #endif

--- a/lib/common/fse_decompress.c
+++ b/lib/common/fse_decompress.c
@@ -52,7 +52,9 @@
 #define FSE_STATIC_ASSERT(c) DEBUG_STATIC_ASSERT(c)   /* use only *after* variable declarations */
 
 /* check and forward error code */
+#ifndef CHECK_F
 #define CHECK_F(f) { size_t const e = f; if (FSE_isError(e)) return e; }
+#endif
 
 
 /* **************************************************************

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -61,7 +61,9 @@
 *  Error Management
 ****************************************************************/
 #define HUF_isError ERR_isError
+#ifndef CHECK_F
 #define CHECK_F(f) { size_t const err_ = (f); if (HUF_isError(err_)) return err_; }
+#endif
 
 
 /* **************************************************************


### PR DESCRIPTION
The CHECK_F macros differ slightly (but eventually do the same thing) so the guards allow all the decoder files to be 'amalgamated' into a single file.

Older GCC needs to fallback on the old-style pragma optimisation flags (the alternative path was verified with GCC4).