### PR TITLE
Freeing the memory no longer in use

### DIFF
--- a/doc/educational_decoder/harness.c
+++ b/doc/educational_decoder/harness.c
@@ -46,6 +46,7 @@ static size_t read_file(const char *path, u8 **ptr)
     }
 
     fclose(f);
+    free(*ptr);
 
     return read;
 }


### PR DESCRIPTION
The function read_file allocated a memory of size 'size' to *ptr without freeing or deallocating it afterwards leading to memory leak.