### PR TITLE
Fix performance regression on aarch64 with clang

### DIFF
--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -817,7 +817,7 @@ HUF_decompress4X2_usingDTable_internal_body(
 
         /* 16-32 symbols per loop (4-8 symbols per stream) */
         for ( ; (endSignal) & (op4 < olimit); ) {
-#ifdef __clang__
+#if defined(__clang__) && (defined(__x86_64__) || defined(__i386__))
             HUF_DECODE_SYMBOLX2_2(op1, &bitD1);
             HUF_DECODE_SYMBOLX2_1(op1, &bitD1);
             HUF_DECODE_SYMBOLX2_2(op1, &bitD1);
@@ -855,10 +855,11 @@ HUF_decompress4X2_usingDTable_internal_body(
             HUF_DECODE_SYMBOLX2_0(op2, &bitD2);
             HUF_DECODE_SYMBOLX2_0(op3, &bitD3);
             HUF_DECODE_SYMBOLX2_0(op4, &bitD4);
-            endSignal &= BIT_reloadDStreamFast(&bitD1) == BIT_DStream_unfinished;
-            endSignal &= BIT_reloadDStreamFast(&bitD2) == BIT_DStream_unfinished;
-            endSignal &= BIT_reloadDStreamFast(&bitD3) == BIT_DStream_unfinished;
-            endSignal &= BIT_reloadDStreamFast(&bitD4) == BIT_DStream_unfinished;
+            endSignal = LIKELY(
+                        (BIT_reloadDStreamFast(&bitD1) == BIT_DStream_unfinished)
+                      & (BIT_reloadDStreamFast(&bitD2) == BIT_DStream_unfinished)
+                      & (BIT_reloadDStreamFast(&bitD3) == BIT_DStream_unfinished)
+                      & (BIT_reloadDStreamFast(&bitD4) == BIT_DStream_unfinished));
 #endif
         }
 

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -580,7 +580,7 @@ typedef struct {
  *  Precondition: *ip <= *op
  *  Postcondition: *op - *op >= 8
  */
-static void ZSTD_overlapCopy8(BYTE** op, BYTE const** ip, size_t offset) {
+HINT_INLINE void ZSTD_overlapCopy8(BYTE** op, BYTE const** ip, size_t offset) {
     assert(*ip <= *op);
     if (offset < 8) {
         /* close range match, overlap */


### PR DESCRIPTION
This patch fixes a performance regression on aarch64 phones compiled with clang.
* Only keep the special clang ordering of Huffman decompression on x86_64 and i386. It is neutral on armv7 and negative on aarch64.
* Add a `LIKELY()` to the `endSignal` computation. There isn't a good reason for it other than clang on aarch64 needs it, and it doesn't hurt anyone else.
* Add `HINT_INLINE` to `ZSTD_overlapCopy8()`. Without it `-Oz` will outline this function.

I've tested the performance of `./zstd -b1e1 enwik6` on the following devices.


Machine name | CPU | Clang version | Gcc version | Test command
-- | -- | -- | -- | --
Nexus 4 | 1.5 GHz quad-core Krait | 9.0.8 (ndk-r21) | N/A | ./zstd
Galaxy S6 | Quad-core 2.1 GHz Cortex-A57 + Quad-core 1.5 GHz Cortex-A53 | 9.0.8 (ndk-r21) | N/A | ./zstd
Macbook | 2.4 GHz Intel Core i9 | Apple 10.0.1 | 8.3.0 | ./zstd
Devserver | 2.4 GHz 24 core Intel Skylake | 3.4.2 | 6.2.1 | taskset --cpu-list 0 ./zstd
Nickserv | 3.6 GHz Intel i9-9900K (5.0 GHz turbo) | 9.0.1 | 9.2.0 | cset shield --exec -- ./zstd

The number listed is decompression speed in MB/s.

Machine | Arch | Compiler | zstd-1.4.3 | zstd-1.4.4 | dev | PR
-- | -- | -- | -- | -- | -- | --
Nexus 4 | armv7 | clang -Os | 91.7 | 94.7 | 105.5 | 105.2
Galaxy S6 | aarch64 | clang -Os | 254.3 | 288.3 | 261.6 | 293.5
Macbook | x86_64 | clang -O3 | 925.2 | 1055.6 | 1182.0 | 1182.5
  |   | gcc -O3 | 969.1 | 1205.2 | 1223.6 | 1229.5
Nickserv | x86_64 | clang -O3 | 743.1 | 865.8 | 1064.9 | 1065.9
  |   | gcc -O3 | 854.2 | 1017.2 | 1092.2 | 1089.5
  | i386 | clang -O3 | 535.0 | 587.6 | 597.6 | 597.8
  |   | gcc -O3 | 511.8 | 611.9 | 624.7 | 622.7

