### PR TITLE
WIP: Fix typo in util.c

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -73,7 +73,7 @@ int UTIL_setFileStat(const char *filename, stat_t *statbuf)
     {
         /* (atime, mtime) */
         struct timespec timebuf[2] = { {0, UTIME_NOW} };
-        timebuf[1] = statbuf->st_mtime;
+        timebuf[1].tv_sec = statbuf->st_mtime;
         res += utimensat(AT_FDCWD, filename, timebuf, 0);
     }
 #endif

--- a/programs/util.c
+++ b/programs/util.c
@@ -73,7 +73,7 @@ int UTIL_setFileStat(const char *filename, stat_t *statbuf)
     {
         /* (atime, mtime) */
         struct timespec timebuf[2] = { {0, UTIME_NOW} };
-        timebuf[1] = statbuf->st_mtim;
+        timebuf[1] = statbuf->st_mtime;
         res += utimensat(AT_FDCWD, filename, timebuf, 0);
     }
 #endif


### PR DESCRIPTION
There must be mtim*e*

Error popup if I use gcc-4.4 and build under Ubuntu 10.04.
And in arm builds up to Ubuntu 14.04.

Probably there must be more clever check for attributes of stat_t structure.