### PR TITLE
Fix lowLimit underflow in overflow correction

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1239,8 +1239,8 @@ roundTripTest -g18000017 -P88 17
 roundTripTest -g18000018 -P94 18
 roundTripTest -g18000019 -P96 19
 
-roundTripTest -g5000000000 -P99 "1 --zstd=wlog=27"
-roundTripTest -g3700000000 -P0 "1 --zstd=strategy=6,wlog=27"   # ensure btlazy2 can survive an overflow rescale
+roundTripTest -g5000000000 -P99 "1 --zstd=wlog=25"
+roundTripTest -g3700000000 -P0 "1 --zstd=strategy=6,wlog=25"   # ensure btlazy2 can survive an overflow rescale
 
 fileRoundTripTest -g4193M -P99 1
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1239,8 +1239,8 @@ roundTripTest -g18000017 -P88 17
 roundTripTest -g18000018 -P94 18
 roundTripTest -g18000019 -P96 19
 
-roundTripTest -g5000000000 -P99 1
-roundTripTest -g1700000000 -P0 "1 --zstd=strategy=6"   # ensure btlazy2 can survive an overflow rescale
+roundTripTest -g5000000000 -P99 "1 --zstd=wlog=27"
+roundTripTest -g3700000000 -P0 "1 --zstd=strategy=6,wlog=27"   # ensure btlazy2 can survive an overflow rescale
 
 fileRoundTripTest -g4193M -P99 1
 


### PR DESCRIPTION
After PR #1624 we no longer updated `lowLimit` every block. That means `lowLimit` only gets updated when the round buffer overlaps in single threaded mode, or when we start a new job in multithreaded mode. After that change (and maybe before too), `lowLimit` can underflow. If `lowLimit` underflows, then for the remainder of compression all matches are deemed out of bounds, so compression ratio plummets.

This fixes the problem by ensuring `lowLimit` never underflows. We set `lowLimit` and `dictLimit` to 1 instead, and ensure that we aren't invalidating any of the window.

I've modified two tests in `playTests.sh` to trigger overflow correction. Currently they don't because after PR #1658 we clear the context instead of overflow correction if we are starting within 16 MB of the correction point. Setting a larger window log ensures a larger job size, which doesn't fall within 16 MB of the correction point.

`enwik10` now compresses as expected:
```
> ./zstd enwik10 --ultra -22 -cv | zstd -tq
enwik10              : 20.80%   (10000000000 => 2079998491 bytes, /*stdout*\)
```