### PR TITLE
[opt] Small icc level 1 compression speed gain using #pragma vector 

### DIFF
--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -80,6 +80,10 @@ ZSTD_compressBlock_fast_generic(
     }
 
     /* Main Search Loop */
+#ifdef __INTEL_COMPILER
+    #pragma vector always
+    #pragma ivdep
+#endif
     while (ip1 < ilimit) {   /* < instead of <=, because check at ip0+2 */
         size_t mLength;
         BYTE const* ip2 = ip0 + 2;

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -81,8 +81,11 @@ ZSTD_compressBlock_fast_generic(
 
     /* Main Search Loop */
 #ifdef __INTEL_COMPILER
+    /* From intel 'The vector pragma indicates that the loop should be 
+     * vectorized if it is legal to do so'. Can be used together with 
+     * #pragma ivdep (but have opted to exclude that because intel 
+     * warns against using it).*/
     #pragma vector always
-    #pragma ivdep
 #endif
     while (ip1 < ilimit) {   /* < instead of <=, because check at ip0+2 */
         size_t mLength;


### PR DESCRIPTION
I generally saw a 2-3% gain in level 1 compression speed and didn't notice any regressions. Adding `#pragma ivdep` (which forces vectorization) seems to add another 1-2% to this but because intel says it isn't safe, I don't think we should include it.

Silesia benchmarks: 
|         | gcc       | icc (before) | icc (after) | Improvement |
|---------|-----------|--------------|-------------|-------------|
| dickens | 301 mb/s  | 271 mb/s     | 274 mb/s    | +1.1%       |
| mozilla | 443 mb/s  | 388 mb/s     | 396 mb/s    | +2.0%       |
| mr      | 396 mb/s  | 360 mb/s     | 366 mb/s    | +1.6%       |
| nci     | 874 mb/s  | 793 mb/s     | 792 mb/s    |  -          |
| ooffice | 352 mb/s  | 309 mb/s     | 321 mb/s    | +3.8%       |
| osdb    | 421 mb/s  | 378 mb/s     | 383 mb/s    | +1.5%       |
| reymont | 316 mb/s  | 285 mb/s     | 288 mb/s    | +1%         |
| samba   | 521 mb/s  | 469 mb/s     | 473 mb/s    |  -          |
| sao     | 316 mb/s  | 274 mb/s     | 287 mb/s    | +4.7%       |
| webster | 348 mb/s  | 312 mb/s     | 313 mb/s    |  -          |
| xml     | 740 mb/s  | 664 mb/s     | 664 mb/s    |  -          |
| x-ray   | 793 mb/s  | 697 mb/s     | 697 mb/s    |  -          |
| silesia | 448 mb/s  | 393 mb/s     | 403 mb/s    | +2.5%       |