### PR TITLE
Compile with -pedantic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ zlibwrapper: lib
 ## test: run long-duration tests
 .PHONY: test
 DEBUGLEVEL ?= 1
-test: MOREFLAGS += -g -DDEBUGLEVEL=$(DEBUGLEVEL) -Werror
+test: MOREFLAGS += -g -DDEBUGLEVEL=$(DEBUGLEVEL) -Werror -pedantic
 test:
 	MOREFLAGS="$(MOREFLAGS)" $(MAKE) -j -C $(PRGDIR) allVariants
 	$(MAKE) -C $(TESTDIR) $@


### PR DESCRIPTION
This is a hacky solution to the problem, I'm not particularly proud of it. It should however be sufficient.

We reduce the macro so that we can essentially "deduce" the correct final macro. The final macros are in all versions 2: Either the one that has exactly the number of actual arguments (i.e. non-variadic e.g. for `RETURN_ERROR_IF`, they're 2, `cond` and `err`) or the one that has this number of actual arguments plus the variadic one.

Browsing the makefiles was somewhat difficult, `-pedantic` should definitely be added in other places.