### PR TITLE
RLE test and re-enable RLE in main compression loop

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1999,14 +1999,14 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
     /* long rle test */
     {   size_t sampleSize = 0;
+        size_t expectedCompressedSize = 39; /* two RLE blocks, zstd 1.4.4 */
         DISPLAYLEVEL(3, "test%3i : Long RLE test : ", testNb++);
-        RDG_genBuffer(CNBuffer, sampleSize, compressibility, 0., seed+1);
         memset((char*)CNBuffer+sampleSize, 'B', 256 KB - 1);
         sampleSize += 256 KB - 1;
-        RDG_genBuffer((char*)CNBuffer+sampleSize, 96 KB, compressibility, 0., seed+2);
+        memset((char*)CNBuffer+sampleSize, 'A', 96 KB);
         sampleSize += 96 KB;
         cSize = ZSTD_compress(compressedBuffer, ZSTD_compressBound(sampleSize), CNBuffer, sampleSize, 1);
-        if (ZSTD_isError(cSize)) goto _output_error;
+        if (ZSTD_isError(cSize) || cSize > expectedCompressedSize * 1.1) goto _output_error;
         { CHECK_NEWV(regenSize, ZSTD_decompress(decodedBuffer, sampleSize, compressedBuffer, cSize));
           if (regenSize!=sampleSize) goto _output_error; }
         DISPLAYLEVEL(3, "OK \n");

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1999,14 +1999,14 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
     /* long rle test */
     {   size_t sampleSize = 0;
-        size_t expectedCompressedSize = 39; /* block 1: RLE, block 2: compressed, block 3: RLE, zstd 1.4.4 */
+        size_t expectedCompressedSize = 39; /* block 1, 2: compressed, block 3: RLE, zstd 1.4.4 */
         DISPLAYLEVEL(3, "test%3i : Long RLE test : ", testNb++);
         memset((char*)CNBuffer+sampleSize, 'B', 256 KB - 1);
         sampleSize += 256 KB - 1;
         memset((char*)CNBuffer+sampleSize, 'A', 96 KB);
         sampleSize += 96 KB;
         cSize = ZSTD_compress(compressedBuffer, ZSTD_compressBound(sampleSize), CNBuffer, sampleSize, 1);
-        if (ZSTD_isError(cSize) || cSize > expectedCompressedSize * 1.1) goto _output_error;
+        if (ZSTD_isError(cSize) || cSize > expectedCompressedSize) goto _output_error;
         { CHECK_NEWV(regenSize, ZSTD_decompress(decodedBuffer, sampleSize, compressedBuffer, cSize));
           if (regenSize!=sampleSize) goto _output_error; }
         DISPLAYLEVEL(3, "OK \n");

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1999,7 +1999,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
     /* long rle test */
     {   size_t sampleSize = 0;
-        size_t expectedCompressedSize = 39; /* two RLE blocks, zstd 1.4.4 */
+        size_t expectedCompressedSize = 39; /* block 1: RLE, block 2: compressed, block 3: RLE, zstd 1.4.4 */
         DISPLAYLEVEL(3, "test%3i : Long RLE test : ", testNb++);
         memset((char*)CNBuffer+sampleSize, 'B', 256 KB - 1);
         sampleSize += 256 KB - 1;


### PR DESCRIPTION
Modifies the existing RLE test to compress into two RLE blocks instead of one, and now we also check that there is no significant size regression (arbitrarily set to 10% of 39 bytes) as a proxy for testing that the blocks were indeed compressed with RLE (without RLE it would compress to 47 bytes).

Curiously, the existing test for RLE would compress to the same size regardless of whether RLE blocks were enabled.

Also validated that previous patch will fail this test.