### PR TITLE
[regression] Fix the old streaming regression test

### DIFF
--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -461,17 +461,9 @@ silesia,                            level 13,                           old stre
 silesia,                            level 16,                           old streaming,                      4377389
 silesia,                            level 19,                           old streaming,                      4293262
 silesia,                            no source size,                     old streaming,                      4849455
-silesia,                            long distance mode,                 old streaming,                      12000408
-silesia,                            multithreaded,                      old streaming,                      12000408
-silesia,                            multithreaded long distance mode,   old streaming,                      12000408
-silesia,                            small window log,                   old streaming,                      12000408
-silesia,                            small hash log,                     old streaming,                      12000408
-silesia,                            small chain log,                    old streaming,                      12000408
-silesia,                            explicit params,                    old streaming,                      12000408
 silesia,                            uncompressed literals,              old streaming,                      4849491
 silesia,                            uncompressed literals optimal,      old streaming,                      4293262
 silesia,                            huffman literals,                   old streaming,                      6183385
-silesia,                            multithreaded with advanced params, old streaming,                      12000408
 silesia.tar,                        level -5,                           old streaming,                      6982738
 silesia.tar,                        level -3,                           old streaming,                      6641264
 silesia.tar,                        level -1,                           old streaming,                      6190789
@@ -487,17 +479,9 @@ silesia.tar,                        level 13,                           old stre
 silesia.tar,                        level 16,                           old streaming,                      4381284
 silesia.tar,                        level 19,                           old streaming,                      4281511
 silesia.tar,                        no source size,                     old streaming,                      4861372
-silesia.tar,                        long distance mode,                 old streaming,                      12022046
-silesia.tar,                        multithreaded,                      old streaming,                      12022046
-silesia.tar,                        multithreaded long distance mode,   old streaming,                      12022046
-silesia.tar,                        small window log,                   old streaming,                      12022046
-silesia.tar,                        small hash log,                     old streaming,                      12022046
-silesia.tar,                        small chain log,                    old streaming,                      12022046
-silesia.tar,                        explicit params,                    old streaming,                      12022046
 silesia.tar,                        uncompressed literals,              old streaming,                      4861376
 silesia.tar,                        uncompressed literals optimal,      old streaming,                      4281511
 silesia.tar,                        huffman literals,                   old streaming,                      6190789
-silesia.tar,                        multithreaded with advanced params, old streaming,                      12022046
 github,                             level -5,                           old streaming,                      205285
 github,                             level -5 with dict,                 old streaming,                      46718
 github,                             level -3,                           old streaming,                      190643
@@ -527,17 +511,9 @@ github,                             level 16 with dict,                 old stre
 github,                             level 19,                           old streaming,                      133717
 github,                             level 19 with dict,                 old streaming,                      37576
 github,                             no source size,                     old streaming,                      140631
-github,                             long distance mode,                 old streaming,                      412933
-github,                             multithreaded,                      old streaming,                      412933
-github,                             multithreaded long distance mode,   old streaming,                      412933
-github,                             small window log,                   old streaming,                      412933
-github,                             small hash log,                     old streaming,                      412933
-github,                             small chain log,                    old streaming,                      412933
-github,                             explicit params,                    old streaming,                      412933
 github,                             uncompressed literals,              old streaming,                      136311
 github,                             uncompressed literals optimal,      old streaming,                      133717
 github,                             huffman literals,                   old streaming,                      175568
-github,                             multithreaded with advanced params, old streaming,                      412933
 silesia,                            level -5,                           old streaming advanced,             6882466
 silesia,                            level -3,                           old streaming advanced,             6568358
 silesia,                            level -1,                           old streaming advanced,             6183385
@@ -553,17 +529,17 @@ silesia,                            level 13,                           old stre
 silesia,                            level 16,                           old streaming advanced,             4377389
 silesia,                            level 19,                           old streaming advanced,             4293262
 silesia,                            no source size,                     old streaming advanced,             4849455
-silesia,                            long distance mode,                 old streaming advanced,             12000408
-silesia,                            multithreaded,                      old streaming advanced,             12000408
-silesia,                            multithreaded long distance mode,   old streaming advanced,             12000408
-silesia,                            small window log,                   old streaming advanced,             12000408
-silesia,                            small hash log,                     old streaming advanced,             12000408
-silesia,                            small chain log,                    old streaming advanced,             12000408
-silesia,                            explicit params,                    old streaming advanced,             12000408
+silesia,                            long distance mode,                 old streaming advanced,             4849491
+silesia,                            multithreaded,                      old streaming advanced,             4849491
+silesia,                            multithreaded long distance mode,   old streaming advanced,             4849491
+silesia,                            small window log,                   old streaming advanced,             7123534
+silesia,                            small hash log,                     old streaming advanced,             6554898
+silesia,                            small chain log,                    old streaming advanced,             4931093
+silesia,                            explicit params,                    old streaming advanced,             4797048
 silesia,                            uncompressed literals,              old streaming advanced,             4849491
 silesia,                            uncompressed literals optimal,      old streaming advanced,             4293262
 silesia,                            huffman literals,                   old streaming advanced,             6183385
-silesia,                            multithreaded with advanced params, old streaming advanced,             12000408
+silesia,                            multithreaded with advanced params, old streaming advanced,             4849491
 silesia.tar,                        level -5,                           old streaming advanced,             6982738
 silesia.tar,                        level -3,                           old streaming advanced,             6641264
 silesia.tar,                        level -1,                           old streaming advanced,             6190789
@@ -579,238 +555,82 @@ silesia.tar,                        level 13,                           old stre
 silesia.tar,                        level 16,                           old streaming advanced,             4381284
 silesia.tar,                        level 19,                           old streaming advanced,             4281511
 silesia.tar,                        no source size,                     old streaming advanced,             4861372
-silesia.tar,                        long distance mode,                 old streaming advanced,             12022046
-silesia.tar,                        multithreaded,                      old streaming advanced,             12022046
-silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             12022046
-silesia.tar,                        small window log,                   old streaming advanced,             12022046
-silesia.tar,                        small hash log,                     old streaming advanced,             12022046
-silesia.tar,                        small chain log,                    old streaming advanced,             12022046
-silesia.tar,                        explicit params,                    old streaming advanced,             12022046
+silesia.tar,                        long distance mode,                 old streaming advanced,             4861376
+silesia.tar,                        multithreaded,                      old streaming advanced,             4861376
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861376
+silesia.tar,                        small window log,                   old streaming advanced,             7127552
+silesia.tar,                        small hash log,                     old streaming advanced,             6587834
+silesia.tar,                        small chain log,                    old streaming advanced,             4943271
+silesia.tar,                        explicit params,                    old streaming advanced,             4808570
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4861376
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4281511
 silesia.tar,                        huffman literals,                   old streaming advanced,             6190789
-silesia.tar,                        multithreaded with advanced params, old streaming advanced,             12022046
-github,                             level -5,                           old streaming advanced,             205285
-github,                             level -5 with dict,                 old streaming advanced,             46718
-github,                             level -3,                           old streaming advanced,             190643
-github,                             level -3 with dict,                 old streaming advanced,             45395
-github,                             level -1,                           old streaming advanced,             175568
-github,                             level -1 with dict,                 old streaming advanced,             43170
-github,                             level 0,                            old streaming advanced,             136311
-github,                             level 0 with dict,                  old streaming advanced,             41148
-github,                             level 1,                            old streaming advanced,             142450
-github,                             level 1 with dict,                  old streaming advanced,             41682
-github,                             level 3,                            old streaming advanced,             136311
-github,                             level 3 with dict,                  old streaming advanced,             41148
-github,                             level 4,                            old streaming advanced,             136144
-github,                             level 4 with dict,                  old streaming advanced,             41251
-github,                             level 5,                            old streaming advanced,             135106
-github,                             level 5 with dict,                  old streaming advanced,             38938
-github,                             level 6,                            old streaming advanced,             135108
-github,                             level 6 with dict,                  old streaming advanced,             38632
-github,                             level 7,                            old streaming advanced,             135108
-github,                             level 7 with dict,                  old streaming advanced,             38766
-github,                             level 9,                            old streaming advanced,             135108
-github,                             level 9 with dict,                  old streaming advanced,             39326
-github,                             level 13,                           old streaming advanced,             133717
-github,                             level 13 with dict,                 old streaming advanced,             39716
-github,                             level 16,                           old streaming advanced,             133717
-github,                             level 16 with dict,                 old streaming advanced,             37577
+silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861376
+github,                             level -5,                           old streaming advanced,             216734
+github,                             level -5 with dict,                 old streaming advanced,             49562
+github,                             level -3,                           old streaming advanced,             192160
+github,                             level -3 with dict,                 old streaming advanced,             44956
+github,                             level -1,                           old streaming advanced,             181108
+github,                             level -1 with dict,                 old streaming advanced,             42383
+github,                             level 0,                            old streaming advanced,             141090
+github,                             level 0 with dict,                  old streaming advanced,             41113
+github,                             level 1,                            old streaming advanced,             143682
+github,                             level 1 with dict,                  old streaming advanced,             42430
+github,                             level 3,                            old streaming advanced,             141090
+github,                             level 3 with dict,                  old streaming advanced,             41113
+github,                             level 4,                            old streaming advanced,             141090
+github,                             level 4 with dict,                  old streaming advanced,             41084
+github,                             level 5,                            old streaming advanced,             139391
+github,                             level 5 with dict,                  old streaming advanced,             39159
+github,                             level 6,                            old streaming advanced,             139394
+github,                             level 6 with dict,                  old streaming advanced,             38749
+github,                             level 7,                            old streaming advanced,             138675
+github,                             level 7 with dict,                  old streaming advanced,             38746
+github,                             level 9,                            old streaming advanced,             138675
+github,                             level 9 with dict,                  old streaming advanced,             38987
+github,                             level 13,                           old streaming advanced,             138675
+github,                             level 13 with dict,                 old streaming advanced,             39724
+github,                             level 16,                           old streaming advanced,             138675
+github,                             level 16 with dict,                 old streaming advanced,             40771
 github,                             level 19,                           old streaming advanced,             133717
 github,                             level 19 with dict,                 old streaming advanced,             37576
 github,                             no source size,                     old streaming advanced,             140631
-github,                             long distance mode,                 old streaming advanced,             412933
-github,                             multithreaded,                      old streaming advanced,             412933
-github,                             multithreaded long distance mode,   old streaming advanced,             412933
-github,                             small window log,                   old streaming advanced,             412933
-github,                             small hash log,                     old streaming advanced,             412933
-github,                             small chain log,                    old streaming advanced,             412933
-github,                             explicit params,                    old streaming advanced,             412933
-github,                             uncompressed literals,              old streaming advanced,             136311
+github,                             long distance mode,                 old streaming advanced,             141090
+github,                             multithreaded,                      old streaming advanced,             141090
+github,                             multithreaded long distance mode,   old streaming advanced,             141090
+github,                             small window log,                   old streaming advanced,             141090
+github,                             small hash log,                     old streaming advanced,             141578
+github,                             small chain log,                    old streaming advanced,             139258
+github,                             explicit params,                    old streaming advanced,             140930
+github,                             uncompressed literals,              old streaming advanced,             141090
 github,                             uncompressed literals optimal,      old streaming advanced,             133717
-github,                             huffman literals,                   old streaming advanced,             175568
-github,                             multithreaded with advanced params, old streaming advanced,             412933
-silesia,                            level -5,                           old streaming cdcit,                6882466
-silesia,                            level -3,                           old streaming cdcit,                6568358
-silesia,                            level -1,                           old streaming cdcit,                6183385
-silesia,                            level 0,                            old streaming cdcit,                4849491
-silesia,                            level 1,                            old streaming cdcit,                5314109
-silesia,                            level 3,                            old streaming cdcit,                4849491
-silesia,                            level 4,                            old streaming cdcit,                4786913
-silesia,                            level 5,                            old streaming cdcit,                4710178
-silesia,                            level 6,                            old streaming cdcit,                4659996
-silesia,                            level 7,                            old streaming cdcit,                4596234
-silesia,                            level 9,                            old streaming cdcit,                4543862
-silesia,                            level 13,                           old streaming cdcit,                4482073
-silesia,                            level 16,                           old streaming cdcit,                4377389
-silesia,                            level 19,                           old streaming cdcit,                4293262
-silesia,                            no source size,                     old streaming cdcit,                4849455
-silesia,                            long distance mode,                 old streaming cdcit,                12000408
-silesia,                            multithreaded,                      old streaming cdcit,                12000408
-silesia,                            multithreaded long distance mode,   old streaming cdcit,                12000408
-silesia,                            small window log,                   old streaming cdcit,                12000408
-silesia,                            small hash log,                     old streaming cdcit,                12000408
-silesia,                            small chain log,                    old streaming cdcit,                12000408
-silesia,                            explicit params,                    old streaming cdcit,                12000408
-silesia,                            uncompressed literals,              old streaming cdcit,                4849491
-silesia,                            uncompressed literals optimal,      old streaming cdcit,                4293262
-silesia,                            huffman literals,                   old streaming cdcit,                6183385
-silesia,                            multithreaded with advanced params, old streaming cdcit,                12000408
-silesia.tar,                        level -5,                           old streaming cdcit,                6982738
-silesia.tar,                        level -3,                           old streaming cdcit,                6641264
-silesia.tar,                        level -1,                           old streaming cdcit,                6190789
-silesia.tar,                        level 0,                            old streaming cdcit,                4861376
-silesia.tar,                        level 1,                            old streaming cdcit,                5336879
-silesia.tar,                        level 3,                            old streaming cdcit,                4861376
-silesia.tar,                        level 4,                            old streaming cdcit,                4799583
-silesia.tar,                        level 5,                            old streaming cdcit,                4722276
-silesia.tar,                        level 6,                            old streaming cdcit,                4672240
-silesia.tar,                        level 7,                            old streaming cdcit,                4606657
-silesia.tar,                        level 9,                            old streaming cdcit,                4554106
-silesia.tar,                        level 13,                           old streaming cdcit,                4491707
-silesia.tar,                        level 16,                           old streaming cdcit,                4381284
-silesia.tar,                        level 19,                           old streaming cdcit,                4281511
-silesia.tar,                        no source size,                     old streaming cdcit,                4861372
-silesia.tar,                        long distance mode,                 old streaming cdcit,                12022046
-silesia.tar,                        multithreaded,                      old streaming cdcit,                12022046
-silesia.tar,                        multithreaded long distance mode,   old streaming cdcit,                12022046
-silesia.tar,                        small window log,                   old streaming cdcit,                12022046
-silesia.tar,                        small hash log,                     old streaming cdcit,                12022046
-silesia.tar,                        small chain log,                    old streaming cdcit,                12022046
-silesia.tar,                        explicit params,                    old streaming cdcit,                12022046
-silesia.tar,                        uncompressed literals,              old streaming cdcit,                4861376
-silesia.tar,                        uncompressed literals optimal,      old streaming cdcit,                4281511
-silesia.tar,                        huffman literals,                   old streaming cdcit,                6190789
-silesia.tar,                        multithreaded with advanced params, old streaming cdcit,                12022046
-github,                             level -5,                           old streaming cdcit,                205285
+github,                             huffman literals,                   old streaming advanced,             181108
+github,                             multithreaded with advanced params, old streaming advanced,             141090
 github,                             level -5 with dict,                 old streaming cdcit,                46718
-github,                             level -3,                           old streaming cdcit,                190643
 github,                             level -3 with dict,                 old streaming cdcit,                45395
-github,                             level -1,                           old streaming cdcit,                175568
 github,                             level -1 with dict,                 old streaming cdcit,                43170
-github,                             level 0,                            old streaming cdcit,                136311
 github,                             level 0 with dict,                  old streaming cdcit,                41148
-github,                             level 1,                            old streaming cdcit,                142450
 github,                             level 1 with dict,                  old streaming cdcit,                41682
-github,                             level 3,                            old streaming cdcit,                136311
 github,                             level 3 with dict,                  old streaming cdcit,                41148
-github,                             level 4,                            old streaming cdcit,                136144
 github,                             level 4 with dict,                  old streaming cdcit,                41251
-github,                             level 5,                            old streaming cdcit,                135106
 github,                             level 5 with dict,                  old streaming cdcit,                38938
-github,                             level 6,                            old streaming cdcit,                135108
 github,                             level 6 with dict,                  old streaming cdcit,                38632
-github,                             level 7,                            old streaming cdcit,                135108
 github,                             level 7 with dict,                  old streaming cdcit,                38766
-github,                             level 9,                            old streaming cdcit,                135108
 github,                             level 9 with dict,                  old streaming cdcit,                39326
-github,                             level 13,                           old streaming cdcit,                133717
 github,                             level 13 with dict,                 old streaming cdcit,                39716
-github,                             level 16,                           old streaming cdcit,                133717
 github,                             level 16 with dict,                 old streaming cdcit,                37577
-github,                             level 19,                           old streaming cdcit,                133717
 github,                             level 19 with dict,                 old streaming cdcit,                37576
-github,                             no source size,                     old streaming cdcit,                140631
-github,                             long distance mode,                 old streaming cdcit,                412933
-github,                             multithreaded,                      old streaming cdcit,                412933
-github,                             multithreaded long distance mode,   old streaming cdcit,                412933
-github,                             small window log,                   old streaming cdcit,                412933
-github,                             small hash log,                     old streaming cdcit,                412933
-github,                             small chain log,                    old streaming cdcit,                412933
-github,                             explicit params,                    old streaming cdcit,                412933
-github,                             uncompressed literals,              old streaming cdcit,                136311
-github,                             uncompressed literals optimal,      old streaming cdcit,                133717
-github,                             huffman literals,                   old streaming cdcit,                175568
-github,                             multithreaded with advanced params, old streaming cdcit,                412933
-silesia,                            level -5,                           old streaming advanced cdict,       6882466
-silesia,                            level -3,                           old streaming advanced cdict,       6568358
-silesia,                            level -1,                           old streaming advanced cdict,       6183385
-silesia,                            level 0,                            old streaming advanced cdict,       4849491
-silesia,                            level 1,                            old streaming advanced cdict,       5314109
-silesia,                            level 3,                            old streaming advanced cdict,       4849491
-silesia,                            level 4,                            old streaming advanced cdict,       4786913
-silesia,                            level 5,                            old streaming advanced cdict,       4710178
-silesia,                            level 6,                            old streaming advanced cdict,       4659996
-silesia,                            level 7,                            old streaming advanced cdict,       4596234
-silesia,                            level 9,                            old streaming advanced cdict,       4543862
-silesia,                            level 13,                           old streaming advanced cdict,       4482073
-silesia,                            level 16,                           old streaming advanced cdict,       4377389
-silesia,                            level 19,                           old streaming advanced cdict,       4293262
-silesia,                            no source size,                     old streaming advanced cdict,       4849455
-silesia,                            long distance mode,                 old streaming advanced cdict,       12000408
-silesia,                            multithreaded,                      old streaming advanced cdict,       12000408
-silesia,                            multithreaded long distance mode,   old streaming advanced cdict,       12000408
-silesia,                            small window log,                   old streaming advanced cdict,       12000408
-silesia,                            small hash log,                     old streaming advanced cdict,       12000408
-silesia,                            small chain log,                    old streaming advanced cdict,       12000408
-silesia,                            explicit params,                    old streaming advanced cdict,       12000408
-silesia,                            uncompressed literals,              old streaming advanced cdict,       4849491
-silesia,                            uncompressed literals optimal,      old streaming advanced cdict,       4293262
-silesia,                            huffman literals,                   old streaming advanced cdict,       6183385
-silesia,                            multithreaded with advanced params, old streaming advanced cdict,       12000408
-silesia.tar,                        level -5,                           old streaming advanced cdict,       6982738
-silesia.tar,                        level -3,                           old streaming advanced cdict,       6641264
-silesia.tar,                        level -1,                           old streaming advanced cdict,       6190789
-silesia.tar,                        level 0,                            old streaming advanced cdict,       4861376
-silesia.tar,                        level 1,                            old streaming advanced cdict,       5336879
-silesia.tar,                        level 3,                            old streaming advanced cdict,       4861376
-silesia.tar,                        level 4,                            old streaming advanced cdict,       4799583
-silesia.tar,                        level 5,                            old streaming advanced cdict,       4722276
-silesia.tar,                        level 6,                            old streaming advanced cdict,       4672240
-silesia.tar,                        level 7,                            old streaming advanced cdict,       4606657
-silesia.tar,                        level 9,                            old streaming advanced cdict,       4554106
-silesia.tar,                        level 13,                           old streaming advanced cdict,       4491707
-silesia.tar,                        level 16,                           old streaming advanced cdict,       4381284
-silesia.tar,                        level 19,                           old streaming advanced cdict,       4281511
-silesia.tar,                        no source size,                     old streaming advanced cdict,       4861372
-silesia.tar,                        long distance mode,                 old streaming advanced cdict,       12022046
-silesia.tar,                        multithreaded,                      old streaming advanced cdict,       12022046
-silesia.tar,                        multithreaded long distance mode,   old streaming advanced cdict,       12022046
-silesia.tar,                        small window log,                   old streaming advanced cdict,       12022046
-silesia.tar,                        small hash log,                     old streaming advanced cdict,       12022046
-silesia.tar,                        small chain log,                    old streaming advanced cdict,       12022046
-silesia.tar,                        explicit params,                    old streaming advanced cdict,       12022046
-silesia.tar,                        uncompressed literals,              old streaming advanced cdict,       4861376
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced cdict,       4281511
-silesia.tar,                        huffman literals,                   old streaming advanced cdict,       6190789
-silesia.tar,                        multithreaded with advanced params, old streaming advanced cdict,       12022046
-github,                             level -5,                           old streaming advanced cdict,       205285
-github,                             level -5 with dict,                 old streaming advanced cdict,       46718
-github,                             level -3,                           old streaming advanced cdict,       190643
-github,                             level -3 with dict,                 old streaming advanced cdict,       45395
-github,                             level -1,                           old streaming advanced cdict,       175568
-github,                             level -1 with dict,                 old streaming advanced cdict,       43170
-github,                             level 0,                            old streaming advanced cdict,       136311
-github,                             level 0 with dict,                  old streaming advanced cdict,       41148
-github,                             level 1,                            old streaming advanced cdict,       142450
-github,                             level 1 with dict,                  old streaming advanced cdict,       41682
-github,                             level 3,                            old streaming advanced cdict,       136311
-github,                             level 3 with dict,                  old streaming advanced cdict,       41148
-github,                             level 4,                            old streaming advanced cdict,       136144
-github,                             level 4 with dict,                  old streaming advanced cdict,       41251
-github,                             level 5,                            old streaming advanced cdict,       135106
-github,                             level 5 with dict,                  old streaming advanced cdict,       38938
-github,                             level 6,                            old streaming advanced cdict,       135108
-github,                             level 6 with dict,                  old streaming advanced cdict,       38632
-github,                             level 7,                            old streaming advanced cdict,       135108
-github,                             level 7 with dict,                  old streaming advanced cdict,       38766
-github,                             level 9,                            old streaming advanced cdict,       135108
-github,                             level 9 with dict,                  old streaming advanced cdict,       39326
-github,                             level 13,                           old streaming advanced cdict,       133717
-github,                             level 13 with dict,                 old streaming advanced cdict,       39716
-github,                             level 16,                           old streaming advanced cdict,       133717
-github,                             level 16 with dict,                 old streaming advanced cdict,       37577
-github,                             level 19,                           old streaming advanced cdict,       133717
+github,                             level -5 with dict,                 old streaming advanced cdict,       49562
+github,                             level -3 with dict,                 old streaming advanced cdict,       44956
+github,                             level -1 with dict,                 old streaming advanced cdict,       42383
+github,                             level 0 with dict,                  old streaming advanced cdict,       41113
+github,                             level 1 with dict,                  old streaming advanced cdict,       42430
+github,                             level 3 with dict,                  old streaming advanced cdict,       41113
+github,                             level 4 with dict,                  old streaming advanced cdict,       41084
+github,                             level 5 with dict,                  old streaming advanced cdict,       39158
+github,                             level 6 with dict,                  old streaming advanced cdict,       38748
+github,                             level 7 with dict,                  old streaming advanced cdict,       38744
+github,                             level 9 with dict,                  old streaming advanced cdict,       38986
+github,                             level 13 with dict,                 old streaming advanced cdict,       39724
+github,                             level 16 with dict,                 old streaming advanced cdict,       40771
 github,                             level 19 with dict,                 old streaming advanced cdict,       37576
-github,                             no source size,                     old streaming advanced cdict,       140631
-github,                             long distance mode,                 old streaming advanced cdict,       412933
-github,                             multithreaded,                      old streaming advanced cdict,       412933
-github,                             multithreaded long distance mode,   old streaming advanced cdict,       412933
-github,                             small window log,                   old streaming advanced cdict,       412933
-github,                             small hash log,                     old streaming advanced cdict,       412933
-github,                             small chain log,                    old streaming advanced cdict,       412933
-github,                             explicit params,                    old streaming advanced cdict,       412933
-github,                             uncompressed literals,              old streaming advanced cdict,       136311
-github,                             uncompressed literals optimal,      old streaming advanced cdict,       133717
-github,                             huffman literals,                   old streaming advanced cdict,       175568
-github,                             multithreaded with advanced params, old streaming advanced cdict,       412933


### PR DESCRIPTION
* A copy-paste error made it so we weren't running the advanced/cdict
  streaming tests with the old API.
* Clean up the old streaming tests to skip incompatible configs.
* Update `results.csv`.

The tests now catch the bug in #1787.