### PR TITLE
small refactoring : remove global variable g_displayOut

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1173,6 +1173,17 @@ roundTripTest -g1M -P50 "1 --single-thread --long=29" " --long=28 --memory=512MB
 roundTripTest -g1M -P50 "1 --single-thread --long=29" " --zstd=wlog=28 --memory=512MB"
 
 
+
+
+if [ "$1" != "--test-large-data" ]; then
+    println "Skipping large data tests"
+    exit 0
+fi
+
+
+#############################################################################
+
+
 if [ -n "$hasMT" ]
 then
     println "\n===>   adaptive mode "
@@ -1189,14 +1200,6 @@ then
     $ZSTD -f -vv --rsyncable --single-thread tmp && die "--rsyncable must fail with --single-thread"
 fi
 
-
-if [ "$1" != "--test-large-data" ]; then
-    println "Skipping large data tests"
-    exit 0
-fi
-
-
-#############################################################################
 
 println "\n===>   large files tests "
 


### PR DESCRIPTION
displaying into `stderr` or `stdout` is now an explicit operation.

I was bothered by this "hidden contract", making the rest of the unit (slightly) more difficult to anticipate.

Case in point : `initCLevel()` would not work during initialization, 
it was necessary to wait first for `g_displayOut` initialization,
since the function may output an error message in case of incorrect environment variable.
But `g_displayOut` could not be initialized at compile time, since `stderr` is not considered a constant.

Doing it nonetheless would result in undefined behavior at runtime, with no prior compilation warning.

As a rule of thumb, removing secret contracts is generally a good improvement for code maintenance.

Also : fix a slight discrepancy between `-V` and `--version`.