### PR TITLE
_BitScan{Reverse,Forward} add check for undefined

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -162,8 +162,7 @@ MEM_STATIC unsigned BIT_highbit32 (U32 val)
     {
 #   if defined(_MSC_VER)   /* Visual */
         unsigned long r=0;
-        _BitScanReverse ( &r, val );
-        return (unsigned) r;
+        _BitScanReverse ( &r, val ) ? (unsigned)r : 0;
 #   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* Use GCC Intrinsic */
         return __builtin_clz (val) ^ 31;
 #   elif defined(__ICCARM__)    /* IAR Intrinsic */

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -162,7 +162,7 @@ MEM_STATIC unsigned BIT_highbit32 (U32 val)
     {
 #   if defined(_MSC_VER)   /* Visual */
         unsigned long r=0;
-        _BitScanReverse ( &r, val ) ? (unsigned)r : 0;
+        return _BitScanReverse ( &r, val ) ? (unsigned)r : 0;
 #   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* Use GCC Intrinsic */
         return __builtin_clz (val) ^ 31;
 #   elif defined(__ICCARM__)    /* IAR Intrinsic */

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -298,8 +298,7 @@ MEM_STATIC U32 ZSTD_highbit32(U32 val)   /* compress, dictBuilder, decodeCorpus 
     {
 #   if defined(_MSC_VER)   /* Visual */
         unsigned long r=0;
-        _BitScanReverse(&r, val);
-        return (unsigned)r;
+        _BitScanReverse(&r, val) ? (unsigned)r : 0;
 #   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* GCC Intrinsic */
         return __builtin_clz (val) ^ 31;
 #   elif defined(__ICCARM__)    /* IAR Intrinsic */

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -298,7 +298,7 @@ MEM_STATIC U32 ZSTD_highbit32(U32 val)   /* compress, dictBuilder, decodeCorpus 
     {
 #   if defined(_MSC_VER)   /* Visual */
         unsigned long r=0;
-        _BitScanReverse(&r, val) ? (unsigned)r : 0;
+        return _BitScanReverse(&r, val) ? (unsigned)r : 0;
 #   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* GCC Intrinsic */
         return __builtin_clz (val) ^ 31;
 #   elif defined(__ICCARM__)    /* IAR Intrinsic */

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -465,7 +465,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         } else { /* 32 bits */
 #       if defined(_MSC_VER)
             unsigned long r=0;
-            return _BitScanForward( &r, (U32)val ) ? return (unsigned)(r >> 3) : 0;
+            return _BitScanForward( &r, (U32)val ) ? (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 3)
             return (__builtin_ctz((U32)val) >> 3);
 #       else

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -465,7 +465,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         } else { /* 32 bits */
 #       if defined(_MSC_VER)
             unsigned long r=0;
-            _BitScanForward( &r, (U32)val ) ? return (unsigned)(r >> 3) : 0;
+            return _BitScanForward( &r, (U32)val ) ? return (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 3)
             return (__builtin_ctz((U32)val) >> 3);
 #       else
@@ -480,7 +480,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         if (MEM_64bits()) {
 #       if defined(_MSC_VER) && defined(_WIN64)
             unsigned long r = 0;
-            _BitScanReverse64( &r, val ) ? (unsigned)(r >> 3) : 0;
+            return _BitScanReverse64( &r, val ) ? (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 4)
             return (__builtin_clzll(val) >> 3);
 #       else
@@ -494,7 +494,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         } else { /* 32 bits */
 #       if defined(_MSC_VER)
             unsigned long r = 0;
-            _BitScanReverse( &r, (unsigned long)val ) ? (unsigned)(r >> 3) : 0;
+            return _BitScanReverse( &r, (unsigned long)val ) ? (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 3)
             return (__builtin_clz((U32)val) >> 3);
 #       else

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -448,8 +448,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         if (MEM_64bits()) {
 #       if defined(_MSC_VER) && defined(_WIN64)
             unsigned long r = 0;
-            _BitScanForward64( &r, (U64)val );
-            return (unsigned)(r>>3);
+            return _BitScanForward64( &r, (U64)val ) ? (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 4)
             return (__builtin_ctzll((U64)val) >> 3);
 #       else
@@ -466,8 +465,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         } else { /* 32 bits */
 #       if defined(_MSC_VER)
             unsigned long r=0;
-            _BitScanForward( &r, (U32)val );
-            return (unsigned)(r>>3);
+            _BitScanForward( &r, (U32)val ) ? return (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 3)
             return (__builtin_ctz((U32)val) >> 3);
 #       else
@@ -482,8 +480,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         if (MEM_64bits()) {
 #       if defined(_MSC_VER) && defined(_WIN64)
             unsigned long r = 0;
-            _BitScanReverse64( &r, val );
-            return (unsigned)(r>>3);
+            _BitScanReverse64( &r, val ) ? (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 4)
             return (__builtin_clzll(val) >> 3);
 #       else
@@ -497,8 +494,7 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         } else { /* 32 bits */
 #       if defined(_MSC_VER)
             unsigned long r = 0;
-            _BitScanReverse( &r, (unsigned long)val );
-            return (unsigned)(r>>3);
+            _BitScanReverse( &r, (unsigned long)val ) ? (unsigned)(r >> 3) : 0;
 #       elif defined(__GNUC__) && (__GNUC__ >= 3)
             return (__builtin_clz((U32)val) >> 3);
 #       else


### PR DESCRIPTION
https://github.com/facebook/zstd/issues/1951

I've managed to reproduce this error on my windows vm, visual 2019 with: 

```
#include <iostream>
#include <cassert>

using namespace std;

int main()
{
  unsigned long index = 0;
  _BitScanReverse64(&index, 0x0ull);

  cout << index << endl;

  assert(index == 0);

  return 0;
}
```

Silesia entire file benchmarks: 
| level | zstd-clang (before) | zstd-clang (after)  | zstd-gcc (before) | zstd-gcc (after) |
|-------|---------------------|---------------------|-------------------|------------------|
| 1     | 440 mb/s            | 440 mb/s (-)        | 454 mb/s          | 454 mb/s (-)     |
| 2     | 334 mb/s            | 337 mb/s (-)        | 334 mb/s          | 336 mb/s (-)     |
| 3     | 239 mb/s            | 243 mb/s (+1%)      | 241 mb/s          | 242 mb/s (-)     |
| 4     | 233 mb/s            | 230 mb/s (-1%)      | 226 mb/s          | 227 mb/s (-)     |
| 5     | 126 mb/s            | 128 mb/s (-)        | 126 mb/s          | 127 mb/s (-)     |
| 6     | 101 mb/s            | 101 mb/s (-)        | 102 mb/s          | 102 mb/s (-)     |
| 7     | 68 mb/s             | 67 mb/s (-)         | 72 mb/s           | 72 mb/s (-)      |
| 8     | 53 mb/s             | 54 mb/s (-)         | 58 mb/s           | 58 mb/s (-)      |
| 9     | 38 mb/s             | 38 mb/s (-)         | 42 mb/s           | 42 mb/s (-)      |
| 10    | 25 mb/s             | 25 mb/s (-)         | 27 mb/s           | 27 mb/s (-)      |
| 11    | 19 mb/s             | 19 mb/s (-)         | 19 mb/s           | 19 mb/s (-)      |
| 12    | 13 mb/s             | 14 mb/s (+4%)       | 13 mb/s           | 13 mb/s (-)      |
| 13    | 11.0 mb/s           | 10.95 mb/s (-)      | 10.99 mb/s        | 10.95 mb/s (-)   |
| 14    | 8.49 mb/s           | 8.44 mb/s (-)       | 8.16 mb/s         | 8.11 mb/s (-)    |
| 15    | 6.40 mb/s           | 6.34 mb/s (-)       | 6.24 mb/s         | 6.22 mb/s (-)    |
| 16    | 4.94 mb/s           | 4.92 mb/s (-)       | 5.15 mb/s         | 5.25 mb/s (-)    |
| 17    | 3.97 mb/s           | 3.95 mb/s (-)       | 4.06 mb/s         | 4.07 mb/s (-)    |
| 18    | 3.20 mb/s           | 3.20 mb/s (-)       | 3.31 mb/s         | 3.33 mb/s (-)    |
| 19    | 2.64 mb/s           | 2.66 mb/s (-)       | 2.77 mb/s         | 2.80 mb/s (-)    |