### PR TITLE
Fix the c99/cmake build under Cygwin/MSYS2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -188,6 +188,9 @@
   environment:
     matrix:
     - COMPILER: "gcc"
+      HOST:     "cygwin"
+      PLATFORM: "x64"
+    - COMPILER: "gcc"
       HOST:     "mingw"
       PLATFORM: "x64"
       SCRIPT:   "CPPFLAGS=-DDEBUGLEVEL=2 CFLAGS=-Werror make -j allzstd DEBUGLEVEL=2"
@@ -220,6 +223,14 @@
   install:
   - ECHO Installing %COMPILER% %PLATFORM% %CONFIGURATION%
   - SET PATH_ORIGINAL=%PATH%
+  - if [%HOST%]==[cygwin] (
+      ECHO Installing Cygwin Packages &&
+      C:\cygwin64\setup-x86_64.exe -qnNdO -R "C:\cygwin64" -g -P ^
+        gcc-g++,^
+        gcc,^
+        cmake,^
+        make
+    )
   - if [%HOST%]==[mingw] (
       SET "PATH_MINGW32=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin" &&
       SET "PATH_MINGW64=C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin" &&
@@ -232,6 +243,16 @@
 
   build_script:
   - ECHO Building %COMPILER% %PLATFORM% %CONFIGURATION%
+  - if [%HOST%]==[cygwin] (
+      set CHERE_INVOKING=yes &&
+      set CC=%COMPILER% &&
+      C:\cygwin64\bin\bash --login -c "
+        set -e;
+        cd build/cmake;
+        CFLAGS='-Werror' cmake -G 'Unix Makefiles' .;
+        make -j4;
+      "
+    )
   - if [%HOST%]==[mingw] (
       ( if [%PLATFORM%]==[x64] (
         SET "PATH=%PATH_MINGW64%;%PATH_ORIGINAL%"

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -90,7 +90,7 @@ extern "C" {
      && ( defined(__unix__) || defined(__unix) \
        || defined(__midipix__) || defined(__VMS) || defined(__HAIKU__) )
 
-#    if defined(__linux__) || defined(__linux)
+#    if defined(__linux__) || defined(__linux) || defined(__CYGWIN__)
 #      ifndef _POSIX_C_SOURCE
 #        define _POSIX_C_SOURCE 200809L  /* feature test macro : https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html */
 #      endif
@@ -123,11 +123,11 @@ extern "C" {
 ************************************************/
 #if (defined(__linux__) && (PLATFORM_POSIX_VERSION > 1)) \
  || (PLATFORM_POSIX_VERSION >= 200112L) \
- || defined(__DJGPP__) \
- || defined(__MSYS__)
+ || defined(__DJGPP__)
 #  include <unistd.h>   /* isatty */
+#  include <stdio.h>    /* fileno */
 #  define IS_CONSOLE(stdStream) isatty(fileno(stdStream))
-#elif defined(MSDOS) || defined(OS2) || defined(__CYGWIN__)
+#elif defined(MSDOS) || defined(OS2)
 #  include <io.h>       /* _isatty */
 #  define IS_CONSOLE(stdStream) _isatty(_fileno(stdStream))
 #elif defined(WIN32) || defined(_WIN32)


### PR DESCRIPTION
When building zst under cygwin or msys2 with std=c99 the build would fail because
of an undefined fileno()/_fileno(), which is used by the IS_CONSOLE() macro.

When building with -std=c99 (gcc otherwise defaults to gnu, which implies POSIX),
which is the default of the cmake build, then including unistd.h wont define
_POSIX_VERSION and all other headers also wont expose POSIX API.

To fix this make sure to define _POSIX_C_SOURCE with the version we want before including
unistd.h and so that _POSIX_VERSION is set to the version provided by the system.

Since Cygwin/MSYS2 just follow POSIX we can also remove their special cases for
defining IS_CONSOLE().

And, for completeness, also explicitly include stdio.h which is what actually declares fileno().

Tested with the normal make file and cmake under MSYS2 and Cygwin.