### PR TITLE
Allows zstd-fast compression loop to run with an unitialized hashtable.

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1350,7 +1350,7 @@ static size_t ZSTD_continueCCtx(ZSTD_CCtx* cctx, ZSTD_CCtx_params params, U64 pl
     return 0;
 }
 
-typedef enum { ZSTDcrp_continue, ZSTDcrp_noMemset } ZSTD_compResetPolicy_e;
+typedef enum { ZSTDcrp_continue, ZSTDcrp_noMemset, ZSTDcrp_forceMemset } ZSTD_compResetPolicy_e;
 
 typedef enum { ZSTD_resetTarget_CDict, ZSTD_resetTarget_CCtx } ZSTD_resetTarget_e;
 
@@ -1364,7 +1364,6 @@ ZSTD_reset_matchState(ZSTD_matchState_t* ms,
     size_t const hSize = ((size_t)1) << cParams->hashLog;
     U32    const hashLog3 = ((forWho == ZSTD_resetTarget_CCtx) && cParams->minMatch==3) ? MIN(ZSTD_HASHLOG3_MAX, cParams->windowLog) : 0;
     size_t const h3Size = ((size_t)1) << hashLog3;
-    size_t const tableSpace = (chainSize + hSize + h3Size) * sizeof(U32);
 
     assert(((size_t)ptr & 3) == 0);
 
@@ -1390,9 +1389,31 @@ ZSTD_reset_matchState(ZSTD_matchState_t* ms,
     }
 
     /* table Space */
-    DEBUGLOG(4, "reset table : %u", crp!=ZSTDcrp_noMemset);
+    DEBUGLOG(4, "reset table : %u", crp!=ZSTDcrp_noMemset && (crp == ZSTDcrp_forceMemset || cParams->strategy != ZSTD_fast));
     assert(((size_t)ptr & 3) == 0);  /* ensure ptr is properly aligned */
+#ifdef NORESET
+    if (crp!=ZSTDcrp_noMemset) {
+       size_t tableSpace;
+       if (cParams->strategy == ZSTD_fast && crp!=ZSTDcrp_forceMemset)  {
+           /* Randomize the offset table.
+              This is for testing purpose, this makes sure that ZSTD_fast compression
+              is robust to uninitialized table. */
+           size_t i;
+           U32 * p = (U32 *)ptr;
+           for (i=0; i < hSize; i++) {
+               *(p++) = (U32)(0x98765432 * (i+1));
+           }
+           tableSpace = (chainSize + h3Size) * sizeof(U32);
+           memset(p , 0, tableSpace);
+       } else {
+           tableSpace = (chainSize + hSize + h3Size) * sizeof(U32);
+           memset(ptr, 0, tableSpace);   /* reset tables only */
+       }
+    }
+#else
+    size_t const tableSpace = (chainSize + hSize + h3Size) * sizeof(U32);
     if (crp!=ZSTDcrp_noMemset) memset(ptr, 0, tableSpace);   /* reset tables only */
+#endif
     ms->hashTable = (U32*)(ptr);
     ms->chainTable = ms->hashTable + hSize;
     ms->hashTable3 = ms->chainTable + chainSize;
@@ -1651,7 +1672,7 @@ ZSTD_resetCCtx_byAttachingCDict(ZSTD_CCtx* cctx,
         params.cParams = ZSTD_adjustCParams_internal(*cdict_cParams, pledgedSrcSize, 0);
         params.cParams.windowLog = windowLog;
         ZSTD_resetCCtx_internal(cctx, params, pledgedSrcSize,
-                                ZSTDcrp_continue, zbuff);
+                                ZSTDcrp_forceMemset, zbuff);
         assert(cctx->appliedParams.cParams.strategy == cdict_cParams->strategy);
     }
 
@@ -3072,7 +3093,7 @@ static size_t ZSTD_initCDict_internal(
     {   void* const end = ZSTD_reset_matchState(&cdict->matchState,
                             (U32*)cdict->workspace + HUF_WORKSPACE_SIZE_U32,
                             &cParams,
-                             ZSTDcrp_continue, ZSTD_resetTarget_CDict);
+                             ZSTDcrp_forceMemset, ZSTD_resetTarget_CDict);
         assert(end == (char*)cdict->workspace + cdict->workspaceSize);
         (void)end;
     }

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -90,8 +90,13 @@ size_t ZSTD_compressBlock_fast_generic(
         U32 const val1 = MEM_read32(ip1);
         U32 const current0 = (U32)(ip0-base);
         U32 const current1 = (U32)(ip1-base);
+#ifdef NORESET
+        U32 const matchIndex0 = (hashTable[h0] >= current0) ? 0 : hashTable[h0];
+        U32 const matchIndex1 = (hashTable[h1] >= current1) ? 0 : hashTable[h1];
+#else
         U32 const matchIndex0 = hashTable[h0];
         U32 const matchIndex1 = hashTable[h1];
+#endif
         BYTE const* repMatch = ip2-offset_1;
         const BYTE* match0 = base + matchIndex0;
         const BYTE* match1 = base + matchIndex1;
@@ -252,7 +257,11 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
         size_t mLength;
         size_t const h = ZSTD_hashPtr(ip, hlog, mls);
         U32 const current = (U32)(ip-base);
+#ifdef NORESET
+        U32 const matchIndex = (hashTable[h] >= current) ? 0 : hashTable[h];
+#else
         U32 const matchIndex = hashTable[h];
+#endif
         const BYTE* match = base + matchIndex;
         const U32 repIndex = current + 1 - offset_1;
         const BYTE* repMatch = (repIndex < prefixStartIndex) ?
@@ -401,10 +410,14 @@ static size_t ZSTD_compressBlock_fast_extDict_generic(
     /* Search Loop */
     while (ip < ilimit) {  /* < instead of <=, because (ip+1) */
         const size_t h = ZSTD_hashPtr(ip, hlog, mls);
-        const U32    matchIndex = hashTable[h];
+        const U32    current = (U32)(ip-base);
+#ifdef NORESET
+        const U32 matchIndex = (hashTable[h] >= current) ? 0 : hashTable[h];
+#else
+        const U32 matchIndex = hashTable[h];
+#endif
         const BYTE* const matchBase = matchIndex < prefixStartIndex ? dictBase : base;
         const BYTE*  match = matchBase + matchIndex;
-        const U32    current = (U32)(ip-base);
         const U32    repIndex = current + 1 - offset_1;
         const BYTE* const repBase = repIndex < prefixStartIndex ? dictBase : base;
         const BYTE* const repMatch = repBase + repIndex;

--- a/lib/compress/zstd_fast.h
+++ b/lib/compress/zstd_fast.h
@@ -15,6 +15,8 @@
 extern "C" {
 #endif
 
+#define NORESET 1
+
 #include "mem.h"      /* U32 */
 #include "zstd_compress_internal.h"
 


### PR DESCRIPTION
Initial proposal for T52917010.

For now I kept the changes under #define NO RESET, so as to allow for easy comparison of compress speed, with and without the change.

I am not seeing a measurable compression speed change, when running -b1 benchmark on my MacBook Pro.

This is a benchmark run without the change (avg speed 910 MB/s):
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 939.3 MB/s ,5898.5 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 910.3 MB/s ,5928.2 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 891.3 MB/s ,5766.3 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 926.6 MB/s ,6180.1 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 887.0 MB/s ,5729.7 MB/s

This is a benchmark run with the change (avg speed 890 MB/s)
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 876.4 MB/s ,5869.4 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 877.7 MB/s ,5946.2 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 852.7 MB/s ,6252.4 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 946.0 MB/s ,5760.1 MB/s
vandwalle-mbp:zstd vandwalle$ zstd -b1 ~/Downloads/mpk-shuttle-san-francisco.pdf -o ~/Downloads/testcomp
1#san-francisco.pdf : 3761167 -> 3087340 (1.218), 903.2 MB/s ,6029.0 MB/s