### PR TITLE
Fix streaming compression/decompression examples

### DIFF
--- a/examples/streaming_compression.c
+++ b/examples/streaming_compression.c
@@ -44,8 +44,8 @@ static void compressFile_orDie(const char* fname, const char* outName, int cLeve
      * and writes all output produced to the output file.
      */
     size_t const toRead = buffInSize;
-    size_t read;
-    while ((read = fread_orDie(buffIn, toRead, fin))) {
+    for (;;) {
+        size_t read = fread_orDie(buffIn, toRead, fin);
         /* Select the flush mode.
          * If the read may not be finished (read == toRead) we use
          * ZSTD_e_continue. If this is the last chunk, we use ZSTD_e_end.
@@ -76,6 +76,10 @@ static void compressFile_orDie(const char* fname, const char* outName, int cLeve
         } while (!finished);
         CHECK(input.pos == input.size,
               "Impossible: zstd only returns 0 when the input is completely consumed!");
+
+        if (lastChunk) {
+            break;
+        }
     }
 
     ZSTD_freeCCtx(cctx);


### PR DESCRIPTION
* Handle compression of empty file
* Error in decompression in case of trailing data