### PR TITLE
Changing zip output to artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,5 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: bug_report
-        path: ./out/bug_report
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
We had a last minute design decision to rename the output directory to 'artifacts'. We were wondering if you could integrate it @terrelln Sorry for the inconvenience, and thanks for dog fooding CIFuzz!