### PR TITLE
Make UTIL_countPhysicalCores() work under Cygwin

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -903,7 +903,7 @@ int UTIL_countPhysicalCores(void)
     return numPhysicalCores;
 }
 
-#elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
 
 /* Use POSIX sysconf
  * see: man 3 sysconf */


### PR DESCRIPTION
Cygwin currently uses the fallback implementation which just returns 1 every time,
which leads to bad performance when zstd is called with -T0 for example.

Instead use the POSIX implementation used for the BSDs which works just fine under Cygwin.

Tested under Cygwin and MSYS2.

Before:

```
$ zstd -f -vv -T0 -c mingw-w64-x86_64-python3-3.8.0-1-any.pkg.tar -o mingw-w64-x86_64-python3-3.8.0-1-any.pkg.tar.zst
*** zstd command line interface 64-bits v1.4.4, by Yann Collet ***
Note: 1 physical core(s) detected
```

After:

```
$ zstd -f -vv -T0 -c mingw-w64-x86_64-python3-3.8.0-1-any.pkg.tar -o mingw-w64-x86_64-python3-3.8.0-1-any.pkg.tar.zst
*** zstd command line interface 64-bits v1.4.4, by Yann Collet ***
Note: 16 physical core(s) detected
```