### PR TITLE
pkgconfig: Don't hardcode libdir.

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -244,6 +244,7 @@ libzstd.pc:
 libzstd.pc: libzstd.pc.in
 	@echo creating pkgconfig
 	@sed -e 's|@PREFIX@|$(PREFIX)|' \
+             -e 's|@LIBDIR@|$(LIBDIR)|' \
              -e 's|@VERSION@|$(VERSION)|' \
              $< >$@
 

--- a/lib/libzstd.pc.in
+++ b/lib/libzstd.pc.in
@@ -5,7 +5,7 @@
 prefix=@PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=@LIBDIR@
 
 Name: zstd
 Description: fast lossless compression algorithm library


### PR DESCRIPTION
This fixes the build for the current mesa master on my mulitlib Slackware system when `ld(1)` is given `/usr/lib/libzstd.so` instead of `/usr/lib64/libzstd.zo`.

For an example pkgconfig file see `libpkgconf.pc.in` from the pkgconf project.

https://github.com/pkgconf/pkgconf/blob/c862e030cf83447f679e4f49876f5298f0fc9691/libpkgconf.pc.in