### PR TITLE
[zstdgrep] Log zstd decompression errors to stderr

### DIFF
--- a/programs/zstdgrep
+++ b/programs/zstdgrep
@@ -109,7 +109,7 @@ if [ "$#" -lt 1 ]; then
     # ... on stdin
     set -f # Disable file name generation (globbing).
     # shellcheck disable=SC2086
-    "${zcat}" -f - | "${grep}" ${grep_args} -- "${pattern}" -
+    "${zcat}" - | "${grep}" ${grep_args} -- "${pattern}" -
     EXIT_CODE=$?
     set +f
 else
@@ -121,9 +121,9 @@ else
     while [ "$#" -gt 0 ]; do
         # shellcheck disable=SC2086
         if [ $pattern_found -eq 2 ]; then
-            "${zcat}" -f -- "$1" | "${grep}" --label="${1}" ${grep_args} -- -
+            "${zcat}" -- "$1" | "${grep}" --label="${1}" ${grep_args} -- -
         else
-            "${zcat}" -f -- "$1" | "${grep}" --label="${1}" ${grep_args} -- "${pattern}" -
+            "${zcat}" -- "$1" | "${grep}" --label="${1}" ${grep_args} -- "${pattern}" -
         fi
         [ "$?" -ne 0 ] && EXIT_CODE=1
         shift

--- a/programs/zstdgrep
+++ b/programs/zstdgrep
@@ -109,7 +109,7 @@ if [ "$#" -lt 1 ]; then
     # ... on stdin
     set -f # Disable file name generation (globbing).
     # shellcheck disable=SC2086
-    "${zcat}" -fq - | "${grep}" ${grep_args} -- "${pattern}" -
+    "${zcat}" -f - | "${grep}" ${grep_args} -- "${pattern}" -
     EXIT_CODE=$?
     set +f
 else
@@ -121,9 +121,9 @@ else
     while [ "$#" -gt 0 ]; do
         # shellcheck disable=SC2086
         if [ $pattern_found -eq 2 ]; then
-            "${zcat}" -fq -- "$1" | "${grep}" --label="${1}" ${grep_args} -- -
+            "${zcat}" -f -- "$1" | "${grep}" --label="${1}" ${grep_args} -- -
         else
-            "${zcat}" -fq -- "$1" | "${grep}" --label="${1}" ${grep_args} -- "${pattern}" -
+            "${zcat}" -f -- "$1" | "${grep}" --label="${1}" ${grep_args} -- "${pattern}" -
         fi
         [ "$?" -ne 0 ] && EXIT_CODE=1
         shift

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -63,6 +63,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PRGDIR="$SCRIPT_DIR/../programs"
 TESTDIR="$SCRIPT_DIR/../tests"
 UNAME=$(uname)
+ZSTDGREP="$PRGDIR/zstdgrep"
 
 detectedTerminal=false
 if [ -t 0 ] && [ -t 1 ]
@@ -224,6 +225,17 @@ $ZSTD tmp -c --compress-literals    --fast=1 | $ZSTD -t
 $ZSTD tmp -c --compress-literals    -19      | $ZSTD -t
 $ZSTD -b --fast=1 -i0e1 tmp --compress-literals
 $ZSTD -b --fast=1 -i0e1 tmp --no-compress-literals
+
+println "\n===> zstdgrep tests"
+ln -sf $ZSTD_BIN zstdcat
+rm -f tmp_grep
+echo "1234" > tmp_grep
+$ZSTD -f tmp_grep
+lines=$(ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep tmp_grep.zst | wc -l)
+test 2 -eq $lines
+ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep_bad.zst && die "Should have failed"
+ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep_bad.zst | grep "No such file or directory" || true
+rm -f tmp_grep*
 
 println "\n===>  --exclude-compressed flag"
 rm -rf precompressedFilterTestDir


### PR DESCRIPTION
Don't pass `-fq` to `zstdcat` because it is already implied. This allows errors to be logged to `stderr` and fixes #2020.