### PR TITLE
Update CIFuzz file and turn off dry-run mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,14 @@ jobs:
     - name: Build Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
-        project-name: 'zstd'
-        dry-run: true
+        oss-fuzz-project-name: 'zstd'
+        dry-run: false
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
-        fuzz-time: 600
-        dry-run: true
+        oss-fuzz-project-name: 'zstd'
+        fuzz-seconds: 600
+        dry-run: false
     - name: Upload Crash
       uses: actions/upload-artifact@v1
       if: failure()


### PR DESCRIPTION
Applies #2004 and turns off dry-run mode. If spurious failures pop up, I will turn dry-run mode back on.