### PR TITLE
Optimize compression by using neon function.

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -254,14 +254,19 @@ void ZSTD_wildcopy(void* dst, const void* src, ptrdiff_t length, ZSTD_overlap_e 
          * at that point it is more likely to have a high trip count.
          */
 #ifndef __aarch64__
+        do {
+            COPY16(op, ip);
+        }
+        while (op < oend);
+#else
         COPY16(op, ip);
         if (op >= oend) return;
-#endif
         do {
             COPY16(op, ip);
             COPY16(op, ip);
         }
         while (op < oend);
+#endif
     }
 }
 

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -19,11 +19,11 @@
 /*-*************************************
 *  Dependencies
 ***************************************/
+#ifdef __aarch64__
+#include <arm_neon.h>
+#endif
 #include "compiler.h"
 #include "mem.h"
-#ifdef __aarch64__
-#include "arm_neon.h"
-#endif
 #include "debug.h"                 /* assert, DEBUGLOG, RAWLOG, g_debuglevel */
 #include "error_private.h"
 #define ZSTD_STATIC_LINKING_ONLY

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -250,8 +250,8 @@ void ZSTD_wildcopy(void* dst, const void* src, ptrdiff_t length, ZSTD_overlap_e 
         /* Separate out the first COPY16() call because the copy length is
          * almost certain to be short, so the branches have different
          * probabilities. Since it is almost certain to be short, only do
-	 * one COPY16() in the first call. Then, do two calls per loop since
-	 * at that point it is more likely to have a high trip count.
+         * one COPY16() in the first call. Then, do two calls per loop since
+         * at that point it is more likely to have a high trip count.
          */
 #ifndef __aarch64__
         COPY16(op, ip);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1854,6 +1854,20 @@ ZSTD_reduceTable_internal (U32* const table, U32 const size, U32 const reducerVa
 
     for (rowNb=0 ; rowNb < nbRows ; rowNb++) {
         int column;
+#ifdef __aarch64__
+        for (column=0; column<ZSTD_ROWSIZE; column+=4) {
+            uint32x4_t const zero = {0, 0, 0, 0};
+            uint32x4_t const reducer = vdupq_n_u32(reducerValue);
+            uint32x4_t data = vld1q_u32(table + cellNb);
+            if (preserveMark) {
+                uint32x4_t const mark = {ZSTD_DUBT_UNSORTED_MARK, ZSTD_DUBT_UNSORTED_MARK, ZSTD_DUBT_UNSORTED_MARK, ZSTD_DUBT_UNSORTED_MARK};
+                data = vbslq_u32(vceqq_u32(data, mark), vaddq_u32(data, reducer), data);
+            }
+            data = vbslq_u32(vcltq_u32(data, reducer), zero, vsubq_u32(data, reducer));
+            vst1q_u32(table + cellNb, data);
+            cellNb+=4;
+        }
+#else
         for (column=0; column<ZSTD_ROWSIZE; column++) {
             if (preserveMark) {
                 U32 const adder = (table[cellNb] == ZSTD_DUBT_UNSORTED_MARK) ? reducerValue : 0;
@@ -1862,7 +1876,9 @@ ZSTD_reduceTable_internal (U32* const table, U32 const size, U32 const reducerVa
             if (table[cellNb] < reducerValue) table[cellNb] = 0;
             else table[cellNb] -= reducerValue;
             cellNb++;
-    }   }
+        }
+#endif
+    }
 }
 
 static void ZSTD_reduceTable(U32* const table, U32 const size, U32 const reducerValue)

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1854,20 +1854,6 @@ ZSTD_reduceTable_internal (U32* const table, U32 const size, U32 const reducerVa
 
     for (rowNb=0 ; rowNb < nbRows ; rowNb++) {
         int column;
-#ifdef __aarch64__
-        for (column=0; column<ZSTD_ROWSIZE; column+=4) {
-            uint32x4_t const zero = {0, 0, 0, 0};
-            uint32x4_t const reducer = vdupq_n_u32(reducerValue);
-            uint32x4_t data = vld1q_u32(table + cellNb);
-            if (preserveMark) {
-                uint32x4_t const mark = {ZSTD_DUBT_UNSORTED_MARK, ZSTD_DUBT_UNSORTED_MARK, ZSTD_DUBT_UNSORTED_MARK, ZSTD_DUBT_UNSORTED_MARK};
-                data = vbslq_u32(vceqq_u32(data, mark), vaddq_u32(data, reducer), data);
-            }
-            data = vbslq_u32(vcltq_u32(data, reducer), zero, vsubq_u32(data, reducer));
-            vst1q_u32(table + cellNb, data);
-            cellNb+=4;
-        }
-#else
         for (column=0; column<ZSTD_ROWSIZE; column++) {
             if (preserveMark) {
                 U32 const adder = (table[cellNb] == ZSTD_DUBT_UNSORTED_MARK) ? reducerValue : 0;
@@ -1876,9 +1862,7 @@ ZSTD_reduceTable_internal (U32* const table, U32 const size, U32 const reducerVa
             if (table[cellNb] < reducerValue) table[cellNb] = 0;
             else table[cellNb] -= reducerValue;
             cellNb++;
-        }
-#endif
-    }
+    }   }
 }
 
 static void ZSTD_reduceTable(U32* const table, U32 const size, U32 const reducerValue)


### PR DESCRIPTION
The modification points interact on each other, and the effect of testing separately is not very well.

	Average gains(level 1~19)	gcc9.2.0	clang9.0.0
	Compression			1.67%		1.23%
	Decompression			0.02%		0.36%

**Test environment**

	1)	Measured with lzbench, transplanting the code of Zstd’s develop branch. 
	2)	The testfile is silesia.tar.
	3)	The test environment is as follows:
					aarch64
	Cpu name			Armv8-a
	CPU(s):				128
	Memory Device			DDR4 2666 MT/s 32 GB
	Number Of Memory Devices	16