### PR TITLE
Enable oss-fuzz CIFuzz dogfood

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        project-name: 'zstd'
+        dry-run: true
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        fuzz-time: 600
+        dry-run: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: bug_report
+        path: ./out/bug_report


### PR DESCRIPTION
See PR #1992. I've been unable to test it on my repo, see https://github.com/terrelln/zstd/pull/2. It looks like it only works with the `facebook/zstd` repo, not `terrelln/zstd`, but I verified it still outputs a pass. So we can merge this without it failing any of our PRs, and we can see how it works.