### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ example about how Meson is used to build this project.
 
 Note that default build type is **release**.
 
+### VCPKG
+If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager,
+you can build and install zstd with CMake integration in a single command:
+- `vcpkg install zstd`
+
 ### Visual Studio (Windows)
 
 Going into `build` directory, you will find additional possibilities:

--- a/README.md
+++ b/README.md
@@ -144,9 +144,16 @@ example about how Meson is used to build this project.
 Note that default build type is **release**.
 
 ### VCPKG
-If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager,
-you can build and install zstd with CMake integration in a single command:
-- `vcpkg install zstd`
+You can build and install zstd [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install zstd
+
+The zstd port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ### Visual Studio (Windows)
 


### PR DESCRIPTION
zstd is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build zstd , ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for zstd and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.