### PR TITLE
Improve ZSTD_highbit32's codegen

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -339,7 +339,7 @@ MEM_STATIC U32 ZSTD_highbit32(U32 val)   /* compress, dictBuilder, decodeCorpus 
         _BitScanReverse(&r, val);
         return (unsigned)r;
 #   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* GCC Intrinsic */
-        return 31 - __builtin_clz(val);
+        return __builtin_clz(val) ^ 31;
 #   elif defined(__ICCARM__)    /* IAR Intrinsic */
         return 31 - __CLZ(val);
 #   else   /* Software version */


### PR DESCRIPTION
GCC is unable to simplify '31 - __builtin_clz(val)' and produces ugly assembly. Clang can simplify it.

Use alternative expr "__builtin_clz(val) ^ 31" which is optimized well by Clang and GCC too.

Proof: https://godbolt.org/z/y32jQq