### PR TITLE
Adding --long support for --patch-from

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -945,9 +945,11 @@ size_t ZSTD_CCtx_refPrefix_advanced(
 {
     RETURN_ERROR_IF(cctx->streamStage != zcss_init, stage_wrong);
     ZSTD_clearAllDicts(cctx);
-    cctx->prefixDict.dict = prefix;
-    cctx->prefixDict.dictSize = prefixSize;
-    cctx->prefixDict.dictContentType = dictContentType;
+    if (prefix != NULL && prefixSize > 0) {
+        cctx->prefixDict.dict = prefix;
+        cctx->prefixDict.dictSize = prefixSize;
+        cctx->prefixDict.dictContentType = dictContentType;
+    }
     return 0;
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2813,10 +2813,8 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
 
         ZSTD_overflowCorrectIfNeeded(ms, ws, params, ip, ichunk);
 
-        if (params->ldmParams.enableLdm && ls != NULL && srcSize >= params->ldmParams.minMatchLength) {
+        if (params->ldmParams.enableLdm && ls != NULL && srcSize >= params->ldmParams.minMatchLength)
             ZSTD_ldm_fillHashTable(ls, (const BYTE*)src, (const BYTE*)src + srcSize, &params->ldmParams);
-            break;
-        }
 
         switch(params->cParams.strategy)
         {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2813,7 +2813,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
 
         ZSTD_overflowCorrectIfNeeded(ms, ws, params, ip, ichunk);
 
-        if (params->ldmParams.enableLdm && ls != NULL) {
+        if (params->ldmParams.enableLdm && ls != NULL && srcSize >= params->ldmParams.minMatchLength) {
             ZSTD_ldm_fillHashTable(ls, (const BYTE*)src, (const BYTE*)src + srcSize, &params->ldmParams);
             break;
         }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1011,7 +1011,7 @@ ZSTD_clampCParams(ZSTD_compressionParameters cParams)
 
 /** ZSTD_cycleLog() :
  *  condition for correct operation : hashLog > 1 */
-static U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat)
+U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat)
 {
     U32 const btScale = ((U32)strat >= (U32)ZSTD_btlazy2);
     return hashLog - btScale;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -166,6 +166,7 @@ typedef struct {
 typedef struct {
     ZSTD_window_t window;   /* State for the window round buffer management */
     ldmEntry_t* hashTable;
+    U32 loadedDictEnd;
     BYTE* bucketOffsets;    /* Next position in bucket to insert entry */
     U64 hashPower;          /* Used to compute the rolling hash.
                              * Depends on ldmParams.minMatchLength */

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1052,5 +1052,8 @@ size_t ZSTD_writeLastEmptyBlock(void* dst, size_t dstCapacity);
  */
 size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSeq);
 
+/** ZSTD_cycleLog() :
+ *  condition for correct operation : hashLog > 1 */
+U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat);
 
 #endif /* ZSTD_COMPRESS_H */

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -24,6 +24,10 @@ extern "C" {
 
 #define ZSTD_LDM_DEFAULT_WINDOW_LOG ZSTD_WINDOWLOG_LIMIT_DEFAULT
 
+void ZSTD_ldm_fillHashTable(
+            ldmState_t* state, const BYTE* ip,
+            const BYTE* iend, ldmParams_t const* params);
+
 /**
  * ZSTD_ldm_generateSequences():
  *

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -807,7 +807,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
                                     int cLevel)
 {
     unsigned const fileWindowLog = FIO_highbit64(maxSrcFileSize) + 1;
-    ZSTD_compressionParameters const cParams = ZSTD_getCParams(cLevel, maxSrcFileSize, dictSize);
+    ZSTD_compressionParameters const cParams = ZSTD_getCParams(cLevel, (size_t)maxSrcFileSize, (size_t)dictSize);
     FIO_adjustMemLimitForPatchFromMode(prefs, dictSize, maxSrcFileSize);
     if (fileWindowLog > ZSTD_WINDOWLOG_MAX)
         DISPLAYLEVEL(1, "Max window log exceeded by file (compression ratio will suffer)\n");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -814,6 +814,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
     }
     if (cParams.strategy >= ZSTD_btopt) {
         DISPLAYLEVEL(1, "[Optimal parser notes] Consider the following to improve patch size at the cost of speed:\n");
+		DISPLAYLEVEL(1, "- Use --single-thread mode in the zstd cli");
         DISPLAYLEVEL(1, "- Set a larger targetLength (eg. --zstd=targetLength=4096)\n");
         DISPLAYLEVEL(1, "- Set a larger chainLog (eg. --zstd=chainLog=31)\n");
         DISPLAYLEVEL(1, "Also consdier playing around with searchLog and hashLog\n");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -799,12 +799,13 @@ typedef struct {
 
 static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs, 
                                     ZSTD_compressionParameters* comprParams,
-                                    size_t const dictSize, size_t const maxSrcFileSize,
+                                    unsigned long long const dictSize, 
+                                    unsigned long long const maxSrcFileSize,
                                     int cLevel)
 {
-    unsigned const fileWindowLog = FIO_highbit64((unsigned long long)maxSrcFileSize) + 1;
+    unsigned const fileWindowLog = FIO_highbit64(maxSrcFileSize) + 1;
     ZSTD_compressionParameters const cParams = ZSTD_getCParams(cLevel, maxSrcFileSize, dictSize);
-    FIO_adjustMemLimitForPatchFromMode(prefs, (unsigned long long)dictSize, (unsigned long long)maxSrcFileSize);
+    FIO_adjustMemLimitForPatchFromMode(prefs, dictSize, maxSrcFileSize);
     if (fileWindowLog > ZSTD_WINDOWLOG_MAX)
         DISPLAYLEVEL(1, "Max window log exceeded by file (compression ratio will suffer)\n");
     comprParams->windowLog = MIN(ZSTD_WINDOWLOG_MAX, fileWindowLog);
@@ -839,7 +840,7 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
     /* need to update memLimit before calling createDictBuffer
      * because of memLimit check inside it */
     if (prefs->patchFromMode)
-        FIO_adjustParamsForPatchFromMode(prefs, &comprParams, (size_t)UTIL_getFileSize(dictFileName), maxSrcFileSize, cLevel);
+        FIO_adjustParamsForPatchFromMode(prefs, &comprParams, UTIL_getFileSize(dictFileName), maxSrcFileSize, cLevel);
     ress.dstBuffer = malloc(ress.dstBufferSize);
     ress.dictBufferSize = FIO_createDictBuffer(&ress.dictBuffer, dictFileName, prefs);   /* works with dictFileName==NULL */
     if (!ress.srcBuffer || !ress.dstBuffer)

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -821,6 +821,8 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
         if (fileWindowLog > ZSTD_WINDOWLOG_MAX)
             DISPLAYLEVEL(1, "Max window log exceeded by file (compression ratio will suffer).");
         comprParams.windowLog = MIN(ZSTD_WINDOWLOG_MAX, fileWindowLog);
+        if (fileWindowLog > comprParams.chainLog)
+            FIO_setLdmFlag(prefs, 1);
     }
 
     CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_contentSizeFlag, prefs->contentSize) );  /* always enable content size when available (note: supposed to be default) */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -814,7 +814,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
     }
     if (cParams.strategy >= ZSTD_btopt) {
         DISPLAYLEVEL(1, "[Optimal parser notes] Consider the following to improve patch size at the cost of speed:\n");
-		DISPLAYLEVEL(1, "- Use --single-thread mode in the zstd cli");
+        DISPLAYLEVEL(1, "- Use --single-thread mode in the zstd cli");
         DISPLAYLEVEL(1, "- Set a larger targetLength (eg. --zstd=targetLength=4096)\n");
         DISPLAYLEVEL(1, "- Set a larger chainLog (eg. --zstd=chainLog=31)\n");
         DISPLAYLEVEL(1, "Also consdier playing around with searchLog and hashLog\n");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -791,10 +791,11 @@ typedef struct {
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
-                                    size_t const dictSize, size_t const maxSrcFileSize)
+                                    unsigned long long const dictSize,  
+                                    unsigned long long const maxSrcFileSize)
 {
     if (dictSize != UTIL_FILESIZE_UNKNOWN && maxSrcFileSize != UTIL_FILESIZE_UNKNOWN)
-        FIO_setMemLimit(prefs, MAX(prefs->memLimit, MAX((unsigned)dictSize, (unsigned)maxSrcFileSize)));
+        FIO_setMemLimit(prefs, MAX(prefs->memLimit, MAX(dictSize, maxSrcFileSize)));
 }
 
 static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs, 
@@ -804,7 +805,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
 {
     unsigned const fileWindowLog = FIO_highbit64((unsigned long long)maxSrcFileSize) + 1;
     ZSTD_compressionParameters const cParams = ZSTD_getCParams(cLevel, maxSrcFileSize, dictSize);
-    FIO_adjustMemLimitForPatchFromMode(prefs, dictSize, maxSrcFileSize);
+    FIO_adjustMemLimitForPatchFromMode(prefs, (unsigned long long)dictSize, (unsigned long long)maxSrcFileSize);
     if (fileWindowLog > ZSTD_WINDOWLOG_MAX)
         DISPLAYLEVEL(1, "Max window log exceeded by file (compression ratio will suffer)\n");
     comprParams->windowLog = MIN(ZSTD_WINDOWLOG_MAX, fileWindowLog);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -807,7 +807,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
     if (fileWindowLog > ZSTD_WINDOWLOG_MAX)
         DISPLAYLEVEL(1, "Max window log exceeded by file (compression ratio will suffer)\n");
     comprParams->windowLog = MIN(ZSTD_WINDOWLOG_MAX, fileWindowLog);
-    if (fileWindowLog > comprParams->chainLog) {
+    if (fileWindowLog > ZSTD_cycleLog(comprParams->hashLog, cParams.strategy)) {
         if (!prefs->ldmFlag)
             DISPLAYLEVEL(1, "long mode automaticaly triggered\n");
         FIO_setLdmFlag(prefs, 1);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -45,6 +45,7 @@
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_magicNumber, ZSTD_frameHeaderSize_max */
 #include "zstd.h"
 #include "zstd_errors.h"           /* ZSTD_error_frameParameter_windowTooLarge */
+#include "zstd_compress_internal.h"
 
 #if defined(ZSTD_GZCOMPRESS) || defined(ZSTD_GZDECOMPRESS)
 #  include <zlib.h>
@@ -68,10 +69,6 @@
 /*-*************************************
 *  Constants
 ***************************************/
-#define KB *(1<<10)
-#define MB *(1<<20)
-#define GB *(1U<<30)
-
 #define ADAPT_WINDOWLOG_DEFAULT 23   /* 8 MB */
 #define DICTSIZE_MAX (32 MB)   /* protection against large input (attack scenario) */
 
@@ -768,8 +765,6 @@ static unsigned FIO_highbit64(unsigned long long v)
     while (v) { v >>= 1; count++; }
     return count;
 }
-
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
                                     unsigned long long const dictSize,  

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -775,8 +775,11 @@ static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
                                     unsigned long long const dictSize,  
                                     unsigned long long const maxSrcFileSize)
 {
-    if (dictSize != UTIL_FILESIZE_UNKNOWN && maxSrcFileSize != UTIL_FILESIZE_UNKNOWN)
-        FIO_setMemLimit(prefs, MAX(prefs->memLimit, MAX((unsigned)dictSize, (unsigned)maxSrcFileSize)));
+    unsigned long long maxSize = MAX(prefs->memLimit, MAX(dictSize, maxSrcFileSize));
+    assert(maxSize != UTIL_FILESIZE_UNKNOWN);
+    if (maxSize > UINT_MAX)
+        EXM_THROW(42, "Can't handle files larger than %u GB\n", UINT_MAX/(1 GB) + 1);
+    FIO_setMemLimit(prefs, (unsigned)maxSize);
 }
 
 #ifndef ZSTD_NOCOMPRESS

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -822,7 +822,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
 }
 
 static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
-                                    const char* dictFileName, const size_t maxSrcFileSize,
+                                    const char* dictFileName, unsigned long long const maxSrcFileSize,
                                     int cLevel, ZSTD_compressionParameters comprParams) {
     cRess_t ress;
     memset(&ress, 0, sizeof(ress));
@@ -1591,7 +1591,7 @@ int FIO_compressFilename(FIO_prefs_t* const prefs, const char* dstFileName,
                          const char* srcFileName, const char* dictFileName,
                          int compressionLevel,  ZSTD_compressionParameters comprParams)
 {
-    cRess_t const ress = FIO_createCResources(prefs, dictFileName, (size_t)UTIL_getFileSize(srcFileName), compressionLevel, comprParams);
+    cRess_t const ress = FIO_createCResources(prefs, dictFileName, UTIL_getFileSize(srcFileName), compressionLevel, comprParams);
     int const result = FIO_compressFilename_srcFile(prefs, ress, dstFileName, srcFileName, compressionLevel);
 
 
@@ -1639,11 +1639,12 @@ FIO_determineCompressedName(const char* srcFileName, const char* outDirName, con
     return dstFileNameBuffer;
 }
 
-static size_t FIO_getLargestFileSize(const char** inFileNames, unsigned nbFiles)
+static unsigned long long FIO_getLargestFileSize(const char** inFileNames, unsigned nbFiles)
 {
-    size_t i, fileSize, maxFileSize = 0;
+    size_t i;
+    unsigned long long fileSize, maxFileSize = 0;
     for (i = 0; i < nbFiles; i++) {
-        fileSize = (size_t)UTIL_getFileSize(inFileNames[i]);
+        fileSize = UTIL_getFileSize(inFileNames[i]);
         maxFileSize = fileSize > maxFileSize ? fileSize : maxFileSize;
     }
     return maxFileSize;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -769,6 +769,15 @@ static unsigned FIO_highbit64(unsigned long long v)
     return count;
 }
 
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
+                                    unsigned long long const dictSize,  
+                                    unsigned long long const maxSrcFileSize)
+{
+    if (dictSize != UTIL_FILESIZE_UNKNOWN && maxSrcFileSize != UTIL_FILESIZE_UNKNOWN)
+        FIO_setMemLimit(prefs, MAX(prefs->memLimit, MAX((unsigned)dictSize, (unsigned)maxSrcFileSize)));
+}
 
 #ifndef ZSTD_NOCOMPRESS
 
@@ -787,16 +796,6 @@ typedef struct {
     const char* dictFileName;
     ZSTD_CStream* cctx;
 } cRess_t;
-
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
-static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
-                                    unsigned long long const dictSize,  
-                                    unsigned long long const maxSrcFileSize)
-{
-    if (dictSize != UTIL_FILESIZE_UNKNOWN && maxSrcFileSize != UTIL_FILESIZE_UNKNOWN)
-        FIO_setMemLimit(prefs, MAX(prefs->memLimit, MAX((unsigned)dictSize, (unsigned)maxSrcFileSize)));
-}
 
 static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs, 
                                     ZSTD_compressionParameters* comprParams,

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -795,7 +795,7 @@ static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
                                     unsigned long long const maxSrcFileSize)
 {
     if (dictSize != UTIL_FILESIZE_UNKNOWN && maxSrcFileSize != UTIL_FILESIZE_UNKNOWN)
-        FIO_setMemLimit(prefs, MAX(prefs->memLimit, MAX(dictSize, maxSrcFileSize)));
+        FIO_setMemLimit(prefs, MAX(prefs->memLimit, MAX((unsigned)dictSize, (unsigned)maxSrcFileSize)));
 }
 
 static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs, 

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -128,6 +128,12 @@ the last one takes effect.
     selection, namely that windowSize > srcSize.
 
     Note: cannot use both this and -D together
+    Note: consider using --patch-from with `--long` mode on large files
+    Note: `--long` mode will be automatically activated if chainLog < fileLog
+        (fileLog being the windowLog requried to cover the whole file)
+    Note: for level 19, you can get increased compression ratio at the cost 
+        of speed by specifying `--zstd=targetLength=` to be something large 
+        (i.e 4096)
 * `-M#`, `--memory=#`:
     Set a memory usage limit. By default, Zstandard uses 128 MB for decompression
     as the maximum amount of memory the decompressor is allowed to use, but you can

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -128,9 +128,9 @@ the last one takes effect.
     selection, namely that windowSize > srcSize.
 
     Note: cannot use both this and -D together
-    Note: consider using --patch-from with `--long` mode on large files
     Note: `--long` mode will be automatically activated if chainLog < fileLog
-        (fileLog being the windowLog requried to cover the whole file)
+        (fileLog being the windowLog requried to cover the whole file). You 
+        can also manually force it.
     Note: for level 19, you can get increased compression ratio at the cost 
         of speed by specifying `--zstd=targetLength=` to be something large 
         (i.e 4096)

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -131,9 +131,11 @@ the last one takes effect.
     Note: `--long` mode will be automatically activated if chainLog < fileLog
         (fileLog being the windowLog requried to cover the whole file). You 
         can also manually force it.
+	Node: for all levels, you can use --patch-from in --single-thread mode
+		to improve compression ratio at the cost of speed
     Note: for level 19, you can get increased compression ratio at the cost 
         of speed by specifying `--zstd=targetLength=` to be something large 
-        (i.e 4096)
+        (i.e 4096), and by setting a large `--zstd=chainLog=`
 * `-M#`, `--memory=#`:
     Set a memory usage limit. By default, Zstandard uses 128 MB for decompression
     as the maximum amount of memory the decompressor is allowed to use, but you can

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1271,7 +1271,7 @@ int main(int const argCount, const char* argv[])
             const unsigned long long fileSize = UTIL_getFileSize(srcFileName);
             const unsigned long long dictSize = UTIL_getFileSize(patchFromDictFileName);
             if (fileSize != UTIL_FILESIZE_UNKNOWN && dictSize != UTIL_FILESIZE_UNKNOWN) {
-                memLimit = MAX(memLimit, MAX(dictSize, fileSize));
+                memLimit = MAX(memLimit, MAX((unsigned)dictSize, (unsigned)fileSize));
                 ldmFlag = fileSize + dictSize > PATCHFROM_LONG_THRESH;
             }
         }

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -591,8 +591,6 @@ static int init_cLevel(void) {
     return ZSTDCLI_CLEVEL_DEFAULT;
 }
 
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 #define ZSTD_NB_STRATEGIES 9
 
 static const char* ZSTD_strategyMap[ZSTD_NB_STRATEGIES + 1] = { "", "ZSTD_fast",
@@ -1260,15 +1258,8 @@ int main(int const argCount, const char* argv[])
         } else {
             memLimit = (U32)1 << (compressionParams.windowLog & 31);
     }   }
-    if (patchFromDictFileName != NULL) {
-        const char* const srcFileName = filenames->fileNames[0];
-        const unsigned long long fileSize = UTIL_getFileSize(srcFileName);
-        const unsigned long long dictSize = UTIL_getFileSize(patchFromDictFileName);
+    if (patchFromDictFileName != NULL)
         dictFileName = patchFromDictFileName;
-        if (fileSize != UTIL_FILESIZE_UNKNOWN && dictSize != UTIL_FILESIZE_UNKNOWN) {
-            memLimit = MAX(memLimit, MAX((unsigned)dictSize, (unsigned)fileSize));
-        }
-    }
     FIO_setMemLimit(prefs, memLimit);
     if (operation==zom_compress) {
 #ifndef ZSTD_NOCOMPRESS

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -593,8 +593,6 @@ static int init_cLevel(void) {
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
-#define PATCHFROM_LONG_THRESH 32 MB
-
 #define ZSTD_NB_STRATEGIES 9
 
 static const char* ZSTD_strategyMap[ZSTD_NB_STRATEGIES + 1] = { "", "ZSTD_fast",
@@ -1272,7 +1270,6 @@ int main(int const argCount, const char* argv[])
             const unsigned long long dictSize = UTIL_getFileSize(patchFromDictFileName);
             if (fileSize != UTIL_FILESIZE_UNKNOWN && dictSize != UTIL_FILESIZE_UNKNOWN) {
                 memLimit = MAX(memLimit, MAX((unsigned)dictSize, (unsigned)fileSize));
-                ldmFlag = fileSize + dictSize > PATCHFROM_LONG_THRESH;
             }
         }
         FIO_setMemLimit(prefs, memLimit);

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1260,19 +1260,18 @@ int main(int const argCount, const char* argv[])
         } else {
             memLimit = (U32)1 << (compressionParams.windowLog & 31);
     }   }
-    if (patchFromDictFileName != NULL)
+    if (patchFromDictFileName != NULL) {
+        const char* const srcFileName = filenames->fileNames[0];
+        const unsigned long long fileSize = UTIL_getFileSize(srcFileName);
+        const unsigned long long dictSize = UTIL_getFileSize(patchFromDictFileName);
         dictFileName = patchFromDictFileName;
+        if (fileSize != UTIL_FILESIZE_UNKNOWN && dictSize != UTIL_FILESIZE_UNKNOWN) {
+            memLimit = MAX(memLimit, MAX((unsigned)dictSize, (unsigned)fileSize));
+        }
+    }
+    FIO_setMemLimit(prefs, memLimit);
     if (operation==zom_compress) {
 #ifndef ZSTD_NOCOMPRESS
-        if (patchFromDictFileName != NULL) {
-            const char* const srcFileName = filenames->fileNames[0];
-            const unsigned long long fileSize = UTIL_getFileSize(srcFileName);
-            const unsigned long long dictSize = UTIL_getFileSize(patchFromDictFileName);
-            if (fileSize != UTIL_FILESIZE_UNKNOWN && dictSize != UTIL_FILESIZE_UNKNOWN) {
-                memLimit = MAX(memLimit, MAX((unsigned)dictSize, (unsigned)fileSize));
-            }
-        }
-        FIO_setMemLimit(prefs, memLimit);
         FIO_setContentSize(prefs, contentSize);
         FIO_setNbWorkers(prefs, nbWorkers);
         FIO_setBlockSize(prefs, (int)blockSize);
@@ -1326,7 +1325,6 @@ int main(int const argCount, const char* argv[])
 #endif
     } else {  /* decompression or test */
 #ifndef ZSTD_NODECOMPRESS
-        FIO_setMemLimit(prefs, memLimit);
         if (filenames->tableSize == 1 && outFileName) {
             operationResult = FIO_decompressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName);
         } else {

--- a/tests/fuzz/dictionary_decompress.c
+++ b/tests/fuzz/dictionary_decompress.c
@@ -42,9 +42,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
         ddict = ZSTD_createDDict(dict.buff, dict.size);
         FUZZ_ASSERT(ddict);
     } else {
-        FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
+        if (FUZZ_dataProducer_uint32Range(producer, 0, 1) == 0)
+            FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
                 dctx, dict.buff, dict.size,
                 (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
+                (ZSTD_dictContentType_e)FUZZ_dataProducer_uint32Range(producer, 0, 2)));
+        else
+            FUZZ_ZASSERT(ZSTD_DCtx_refPrefix_advanced(
+                dctx, dict.buff, dict.size,
                 (ZSTD_dictContentType_e)FUZZ_dataProducer_uint32Range(producer, 0, 2)));
     }
 

--- a/tests/fuzz/dictionary_loader.c
+++ b/tests/fuzz/dictionary_loader.c
@@ -28,10 +28,15 @@ static size_t compress(void* compressed, size_t compressedCapacity,
                        void const* source, size_t sourceSize,
                        void const* dict, size_t dictSize,
                        ZSTD_dictLoadMethod_e dictLoadMethod,
-                       ZSTD_dictContentType_e dictContentType)
+                       ZSTD_dictContentType_e dictContentType,
+                       int const refPrefix)
 {
     ZSTD_CCtx* cctx = ZSTD_createCCtx();
-    FUZZ_ZASSERT(ZSTD_CCtx_loadDictionary_advanced(
+    if (refPrefix)
+        FUZZ_ZASSERT(ZSTD_CCtx_refPrefix_advanced(
+            cctx, dict, dictSize, dictContentType));
+    else 
+        FUZZ_ZASSERT(ZSTD_CCtx_loadDictionary_advanced(
             cctx, dict, dictSize, dictLoadMethod, dictContentType));
     size_t const compressedSize = ZSTD_compress2(
             cctx, compressed, compressedCapacity, source, sourceSize);
@@ -43,10 +48,15 @@ static size_t decompress(void* result, size_t resultCapacity,
                          void const* compressed, size_t compressedSize,
                          void const* dict, size_t dictSize,
                        ZSTD_dictLoadMethod_e dictLoadMethod,
-                         ZSTD_dictContentType_e dictContentType)
+                         ZSTD_dictContentType_e dictContentType,
+                         int const refPrefix)
 {
     ZSTD_DCtx* dctx = ZSTD_createDCtx();
-    FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
+    if (refPrefix)
+        FUZZ_ZASSERT(ZSTD_DCtx_refPrefix_advanced(
+            dctx, dict, dictSize, dictContentType));
+    else
+        FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
             dctx, dict, dictSize, dictLoadMethod, dictContentType));
     size_t const resultSize = ZSTD_decompressDCtx(
             dctx, result, resultCapacity, compressed, compressedSize);
@@ -58,6 +68,7 @@ static size_t decompress(void* result, size_t resultCapacity,
 int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(src, size);
+    int const refPrefix = FUZZ_dataProducer_uint32Range(producer, 0, 1) != 0;
     ZSTD_dictLoadMethod_e const dlm =
     size = FUZZ_dataProducer_uint32Range(producer, 0, 1);
     ZSTD_dictContentType_e const dct =
@@ -75,14 +86,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
     FUZZ_ASSERT(cBuf);
 
     size_t const cSize =
-            compress(cBuf, cBufSize, src, size, src, size, dlm, dct);
+            compress(cBuf, cBufSize, src, size, src, size, dlm, dct, refPrefix);
     /* compression failing is okay */
     if (ZSTD_isError(cSize)) {
       FUZZ_ASSERT_MSG(dct != ZSTD_dct_rawContent, "Raw must always succeed!");
       goto out;
     }
     size_t const rSize =
-            decompress(rBuf, size, cBuf, cSize, src, size, dlm, dct);
+            decompress(rBuf, size, cBuf, cSize, src, size, dlm, dct, refPrefix);
     FUZZ_ASSERT_MSG(rSize == size, "Incorrect regenerated size");
     FUZZ_ASSERT_MSG(!memcmp(src, rBuf, size), "Corruption!");
 

--- a/tests/fuzz/dictionary_round_trip.c
+++ b/tests/fuzz/dictionary_round_trip.c
@@ -32,6 +32,7 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
 {
     ZSTD_dictContentType_e dictContentType = ZSTD_dct_auto;
     FUZZ_dict_t dict = FUZZ_train(src, srcSize, producer);
+    int const refPrefix = FUZZ_dataProducer_uint32Range(producer, 0, 1) != 0;
     size_t cSize;
     if (FUZZ_dataProducer_uint32Range(producer, 0, 15) == 0) {
         int const cLevel = FUZZ_dataProducer_int32Range(producer, kMinClevel, kMaxClevel);
@@ -42,21 +43,33 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
                 dict.buff, dict.size,
                 cLevel);
     } else {
-        dictContentType = FUZZ_dataProducer_uint32Range(producer, 0, 2);
+        /* refPrefix seems to fail when not used with auto? */
+        if (!refPrefix)
+            dictContentType = FUZZ_dataProducer_uint32Range(producer, 0, 2);
         FUZZ_setRandomParameters(cctx, srcSize, producer);
         /* Disable checksum so we can use sizes smaller than compress bound. */
         FUZZ_ZASSERT(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 0));
-        FUZZ_ZASSERT(ZSTD_CCtx_loadDictionary_advanced(
+        if (refPrefix)
+            FUZZ_ZASSERT(ZSTD_CCtx_refPrefix_advanced(
+                cctx, dict.buff, dict.size,
+                dictContentType));
+        else 
+            FUZZ_ZASSERT(ZSTD_CCtx_loadDictionary_advanced(
                 cctx, dict.buff, dict.size,
                 (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
                 dictContentType));
         cSize = ZSTD_compress2(cctx, compressed, compressedCapacity, src, srcSize);
     }
     FUZZ_ZASSERT(cSize);
-    FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
-        dctx, dict.buff, dict.size,
-        (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
-        dictContentType));
+    if (refPrefix)
+        FUZZ_ZASSERT(ZSTD_DCtx_refPrefix_advanced(
+            dctx, dict.buff, dict.size,
+            dictContentType));
+    else
+        FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
+            dctx, dict.buff, dict.size,
+            (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
+            dictContentType));
     {
         size_t const ret = ZSTD_decompressDCtx(
                 dctx, result, resultCapacity, compressed, cSize);

--- a/tests/fuzz/dictionary_round_trip.c
+++ b/tests/fuzz/dictionary_round_trip.c
@@ -43,9 +43,7 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
                 dict.buff, dict.size,
                 cLevel);
     } else {
-        /* refPrefix seems to fail when not used with auto? */
-        if (!refPrefix)
-            dictContentType = FUZZ_dataProducer_uint32Range(producer, 0, 2);
+        dictContentType = FUZZ_dataProducer_uint32Range(producer, 0, 2);
         FUZZ_setRandomParameters(cctx, srcSize, producer);
         /* Disable checksum so we can use sizes smaller than compress bound. */
         FUZZ_ZASSERT(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 0));

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -589,6 +589,24 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : testing dict compression with enableLdm and forceMaxWindow : ", testNb++);
+    {
+        ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+        void* dict = (void*)malloc(CNBuffSize);
+        
+        RDG_genBuffer(dict, CNBuffSize, 0.5, 0.5, seed);
+        RDG_genBuffer(CNBuffer, CNBuffSize, 0.6, 0.6, seed);
+        
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_forceMaxWindow, 1));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 1));
+        assert(!ZSTD_isError(ZSTD_compress_usingDict(cctx, compressedBuffer, compressedBufferSize, 
+            CNBuffer, CNBuffSize, dict, CNBuffSize, 3)));
+        
+        ZSTD_freeCCtx(cctx); 
+        free(dict);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     DISPLAYLEVEL(3, "test%3d: superblock uncompressible data, too many nocompress superblocks : ", testNb++);
     {
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -611,7 +611,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
     {
         /* test a big buffer so that ldm can take effect */
         size_t const size = 100 MB;
-        size_t const windowLog = 27;
+        int const windowLog = 27;
         size_t const dstSize = ZSTD_compressBound(size);
 
         void* dict = (void*)malloc(size);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -566,6 +566,29 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : ldm fill dict out-of-bounds check", testNb++);
+    {
+        ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+
+        size_t const size = (1U << 10);
+        size_t const dstCapacity = ZSTD_compressBound(size);
+        void* dict = (void*)malloc(size);
+        void* src = (void*)malloc(size);
+        void* dst = (void*)malloc(dstCapacity);
+
+        RDG_genBuffer(dict, size, 0.5, 0.5, seed);
+        RDG_genBuffer(src, size, 0.5, 0.5, seed);
+
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 1));
+        assert(!ZSTD_isError(ZSTD_compress_usingDict(cctx, dst, dstCapacity, src, size, dict, size, 3)));
+
+        ZSTD_freeCCtx(cctx);
+        free(dict);
+        free(src);
+        free(dst);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     DISPLAYLEVEL(3, "test%3d: superblock uncompressible data, too many nocompress superblocks : ", testNb++);
     {
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -536,15 +536,15 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
         BYTE* const dst = (BYTE*)compressedBuffer;
         ZSTD_DCtx* dctx = ZSTD_createDCtx();
-        
+
         /* create a large frame and then a bunch of small frames */
-        size_t srcSize = ZSTD_compress((void*)dst, 
+        size_t srcSize = ZSTD_compress((void*)dst,
             compressedBufferSize, CNBuffer, largeFrameSrcSize, 3);
-        for (i = 0; i < nbFrames; i++) 
-            srcSize += ZSTD_compress((void*)(dst + srcSize), 
-                compressedBufferSize - srcSize, CNBuffer, 
+        for (i = 0; i < nbFrames; i++)
+            srcSize += ZSTD_compress((void*)(dst + srcSize),
+                compressedBufferSize - srcSize, CNBuffer,
                 smallFrameSrcSize, 3);
-            
+
         /* decompressStream and make sure that dctx size was reduced at least once */
         while (consumed < srcSize) {
             ZSTD_inBuffer in = {(void*)(dst + consumed), MIN(1, srcSize - consumed), 0};
@@ -593,16 +593,16 @@ static int basicUnitTests(U32 const seed, double compressibility)
     {
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();
         void* dict = (void*)malloc(CNBuffSize);
-        
+
         RDG_genBuffer(dict, CNBuffSize, 0.5, 0.5, seed);
         RDG_genBuffer(CNBuffer, CNBuffSize, 0.6, 0.6, seed);
-        
+
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_forceMaxWindow, 1));
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 1));
-        assert(!ZSTD_isError(ZSTD_compress_usingDict(cctx, compressedBuffer, compressedBufferSize, 
+        assert(!ZSTD_isError(ZSTD_compress_usingDict(cctx, compressedBuffer, compressedBufferSize,
             CNBuffer, CNBuffSize, dict, CNBuffSize, 3)));
-        
-        ZSTD_freeCCtx(cctx); 
+
+        ZSTD_freeCCtx(cctx);
         free(dict);
     }
     DISPLAYLEVEL(3, "OK \n");
@@ -626,12 +626,12 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();
         ZSTD_DCtx* const dctx = ZSTD_createDCtx();
-        
+
         /* make dict and src the same uncompressible data */
         RDG_genBuffer(src, size, 0, 0, seed);
         memcpy(dict, src, size);
         assert(!memcmp(dict, src, size));
-        
+
         /* set level 1 and windowLog to cover src */
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 1));
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog, windowLog));
@@ -647,7 +647,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         assert(!ZSTD_isError(reconSize));
         assert(reconSize == size);
         assert(!memcmp(recon, src, size));
-         
+
         /* compress on level 1 using refPrefix and ldm */
         ZSTD_CCtx_refPrefix(cctx, dict, size);;
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 1))
@@ -661,13 +661,13 @@ static int basicUnitTests(U32 const seed, double compressibility)
         assert(reconSize == size);
         assert(!memcmp(recon, src, size));
 
-        /* make sure that refPrefixCompressedSize is greater */
-        assert(refPrefixCompressedSize > refPrefixLdmComrpessedSize);
+        /* make sure that refPrefixCompressedSize is significantly greater */
+        assert(refPrefixCompressedSize > 10 * refPrefixLdmComrpessedSize);
         /* make sure the ldm comrpessed size is less than 1% of original */
         assert((double)refPrefixLdmComrpessedSize / (double)size < 0.01);
 
         ZSTD_freeDCtx(dctx);
-        ZSTD_freeCCtx(cctx); 
+        ZSTD_freeCCtx(cctx);
         free(recon);
         free(dict);
         free(src);

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1262,10 +1262,19 @@ println "\n===> patch-from tests"
 
 datagen -g1000 -P50 > tmp_dict
 datagen -g1000 -P10 > tmp_patch
-zstd --memory=10000 --patch-from=tmp_dict tmp_patch -o tmp_patch_diff
-zstd -d --memory=10000 --patch-from=tmp_dict tmp_patch_diff -o tmp_patch_recon
+zstd --patch-from=tmp_dict tmp_patch -o tmp_patch_diff
+zstd -d --patch-from=tmp_dict tmp_patch_diff -o tmp_patch_recon
 $DIFF -s tmp_patch_recon tmp_patch
 rm -rf tmp_*
+
+println "\n===> patch-from recursive tests"
+
+mkdir tmp_dir
+datagen > tmp_dir/tmp1 
+datagen > tmp_dir/tmp2
+datagen > tmp_dict
+zstd --patch-from=tmp_dict -r tmp_dir && die
+rm -rf tmp* 
 
 println "\n===>   large files tests "
 


### PR DESCRIPTION
**Patch From**
Zstandard is introducing a new command line option —patch-from= which leverages our existing compressors, dictionaries and the long range match finder to deliver a high speed engine for producing and applying patches to files.

Patch from increases the previous maximum limit for dictionaries from 32 MB to 4 GB. Additionally, it maintains fast speeds on lower compression levels without compromising patch size by using the long range match finder (now extended to find dictionary matches). By default, Zstandard uses a heuristic based on file size and internal compression parameters to determine when to activate long mode but it can also be manually specified as before. 

Patch from also works with multi-threading mode at a minimal compression ratio cost loss single threaded mode. 

**Example usage:**
```
# create the patch
zstd —patch-from=<oldfile> <newfile> <patchfile>

# apply the patch
zstd -d —patch-from=<oldfile> <patchfile> <newfile>
``` 

**Benchmarks:** 
We compared zstd to bsdiff, a popular industry grade diff engine. Our testing data were tarballs of different versions of source code from popular GitHub repositories. Specifically 

```
repos = {
    # ~31mb (small file)
    "zstd": {"url": "https://github.com/facebook/zstd", "dict-branch": "refs/tags/v1.4.2", "src-branch": "refs/tags/v1.4.3"},
    # ~273mb (medium file)
    "wordpress": {"url": "https://github.com/WordPress/WordPress", "dict-branch": "refs/tags/5.3.1", "src-branch": "refs/tags/5.3.2"},
    # ~1.66gb (large file)
    "llvm": {"url": "https://github.com/llvm/llvm-project", "dict-branch": "refs/tags/llvmorg-9.0.0", "src-branch": "refs/tags/llvmorg-9.0.1"}
}
```
![alt text](https://i.imgur.com/zhnYlQO.png)
Patch from on level 19 (with chainLog=30 and targetLength=4kb) remains competitive with bsdiff when comparing patch sizes.  
![alt text](https://i.imgur.com/OvdNzGY.png)
And patch from greatly outperforms bsdiff in speed even on its slowest setting of level 19 boasting an average speedup of ~7X. Patch from is >200X faster on level 1 and >100X faster on level 3 vs bsdiff while still delivering patch sizes less than 0.5% of the original file size.

And of course, there is no change to the fast zstd decompression speed.