### PR TITLE
Use statbuf->st_mtim Again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,13 @@ matrix:
         - make arminstall
         - make armfuzz
 
+    # Introduced to check compat with old toolchains, to prevent e.g. #1872
+    - name: ARM Build Test (on Trusty)
+      dist: trusty
+      script:
+        - make arminstall
+        - make armbuild
+
     - name: Qemu PPC + Fuzz Test    # ~13mn
       dist: trusty   # it seems ppc cross-compilation fails on "current"
       script:

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -109,6 +109,15 @@ extern "C" {
 #endif   /* PLATFORM_POSIX_VERSION */
 
 
+#if PLATFORM_POSIX_VERSION > 1
+   /* glibc < 2.26 may not expose struct timespec def without this.
+    * See issue #1920. */
+#  ifndef _ATFILE_SOURCE
+#    define _ATFILE_SOURCE
+#  endif
+#endif
+
+
 /*-*********************************************
 *  Detect if isatty() and fileno() are available
 ************************************************/

--- a/programs/util.c
+++ b/programs/util.c
@@ -145,19 +145,19 @@ int UTIL_setFileStat(const char *filename, stat_t *statbuf)
         return -1;
 
     /* set access and modification times */
-#if defined(_WIN32) || (PLATFORM_POSIX_VERSION < 200809L)
+#if (PLATFORM_POSIX_VERSION >= 200809L) && defined(st_mtime)
+    {
+        /* (atime, mtime) */
+        struct timespec timebuf[2] = { {0, UTIME_NOW} };
+        timebuf[1] = statbuf->st_mtim;
+        res += utimensat(AT_FDCWD, filename, timebuf, 0);
+    }
+#else
     {
         struct utimbuf timebuf;
         timebuf.actime = time(NULL);
         timebuf.modtime = statbuf->st_mtime;
         res += utime(filename, &timebuf);
-    }
-#else
-    {
-        /* (atime, mtime) */
-        struct timespec timebuf[2] = { {0, UTIME_NOW} };
-        timebuf[1].tv_sec = statbuf->st_mtime;
-        res += utimensat(AT_FDCWD, filename, timebuf, 0);
     }
 #endif
 

--- a/programs/util.c
+++ b/programs/util.c
@@ -145,6 +145,10 @@ int UTIL_setFileStat(const char *filename, stat_t *statbuf)
         return -1;
 
     /* set access and modification times */
+    /* We check that st_mtime is a macro here in order to give us confidence
+     * that struct stat has a struct timespec st_mtim member. We need this
+     * check because there are some platforms that claim to be POSIX 2008
+     * compliant but which do not have st_mtim... */
 #if (PLATFORM_POSIX_VERSION >= 200809L) && defined(st_mtime)
     {
         /* (atime, mtime) */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -330,7 +330,7 @@ test-zstd-nolegacy: zstd-nolegacy
 
 test-zstd test-zstd32 test-zstd-nolegacy: datagen
 	file $(ZSTD)
-	ZSTD="$(QEMU_SYS) $(ZSTD)" ./playTests.sh $(ZSTDRTTEST)
+	EXE_PREFIX="$(QEMU_SYS)" ZSTD_BIN="$(ZSTD)" ./playTests.sh $(ZSTDRTTEST)
 
 
 test-gzstd: gzstd

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -102,9 +102,11 @@ case "$UNAME" in
   SunOS) DIFF="gdiff" ;;
 esac
 
-println "\nStarting playTests.sh isWindows=$isWindows ZSTD='$ZSTD'"
+println "\nStarting playTests.sh isWindows=$isWindows EXE_PREFIX='$EXE_PREFIX' ZSTD_BIN='$ZSTD_BIN'"
 
-[ -n "$ZSTD" ] || die "ZSTD variable must be defined!"
+[ -n "$ZSTD_BIN" ] || die "ZSTD_BIN variable must be defined!"
+
+ZSTD="$EXE_PREFIX $ZSTD_BIN"
 
 if echo hello | $ZSTD -v -T2 2>&1 > $INTOVOID | grep -q 'multi-threading is disabled'
 then
@@ -493,19 +495,19 @@ cat hello.zstd world.zstd > helloworld.zstd
 $ZSTD -dc helloworld.zstd > result.tmp
 $DIFF helloworld.tmp result.tmp
 println "testing zstdcat symlink"
-ln -sf $ZSTD zstdcat
-./zstdcat helloworld.zstd > result.tmp
+ln -sf $ZSTD_BIN zstdcat
+$EXE_PREFIX ./zstdcat helloworld.zstd > result.tmp
 $DIFF helloworld.tmp result.tmp
 ln -s helloworld.zstd helloworld.link.zstd
-./zstdcat helloworld.link.zstd > result.tmp
+$EXE_PREFIX ./zstdcat helloworld.link.zstd > result.tmp
 $DIFF helloworld.tmp result.tmp
 rm zstdcat
 rm result.tmp
 println "testing zcat symlink"
-ln -sf $ZSTD zcat
-./zcat helloworld.zstd > result.tmp
+ln -sf $ZSTD_BIN zcat
+$EXE_PREFIX ./zcat helloworld.zstd > result.tmp
 $DIFF helloworld.tmp result.tmp
-./zcat helloworld.link.zstd > result.tmp
+$EXE_PREFIX ./zcat helloworld.link.zstd > result.tmp
 $DIFF helloworld.tmp result.tmp
 rm zcat
 rm ./*.tmp ./*.zstd


### PR DESCRIPTION
Let's try this again. Changes:

1. I believe checking `defined(_WIN32)` is redundant with checking the POSIX version. So I've removed that.
2. I flipped the order, we should do the preferred behavior first and the fallback next.
3. I added a check for whether `st_mtime` is defined. When `st_mtim` replaced `st_mtime`, `st_mtime` became a macro that expanded to `st_mtim.tv_sec` for backwards compatibility. Since we have found examples where the platform advertising POSIX 2008 still doesn't have `st_mtim`, this additional check should be defensive. The only concern is whether there are platforms that have `st_mtim` but not the `st_mtime` macro. I don't believe that there should be: the `st_mtime` macro is also part of POSIX 2008 (although we've seen where that gets us...). At any rate, failing this check will just cause us to fall back to the less preferable behavior.

Reference: [POSIX 2008 `sys/stat.h` Spec](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/basedefs/sys_stat.h.html).