### PR TITLE
fix #1904

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ matrix:
 
     - name: make test (complete)
       script:
-        - make test
+        # DEVNULLRIGHTS : will request sudo rights to test permissions on /dev/null
+        - DEVNULLRIGHTS=test make test
 
     - name: gcc-6 + gcc-7 compilation
       script:

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -502,7 +502,7 @@ static int FIO_remove(const char* path)
 #if defined(_WIN32) || defined(WIN32)
     /* windows doesn't allow remove read-only files,
      * so try to make it writable first */
-    chmod(path, _S_IWRITE);
+    UTIL_chmod(path, _S_IWRITE);
 #endif
     return remove(path);
 }
@@ -526,9 +526,7 @@ static FILE* FIO_openSrcFile(const char* srcFileName)
     }
 
     if (!UTIL_isRegularFile(srcFileName)
-#ifndef _MSC_VER
-        && !UTIL_isFIFO(srcFileName)
-#endif /* _MSC_VER */
+     && !UTIL_isFIFO(srcFileName)
     ) {
         DISPLAYLEVEL(1, "zstd: %s is not a regular file -- ignored \n",
                         srcFileName);
@@ -613,7 +611,7 @@ FIO_openDstFile(FIO_prefs_t* const prefs,
                && strcmp (srcFileName, stdinmark)
                && strcmp(dstFileName, nulmark) ) {
             /* reduce rights on newly created dst file while compression is ongoing */
-            chmod(dstFileName, 00600);
+            UTIL_chmod(dstFileName, 00600);
         }
         return f;
     }

--- a/programs/util.h
+++ b/programs/util.h
@@ -30,12 +30,12 @@ extern "C" {
 #  include <io.h>         /* _chmod */
 #else
 #  include <unistd.h>     /* chown, stat */
-#if PLATFORM_POSIX_VERSION < 200809L
-#  include <utime.h>      /* utime */
-#else
-#  include <fcntl.h>      /* AT_FDCWD */
-#  include <sys/stat.h>   /* utimensat */
-#endif
+#  if PLATFORM_POSIX_VERSION < 200809L
+#    include <utime.h>      /* utime */
+#  else
+#    include <fcntl.h>      /* AT_FDCWD */
+#    include <sys/stat.h>   /* utimensat */
+#  endif
 #endif
 #include <time.h>         /* clock_t, clock, CLOCKS_PER_SEC, nanosleep */
 #include "mem.h"          /* U32, U64 */
@@ -85,12 +85,6 @@ extern "C" {
 #endif
 
 
-/*-*************************************
-*  Constants
-***************************************/
-#define LIST_SIZE_INCREASE   (8*1024)
-
-
 /*-****************************************
 *  Compiler specifics
 ******************************************/
@@ -120,7 +114,6 @@ extern int g_utilDisplayLevel;
 *  File functions
 ******************************************/
 #if defined(_MSC_VER)
-    #define chmod _chmod
     typedef struct __stat64 stat_t;
 #else
     typedef struct stat stat_t;
@@ -129,30 +122,29 @@ extern int g_utilDisplayLevel;
 
 int UTIL_fileExist(const char* filename);
 int UTIL_isRegularFile(const char* infilename);
-int UTIL_setFileStat(const char* filename, stat_t* statbuf);
-U32 UTIL_isDirectory(const char* infilename);
-int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
+int UTIL_isDirectory(const char* infilename);
 int UTIL_isSameFile(const char* file1, const char* file2);
-int UTIL_compareStr(const void *p1, const void *p2);
 int UTIL_isCompressedFile(const char* infilename, const char *extensionList[]);
-const char* UTIL_getFileExtension(const char* infilename);
+int UTIL_isLink(const char* infilename);
+int UTIL_isFIFO(const char* infilename);
 
-#ifndef _MSC_VER
-U32 UTIL_isFIFO(const char* infilename);
-#endif
-U32 UTIL_isLink(const char* infilename);
 #define UTIL_FILESIZE_UNKNOWN  ((U64)(-1))
 U64 UTIL_getFileSize(const char* infilename);
-
 U64 UTIL_getTotalFileSize(const char* const * const fileNamesTable, unsigned nbFiles);
+int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
+int UTIL_setFileStat(const char* filename, stat_t* statbuf);
+int UTIL_chmod(char const* filename, mode_t permissions);   /*< like chmod, but avoid changing permission of /dev/null */
+int UTIL_compareStr(const void *p1, const void *p2);
+const char* UTIL_getFileExtension(const char* infilename);
+
 
 /*
  * A modified version of realloc().
  * If UTIL_realloc() fails the original block is freed.
 */
-UTIL_STATIC void* UTIL_realloc(void *ptr, size_t size)
+UTIL_STATIC void* UTIL_realloc(void* ptr, size_t size)
 {
-    void *newptr = realloc(ptr, size);
+    void* const newptr = realloc(ptr, size);
     if (newptr) return newptr;
     free(ptr);
     return NULL;

--- a/programs/util.h
+++ b/programs/util.h
@@ -115,6 +115,7 @@ extern int g_utilDisplayLevel;
 ******************************************/
 #if defined(_MSC_VER)
     typedef struct __stat64 stat_t;
+    typedef int mode_t;
 #else
     typedef struct stat stat_t;
 #endif

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1005,16 +1005,13 @@ int main(int argCount, const char* argv[])
     if (!followLinks) {
         unsigned u;
         for (u=0, fileNamesNb=0; u<filenameIdx; u++) {
-            if (UTIL_isLink(filenameTable[u])
-#ifndef _MSC_VER
-                && !UTIL_isFIFO(filenameTable[u])
-#endif /* _MSC_VER */
+            if ( UTIL_isLink(filenameTable[u])
+             && !UTIL_isFIFO(filenameTable[u])
             ) {
                 DISPLAYLEVEL(2, "Warning : %s is a symbolic link, ignoring\n", filenameTable[u]);
             } else {
                 filenameTable[fileNamesNb++] = filenameTable[u];
-            }
-        }
+        }   }
         if (fileNamesNb == 0 && filenameIdx > 0)
             CLEAN_RETURN(1);
         filenameIdx = fileNamesNb;
@@ -1027,8 +1024,7 @@ int main(int argCount, const char* argv[])
             free((void*)filenameTable);
             filenameTable = extendedFileList;
             filenameIdx = fileNamesNb;
-        }
-    }
+    }   }
 #else
     (void)followLinks;
 #endif
@@ -1074,18 +1070,15 @@ int main(int argCount, const char* argv[])
                     DISPLAYLEVEL(3, "Benchmarking %s \n", filenameTable[i]);
                     for(c = cLevel; c <= cLevelLast; c++) {
                         BMK_benchFilesAdvanced(&filenameTable[i], 1, dictFileName, c, &compressionParams, g_displayLevel, &benchParams);
-                    }
-                }
+                }   }
             } else {
                 for(; cLevel <= cLevelLast; cLevel++) {
                     BMK_benchFilesAdvanced(filenameTable, filenameIdx, dictFileName, cLevel, &compressionParams, g_displayLevel, &benchParams);
-                }
-            }
+            }   }
         } else {
             for(; cLevel <= cLevelLast; cLevel++) {
                 BMK_syntheticTest(cLevel, compressibility, &compressionParams, g_displayLevel, &benchParams);
-            }
-        }
+        }   }
 
 #else
         (void)bench_nbSeconds; (void)blockSize; (void)setRealTimePrio; (void)separateFiles; (void)compressibility;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -220,13 +220,12 @@ $ZSTD tmp -c --compress-literals    -19      | $ZSTD -t
 $ZSTD -b --fast=1 -i0e1 tmp --compress-literals
 $ZSTD -b --fast=1 -i0e1 tmp --no-compress-literals
 
-println "test: --exclude-compressed flag"
+println "\n===>  --exclude-compressed flag"
 rm -rf precompressedFilterTestDir
 mkdir -p precompressedFilterTestDir
 ./datagen $size > precompressedFilterTestDir/input.5
 ./datagen $size > precompressedFilterTestDir/input.6
 $ZSTD --exclude-compressed --long --rm -r precompressedFilterTestDir
-sleep 5
 ./datagen $size > precompressedFilterTestDir/input.7
 ./datagen $size > precompressedFilterTestDir/input.8
 $ZSTD --exclude-compressed --long --rm -r precompressedFilterTestDir
@@ -251,7 +250,7 @@ test -f precompressedFilterTestDir/input.5.zst.zst
 test -f precompressedFilterTestDir/input.6.zst.zst
 println "Test completed"
 
-println "test : file removal"
+println "\n===>  file removal"
 $ZSTD -f --rm tmp
 test ! -f tmp  # tmp should no longer be present
 $ZSTD -f -d --rm tmp.zst
@@ -278,13 +277,16 @@ $ZSTD -f tmp && die "attempt to compress a non existing file"
 test -f tmp.zst  # destination file should still be present
 rm -rf tmp*  # may also erase tmp* directory from previous failed run
 
-println "\n===> decompression only tests "
-dd bs=1 count=1048576 if=/dev/zero of=tmp
+println "\n===>  decompression only tests "
+# the following test verifies that the decoder is compatible with RLE as first block
+# older versions of zstd cli are not able to decode such corner case.
+# As a consequence, the zstd cli do not generate them, to maintain compatibility with older versions.
+dd bs=1048576 count=1 if=/dev/zero of=tmp
 $ZSTD -d -o tmp1 "$TESTDIR/golden-decompression/rle-first-block.zst"
 $DIFF -s tmp1 tmp
 rm tmp*
 
-println "test : compress multiple files"
+println "\m===>  compress multiple files"
 println hello > tmp1
 println world > tmp2
 $ZSTD tmp1 tmp2 -o "$INTOVOID" -f
@@ -306,7 +308,17 @@ if [ "$?" -eq 139 ]; then
 fi
 rm tmp*
 
-println "test : compress multiple files into an output directory, --output-dir-flat"
+if [ -n "$DEVNULLRIGHTS" ]
+then
+    # these tests requires sudo rights, which is uncommon.
+    # they are only triggered if DEVNULLRIGHTS macro is defined.
+    println "\n===> checking /dev/null permissions are unaltered "
+    ./datagen > tmp
+    sudo $ZSTD tmp -o $INTOVOID   # sudo rights could modify /dev/null permissions
+    ls -las $INTOVOID | grep "rw-rw-rw-"
+fi
+
+println "\n===>  compress multiple files into an output directory, --output-dir-flat"
 println henlo > tmp1
 mkdir tmpInputTestDir
 mkdir tmpInputTestDir/we
@@ -352,7 +364,6 @@ $ZSTD -dcf tmp1
 
 
 println "\n===>  frame concatenation "
-
 println "hello " > hello.tmp
 println "world!" > world.tmp
 cat hello.tmp world.tmp > helloworld.tmp

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -315,6 +315,10 @@ then
     println "\n===> checking /dev/null permissions are unaltered "
     ./datagen > tmp
     sudo $ZSTD tmp -o $INTOVOID   # sudo rights could modify /dev/null permissions
+    sudo $ZSTD tmp -c > $INTOVOID
+    $ZSTD tmp -f -o tmp.zst
+    sudo $ZSTD -d tmp.zst -c > $INTOVOID
+    sudo $ZSTD -d tmp.zst -o $INTOVOID
     ls -las $INTOVOID | grep "rw-rw-rw-"
 fi
 


### PR DESCRIPTION
fix #1904

`/dev/null` permissions were modified when targeted as destination file using `sudo` rights.
Bug fixed for both compression and decompression.

More importantly, this patch adds a test, [triggered in TravisCI](https://travis-ci.org/facebook/zstd/jobs/616825323#L676),
ensuring unaltered `/dev/null` permissions when using `sudo` rights.

minor : improves speed of `make check`, by removing some inefficiencies.