### PR TITLE
Replaced targetLen with targetLength

### DIFF
--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -371,7 +371,7 @@ Larger search lengths usually decrease compression ratio but improve decompressi
 The minimum \fImml\fR is 3 and the maximum is 7\.
 .
 .TP
-\fBtargetLen\fR=\fItlen\fR, \fBtlen\fR=\fItlen\fR
+\fBtargetLength\fR=\fItlen\fR, \fBtlen\fR=\fItlen\fR
 The impact of this field vary depending on selected strategy\.
 .
 .IP


### PR DESCRIPTION
The actual name of the option is targetLength. Using targetLen as indicated in the man page resulted in errors.