### PR TITLE
Fix pkg-config File Generation Again

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -134,11 +134,12 @@ endif ()
 if (UNIX)
     # pkg-config
     set(PREFIX "${CMAKE_INSTALL_PREFIX}")
-    set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+    set(LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+    set(INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
     set(VERSION "${zstd_VERSION_MAJOR}.${zstd_VERSION_MINOR}.${zstd_VERSION_PATCH}")
     add_custom_target(libzstd.pc ALL
             ${CMAKE_COMMAND} -DIN="${LIBRARY_DIR}/libzstd.pc.in" -DOUT="libzstd.pc"
-            -DPREFIX="${PREFIX}" -DVERSION="${VERSION}"
+            -DPREFIX="${PREFIX}" -DLIBDIR="${LIBDIR}" -DINCLUDEDIR="${INCLUDEDIR}" -DVERSION="${VERSION}"
             -P "${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig.cmake"
             COMMENT "Creating pkg-config file")
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -227,11 +227,20 @@ INCLUDEDIR  ?= $(includedir)
 PCLIBDIR ?= $(shell echo "$(LIBDIR)" | sed -n -e "s@^$(exec_prefix)\\(/\\|$$\\)@@p")
 PCINCDIR ?= $(shell echo "$(INCLUDEDIR)" | sed -n -e "s@^$(prefix)\\(/\\|$$\\)@@p")
 
+ifeq (,$(PCLIBDIR))
+# Additional prefix check is required, since the empty string is technically a
+# valid PCLIBDIR
 ifeq (,$(shell echo "$(LIBDIR)" | sed -n -e "\\@^$(exec_prefix)\\(/\\|$$\\)@ p"))
 $(error configured libdir ($(LIBDIR)) is outside of prefix ($(prefix)), can't generate pkg-config file)
 endif
+endif
+
+ifeq (,$(PCINCDIR))
+# Additional prefix check is required, since the empty string is technically a
+# valid PCINCDIR
 ifeq (,$(shell echo "$(INCLUDEDIR)" | sed -n -e "\\@^$(prefix)\\(/\\|$$\\)@ p"))
 $(error configured includedir ($(INCLUDEDIR)) is outside of exec_prefix ($(exec_prefix)), can't generate pkg-config file)
+endif
 endif
 
 ifneq (,$(filter $(shell uname),FreeBSD NetBSD DragonFly))

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -219,27 +219,28 @@ DESTDIR     ?=
 prefix      ?= /usr/local
 PREFIX      ?= $(prefix)
 exec_prefix ?= $(PREFIX)
-libdir      ?= $(exec_prefix)/lib
+EXEC_PREFIX ?= $(exec_prefix)
+libdir      ?= $(EXEC_PREFIX)/lib
 LIBDIR      ?= $(libdir)
 includedir  ?= $(PREFIX)/include
 INCLUDEDIR  ?= $(includedir)
 
-PCLIBDIR ?= $(shell echo "$(LIBDIR)" | sed -n -e "s@^$(exec_prefix)\\(/\\|$$\\)@@p")
-PCINCDIR ?= $(shell echo "$(INCLUDEDIR)" | sed -n -e "s@^$(prefix)\\(/\\|$$\\)@@p")
+PCLIBDIR ?= $(shell echo "$(LIBDIR)" | sed -n -e "s@^$(EXEC_PREFIX)\\(/\\|$$\\)@@p")
+PCINCDIR ?= $(shell echo "$(INCLUDEDIR)" | sed -n -e "s@^$(PREFIX)\\(/\\|$$\\)@@p")
 
 ifeq (,$(PCLIBDIR))
 # Additional prefix check is required, since the empty string is technically a
 # valid PCLIBDIR
-ifeq (,$(shell echo "$(LIBDIR)" | sed -n -e "\\@^$(exec_prefix)\\(/\\|$$\\)@ p"))
-$(error configured libdir ($(LIBDIR)) is outside of prefix ($(prefix)), can't generate pkg-config file)
+ifeq (,$(shell echo "$(LIBDIR)" | sed -n -e "\\@^$(EXEC_PREFIX)\\(/\\|$$\\)@ p"))
+$(error configured libdir ($(LIBDIR)) is outside of prefix ($(PREFIX)), can't generate pkg-config file)
 endif
 endif
 
 ifeq (,$(PCINCDIR))
 # Additional prefix check is required, since the empty string is technically a
 # valid PCINCDIR
-ifeq (,$(shell echo "$(INCLUDEDIR)" | sed -n -e "\\@^$(prefix)\\(/\\|$$\\)@ p"))
-$(error configured includedir ($(INCLUDEDIR)) is outside of exec_prefix ($(exec_prefix)), can't generate pkg-config file)
+ifeq (,$(shell echo "$(INCLUDEDIR)" | sed -n -e "\\@^$(PREFIX)\\(/\\|$$\\)@ p"))
+$(error configured includedir ($(INCLUDEDIR)) is outside of exec_prefix ($(EXEC_PREFIX)), can't generate pkg-config file)
 endif
 endif
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -224,6 +224,16 @@ LIBDIR      ?= $(libdir)
 includedir  ?= $(PREFIX)/include
 INCLUDEDIR  ?= $(includedir)
 
+PCLIBDIR ?= $(shell echo "$(LIBDIR)" | sed -n -e "s@^$(exec_prefix)\\(/\\|$$\\)@@p")
+PCINCDIR ?= $(shell echo "$(INCLUDEDIR)" | sed -n -e "s@^$(prefix)\\(/\\|$$\\)@@p")
+
+ifeq (,$(shell echo "$(LIBDIR)" | sed -n -e "\\@^$(exec_prefix)\\(/\\|$$\\)@ p"))
+$(error configured libdir ($(LIBDIR)) is outside of prefix ($(prefix)), can't generate pkg-config file)
+endif
+ifeq (,$(shell echo "$(INCLUDEDIR)" | sed -n -e "\\@^$(prefix)\\(/\\|$$\\)@ p"))
+$(error configured includedir ($(INCLUDEDIR)) is outside of exec_prefix ($(exec_prefix)), can't generate pkg-config file)
+endif
+
 ifneq (,$(filter $(shell uname),FreeBSD NetBSD DragonFly))
 PKGCONFIGDIR ?= $(PREFIX)/libdata/pkgconfig
 else
@@ -239,11 +249,11 @@ endif
 INSTALL_PROGRAM ?= $(INSTALL)
 INSTALL_DATA    ?= $(INSTALL) -m 644
 
-
-libzstd.pc:
 libzstd.pc: libzstd.pc.in
 	@echo creating pkgconfig
 	@sed -e 's|@PREFIX@|$(PREFIX)|' \
+             -e 's|@LIBDIR@|$(PCLIBDIR)|' \
+             -e 's|@INCLUDEDIR@|$(PCINCDIR)|' \
              -e 's|@VERSION@|$(VERSION)|' \
              $< >$@
 

--- a/lib/libzstd.pc.in
+++ b/lib/libzstd.pc.in
@@ -4,8 +4,8 @@
 
 prefix=@PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+includedir=${prefix}/@INCLUDEDIR@
+libdir=${exec_prefix}/@LIBDIR@
 
 Name: zstd
 Description: fast lossless compression algorithm library


### PR DESCRIPTION
Revises #1851. Fixes #1900. Replaces #1930.

Thanks to @orbea, @neheb, @Polynomial-C, and particularly @eli-schwartz for pointing out the problem and suggesting solutions.

Tested with

  ```
  make -C lib clean libzstd.pc
  cat lib/libzstd.pc

  # should fail
  make -C lib clean libzstd.pc     LIBDIR=/foo
  make -C lib clean libzstd.pc INCLUDEDIR=/foo
  make -C lib clean libzstd.pc     LIBDIR=/usr/localfoo
  make -C lib clean libzstd.pc INCLUDEDIR=/usr/localfoo
  make -C lib clean libzstd.pc     LIBDIR=/usr/local/lib     prefix=/foo
  make -C lib clean libzstd.pc INCLUDEDIR=/usr/local/include prefix=/foo

  # should succeed
  make -C lib clean libzstd.pc     LIBDIR=/usr/local/foo
  make -C lib clean libzstd.pc INCLUDEDIR=/usr/local/foo
  make -C lib clean libzstd.pc     LIBDIR=/usr/local/
  make -C lib clean libzstd.pc INCLUDEDIR=/usr/local/
  make -C lib clean libzstd.pc     LIBDIR=/usr/local
  make -C lib clean libzstd.pc INCLUDEDIR=/usr/local
  make -C lib clean libzstd.pc     LIBDIR=/tmp/foo prefix=/tmp
  make -C lib clean libzstd.pc INCLUDEDIR=/tmp/foo prefix=/tmp
  make -C lib clean libzstd.pc     LIBDIR=/tmp/foo prefix=/tmp/foo
  make -C lib clean libzstd.pc INCLUDEDIR=/tmp/foo prefix=/tmp/foo

  # should also succeed
  make -C lib clean libzstd.pc prefix=/foo LIBDIR=/foo/bar INCLUDEDIR=/foo/
  cat lib/libzstd.pc

  mkdir out
  cd out
  cmake ../build/cmake
  make
  cat lib/libzstd.pc
  ```