### PR TITLE
Optimize Compression

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -134,6 +134,10 @@ typedef struct {
 
 typedef struct ZSTD_matchState_t ZSTD_matchState_t;
 struct ZSTD_matchState_t {
+    U32* hashTable;
+    U32* chainTable;
+    U32* hashTable3;
+    U32 hashLog3;           /* dispatch table for matches of len==3 : larger == faster, more memory */
     ZSTD_window_t window;   /* State for window round buffer management */
     U32 loadedDictEnd;      /* index of end of dictionary, within context's referential.
                              * When loadedDictEnd != 0, a dictionary is in use, and still valid.
@@ -143,10 +147,6 @@ struct ZSTD_matchState_t {
                              * loadedDictEnd == dictSize, since referential starts from zero.
                              */
     U32 nextToUpdate;       /* index from which to continue table update */
-    U32 hashLog3;           /* dispatch table for matches of len==3 : larger == faster, more memory */
-    U32* hashTable;
-    U32* hashTable3;
-    U32* chainTable;
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -154,7 +154,7 @@ size_t ZSTD_compressBlock_doubleFast_generic(
 
         /* check noDict repcode */
         if ( dictMode == ZSTD_noDict
-          && ((offset_1 > 0) & (MEM_read32(ip+1-offset_1) == MEM_read32(ip+1)))) {
+          && ((offset_1 > 0) && (MEM_read32(ip+1-offset_1) == MEM_read32(ip+1)))) {
             mLength = ZSTD_count(ip+1+4, ip+1+4-offset_1, iend) + 4;
             ip++;
             ZSTD_storeSeq(seqStore, (size_t)(ip-anchor), anchor, iend, 0, mLength-MINMATCH);


### PR DESCRIPTION
**Changelist**

	① Optimize by ordering the member variables in matchState_t.
	② Replace “&” with “&&” on the condtion of “dictMode == ZSTD_noDict” in the while loop of double_fast.

**Test result**
The value is the average agains of level 1~19, and the testfile is silesia.tar.

		changelist	x86		gcc9.2.0	clang9.0.0
		①		Compress	1.59%		-0.01%
				Decompress	1.01%		-2.47%
		①+②		Compress	2.07%		3.11%
				Decompress	0.72%		-0.69%
				
		changelist	aarch64		gcc9.2.0	clang9.0.0
		①		Compress	0.45%		-0.90%
				Decompress	-2.88%		-0.08%
		①+②		Compress	0.58%		-0.46%
				Decompress	-1.54%		0.61%

**Test environment**

	1)Measured with lzbench, transplanting the code of Zstd’s develop branch. 
	2)The test environment is as follows:
					x86						aarch64
	Cpu name			Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz	Armv8-a
	CPU(s):				160						128
	Memory Device			DDR4 2666 MT/s 32 GB				DDR4 2666 MT/s 32 GB
	Number Of Memory Devices	24						16