### PR TITLE
[refactor] Centralize match finding logic inside lazy 

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -154,7 +154,7 @@ ZSTD_DUBT_findBetterDictMatch (
         const BYTE* const ip, const BYTE* const iend,
         size_t* offsetPtr,
         size_t bestLength,
-        U32 nbCompares,
+        size_t nbCompares,
         U32 const mls,
         const ZSTD_dictMode_e dictMode)
 {


### PR DESCRIPTION
In preparation for new dictionary search structure. I don't think I nee to refactor opt since there is only one place where dictionary searching happens. 