### PR TITLE
[fuzz] Fix regression_driver.c with directory input

### DIFF
--- a/tests/fuzz/regression_driver.c
+++ b/tests/fuzz/regression_driver.c
@@ -20,23 +20,28 @@ int main(int argc, char const **argv) {
   int const kFollowLinks = 1;
   FileNamesTable* files;
   const char** const fnTable = argv + 1;
-  unsigned numFiles = (unsigned)(argc - 1);
   uint8_t *buffer = NULL;
   size_t bufferSize = 0;
   unsigned i;
-  int ret;
+  unsigned numFilesTested = 0;
+  int ret = 0;
 
+  {
+    unsigned const numFiles = (unsigned)(argc - 1);
 #ifdef UTIL_HAS_CREATEFILELIST
-  files = UTIL_createExpandedFNT(fnTable, numFiles, kFollowLinks);
-  if (!files) numFiles = 0;
+    files = UTIL_createExpandedFNT(fnTable, numFiles, kFollowLinks);
 #else
-  files = UTIL_createFNT_fromROTable(fnTable, numFiles);
-  if (!files) numFiles = 0;
-  assert(numFiles == files->tableSize);
+    files = UTIL_createFNT_fromROTable(fnTable, numFiles);
+    assert(numFiles == files->tableSize);
 #endif
-  if (numFiles == 0)
+  }
+  if (!files) {
+    fprintf(stderr, "ERROR: Failed to create file names table\n");
+    return 1;
+  }
+  if (files->tableSize == 0)
     fprintf(stderr, "WARNING: No files passed to %s\n", argv[0]);
-  for (i = 0; i < numFiles; ++i) {
+  for (i = 0; i < files->tableSize; ++i) {
     char const *fileName = files->fileNames[i];
     DEBUGLOG(3, "Running %s", fileName);
     size_t const fileSize = UTIL_getFileSize(fileName);
@@ -45,9 +50,10 @@ int main(int argc, char const **argv) {
 
     /* Check that it is a regular file, and that the fileSize is valid.
      * If it is not a regular file, then it may have been deleted since we
-     * constructed the list, so just skip it.
+     * constructed the list, so just skip it, but return an error exit code.
      */
     if (!UTIL_isRegularFile(fileName)) {
+      ret = 1;
       continue;
     }
     FUZZ_ASSERT_MSG(fileSize <= kMaxFileSize, fileName);
@@ -68,9 +74,14 @@ int main(int argc, char const **argv) {
     fclose(file);
     /* Run the fuzz target */
     LLVMFuzzerTestOneInput(buffer, fileSize);
+    ++numFilesTested;
   }
-
-  ret = 0;
+  fprintf(stderr, "Tested %u files: ", numFilesTested);
+  if (ret == 0) {
+    fprintf(stderr, "Success!\n");
+  } else {
+    fprintf(stderr, "Failure!\n");
+  }
   free(buffer);
   UTIL_freeFileNamesTable(files);
   return ret;


### PR DESCRIPTION
The `numFiles` variable wasn't updated, so the fuzzer only tested one input in the directory. I did two things to fix this:

1. Remove the `numFiles` variable entirely.
2. Error if we can't open a file and print the number of files tested.