### PR TITLE
Adding new cli endpoint --patch-from=

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -77,6 +77,7 @@
 
 #define FNSPACE 30
 
+#define DIFFFROM_WINDOWSIZE_EXTRA_BYTES 1 KB
 
 /*-*************************************
 *  Macros
@@ -321,6 +322,7 @@ struct FIO_prefs_s {
     int nbWorkers;
 
     int excludeCompressedFiles;
+    int diffFromMode;
 };
 
 
@@ -487,6 +489,10 @@ void FIO_setLdmHashRateLog(FIO_prefs_t* const prefs, int ldmHashRateLog) {
     prefs->ldmHashRateLog = ldmHashRateLog;
 }
 
+void FIO_setDiffFromMode(FIO_prefs_t* const prefs, int diffFromMode)
+{
+    prefs->diffFromMode = diffFromMode;
+}
 
 /*-*************************************
 *  Functions
@@ -624,7 +630,7 @@ FIO_openDstFile(FIO_prefs_t* const prefs,
  * @return : loaded size
  *  if fileName==NULL, returns 0 and a NULL pointer
  */
-static size_t FIO_createDictBuffer(void** bufferPtr, const char* fileName)
+static size_t FIO_createDictBuffer(FIO_prefs_t* const prefs, void** bufferPtr, const char* fileName)
 {
     FILE* fileHandle;
     U64 fileSize;
@@ -638,9 +644,12 @@ static size_t FIO_createDictBuffer(void** bufferPtr, const char* fileName)
     if (fileHandle==NULL) EXM_THROW(31, "%s: %s", fileName, strerror(errno));
 
     fileSize = UTIL_getFileSize(fileName);
-    if (fileSize > DICTSIZE_MAX) {
-        EXM_THROW(32, "Dictionary file %s is too large (> %u MB)",
-                        fileName, DICTSIZE_MAX >> 20);   /* avoid extreme cases */
+    {
+        size_t dictSizeMax = prefs->diffFromMode ? prefs->memLimit : DICTSIZE_MAX;
+        if (fileSize >  dictSizeMax) {
+            EXM_THROW(32, "Dictionary file %s is too large (> %u bytes)",
+                            fileName,  (unsigned)dictSizeMax);   /* avoid extreme cases */
+        }
     }
     *bufferPtr = malloc((size_t)fileSize);
     if (*bufferPtr==NULL) EXM_THROW(34, "%s", strerror(errno));
@@ -759,9 +768,16 @@ typedef struct {
     ZSTD_CStream* cctx;
 } cRess_t;
 
+static unsigned int FIO_log2(const size_t x)
+{
+    size_t tmp = x; int res = 0;
+    while (tmp >>= 1) res++;
+    return res;
+}
+
 static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
-                                    const char* dictFileName, int cLevel,
-                                    ZSTD_compressionParameters comprParams) {
+                                    const char* dictFileName, const size_t maxSrcFileSize,
+                                    int cLevel, ZSTD_compressionParameters comprParams) {
     cRess_t ress;
     memset(&ress, 0, sizeof(ress));
 
@@ -779,13 +795,17 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
 
     /* Advanced parameters, including dictionary */
     {   void* dictBuffer;
-        size_t const dictBuffSize = FIO_createDictBuffer(&dictBuffer, dictFileName);   /* works with dictFileName==NULL */
+        size_t const dictBuffSize = FIO_createDictBuffer(prefs, &dictBuffer, dictFileName);   /* works with dictFileName==NULL */
         if (dictFileName && (dictBuffer==NULL))
             EXM_THROW(32, "allocation error : can't create dictBuffer");
         ress.dictFileName = dictFileName;
 
         if (prefs->adaptiveMode && !prefs->ldmFlag && !comprParams.windowLog)
             comprParams.windowLog = ADAPT_WINDOWLOG_DEFAULT;
+
+        if (prefs->diffFromMode) {
+            comprParams.windowLog = FIO_log2(maxSrcFileSize + DIFFFROM_WINDOWSIZE_EXTRA_BYTES);
+        }
 
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_contentSizeFlag, 1) );  /* always enable content size when available (note: supposed to be default) */
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_dictIDFlag, prefs->dictIDFlag) );
@@ -1515,7 +1535,7 @@ int FIO_compressFilename(FIO_prefs_t* const prefs, const char* dstFileName,
                          const char* srcFileName, const char* dictFileName,
                          int compressionLevel,  ZSTD_compressionParameters comprParams)
 {
-    cRess_t const ress = FIO_createCResources(prefs, dictFileName, compressionLevel, comprParams);
+    cRess_t const ress = FIO_createCResources(prefs, dictFileName, (size_t)UTIL_getFileSize(srcFileName), compressionLevel, comprParams);
     int const result = FIO_compressFilename_srcFile(prefs, ress, dstFileName, srcFileName, compressionLevel);
 
 
@@ -1563,6 +1583,15 @@ FIO_determineCompressedName(const char* srcFileName, const char* outDirName, con
     return dstFileNameBuffer;
 }
 
+static size_t FIO_getLargestFileSize(const char** inFileNames, unsigned nbFiles)
+{
+    size_t i; size_t fileSize; size_t maxFileSize = 0;
+    for (i = 0; i < nbFiles; i++) {
+        fileSize = UTIL_getFileSize(inFileNames[i]);
+        maxFileSize = fileSize > maxFileSize ? fileSize : maxFileSize;
+    }
+    return maxFileSize;
+}
 
 /* FIO_compressMultipleFilenames() :
  * compress nbFiles files
@@ -1578,7 +1607,9 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
                                   ZSTD_compressionParameters comprParams)
 {
     int error = 0;
-    cRess_t ress = FIO_createCResources(prefs, dictFileName, compressionLevel, comprParams);
+    cRess_t ress = FIO_createCResources(prefs, dictFileName,
+        FIO_getLargestFileSize(inFileNamesTable, nbFiles),
+        compressionLevel, comprParams);
 
     /* init */
     assert(outFileName != NULL || suffix != NULL);
@@ -1648,7 +1679,7 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
 
     /* dictionary */
     {   void* dictBuffer;
-        size_t const dictBufferSize = FIO_createDictBuffer(&dictBuffer, dictFileName);
+        size_t const dictBufferSize = FIO_createDictBuffer(prefs, &dictBuffer, dictFileName);
         CHECK( ZSTD_initDStream_usingDict(ress.dctx, dictBuffer, dictBufferSize) );
         free(dictBuffer);
     }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -630,7 +630,7 @@ FIO_openDstFile(FIO_prefs_t* const prefs,
  * @return : loaded size
  *  if fileName==NULL, returns 0 and a NULL pointer
  */
-static size_t FIO_createDictBuffer(FIO_prefs_t* const prefs, void** bufferPtr, const char* fileName)
+static size_t FIO_createDictBuffer(void** bufferPtr, const char* fileName, FIO_prefs_t* const prefs)
 {
     FILE* fileHandle;
     U64 fileSize;
@@ -801,7 +801,7 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
 
     /* Advanced parameters, including dictionary */
     {   void* dictBuffer;
-        size_t const dictBuffSize = FIO_createDictBuffer(prefs, &dictBuffer, dictFileName);   /* works with dictFileName==NULL */
+        size_t const dictBuffSize = FIO_createDictBuffer(&dictBuffer, dictFileName, prefs);   /* works with dictFileName==NULL */
         if (dictFileName && (dictBuffer==NULL))
             EXM_THROW(32, "allocation error : can't create dictBuffer");
         ress.dictFileName = dictFileName;
@@ -1685,7 +1685,7 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
 
     /* dictionary */
     {   void* dictBuffer;
-        size_t const dictBufferSize = FIO_createDictBuffer(prefs, &dictBuffer, dictFileName);
+        size_t const dictBufferSize = FIO_createDictBuffer(&dictBuffer, dictFileName, prefs);
         CHECK( ZSTD_initDStream_usingDict(ress.dctx, dictBuffer, dictBufferSize) );
         free(dictBuffer);
     }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1591,7 +1591,7 @@ FIO_determineCompressedName(const char* srcFileName, const char* outDirName, con
 
 static size_t FIO_getLargestFileSize(const char** inFileNames, unsigned nbFiles)
 {
-    size_t i; size_t fileSize; size_t maxFileSize = 0;
+    size_t i, fileSize, maxFileSize = 0;
     for (i = 0; i < nbFiles; i++) {
         fileSize = (size_t)UTIL_getFileSize(inFileNames[i]);
         maxFileSize = fileSize > maxFileSize ? fileSize : maxFileSize;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -491,7 +491,7 @@ void FIO_setLdmHashRateLog(FIO_prefs_t* const prefs, int ldmHashRateLog) {
 
 void FIO_setDiffFromMode(FIO_prefs_t* const prefs, int diffFromMode)
 {
-    prefs->diffFromMode = diffFromMode;
+    prefs->diffFromMode = diffFromMode != 0;
 }
 
 /*-*************************************

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1585,7 +1585,7 @@ FIO_determineCompressedName(const char* srcFileName, const char* outDirName, con
 
 static size_t FIO_getLargestFileSize(const char** inFileNames, unsigned nbFiles)
 {
-    size_t i, fileSize, maxFileSize = 0;
+    size_t i; size_t fileSize; size_t maxFileSize = 0;
     for (i = 0; i < nbFiles; i++) {
         fileSize = (size_t)UTIL_getFileSize(inFileNames[i]);
         maxFileSize = fileSize > maxFileSize ? fileSize : maxFileSize;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1585,7 +1585,7 @@ FIO_determineCompressedName(const char* srcFileName, const char* outDirName, con
 
 static size_t FIO_getLargestFileSize(const char** inFileNames, unsigned nbFiles)
 {
-    size_t i; size_t fileSize; size_t maxFileSize = 0;
+    size_t i, fileSize, maxFileSize = 0;
     for (i = 0; i < nbFiles; i++) {
         fileSize = (size_t)UTIL_getFileSize(inFileNames[i]);
         maxFileSize = fileSize > maxFileSize ? fileSize : maxFileSize;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -768,11 +768,17 @@ typedef struct {
     ZSTD_CStream* cctx;
 } cRess_t;
 
-static unsigned int FIO_log2(const size_t x)
+/* FIO_highbit64() :
+ * gives position of highest bit.
+ * note : only works for v > 0 !
+ */
+static unsigned FIO_highbit64(unsigned long long v)
 {
-    size_t tmp = x; int res = 0;
-    while (tmp >>= 1) res++;
-    return res;
+    unsigned count = 0;
+    assert(v != 0);
+    v >>= 1;
+    while (v) { v >>= 1; count++; }
+    return count;
 }
 
 static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
@@ -804,7 +810,7 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
             comprParams.windowLog = ADAPT_WINDOWLOG_DEFAULT;
 
         if (prefs->patchFromMode) {
-            comprParams.windowLog = FIO_log2(maxSrcFileSize + PATCHFROM_WINDOWSIZE_EXTRA_BYTES);
+            comprParams.windowLog = FIO_highbit64((unsigned long long)maxSrcFileSize + PATCHFROM_WINDOWSIZE_EXTRA_BYTES);
         }
 
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_contentSizeFlag, 1) );  /* always enable content size when available (note: supposed to be default) */
@@ -1822,19 +1828,6 @@ static int FIO_passThrough(const FIO_prefs_t* const prefs,
 
     FIO_fwriteSparseEnd(prefs, foutput, storedSkips);
     return 0;
-}
-
-/* FIO_highbit64() :
- * gives position of highest bit.
- * note : only works for v > 0 !
- */
-static unsigned FIO_highbit64(unsigned long long v)
-{
-    unsigned count = 0;
-    assert(v != 0);
-    v >>= 1;
-    while (v) { v >>= 1; count++; }
-    return count;
 }
 
 /* FIO_zstdErrorHelp() :

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -752,6 +752,20 @@ FIO_createFilename_fromOutDir(const char* path, const char* outDirName, const si
     return result;
 }
 
+/* FIO_highbit64() :
+ * gives position of highest bit.
+ * note : only works for v > 0 !
+ */
+static unsigned FIO_highbit64(unsigned long long v)
+{
+    unsigned count = 0;
+    assert(v != 0);
+    v >>= 1;
+    while (v) { v >>= 1; count++; }
+    return count;
+}
+
+
 #ifndef ZSTD_NOCOMPRESS
 
 /* **********************************************************************
@@ -767,19 +781,6 @@ typedef struct {
     const char* dictFileName;
     ZSTD_CStream* cctx;
 } cRess_t;
-
-/* FIO_highbit64() :
- * gives position of highest bit.
- * note : only works for v > 0 !
- */
-static unsigned FIO_highbit64(unsigned long long v)
-{
-    unsigned count = 0;
-    assert(v != 0);
-    v >>= 1;
-    while (v) { v >>= 1; count++; }
-    return count;
-}
 
 static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
                                     const char* dictFileName, const size_t maxSrcFileSize,

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1587,7 +1587,7 @@ static size_t FIO_getLargestFileSize(const char** inFileNames, unsigned nbFiles)
 {
     size_t i; size_t fileSize; size_t maxFileSize = 0;
     for (i = 0; i < nbFiles; i++) {
-        fileSize = UTIL_getFileSize(inFileNames[i]);
+        fileSize = (size_t)UTIL_getFileSize(inFileNames[i]);
         maxFileSize = fileSize > maxFileSize ? fileSize : maxFileSize;
     }
     return maxFileSize;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -77,7 +77,7 @@
 
 #define FNSPACE 30
 
-#define DIFFFROM_WINDOWSIZE_EXTRA_BYTES 1 KB
+#define PATCHFROM_WINDOWSIZE_EXTRA_BYTES 1 KB
 
 /*-*************************************
 *  Macros
@@ -804,7 +804,7 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
             comprParams.windowLog = ADAPT_WINDOWLOG_DEFAULT;
 
         if (prefs->patchFromMode) {
-            comprParams.windowLog = FIO_log2(maxSrcFileSize + DIFFFROM_WINDOWSIZE_EXTRA_BYTES);
+            comprParams.windowLog = FIO_log2(maxSrcFileSize + PATCHFROM_WINDOWSIZE_EXTRA_BYTES);
         }
 
         CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_contentSizeFlag, 1) );  /* always enable content size when available (note: supposed to be default) */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -322,7 +322,7 @@ struct FIO_prefs_s {
     int nbWorkers;
 
     int excludeCompressedFiles;
-    int diffFromMode;
+    int patchFromMode;
 };
 
 
@@ -489,9 +489,9 @@ void FIO_setLdmHashRateLog(FIO_prefs_t* const prefs, int ldmHashRateLog) {
     prefs->ldmHashRateLog = ldmHashRateLog;
 }
 
-void FIO_setDiffFromMode(FIO_prefs_t* const prefs, int diffFromMode)
+void FIO_setPatchFromMode(FIO_prefs_t* const prefs, int value)
 {
-    prefs->diffFromMode = diffFromMode != 0;
+    prefs->patchFromMode = value != 0;
 }
 
 /*-*************************************
@@ -645,7 +645,7 @@ static size_t FIO_createDictBuffer(FIO_prefs_t* const prefs, void** bufferPtr, c
 
     fileSize = UTIL_getFileSize(fileName);
     {
-        size_t dictSizeMax = prefs->diffFromMode ? prefs->memLimit : DICTSIZE_MAX;
+        size_t dictSizeMax = prefs->patchFromMode ? prefs->memLimit : DICTSIZE_MAX;
         if (fileSize >  dictSizeMax) {
             EXM_THROW(32, "Dictionary file %s is too large (> %u bytes)",
                             fileName,  (unsigned)dictSizeMax);   /* avoid extreme cases */
@@ -803,7 +803,7 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
         if (prefs->adaptiveMode && !prefs->ldmFlag && !comprParams.windowLog)
             comprParams.windowLog = ADAPT_WINDOWLOG_DEFAULT;
 
-        if (prefs->diffFromMode) {
+        if (prefs->patchFromMode) {
             comprParams.windowLog = FIO_log2(maxSrcFileSize + DIFFFROM_WINDOWSIZE_EXTRA_BYTES);
         }
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -645,7 +645,7 @@ static size_t FIO_createDictBuffer(FIO_prefs_t* const prefs, void** bufferPtr, c
 
     fileSize = UTIL_getFileSize(fileName);
     {
-        size_t dictSizeMax = prefs->patchFromMode ? prefs->memLimit : DICTSIZE_MAX;
+        size_t const dictSizeMax = prefs->patchFromMode ? prefs->memLimit : DICTSIZE_MAX;
         if (fileSize >  dictSizeMax) {
             EXM_THROW(32, "Dictionary file %s is too large (> %u bytes)",
                             fileName,  (unsigned)dictSizeMax);   /* avoid extreme cases */

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -94,6 +94,7 @@ void FIO_setLiteralCompressionMode(
 void FIO_setNoProgress(unsigned noProgress);
 void FIO_setNotificationLevel(int level);
 void FIO_setExcludeCompressedFile(FIO_prefs_t* const prefs, int excludeCompressedFiles);
+void FIO_setDiffFromMode(FIO_prefs_t* const prefs, int diffFromMode);
 
 /*-*************************************
 *  Single File functions

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -94,7 +94,7 @@ void FIO_setLiteralCompressionMode(
 void FIO_setNoProgress(unsigned noProgress);
 void FIO_setNotificationLevel(int level);
 void FIO_setExcludeCompressedFile(FIO_prefs_t* const prefs, int excludeCompressedFiles);
-void FIO_setDiffFromMode(FIO_prefs_t* const prefs, int diffFromMode);
+void FIO_setPatchFromMode(FIO_prefs_t* const prefs, int value);
 
 /*-*************************************
 *  Single File functions

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -122,11 +122,18 @@ the last one takes effect.
 
     Note: If `windowLog` is set to larger than 27, `--long=windowLog` or
     `--memory=windowSize` needs to be passed to the decompressor.
+* `--diff-from=#`:
+    Specify the file to be used as a reference point for zstd's diff engine.
+    This is effectively dictionary compression with some convenient parameter
+    selection, namely that windowSize > srcSize.
 * `-M#`, `--memory=#`:
-    Set a memory usage limit for decompression. By default, Zstandard uses 128 MB
+    Set a memory usage limit. By default, Zstandard uses 128 MB for decompression
     as the maximum amount of memory the decompressor is allowed to use, but you can
     override this manually if need be in either direction (ie. you can increase or
     decrease it).
+
+    This is also used during compression when using with --diff-from=. In this case,
+    this parameter overrides that maximum size allowed for a dictionary. (128 MB).
 * `-T#`, `--threads=#`:
     Compress using `#` working threads (default: 1).
     If `#` is 0, attempt to detect and use the number of physical CPU cores.

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -126,6 +126,8 @@ the last one takes effect.
     Specify the file to be used as a reference point for zstd's diff engine.
     This is effectively dictionary compression with some convenient parameter
     selection, namely that windowSize > srcSize.
+
+    Note: cannot use both this and -D together
 * `-M#`, `--memory=#`:
     Set a memory usage limit. By default, Zstandard uses 128 MB for decompression
     as the maximum amount of memory the decompressor is allowed to use, but you can

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -122,7 +122,7 @@ the last one takes effect.
 
     Note: If `windowLog` is set to larger than 27, `--long=windowLog` or
     `--memory=windowSize` needs to be passed to the decompressor.
-* `--diff-from=#`:
+* `--patch-from=FILE`:
     Specify the file to be used as a reference point for zstd's diff engine.
     This is effectively dictionary compression with some convenient parameter
     selection, namely that windowSize > srcSize.
@@ -134,7 +134,7 @@ the last one takes effect.
     override this manually if need be in either direction (ie. you can increase or
     decrease it).
 
-    This is also used during compression when using with --diff-from=. In this case,
+    This is also used during compression when using with --patch-from=. In this case,
     this parameter overrides that maximum size allowed for a dictionary. (128 MB).
 * `-T#`, `--threads=#`:
     Compress using `#` working threads (default: 1).

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -597,7 +597,7 @@ int main(int const argCount, const char* argv[])
     const char* outFileName = NULL;
     const char* outDirName = NULL;
     const char* dictFileName = NULL;
-    const char* diffFromDictFileName = NULL;
+    const char* patchFromDictFileName = NULL;
     const char* suffix = ZSTD_EXTENSION;
     unsigned maxDictSize = g_defaultMaxDictSize;
     unsigned dictID = 0;
@@ -759,7 +759,7 @@ int main(int const argCount, const char* argv[])
                 if (longCommandWArg(&argument, "--target-compressed-block-size=")) { targetCBlockSize = readU32FromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--size-hint=")) { srcSizeHint = readU32FromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--output-dir-flat=")) { outDirName = argument; continue; }
-                if (longCommandWArg(&argument, "--diff-from=")) { diffFromDictFileName = argument; continue; }
+                if (longCommandWArg(&argument, "--patch-from=")) { patchFromDictFileName = argument; continue; }
                 if (longCommandWArg(&argument, "--long")) {
                     unsigned ldmWindowLog = 0;
                     ldmFlag = 1;
@@ -1169,7 +1169,7 @@ int main(int const argCount, const char* argv[])
     }   }
 #endif
 
-    if (dictFileName != NULL && diffFromDictFileName != NULL) {
+    if (dictFileName != NULL && patchFromDictFileName != NULL) {
         DISPLAY("error : can't use -D and --diff-from=# at the same time \n");
         CLEAN_RETURN(1);
     }
@@ -1180,9 +1180,9 @@ int main(int const argCount, const char* argv[])
 
     /* IO Stream/File */
     FIO_setNotificationLevel(g_displayLevel);
-    FIO_setDiffFromMode(prefs, diffFromDictFileName != NULL);
-    if (diffFromDictFileName != NULL) {
-        dictFileName = diffFromDictFileName;
+    FIO_setPatchFromMode(prefs, patchFromDictFileName != NULL);
+    if (patchFromDictFileName != NULL) {
+        dictFileName = patchFromDictFileName;
     }
     if (memLimit == 0) {
         if (compressionParams.windowLog == 0) {

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1169,6 +1169,11 @@ int main(int const argCount, const char* argv[])
     }   }
 #endif
 
+    if (dictFileName != NULL && diffFromDictFileName != NULL) {
+        DISPLAY("error : can't use -D and --diff-from=# at the same time \n");
+        CLEAN_RETURN(1);
+    }
+
     /* No status message in pipe mode (stdin - stdout) or multi-files mode */
     if (!strcmp(filenames->fileNames[0], stdinmark) && outFileName && !strcmp(outFileName,stdoutmark) && (g_displayLevel==2)) g_displayLevel=1;
     if ((filenames->tableSize > 1) & (g_displayLevel==2)) g_displayLevel=1;

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1170,7 +1170,7 @@ int main(int const argCount, const char* argv[])
 #endif
 
     if (dictFileName != NULL && patchFromDictFileName != NULL) {
-        DISPLAY("error : can't use -D and --diff-from=# at the same time \n");
+        DISPLAY("error : can't use -D and --patch-from=# at the same time \n");
         CLEAN_RETURN(1);
     }
 

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -570,6 +570,7 @@ int main(int const argCount, const char* argv[])
         adaptMax = MAXCLEVEL,
         rsyncable = 0,
         nextArgumentIsOutFileName = 0,
+        nextArgumentIsDiffFromDictFileName = 0,
         nextArgumentIsOutDirName = 0,
         nextArgumentIsMaxDict = 0,
         nextArgumentIsDictID = 0,
@@ -597,6 +598,7 @@ int main(int const argCount, const char* argv[])
     const char* outFileName = NULL;
     const char* outDirName = NULL;
     const char* dictFileName = NULL;
+    const char* diffFromDictFileName = NULL;
     const char* suffix = ZSTD_EXTENSION;
     unsigned maxDictSize = g_defaultMaxDictSize;
     unsigned dictID = 0;
@@ -618,7 +620,7 @@ int main(int const argCount, const char* argv[])
 
     /* init */
     (void)recursive; (void)cLevelLast;    /* not used when ZSTD_NOBENCH set */
-    (void)memLimit;   /* not used when ZSTD_NODECOMPRESS set */
+    (void)memLimit;
     assert(argCount >= 1);
     if ((filenames==NULL) || (file_of_names==NULL)) { DISPLAY("zstd: allocation error \n"); exit(1); }
     programName = lastNameFromPath(programName);
@@ -691,6 +693,7 @@ int main(int const argCount, const char* argv[])
                 if (!strcmp(argument, "--rm")) { FIO_setRemoveSrcFile(prefs, 1); continue; }
                 if (!strcmp(argument, "--priority=rt")) { setRealTimePrio = 1; continue; }
                 if (!strcmp(argument, "--output-dir-flat")) {nextArgumentIsOutDirName=1; lastCommand=1; continue; }
+                if (!strcmp(argument, "--diff-from")) {nextArgumentIsDiffFromDictFileName=1; lastCommand=1; continue; }
                 if (!strcmp(argument, "--adapt")) { adapt = 1; continue; }
                 if (longCommandWArg(&argument, "--adapt=")) { adapt = 1; if (!parseAdaptParameters(argument, &adaptMin, &adaptMax)) { badusage(programName); CLEAN_RETURN(1); } continue; }
                 if (!strcmp(argument, "--single-thread")) { nbWorkers = 0; singleThread = 1; continue; }
@@ -758,6 +761,7 @@ int main(int const argCount, const char* argv[])
                 if (longCommandWArg(&argument, "--target-compressed-block-size=")) { targetCBlockSize = readU32FromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--size-hint=")) { srcSizeHint = readU32FromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--output-dir-flat=")) { outDirName = argument; continue; }
+                if (longCommandWArg(&argument, "--diff-from=")) { diffFromDictFileName = argument; continue; }
                 if (longCommandWArg(&argument, "--long")) {
                     unsigned ldmWindowLog = 0;
                     ldmFlag = 1;
@@ -868,7 +872,7 @@ int main(int const argCount, const char* argv[])
                     /* destination file name */
                 case 'o': nextArgumentIsOutFileName=1; lastCommand=1; argument++; break;
 
-                    /* limit decompression memory */
+                    /* limit memory */
                 case 'M':
                     argument++;
                     memLimit = readU32FromChar(&argument);
@@ -948,6 +952,13 @@ int main(int const argCount, const char* argv[])
             }
             continue;
         }   /* if (argument[0]=='-') */
+
+        if (nextArgumentIsDiffFromDictFileName) {
+            nextArgumentIsDiffFromDictFileName = 0;
+            lastCommand = 0;
+            diffFromDictFileName = argument;
+            continue;
+        }
 
         if (nextArgumentIsMaxDict) {  /* kept available for compatibility with old syntax ; will be removed one day */
             nextArgumentIsMaxDict = 0;
@@ -1173,6 +1184,17 @@ int main(int const argCount, const char* argv[])
 
     /* IO Stream/File */
     FIO_setNotificationLevel(g_displayLevel);
+    FIO_setDiffFromMode(prefs, diffFromDictFileName != NULL);
+    if (diffFromDictFileName != NULL) {
+        dictFileName = diffFromDictFileName;
+    }
+    if (memLimit == 0) {
+        if (compressionParams.windowLog == 0) {
+            memLimit = (U32)1 << g_defaultMaxWindowLog;
+        } else {
+            memLimit = (U32)1 << (compressionParams.windowLog & 31);
+    }   }
+    FIO_setMemLimit(prefs, memLimit);
     if (operation==zom_compress) {
 #ifndef ZSTD_NOCOMPRESS
         FIO_setNbWorkers(prefs, nbWorkers);
@@ -1204,13 +1226,6 @@ int main(int const argCount, const char* argv[])
 #endif
     } else {  /* decompression or test */
 #ifndef ZSTD_NODECOMPRESS
-        if (memLimit == 0) {
-            if (compressionParams.windowLog == 0) {
-                memLimit = (U32)1 << g_defaultMaxWindowLog;
-            } else {
-                memLimit = (U32)1 << (compressionParams.windowLog & 31);
-        }   }
-        FIO_setMemLimit(prefs, memLimit);
         if (filenames->tableSize == 1 && outFileName) {
             operationResult = FIO_decompressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName);
         } else {

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -570,7 +570,6 @@ int main(int const argCount, const char* argv[])
         adaptMax = MAXCLEVEL,
         rsyncable = 0,
         nextArgumentIsOutFileName = 0,
-        nextArgumentIsDiffFromDictFileName = 0,
         nextArgumentIsOutDirName = 0,
         nextArgumentIsMaxDict = 0,
         nextArgumentIsDictID = 0,
@@ -693,7 +692,6 @@ int main(int const argCount, const char* argv[])
                 if (!strcmp(argument, "--rm")) { FIO_setRemoveSrcFile(prefs, 1); continue; }
                 if (!strcmp(argument, "--priority=rt")) { setRealTimePrio = 1; continue; }
                 if (!strcmp(argument, "--output-dir-flat")) {nextArgumentIsOutDirName=1; lastCommand=1; continue; }
-                if (!strcmp(argument, "--diff-from")) {nextArgumentIsDiffFromDictFileName=1; lastCommand=1; continue; }
                 if (!strcmp(argument, "--adapt")) { adapt = 1; continue; }
                 if (longCommandWArg(&argument, "--adapt=")) { adapt = 1; if (!parseAdaptParameters(argument, &adaptMin, &adaptMax)) { badusage(programName); CLEAN_RETURN(1); } continue; }
                 if (!strcmp(argument, "--single-thread")) { nbWorkers = 0; singleThread = 1; continue; }
@@ -952,13 +950,6 @@ int main(int const argCount, const char* argv[])
             }
             continue;
         }   /* if (argument[0]=='-') */
-
-        if (nextArgumentIsDiffFromDictFileName) {
-            nextArgumentIsDiffFromDictFileName = 0;
-            lastCommand = 0;
-            diffFromDictFileName = argument;
-            continue;
-        }
 
         if (nextArgumentIsMaxDict) {  /* kept available for compatibility with old syntax ; will be removed one day */
             nextArgumentIsMaxDict = 0;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1202,7 +1202,7 @@ then
     $ZSTD -f -vv --rsyncable --single-thread tmp && die "--rsyncable must fail with --single-thread"
 fi
 
-println "\n===> diff-from tests"
+println "\n===> patch-from tests"
 
 ./datagen -g1000 -P50 > tmp_dict
 ./datagen -g1000 -P10 > tmp_patch

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1177,10 +1177,10 @@ roundTripTest -g1M -P50 "1 --single-thread --long=29" " --zstd=wlog=28 --memory=
 
 
 
-# if [ "$1" != "--test-large-data" ]; then
-#     println "Skipping large data tests"
-#     exit 0
-# fi
+if [ "$1" != "--test-large-data" ]; then
+    println "Skipping large data tests"
+    exit 0
+fi
 
 
 #############################################################################

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1177,10 +1177,10 @@ roundTripTest -g1M -P50 "1 --single-thread --long=29" " --zstd=wlog=28 --memory=
 
 
 
-if [ "$1" != "--test-large-data" ]; then
-    println "Skipping large data tests"
-    exit 0
-fi
+# if [ "$1" != "--test-large-data" ]; then
+#     println "Skipping large data tests"
+#     exit 0
+# fi
 
 
 #############################################################################
@@ -1206,8 +1206,8 @@ println "\n===> diff-from tests"
 
 ./datagen -g1000 -P50 > tmp_dict
 ./datagen -g1000 -P10 > tmp_patch
-$ZSTD --memory=10000 --diff-from=tmp_dict tmp_patch -o tmp_patch_diff
-$ZSTD -d --memory=10000 --diff-from=tmp_dict tmp_patch_diff -o tmp_patch_recon
+$ZSTD --memory=10000 --patch-from=tmp_dict tmp_patch -o tmp_patch_diff
+$ZSTD -d --memory=10000 --patch-from=tmp_dict tmp_patch_diff -o tmp_patch_recon
 $DIFF -s tmp_patch_recon tmp_patch
 rm -rf tmp_*
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1202,6 +1202,14 @@ then
     $ZSTD -f -vv --rsyncable --single-thread tmp && die "--rsyncable must fail with --single-thread"
 fi
 
+println "\n===> diff-from tests"
+
+./datagen -g1000 -P50 > tmp_dict
+./datagen -g1000 -P10 > tmp_patch
+$ZSTD --memory=10000 --diff-from=tmp_dict tmp_patch -o tmp_patch_diff
+$ZSTD -d --memory=10000 --diff-from=tmp_dict tmp_patch_diff -o tmp_patch_recon
+$DIFF -s tmp_patch_recon tmp_patch
+rm -rf tmp_*
 
 println "\n===>   large files tests "
 


### PR DESCRIPTION
* Add new cli endpoint --diff-from 
* Overrides 32 MB dict limit with --memory=# when using --diff-from
* Ensures that windowSize > srcSize on compression using --diff-from
https://github.com/facebook/zstd/issues/1935