### PR TITLE
Fix parameter selection and adjustment with srcSize == 0

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -940,6 +940,7 @@ MEM_STATIC void ZSTD_debugTable(const U32* table, U32 max)
 /* ZSTD_getCParamsFromCCtxParams() :
  * cParams are built depending on compressionLevel, src size hints,
  * LDM and manually set compression parameters.
+ * Note: srcSizeHint == 0 means 0!
  */
 ZSTD_compressionParameters ZSTD_getCParamsFromCCtxParams(
         const ZSTD_CCtx_params* CCtxParams, U64 srcSizeHint, size_t dictSize);

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1076,7 +1076,7 @@ void ZSTDMT_updateCParams_whileCompressing(ZSTDMT_CCtx* mtctx, const ZSTD_CCtx_p
     DEBUGLOG(5, "ZSTDMT_updateCParams_whileCompressing (level:%i)",
                 compressionLevel);
     mtctx->params.compressionLevel = compressionLevel;
-    {   ZSTD_compressionParameters cParams = ZSTD_getCParamsFromCCtxParams(cctxParams, 0, 0);
+    {   ZSTD_compressionParameters cParams = ZSTD_getCParamsFromCCtxParams(cctxParams, ZSTD_CONTENTSIZE_UNKNOWN, 0);
         cParams.windowLog = saved_wlog;
         mtctx->params.cParams = cParams;
     }


### PR DESCRIPTION
* Make `_internal()` versions of functions `ZSTD_getCParams()` and `ZSTD_getParams()` that don't translate 0 to unknown.
* Call the `_internal()` versions internally.
* Clean up the logic in `ZSTD_getCParams_internal()`.
* Make `ZSTD_getCParamsfromCCtxParams()` treat 0 as 0 and switch callers to `ZSTD_CONTENTSIZE_UNKNOWN`.
* Add a test for the issue in #1863 to `fuzzer.c`.
* Run the regression test suite to make sure we didn't regress anything obvious.

Fixes https://github.com/facebook/zstd/issues/1863.