### PR TITLE
test installation with MSYS2+mingw-w64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ clean:
 #------------------------------------------------------------------------------
 # make install is validated only for Linux, macOS, Hurd and some BSD targets
 #------------------------------------------------------------------------------
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD DragonFly NetBSD MSYS_NT Haiku))
+ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD DragonFly NetBSD MSYS_NT Haiku MINGW%,$(shell uname)))
 
 HOST_OS = POSIX
 CMAKE_PARAMS = -DZSTD_BUILD_CONTRIB:BOOL=ON -DZSTD_BUILD_STATIC:BOOL=ON -DZSTD_BUILD_TESTS:BOOL=ON -DZSTD_ZLIB_SUPPORT:BOOL=ON -DZSTD_LZMA_SUPPORT:BOOL=ON -DCMAKE_BUILD_TYPE=Release

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -158,10 +158,10 @@ libzstd.a-mt: libzstd.a
 
 ifneq (,$(filter Windows%,$(OS)))
 
-LIBZSTD = dll\libzstd.dll
+LIBZSTD = dll/libzstd-$(LIBVER_MAJOR).dll
 $(LIBZSTD): $(ZSTD_FILES)
 	@echo compiling dynamic library $(LIBVER)
-	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--out-implib,dll\libzstd.dll.a -shared $^ -o $@
+	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--out-implib,dll/libzstd.dll.a -shared $^ -o $@
 
 else
 
@@ -210,7 +210,7 @@ clean:
 #-----------------------------------------------------------------------------
 # make install is validated only for Linux, macOS, BSD, Hurd and Solaris targets
 #-----------------------------------------------------------------------------
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku))
+ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MINGW%,$(shell uname)))
 
 DESTDIR     ?=
 # directory variables : GNU conventions prefer lowercase
@@ -223,6 +223,8 @@ libdir      ?= $(exec_prefix)/lib
 LIBDIR      ?= $(libdir)
 includedir  ?= $(PREFIX)/include
 INCLUDEDIR  ?= $(includedir)
+bindir      ?= $(PREFIX)/bin
+BINDIR      ?= $(bindir)
 
 ifneq (,$(filter $(shell uname),FreeBSD NetBSD DragonFly))
 PKGCONFIGDIR ?= $(PREFIX)/libdata/pkgconfig
@@ -262,9 +264,15 @@ install-static: libzstd.a
 install-shared: libzstd
 	@echo Installing shared library
 	@$(INSTALL) -d -m 755 $(DESTDIR)$(LIBDIR)/
+ifneq (,$(filter MINGW%,$(shell uname)))
+	@$(INSTALL) -d -m 755 $(DESTDIR)$(BINDIR)/
+	@$(INSTALL_PROGRAM) $(LIBZSTD) $(DESTDIR)$(BINDIR)
+	@$(INSTALL_PROGRAM) dll/libzstd.dll.a $(DESTDIR)$(LIBDIR)
+else
 	@$(INSTALL_PROGRAM) $(LIBZSTD) $(DESTDIR)$(LIBDIR)
 	@ln -sf $(LIBZSTD) $(DESTDIR)$(LIBDIR)/libzstd.$(SHARED_EXT_MAJOR)
 	@ln -sf $(LIBZSTD) $(DESTDIR)$(LIBDIR)/libzstd.$(SHARED_EXT)
+endif
 
 install-includes:
 	@echo Installing includes
@@ -276,9 +284,14 @@ install-includes:
 
 uninstall:
 	@$(RM) $(DESTDIR)$(LIBDIR)/libzstd.a
+ifneq (,$(filter MINGW%,$(shell uname)))
+	@$(RM) $(DESTDIR)$(BINDIR)/$(LIBZSTD)
+	@$(RM) $(DESTDIR)$(LIBDIR)/libzstd.dll.a
+else
 	@$(RM) $(DESTDIR)$(LIBDIR)/libzstd.$(SHARED_EXT)
 	@$(RM) $(DESTDIR)$(LIBDIR)/libzstd.$(SHARED_EXT_MAJOR)
 	@$(RM) $(DESTDIR)$(LIBDIR)/$(LIBZSTD)
+endif
 	@$(RM) $(DESTDIR)$(PKGCONFIGDIR)/libzstd.pc
 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/zstd.h
 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/zstd_errors.h

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -290,7 +290,7 @@ preview-man: clean-man man
 #-----------------------------------------------------------------------------
 # make install is validated only for Linux, macOS, BSD, Hurd and Solaris targets
 #-----------------------------------------------------------------------------
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku))
+ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MINGW%,$(shell uname)))
 
 HAVE_COLORNEVER = $(shell echo a | egrep --color=never a > /dev/null 2> /dev/null && echo 1 || echo 0)
 EGREP_OPTIONS ?=


### PR DESCRIPTION
appveyorCI has been updated to add an installation test
which fails without this patch.
It should pass with it.