### PR TITLE
[experimental] Use `seccomp()` to Sandbox Zstd

### DIFF
--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -14,6 +14,7 @@
 #include "debug.h"     /* assert */
 #include "zstd_internal.h"  /* ZSTD_malloc, ZSTD_free */
 #include "pool.h"
+#include "zstd_seccomp.h" /* ZSTD_disable_syscalls_for_worker_thread */
 
 /* ======   Compiler specifics   ====== */
 #if defined(_MSC_VER)
@@ -67,6 +68,9 @@ struct POOL_ctx_s {
 static void* POOL_thread(void* opaque) {
     POOL_ctx* const ctx = (POOL_ctx*)opaque;
     if (!ctx) { return NULL; }
+
+    if (!ZSTD_disable_syscalls_for_worker_thread()) { return NULL; }
+
     for (;;) {
         /* Lock the mutex and wait for a non-empty queue or until shutdown */
         ZSTD_pthread_mutex_lock(&ctx->queueMutex);

--- a/lib/common/zstd_seccomp.c
+++ b/lib/common/zstd_seccomp.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+#include "zstd_seccomp.h"
+
+#include "debug.h" /* DEBUGLOG */
+
+int ZSTD_disable_syscalls_for_worker_thread(void) {
+    return 1;
+}

--- a/lib/common/zstd_seccomp.c
+++ b/lib/common/zstd_seccomp.c
@@ -12,6 +12,99 @@
 
 #include "debug.h" /* DEBUGLOG */
 
+#ifdef ZSTD_FORCE_USE_SECCOMP
+#  ifndef ZSTD_USE_SECCOMP
+#    define ZSTD_USE_SECCOMP 1
+#  endif
+#endif
+
+#ifdef ZSTD_TRY_USE_SECCOMP
+/* Impl only works on linux >= 4.14, and only on x86 & amd64. */
+#  if (defined(__linux__) || defined(__linux)) && (defined(__i386__) || defined(__x86_64__))
+#    include <linux/version.h>
+#    if LINUX_VERSION_CODE > KERNEL_VERSION(4,14,0)
+#      ifndef ZSTD_USE_SECCOMP
+#        define ZSTD_USE_SECCOMP 1
+#      endif
+#    endif
+#  endif
+#endif
+
+#ifndef ZSTD_USE_SECCOMP
+#  define ZSTD_USE_SECCOMP 0
+#endif
+
+#if ZSTD_USE_SECCOMP
+#include <stddef.h> /* offsetof */
+#include <unistd.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <linux/unistd.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+
+#define syscall_nr (offsetof(struct seccomp_data, nr))
+#define arch_nr (offsetof(struct seccomp_data, arch))
+
+#if defined(__i386__)
+#  define REG_SYSCALL  REG_EAX
+#  define ARCH_NR  AUDIT_ARCH_I386
+#elif defined(__x86_64__)
+#  define REG_SYSCALL  REG_RAX
+#  define ARCH_NR  AUDIT_ARCH_X86_64
+#else
+#  error "Platform does not support seccomp filter."
+#endif
+
+#define VALIDATE_ARCHITECTURE \
+  BPF_STMT(BPF_LD+BPF_W+BPF_ABS, arch_nr), \
+  BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARCH_NR, 1, 0), \
+  BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_KILL)
+
+#define EXAMINE_SYSCALL \
+  BPF_STMT(BPF_LD+BPF_W+BPF_ABS, syscall_nr)
+
+#define ALLOW_SYSCALL(name) \
+  BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, __NR_##name, 0, 1), \
+  BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW)
+
+#define ALLOW \
+  BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW)
+
+#define KILL_PROCESS \
+  BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_KILL)
+
+#endif
+
 int ZSTD_disable_syscalls_for_worker_thread(void) {
+#if ZSTD_USE_SECCOMP
+    struct sock_filter filter[] = {
+        VALIDATE_ARCHITECTURE,
+        EXAMINE_SYSCALL,
+        ALLOW_SYSCALL(futex),
+        ALLOW_SYSCALL(brk),
+        ALLOW_SYSCALL(mmap),
+        ALLOW_SYSCALL(munmap),
+        ALLOW_SYSCALL(mprotect),
+        ALLOW_SYSCALL(madvise),
+        ALLOW_SYSCALL(read),
+        ALLOW_SYSCALL(write),
+        ALLOW_SYSCALL(exit),
+        KILL_PROCESS
+    };
+    struct sock_fprog prog = {
+       (unsigned short)(sizeof(filter)/sizeof(filter[0])),
+       filter
+    };
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+        DEBUGLOG(3, "prctl() failed: %m\n");
+        return 0;
+    }
+    if (syscall(SYS_seccomp, SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_LOG, &prog)) {
+        DEBUGLOG(3, "seccomp() failed: %m\n");
+        return 0;
+    }
+#endif
     return 1;
 }

--- a/lib/common/zstd_seccomp.h
+++ b/lib/common/zstd_seccomp.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+#ifndef _ZSTD_SECCOMP_H_
+#define _ZSTD_SECCOMP_H_
+
+/**
+ * These functions use OS APIs, if present/enabled, to voluntarily give up the
+ * ability to make certain system calls. Specifically, we will whitelist only
+ * the syscalls we expect to make, and disable the rest. This is a defensive
+ * measure, so that if someone were to figure out a remote code execution bug
+ * in Zstd, they would be limited to a small set of syscalls, hopefully without
+ * really any of the interesting ones (exec, clone, accept, connect, etc.).
+ */
+
+/**
+ * Restrict this thread's capabilities down to the syscalls used by the zstdmt
+ * worker threads.
+ *
+ * Return: 0 if failed. 1 if succeeded.
+ */
+int ZSTD_disable_syscalls_for_worker_thread(void);
+
+#endif /* _ZSTD_SECCOMP_H_ */

--- a/lib/common/zstd_seccomp.h
+++ b/lib/common/zstd_seccomp.h
@@ -17,6 +17,11 @@
  * measure, so that if someone were to figure out a remote code execution bug
  * in Zstd, they would be limited to a small set of syscalls, hopefully without
  * really any of the interesting ones (exec, clone, accept, connect, etc.).
+ *
+ * So far this functionality has only been implemented for Linux, via the
+ * `seccomp()` API. The build macros `ZSTD_FORCE_USE_SECCOMP` and
+ * `ZSTD_TRY_USE_SECCOMP` control whether we use this functionality or not.
+ * Otherwise, for the time being, it is disabled by default.
  */
 
 /**


### PR DESCRIPTION
I realized Linux has analogous functionality to OpenBSD's `pledge()` (see #1969). This is an experiment exploring using the `seccomp()` syscall to limit what Zstd can do.