### PR TITLE
Only Modify Mode on Regular Files

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -509,7 +509,7 @@ static int FIO_remove(const char* path)
 #if defined(_WIN32) || defined(WIN32)
     /* windows doesn't allow remove read-only files,
      * so try to make it writable first */
-    UTIL_chmod(path, _S_IWRITE);
+    UTIL_chmod(path, _S_IWRITE, 0 /* onlyRegularFiles: already checked above */);
 #endif
     return remove(path);
 }
@@ -618,7 +618,7 @@ FIO_openDstFile(FIO_prefs_t* const prefs,
                && strcmp (srcFileName, stdinmark)
                && strcmp(dstFileName, nulmark) ) {
             /* reduce rights on newly created dst file while compression is ongoing */
-            UTIL_chmod(dstFileName, 00600);
+            UTIL_chmod(dstFileName, 00600, 1 /* onlyRegularFiles */);
         }
         return f;
     }

--- a/programs/util.c
+++ b/programs/util.c
@@ -138,17 +138,25 @@ int UTIL_chmod(char const* filename, mode_t permissions, int onlyRegularFiles)
     return chmod(filename, permissions);
 }
 
-int UTIL_chown(char const* filename, uid_t owner, gid_t group, int onlyRegularFiles) {
+#if !defined(_WIN32)
+static int UTIL_chown(char const* filename,
+                      uid_t owner,
+                      gid_t group,
+                      int onlyRegularFiles) {
     if (onlyRegularFiles && !UTIL_isRegularFile(filename)) {
         return 0;
     }
-#if !defined(_WIN32)
     return chown(filename, owner, group);
-#else
-    /* windows doesn't have the chown concept. */
-    return 0;
-#endif
 }
+#else
+/* windows doesn't have any of this */
+static int UTIL_chown(char const* /* filename */,
+                      int /* owner */,
+                      int /* group */,
+                      int /* onlyRegularFiles */) {
+    return 0;
+}
+#endif
 
 int UTIL_setFileStat(const char *filename, stat_t *statbuf)
 {

--- a/programs/util.h
+++ b/programs/util.h
@@ -97,11 +97,9 @@ extern int g_utilDisplayLevel;
 /*-****************************************
 *  File functions
 ******************************************/
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     typedef struct __stat64 stat_t;
     typedef int mode_t;
-    typedef int uid_t;
-    typedef int gid_t;
 #else
     typedef struct stat stat_t;
 #endif
@@ -121,7 +119,6 @@ U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
 int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
 int UTIL_setFileStat(const char* filename, stat_t* statbuf);
 int UTIL_chmod(char const* filename, mode_t permissions, int onlyRegularFiles);   /*< like chmod, but avoid changing permission of special files */
-int UTIL_chown(char const* filename, uid_t owner, gid_t group, int onlyRegularFiles);   /*< like chown, but avoid changing permission of special files */
 int UTIL_compareStr(const void *p1, const void *p2);
 const char* UTIL_getFileExtension(const char* infilename);
 

--- a/programs/util.h
+++ b/programs/util.h
@@ -100,6 +100,8 @@ extern int g_utilDisplayLevel;
 #if defined(_MSC_VER)
     typedef struct __stat64 stat_t;
     typedef int mode_t;
+    typedef int uid_t;
+    typedef int gid_t;
 #else
     typedef struct stat stat_t;
 #endif
@@ -118,7 +120,8 @@ U64 UTIL_getFileSize(const char* infilename);
 U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
 int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
 int UTIL_setFileStat(const char* filename, stat_t* statbuf);
-int UTIL_chmod(char const* filename, mode_t permissions);   /*< like chmod, but avoid changing permission of /dev/null */
+int UTIL_chmod(char const* filename, mode_t permissions, int onlyRegularFiles);   /*< like chmod, but avoid changing permission of special files */
+int UTIL_chown(char const* filename, uid_t owner, gid_t group, int onlyRegularFiles);   /*< like chown, but avoid changing permission of special files */
 int UTIL_compareStr(const void *p1, const void *p2);
 const char* UTIL_getFileExtension(const char* infilename);
 


### PR DESCRIPTION
Rather than do string comparisons to exclude `/dev/null` specifically, it makes more sense to me to avoid all special files (i.e.: devices, FIFOs, symlinks, sockets, and directories). This change does that, although it finds that in most places that chmod / chown are called from, there are already `UTIL_isRegularFile()` guards.

So I guess this is my proposal to amend #1905 to fix #1904 better.