### PR TITLE
Change c90 to c89

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,9 +351,9 @@ cmakebuild:
 	mkdir $(BUILDIR)/cmake/build
 	cd $(BUILDIR)/cmake/build ; cmake -DCMAKE_INSTALL_PREFIX:PATH=~/install_test_dir $(CMAKE_PARAMS) .. ; $(MAKE) install ; $(MAKE) uninstall
 
-c90build: clean
+c89build: clean
 	$(CC) -v
-	CFLAGS="-std=c90 -Werror" $(MAKE) allmost  # will fail, due to missing support for `long long`
+	CFLAGS="-std=c89 -Werror" $(MAKE) allmost  # will fail, due to missing support for `long long`
 
 gnu90build: clean
 	$(CC) -v

--- a/zlibWrapper/Makefile
+++ b/zlibWrapper/Makefile
@@ -20,8 +20,8 @@ TEST_FILE = ../doc/zstd_compression_format.md
 
 CPPFLAGS += -DXXH_NAMESPACE=ZSTD_ -I$(ZLIB_PATH) -I$(PROGRAMS_PATH)       \
             -I$(ZSTDLIBDIR) -I$(ZSTDLIBDIR)/common -I$(ZLIBWRAPPER_PATH)
-STDFLAGS  = -std=c90 -pedantic -Wno-long-long -Wno-variadic-macros -Wc++-compat \
-            -DNO_snprintf -DNO_vsnprintf  # strict ISO C90 is missing these prototypes
+STDFLAGS  = -std=c89 -pedantic -Wno-long-long -Wno-variadic-macros -Wc++-compat \
+            -DNO_snprintf -DNO_vsnprintf  # strict ANSI C89 is missing these prototypes
 DEBUGFLAGS= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wswitch-enum \
             -Wdeclaration-after-statement -Wstrict-prototypes -Wundef     \
             -Wstrict-aliasing=1


### PR DESCRIPTION
[c89 and c90 are the same language](https://en.wikipedia.org/wiki/ANSI_C#C90). Old compilers like gcc 4.2.1 don't know the c90 alias.

See https://trac.macports.org/ticket/59620