### PR TITLE
Removing assert added when handling related oss fuzz issue

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -260,7 +260,6 @@ MEM_STATIC void BIT_flushBits(BIT_CStream_t* bitC)
 {
     size_t const nbBytes = bitC->bitPos >> 3;
     assert(bitC->bitPos < sizeof(bitC->bitContainer) * 8);
-    assert(bitC->ptr <= bitC->endPtr);
     MEM_writeLEST(bitC->ptr, bitC->bitContainer);
     bitC->ptr += nbBytes;
     if (bitC->ptr > bitC->endPtr) bitC->ptr = bitC->endPtr;


### PR DESCRIPTION
We added this last week when oss-fuzz found a bug in flushBitsFast(). Line 265 handles the overflow for this function unlike flushBitsFast so I think we don't need the assert? 