### PR TITLE
Fix integer parsing in cli

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -254,10 +254,12 @@ static int readU32FromCharChecked(const char** stringPtr, unsigned* value)
 {
     unsigned result = 0;
     while ((**stringPtr >='0') && (**stringPtr <='9')) {
-        unsigned const max = (((unsigned)(-1)) / 10) - 1;
+        unsigned const max = ((unsigned)(-1)) / 10;
+        unsigned last = result;
         if (result > max) return 1; /* overflow error */
         result *= 10;
         result += (unsigned)(**stringPtr - '0');
+        if (result < last) return 1; /* overflow error */
         (*stringPtr)++ ;
     }
     if ((**stringPtr=='K') || (**stringPtr=='M')) {


### PR DESCRIPTION
`readU32FromCharChecked()` currently fails for numbers within the nearest multiple of 10 of the limit for 32-bit unsigned ints:
```
$ zstd -M4294967295
error: numeric value too large
```
This breaks e.g. [lesspipe](https://github.com/wofr06/lesspipe). As unsigned integer 'overflow' is well-defined behaviour in C, we can safely just let it happen and check afterwards.