### PR TITLE
Removing no-tree-vectorize for intel

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -136,7 +136,7 @@
 
 /* vectorization
  * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax */
-#if !defined(__clang__) && defined(__GNUC__)
+#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__)
 #  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
 #    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
 #  else


### PR DESCRIPTION
Removes warning on icc
```
decompress/zstd_decompress_block.c(1119): warning #3175: unrecognized gcc optimization level
  DONT_VECTORIZE
  ^

```