### PR TITLE
Fix to issue #1953

### DIFF
--- a/doc/educational_decoder/harness.c
+++ b/doc/educational_decoder/harness.c
@@ -46,6 +46,7 @@ static size_t read_file(const char *path, u8 **ptr)
     }
 
     fclose(f);
+    free(ptr);
 
     return read;
 }


### PR DESCRIPTION
The issue stated a potential memory leak in the file, due to allocating memory resources on line 37 but not freeing them. This change does the same by freeing the memory allocated to ptr.