### PR TITLE
[test] Fix playTests.sh with space in binary path

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -7,6 +7,26 @@ die() {
     exit 1
 }
 
+datagen() {
+    "$DATAGEN_BIN" $@
+}
+
+zstd() {
+    if [ -z "$EXEC_PREFIX" ]; then
+        "$ZSTD_BIN" $@
+    else
+        "$EXEC_PREFIX" "$ZSTD_BIN" $@
+    fi
+}
+
+sudoZstd() {
+    if [ -z "$EXEC_PREFIX" ]; then
+        sudo "$ZSTD_BIN" $@
+    else
+        sudo "$EXEC_PREFIX" "$ZSTD_BIN" $@
+    fi
+}
+
 roundTripTest() {
     if [ -n "$3" ]; then
         cLevel="$3"
@@ -22,9 +42,9 @@ roundTripTest() {
     fi
 
     rm -f tmp1 tmp2
-    println "roundTripTest: $DATAGEN $1 $proba | $ZSTD -v$cLevel | $ZSTD -d$dLevel"
-    $DATAGEN $1 $proba | $MD5SUM > tmp1
-    $DATAGEN $1 $proba | $ZSTD --ultra -v$cLevel | $ZSTD -d$dLevel  | $MD5SUM > tmp2
+    println "roundTripTest: datagen $1 $proba | zstd -v$cLevel | zstd -d$dLevel"
+    datagen $1 $proba | $MD5SUM > tmp1
+    datagen $1 $proba | zstd --ultra -v$cLevel | zstd -d$dLevel  | $MD5SUM > tmp2
     $DIFF -q tmp1 tmp2
 }
 
@@ -42,11 +62,11 @@ fileRoundTripTest() {
         local_d="$local_c"
     fi
 
-    rm -f tmp.zstd tmp.md5.1 tmp.md5.2
-    println "fileRoundTripTest: $DATAGEN $1 $local_p > tmp && $ZSTD -v$local_c -c tmp | $ZSTD -d$local_d"
-    $DATAGEN $1 $local_p > tmp
+    rm -f tmp.zst tmp.md5.1 tmp.md5.2
+    println "fileRoundTripTest: datagen $1 $local_p > tmp && zstd -v$local_c -c tmp | zstd -d$local_d"
+    datagen $1 $local_p > tmp
     < tmp $MD5SUM > tmp.md5.1
-    $ZSTD --ultra -v$local_c -c tmp | $ZSTD -d$local_d | $MD5SUM > tmp.md5.2
+    zstd --ultra -v$local_c -c tmp | zstd -d$local_d | $MD5SUM > tmp.md5.2
     $DIFF -q tmp.md5.1 tmp.md5.2
 }
 
@@ -105,13 +125,10 @@ esac
 
 println "\nStarting playTests.sh isWindows=$isWindows EXE_PREFIX='$EXE_PREFIX' ZSTD_BIN='$ZSTD_BIN'"
 
-[ -n "$ZSTD_BIN" ] || die "ZSTD_BIN variable must be defined!"
-[ -n "$DATAGEN_BIN" ] || die "DATAGEN_BIN variable must be defined!"
+[ -n "$ZSTD_BIN" ] || die "$ZSTD_BIN variable must be defined!"
+[ -n "$DATAGEN_BIN" ] || die "$DATAGEN_BIN variable must be defined!"
 
-ZSTD="$EXE_PREFIX $ZSTD_BIN"
-DATAGEN="$DATAGEN_BIN"
-
-if echo hello | $ZSTD -v -T2 2>&1 > $INTOVOID | grep -q 'multi-threading is disabled'
+if echo hello | zstd -v -T2 2>&1 > $INTOVOID | grep -q 'multi-threading is disabled'
 then
     hasMT=""
 else
@@ -122,115 +139,115 @@ fi
 
 println "\n===>  simple tests "
 
-$DATAGEN > tmp
+datagen > tmp
 println "test : basic compression "
-$ZSTD -f tmp                      # trivial compression case, creates tmp.zst
+zstd -f tmp                      # trivial compression case, creates tmp.zst
 println "test : basic decompression"
-$ZSTD -df tmp.zst                 # trivial decompression case (overwrites tmp)
+zstd -df tmp.zst                 # trivial decompression case (overwrites tmp)
 println "test : too large compression level => auto-fix"
-$ZSTD -99 -f tmp  # too large compression level, automatic sized down
-$ZSTD -5000000000 -f tmp && die "too large numeric value : must fail"
+zstd -99 -f tmp  # too large compression level, automatic sized down
+zstd -5000000000 -f tmp && die "too large numeric value : must fail"
 println "test : --fast aka negative compression levels"
-$ZSTD --fast -f tmp  # == -1
-$ZSTD --fast=3 -f tmp  # == -3
-$ZSTD --fast=200000 -f tmp  # too low compression level, automatic fixed
-$ZSTD --fast=5000000000 -f tmp && die "too large numeric value : must fail"
-$ZSTD -c --fast=0 tmp > $INTOVOID && die "--fast must not accept value 0"
+zstd --fast -f tmp  # == -1
+zstd --fast=3 -f tmp  # == -3
+zstd --fast=200000 -f tmp  # too low compression level, automatic fixed
+zstd --fast=5000000000 -f tmp && die "too large numeric value : must fail"
+zstd -c --fast=0 tmp > $INTOVOID && die "--fast must not accept value 0"
 println "test : too large numeric argument"
-$ZSTD --fast=9999999999 -f tmp  && die "should have refused numeric value"
+zstd --fast=9999999999 -f tmp  && die "should have refused numeric value"
 println "test : set compression level with environment variable ZSTD_CLEVEL"
-ZSTD_CLEVEL=12  $ZSTD -f tmp # positive compression level
-ZSTD_CLEVEL=-12 $ZSTD -f tmp # negative compression level
-ZSTD_CLEVEL=+12 $ZSTD -f tmp # valid: verbose '+' sign
-ZSTD_CLEVEL=''  $ZSTD -f tmp # empty env var, warn and revert to default setting
-ZSTD_CLEVEL=-   $ZSTD -f tmp # malformed env var, warn and revert to default setting
-ZSTD_CLEVEL=a   $ZSTD -f tmp # malformed env var, warn and revert to default setting
-ZSTD_CLEVEL=+a  $ZSTD -f tmp # malformed env var, warn and revert to default setting
-ZSTD_CLEVEL=3a7 $ZSTD -f tmp # malformed env var, warn and revert to default setting
-ZSTD_CLEVEL=50000000000 $ZSTD -f tmp # numeric value too large, warn and revert to default setting
+ZSTD_CLEVEL=12  zstd -f tmp # positive compression level
+ZSTD_CLEVEL=-12 zstd -f tmp # negative compression level
+ZSTD_CLEVEL=+12 zstd -f tmp # valid: verbose '+' sign
+ZSTD_CLEVEL=''  zstd -f tmp # empty env var, warn and revert to default setting
+ZSTD_CLEVEL=-   zstd -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=a   zstd -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=+a  zstd -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=3a7 zstd -f tmp # malformed env var, warn and revert to default setting
+ZSTD_CLEVEL=50000000000 zstd -f tmp # numeric value too large, warn and revert to default setting
 println "test : override ZSTD_CLEVEL with command line option"
-ZSTD_CLEVEL=12  $ZSTD --fast=3 -f tmp # overridden by command line option
+ZSTD_CLEVEL=12  zstd --fast=3 -f tmp # overridden by command line option
 println "test : compress to stdout"
-$ZSTD tmp -c > tmpCompressed
-$ZSTD tmp --stdout > tmpCompressed       # long command format
+zstd tmp -c > tmpCompressed
+zstd tmp --stdout > tmpCompressed       # long command format
 println "test : compress to named file"
 rm tmpCompressed
-$ZSTD tmp -o tmpCompressed
+zstd tmp -o tmpCompressed
 test -f tmpCompressed   # file must be created
 println "test : -o must be followed by filename (must fail)"
-$ZSTD tmp -of tmpCompressed && die "-o must be followed by filename "
+zstd tmp -of tmpCompressed && die "-o must be followed by filename "
 println "test : force write, correct order"
-$ZSTD tmp -fo tmpCompressed
+zstd tmp -fo tmpCompressed
 println "test : forgotten argument"
 cp tmp tmp2
-$ZSTD tmp2 -fo && die "-o must be followed by filename "
+zstd tmp2 -fo && die "-o must be followed by filename "
 println "test : implied stdout when input is stdin"
-println bob | $ZSTD | $ZSTD -d
+println bob | zstd | zstd -d
 if [ "$isTerminal" = true ]; then
 println "test : compressed data to terminal"
-println bob | $ZSTD && die "should have refused : compressed data to terminal"
+println bob | zstd && die "should have refused : compressed data to terminal"
 println "test : compressed data from terminal (a hang here is a test fail, zstd is wrongly waiting on data from terminal)"
-$ZSTD -d > $INTOVOID && die "should have refused : compressed data from terminal"
+zstd -d > $INTOVOID && die "should have refused : compressed data from terminal"
 fi
 println "test : null-length file roundtrip"
-println -n '' | $ZSTD - --stdout | $ZSTD -d --stdout
+println -n '' | zstd - --stdout | zstd -d --stdout
 println "test : ensure small file doesn't add 3-bytes null block"
-$DATAGEN -g1 > tmp1
-$ZSTD tmp1 -c | wc -c | grep "14"
-$ZSTD < tmp1  | wc -c | grep "14"
+datagen -g1 > tmp1
+zstd tmp1 -c | wc -c | grep "14"
+zstd < tmp1  | wc -c | grep "14"
 println "test : decompress file with wrong suffix (must fail)"
-$ZSTD -d tmpCompressed && die "wrong suffix error not detected!"
-$ZSTD -df tmp && die "should have refused : wrong extension"
+zstd -d tmpCompressed && die "wrong suffix error not detected!"
+zstd -df tmp && die "should have refused : wrong extension"
 println "test : decompress into stdout"
-$ZSTD -d tmpCompressed -c > tmpResult    # decompression using stdout
-$ZSTD --decompress tmpCompressed -c > tmpResult
-$ZSTD --decompress tmpCompressed --stdout > tmpResult
+zstd -d tmpCompressed -c > tmpResult    # decompression using stdout
+zstd --decompress tmpCompressed -c > tmpResult
+zstd --decompress tmpCompressed --stdout > tmpResult
 println "test : decompress from stdin into stdout"
-$ZSTD -dc   < tmp.zst > $INTOVOID   # combine decompression, stdin & stdout
-$ZSTD -dc - < tmp.zst > $INTOVOID
-$ZSTD -d    < tmp.zst > $INTOVOID   # implicit stdout when stdin is used
-$ZSTD -d  - < tmp.zst > $INTOVOID
+zstd -dc   < tmp.zst > $INTOVOID   # combine decompression, stdin & stdout
+zstd -dc - < tmp.zst > $INTOVOID
+zstd -d    < tmp.zst > $INTOVOID   # implicit stdout when stdin is used
+zstd -d  - < tmp.zst > $INTOVOID
 println "test : impose memory limitation (must fail)"
-$ZSTD -d -f tmp.zst -M2K -c > $INTOVOID && die "decompression needs more memory than allowed"
-$ZSTD -d -f tmp.zst --memlimit=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
-$ZSTD -d -f tmp.zst --memory=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
-$ZSTD -d -f tmp.zst --memlimit-decompress=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
+zstd -d -f tmp.zst -M2K -c > $INTOVOID && die "decompression needs more memory than allowed"
+zstd -d -f tmp.zst --memlimit=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
+zstd -d -f tmp.zst --memory=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
+zstd -d -f tmp.zst --memlimit-decompress=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
 println "test : overwrite protection"
-$ZSTD -q tmp && die "overwrite check failed!"
+zstd -q tmp && die "overwrite check failed!"
 println "test : force overwrite"
-$ZSTD -q -f tmp
-$ZSTD -q --force tmp
+zstd -q -f tmp
+zstd -q --force tmp
 println "test : overwrite readonly file"
 rm -f tmpro tmpro.zst
 println foo > tmpro.zst
 println foo > tmpro
 chmod 400 tmpro.zst
-$ZSTD -q tmpro && die "should have refused to overwrite read-only file"
-$ZSTD -q -f tmpro
+zstd -q tmpro && die "should have refused to overwrite read-only file"
+zstd -q -f tmpro
 println "test: --no-progress flag"
-$ZSTD tmpro -c --no-progress | $ZSTD -d -f -o "$INTOVOID" --no-progress
-$ZSTD tmpro -cv --no-progress | $ZSTD -dv -f -o "$INTOVOID" --no-progress
+zstd tmpro -c --no-progress | zstd -d -f -o "$INTOVOID" --no-progress
+zstd tmpro -cv --no-progress | zstd -dv -f -o "$INTOVOID" --no-progress
 rm -f tmpro tmpro.zst
 println "test: overwrite input file (must fail)"
-$ZSTD tmp -fo tmp && die "zstd compression overwrote the input file"
-$ZSTD tmp.zst -dfo tmp.zst && die "zstd decompression overwrote the input file"
+zstd tmp -fo tmp && die "zstd compression overwrote the input file"
+zstd tmp.zst -dfo tmp.zst && die "zstd decompression overwrote the input file"
 println "test: detect that input file does not exist"
-$ZSTD nothere && die "zstd hasn't detected that input file does not exist"
+zstd nothere && die "zstd hasn't detected that input file does not exist"
 println "test: --[no-]compress-literals"
-$ZSTD tmp -c --no-compress-literals -1       | $ZSTD -t
-$ZSTD tmp -c --no-compress-literals --fast=1 | $ZSTD -t
-$ZSTD tmp -c --no-compress-literals -19      | $ZSTD -t
-$ZSTD tmp -c --compress-literals    -1       | $ZSTD -t
-$ZSTD tmp -c --compress-literals    --fast=1 | $ZSTD -t
-$ZSTD tmp -c --compress-literals    -19      | $ZSTD -t
-$ZSTD -b --fast=1 -i0e1 tmp --compress-literals
-$ZSTD -b --fast=1 -i0e1 tmp --no-compress-literals
+zstd tmp -c --no-compress-literals -1       | zstd -t
+zstd tmp -c --no-compress-literals --fast=1 | zstd -t
+zstd tmp -c --no-compress-literals -19      | zstd -t
+zstd tmp -c --compress-literals    -1       | zstd -t
+zstd tmp -c --compress-literals    --fast=1 | zstd -t
+zstd tmp -c --compress-literals    -19      | zstd -t
+zstd -b --fast=1 -i0e1 tmp --compress-literals
+zstd -b --fast=1 -i0e1 tmp --no-compress-literals
 
 println "\n===> zstdgrep tests"
-ln -sf $ZSTD_BIN zstdcat
+ln -sf "$ZSTD_BIN" zstdcat
 rm -f tmp_grep
 echo "1234" > tmp_grep
-$ZSTD -f tmp_grep
+zstd -f tmp_grep
 lines=$(ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep tmp_grep.zst | wc -l)
 test 2 -eq $lines
 ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep_bad.zst && die "Should have failed"
@@ -240,12 +257,12 @@ rm -f tmp_grep*
 println "\n===>  --exclude-compressed flag"
 rm -rf precompressedFilterTestDir
 mkdir -p precompressedFilterTestDir
-$DATAGEN $size > precompressedFilterTestDir/input.5
-$DATAGEN $size > precompressedFilterTestDir/input.6
-$ZSTD --exclude-compressed --long --rm -r precompressedFilterTestDir
-$DATAGEN $size > precompressedFilterTestDir/input.7
-$DATAGEN $size > precompressedFilterTestDir/input.8
-$ZSTD --exclude-compressed --long --rm -r precompressedFilterTestDir
+datagen $size > precompressedFilterTestDir/input.5
+datagen $size > precompressedFilterTestDir/input.6
+zstd --exclude-compressed --long --rm -r precompressedFilterTestDir
+datagen $size > precompressedFilterTestDir/input.7
+datagen $size > precompressedFilterTestDir/input.8
+zstd --exclude-compressed --long --rm -r precompressedFilterTestDir
 test ! -f precompressedFilterTestDir/input.5.zst.zst
 test ! -f precompressedFilterTestDir/input.6.zst.zst
 file1timestamp=`$MTIME precompressedFilterTestDir/input.5.zst`
@@ -256,12 +273,12 @@ else
   println "Test is not successful"
 fi
 # File Extension check.
-$DATAGEN $size > precompressedFilterTestDir/input.zstbar
-$ZSTD --exclude-compressed --long --rm -r precompressedFilterTestDir
-# ZSTD should compress input.zstbar
+datagen $size > precompressedFilterTestDir/input.zstbar
+zstd --exclude-compressed --long --rm -r precompressedFilterTestDir
+# zstd should compress input.zstbar
 test -f precompressedFilterTestDir/input.zstbar.zst
 # Check without the --exclude-compressed flag
-$ZSTD --long --rm -r precompressedFilterTestDir
+zstd --long --rm -r precompressedFilterTestDir
 # Files should get compressed again without the --exclude-compressed flag.
 test -f precompressedFilterTestDir/input.5.zst.zst
 test -f precompressedFilterTestDir/input.6.zst.zst
@@ -270,33 +287,33 @@ println "Test completed"
 
 println "\n===>  recursive mode test "
 # combination of -r with empty list of input file
-$ZSTD -c -r < tmp > tmp.zst
+zstd -c -r < tmp > tmp.zst
 
 
 println "\n===>  file removal"
-$ZSTD -f --rm tmp
+zstd -f --rm tmp
 test ! -f tmp  # tmp should no longer be present
-$ZSTD -f -d --rm tmp.zst
+zstd -f -d --rm tmp.zst
 test ! -f tmp.zst   # tmp.zst should no longer be present
 println "test : should quietly not remove non-regular file"
 println hello > tmp
-$ZSTD tmp -f -o "$DEVDEVICE" 2>tmplog > "$INTOVOID"
+zstd tmp -f -o "$DEVDEVICE" 2>tmplog > "$INTOVOID"
 grep -v "Refusing to remove non-regular file" tmplog
 rm -f tmplog
-$ZSTD tmp -f -o "$INTOVOID" 2>&1 | grep -v "Refusing to remove non-regular file"
+zstd tmp -f -o "$INTOVOID" 2>&1 | grep -v "Refusing to remove non-regular file"
 println "test : --rm on stdin"
-println a | $ZSTD --rm > $INTOVOID   # --rm should remain silent
+println a | zstd --rm > $INTOVOID   # --rm should remain silent
 rm tmp
-$ZSTD -f tmp && die "tmp not present : should have failed"
+zstd -f tmp && die "tmp not present : should have failed"
 test ! -f tmp.zst  # tmp.zst should not be created
 println "test : -d -f do not delete destination when source is not present"
 touch tmp    # create destination file
-$ZSTD -d -f tmp.zst && die "attempt to decompress a non existing file"
+zstd -d -f tmp.zst && die "attempt to decompress a non existing file"
 test -f tmp  # destination file should still be present
 println "test : -f do not delete destination when source is not present"
 rm tmp         # erase source file
 touch tmp.zst  # create destination file
-$ZSTD -f tmp && die "attempt to compress a non existing file"
+zstd -f tmp && die "attempt to compress a non existing file"
 test -f tmp.zst  # destination file should still be present
 rm -rf tmp*  # may also erase tmp* directory from previous failed run
 
@@ -306,7 +323,7 @@ println "\n===>  decompression only tests "
 # older versions of zstd cli are not able to decode such corner case.
 # As a consequence, the zstd cli do not generate them, to maintain compatibility with older versions.
 dd bs=1048576 count=1 if=/dev/zero of=tmp
-$ZSTD -d -o tmp1 "$TESTDIR/golden-decompression/rle-first-block.zst"
+zstd -d -o tmp1 "$TESTDIR/golden-decompression/rle-first-block.zst"
 $DIFF -s tmp1 tmp
 rm tmp*
 
@@ -314,47 +331,47 @@ rm tmp*
 println "\n===>  compress multiple files"
 println hello > tmp1
 println world > tmp2
-$ZSTD tmp1 tmp2 -o "$INTOVOID" -f
-$ZSTD tmp1 tmp2 -c | $ZSTD -t
-$ZSTD tmp1 tmp2 -o tmp.zst
+zstd tmp1 tmp2 -o "$INTOVOID" -f
+zstd tmp1 tmp2 -c | zstd -t
+zstd tmp1 tmp2 -o tmp.zst
 test ! -f tmp1.zst
 test ! -f tmp2.zst
-$ZSTD tmp1 tmp2
-$ZSTD -t tmp1.zst tmp2.zst
-$ZSTD -dc tmp1.zst tmp2.zst
-$ZSTD tmp1.zst tmp2.zst -o "$INTOVOID" -f
-$ZSTD -d tmp1.zst tmp2.zst -o tmp
+zstd tmp1 tmp2
+zstd -t tmp1.zst tmp2.zst
+zstd -dc tmp1.zst tmp2.zst
+zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
+zstd -d tmp1.zst tmp2.zst -o tmp
 touch tmpexists
-$ZSTD tmp1 tmp2 -f -o tmpexists
-$ZSTD tmp1 tmp2 -o tmpexists && die "should have refused to overwrite"
+zstd tmp1 tmp2 -f -o tmpexists
+zstd tmp1 tmp2 -o tmpexists && die "should have refused to overwrite"
 # Bug: PR #972
 if [ "$?" -eq 139 ]; then
   die "should not have segfaulted"
 fi
 println "\n===>  multiple files and shell completion "
-$DATAGEN -s1        > tmp1 2> $INTOVOID
-$DATAGEN -s2 -g100K > tmp2 2> $INTOVOID
-$DATAGEN -s3 -g1M   > tmp3 2> $INTOVOID
+datagen -s1        > tmp1 2> $INTOVOID
+datagen -s2 -g100K > tmp2 2> $INTOVOID
+datagen -s3 -g1M   > tmp3 2> $INTOVOID
 println "compress tmp* : "
-$ZSTD -f tmp*
+zstd -f tmp*
 test -f tmp1.zst
 test -f tmp2.zst
 test -f tmp3.zst
 rm tmp1 tmp2 tmp3
 println "decompress tmp* : "
-$ZSTD -df ./*.zst
+zstd -df ./*.zst
 test -f tmp1
 test -f tmp2
 test -f tmp3
 println "compress tmp* into stdout > tmpall : "
-$ZSTD -c tmp1 tmp2 tmp3 > tmpall
+zstd -c tmp1 tmp2 tmp3 > tmpall
 test -f tmpall  # should check size of tmpall (should be tmp1.zst + tmp2.zst + tmp3.zst)
 println "decompress tmpall* into stdout > tmpdec : "
 cp tmpall tmpall2
-$ZSTD -dc tmpall* > tmpdec
+zstd -dc tmpall* > tmpdec
 test -f tmpdec  # should check size of tmpdec (should be 2*(tmp1 + tmp2 + tmp3))
 println "compress multiple files including a missing one (notHere) : "
-$ZSTD -f tmp1 notHere tmp2 && die "missing file not detected!"
+zstd -f tmp1 notHere tmp2 && die "missing file not detected!"
 rm tmp*
 
 
@@ -364,8 +381,8 @@ if [ "$isWindows" = false ] ; then
     mkfifo tmp_named_pipe
     # note : fifo test doesn't work in combination with `dd` or `cat`
     echo "Hello World!" > tmp_named_pipe &
-    $ZSTD tmp_named_pipe -o tmp_compressed
-    $ZSTD -d -o tmp_decompressed tmp_compressed
+    zstd tmp_named_pipe -o tmp_compressed
+    zstd -d -o tmp_decompressed tmp_compressed
     $DIFF -s tmp_original tmp_decompressed
     rm -rf tmp*
 fi
@@ -375,12 +392,12 @@ if [ -n "$DEVNULLRIGHTS" ] ; then
     # these tests requires sudo rights, which is uncommon.
     # they are only triggered if DEVNULLRIGHTS macro is defined.
     println "\n===> checking /dev/null permissions are unaltered "
-    $DATAGEN > tmp
-    sudo $ZSTD tmp -o $INTOVOID   # sudo rights could modify /dev/null permissions
-    sudo $ZSTD tmp -c > $INTOVOID
-    $ZSTD tmp -f -o tmp.zst
-    sudo $ZSTD -d tmp.zst -c > $INTOVOID
-    sudo $ZSTD -d tmp.zst -o $INTOVOID
+    datagen > tmp
+    sudoZstd tmp -o $INTOVOID   # sudo rights could modify /dev/null permissions
+    sudoZstd tmp -c > $INTOVOID
+    zstd tmp -f -o tmp.zst
+    sudoZstd -d tmp.zst -c > $INTOVOID
+    sudoZstd -d tmp.zst -o $INTOVOID
     ls -las $INTOVOID | grep "rw-rw-rw-"
 fi
 
@@ -394,16 +411,16 @@ mkdir tmpInputTestDir/we/must/go
 mkdir tmpInputTestDir/we/must/go/deeper
 println cool > tmpInputTestDir/we/must/go/deeper/tmp2
 mkdir tmpOutDir
-$ZSTD tmp1 tmpInputTestDir/we/must/go/deeper/tmp2 --output-dir-flat tmpOutDir
+zstd tmp1 tmpInputTestDir/we/must/go/deeper/tmp2 --output-dir-flat tmpOutDir
 test -f tmpOutDir/tmp1.zst
 test -f tmpOutDir/tmp2.zst
 println "test : decompress multiple files into an output directory, --output-dir-flat"
 mkdir tmpOutDirDecomp
-$ZSTD tmpOutDir -r -d --output-dir-flat tmpOutDirDecomp
+zstd tmpOutDir -r -d --output-dir-flat tmpOutDirDecomp
 test -f tmpOutDirDecomp/tmp2
 test -f tmpOutDirDecomp/tmp1
 rm -f tmpOutDirDecomp/*
-$ZSTD tmpOutDir -r -d --output-dir-flat=tmpOutDirDecomp
+zstd tmpOutDir -r -d --output-dir-flat=tmpOutDirDecomp
 test -f tmpOutDirDecomp/tmp2
 test -f tmpOutDirDecomp/tmp1
 rm -rf tmp*
@@ -414,14 +431,14 @@ println "Hello world!, file1" > tmp1
 println "Hello world!, file2" > tmp2
 println tmp1 > tmp_fileList
 println tmp2 >> tmp_fileList
-$ZSTD -f --filelist=tmp_fileList
+zstd -f --filelist=tmp_fileList
 test -f tmp2.zst
 test -f tmp1.zst
 
 println "test : reading file list from a symlink, --filelist=FILE"
 rm -f *.zst
 ln -s tmp_fileList tmp_symLink
-$ZSTD -f --filelist=tmp_symLink
+zstd -f --filelist=tmp_symLink
 test -f tmp2.zst
 test -f tmp1.zst
 
@@ -431,7 +448,7 @@ println "Hello world!, file3" > tmp3
 println "Hello world!, file4" > tmp4
 println tmp3 > tmp_fileList2
 println tmp4 >> tmp_fileList2
-$ZSTD -f --filelist=tmp_fileList --filelist=tmp_fileList2
+zstd -f --filelist=tmp_fileList --filelist=tmp_fileList2
 test -f tmp1.zst
 test -f tmp2.zst
 test -f tmp3.zst
@@ -441,7 +458,7 @@ println "test : decompress multiple files reading them from a file, --filelist=F
 rm -f tmp1 tmp2
 println tmp1.zst > tmpZst
 println tmp2.zst >> tmpZst
-$ZSTD -d -f --filelist=tmpZst
+zstd -d -f --filelist=tmpZst
 test -f tmp1
 test -f tmp2
 
@@ -449,57 +466,57 @@ println "test : decompress multiple files reading them from multiple files, --fi
 rm -f tmp1 tmp2 tmp3 tmp4
 println tmp3.zst > tmpZst2
 println tmp4.zst >> tmpZst2
-$ZSTD -d -f --filelist=tmpZst --filelist=tmpZst2
+zstd -d -f --filelist=tmpZst --filelist=tmpZst2
 test -f tmp1
 test -f tmp2
 test -f tmp3
 test -f tmp4
 
 println "test : survive a list of files which is text garbage (--filelist=FILE)"
-$DATAGEN > tmp_badList
-$ZSTD -f --filelist=tmp_badList && die "should have failed : list is text garbage"
+datagen > tmp_badList
+zstd -f --filelist=tmp_badList && die "should have failed : list is text garbage"
 
 println "test : survive a list of files which is binary garbage (--filelist=FILE)"
-$DATAGEN -P0 -g1M > tmp_badList
-$ZSTD -qq -f --filelist=tmp_badList && die "should have failed : list is binary garbage"  # let's avoid printing binary garbage on console
+datagen -P0 -g1M > tmp_badList
+zstd -qq -f --filelist=tmp_badList && die "should have failed : list is binary garbage"  # let's avoid printing binary garbage on console
 
 println "test : try to overflow internal list of files (--filelist=FILE)"
 touch tmp1 tmp2 tmp3 tmp4 tmp5 tmp6
 ls tmp* > tmpList
-$ZSTD -f tmp1 --filelist=tmpList --filelist=tmpList tmp2 tmp3  # can trigger an overflow of internal file list
+zstd -f tmp1 --filelist=tmpList --filelist=tmpList tmp2 tmp3  # can trigger an overflow of internal file list
 rm -rf tmp*
 
 println "\n===> --[no-]content-size tests"
 
-$DATAGEN > tmp_contentsize
-$ZSTD -f tmp_contentsize
-$ZSTD -lv tmp_contentsize.zst | grep "Decompressed Size:"
-$ZSTD -f --no-content-size tmp_contentsize
-$ZSTD -lv tmp_contentsize.zst | grep "Decompressed Size:" && die
-$ZSTD -f --content-size tmp_contentsize
-$ZSTD -lv tmp_contentsize.zst | grep "Decompressed Size:"
-$ZSTD -f --content-size --no-content-size tmp_contentsize
-$ZSTD -lv tmp_contentsize.zst | grep "Decompressed Size:" && die
+datagen > tmp_contentsize
+zstd -f tmp_contentsize
+zstd -lv tmp_contentsize.zst | grep "Decompressed Size:"
+zstd -f --no-content-size tmp_contentsize
+zstd -lv tmp_contentsize.zst | grep "Decompressed Size:" && die
+zstd -f --content-size tmp_contentsize
+zstd -lv tmp_contentsize.zst | grep "Decompressed Size:"
+zstd -f --content-size --no-content-size tmp_contentsize
+zstd -lv tmp_contentsize.zst | grep "Decompressed Size:" && die
 rm -rf tmp*
 
 println "test : show-default-cparams regular"
-$DATAGEN > tmp
-$ZSTD --show-default-cparams -f tmp
+datagen > tmp
+zstd --show-default-cparams -f tmp
 rm -rf tmp*
 
 println "test : show-default-cparams recursive"
 mkdir tmp_files
-$DATAGEN -g15000 > tmp_files/tmp1
-$DATAGEN -g129000 > tmp_files/tmp2
-$DATAGEN -g257000 > tmp_files/tmp3
-$ZSTD --show-default-cparams -f -r tmp_files
+datagen -g15000 > tmp_files/tmp1
+datagen -g129000 > tmp_files/tmp2
+datagen -g257000 > tmp_files/tmp3
+zstd --show-default-cparams -f -r tmp_files
 rm -rf tmp*
 
 println "\n===>  Advanced compression parameters "
-println "Hello world!" | $ZSTD --zstd=windowLog=21,      - -o tmp.zst && die "wrong parameters not detected!"
-println "Hello world!" | $ZSTD --zstd=windowLo=21        - -o tmp.zst && die "wrong parameters not detected!"
-println "Hello world!" | $ZSTD --zstd=windowLog=21,slog  - -o tmp.zst && die "wrong parameters not detected!"
-println "Hello world!" | $ZSTD --zstd=strategy=10        - -o tmp.zst && die "parameter out of bound not detected!"  # > btultra2 : does not exist
+println "Hello world!" | zstd --zstd=windowLog=21,      - -o tmp.zst && die "wrong parameters not detected!"
+println "Hello world!" | zstd --zstd=windowLo=21        - -o tmp.zst && die "wrong parameters not detected!"
+println "Hello world!" | zstd --zstd=windowLog=21,slog  - -o tmp.zst && die "wrong parameters not detected!"
+println "Hello world!" | zstd --zstd=strategy=10        - -o tmp.zst && die "parameter out of bound not detected!"  # > btultra2 : does not exist
 test ! -f tmp.zst  # tmp.zst should not be created
 roundTripTest -g512K
 roundTripTest -g512K " --zstd=mml=3,tlen=48,strat=6"
@@ -511,42 +528,42 @@ roundTripTest -g64K  "19 --zstd=strat=9"   # btultra2
 
 
 println "\n===>  Pass-Through mode "
-println "Hello world 1!" | $ZSTD -df
-println "Hello world 2!" | $ZSTD -dcf
+println "Hello world 1!" | zstd -df
+println "Hello world 2!" | zstd -dcf
 println "Hello world 3!" > tmp1
-$ZSTD -dcf tmp1
+zstd -dcf tmp1
 
 
 println "\n===>  frame concatenation "
 println "hello " > hello.tmp
 println "world!" > world.tmp
 cat hello.tmp world.tmp > helloworld.tmp
-$ZSTD -c hello.tmp > hello.zstd
-$ZSTD -c world.tmp > world.zstd
-cat hello.zstd world.zstd > helloworld.zstd
-$ZSTD -dc helloworld.zstd > result.tmp
+zstd -c hello.tmp > hello.zst
+zstd -c world.tmp > world.zst
+cat hello.zst world.zst > helloworld.zst
+zstd -dc helloworld.zst > result.tmp
 cat result.tmp
 $DIFF helloworld.tmp result.tmp
 println "frame concatenation without checksum"
-$ZSTD -c hello.tmp > hello.zstd --no-check
-$ZSTD -c world.tmp > world.zstd --no-check
-cat hello.zstd world.zstd > helloworld.zstd
-$ZSTD -dc helloworld.zstd > result.tmp
+zstd -c hello.tmp > hello.zst --no-check
+zstd -c world.tmp > world.zst --no-check
+cat hello.zst world.zst > helloworld.zstd
+zstd -dc helloworld.zst > result.tmp
 $DIFF helloworld.tmp result.tmp
 println "testing zstdcat symlink"
-ln -sf $ZSTD_BIN zstdcat
-$EXE_PREFIX ./zstdcat helloworld.zstd > result.tmp
+ln -sf "$ZSTD_BIN" zstdcat
+$EXE_PREFIX ./zstdcat helloworld.zst > result.tmp
 $DIFF helloworld.tmp result.tmp
-ln -s helloworld.zstd helloworld.link.zstd
-$EXE_PREFIX ./zstdcat helloworld.link.zstd > result.tmp
+ln -s helloworld.zst helloworld.link.zst
+$EXE_PREFIX ./zstdcat helloworld.link.zst > result.tmp
 $DIFF helloworld.tmp result.tmp
 rm zstdcat
 rm result.tmp
 println "testing zcat symlink"
-ln -sf $ZSTD_BIN zcat
-$EXE_PREFIX ./zcat helloworld.zstd > result.tmp
+ln -sf "$ZSTD_BIN" zcat
+$EXE_PREFIX ./zcat helloworld.zst > result.tmp
 $DIFF helloworld.tmp result.tmp
-$EXE_PREFIX ./zcat helloworld.link.zstd > result.tmp
+$EXE_PREFIX ./zcat helloworld.link.zst > result.tmp
 $DIFF helloworld.tmp result.tmp
 rm zcat
 rm ./*.tmp ./*.zstd
@@ -556,10 +573,10 @@ println "frame concatenation tests completed"
 if [ "$isWindows" = false ] && [ "$UNAME" != 'SunOS' ] && [ "$UNAME" != "OpenBSD" ] ; then
 println "\n**** flush write error test **** "
 
-println "println foo | $ZSTD > /dev/full"
-println foo | $ZSTD > /dev/full && die "write error not detected!"
-println "println foo | $ZSTD | $ZSTD -d > /dev/full"
-println foo | $ZSTD | $ZSTD -d > /dev/full && die "write error not detected!"
+println "println foo | zstd > /dev/full"
+println foo | zstd > /dev/full && die "write error not detected!"
+println "println foo | zstd | zstd -d > /dev/full"
+println foo | zstd | zstd -d > /dev/full && die "write error not detected!"
 
 fi
 
@@ -572,15 +589,15 @@ rm -f hello.tmp world.tmp world2.tmp hello.tmp.zst world.tmp.zst
 println "hello world" > hello.tmp
 ln -s hello.tmp world.tmp
 ln -s hello.tmp world2.tmp
-$ZSTD world.tmp hello.tmp || true
+zstd world.tmp hello.tmp || true
 test -f hello.tmp.zst  # regular file should have been compressed!
 test ! -f world.tmp.zst  # symbolic link should not have been compressed!
-$ZSTD world.tmp || true
+zstd world.tmp || true
 test ! -f world.tmp.zst  # symbolic link should not have been compressed!
-$ZSTD world.tmp world2.tmp || true
+zstd world.tmp world2.tmp || true
 test ! -f world.tmp.zst  # symbolic link should not have been compressed!
 test ! -f world2.tmp.zst  # symbolic link should not have been compressed!
-$ZSTD world.tmp hello.tmp -f
+zstd world.tmp hello.tmp -f
 test -f world.tmp.zst  # symbolic link should have been compressed with --force
 rm -f hello.tmp world.tmp world2.tmp hello.tmp.zst world.tmp.zst
 
@@ -589,26 +606,26 @@ fi
 
 println "\n===>  test sparse file support "
 
-$DATAGEN -g5M  -P100 > tmpSparse
-$ZSTD tmpSparse -c | $ZSTD -dv -o tmpSparseRegen
+datagen -g5M  -P100 > tmpSparse
+zstd tmpSparse -c | zstd -dv -o tmpSparseRegen
 $DIFF -s tmpSparse tmpSparseRegen
-$ZSTD tmpSparse -c | $ZSTD -dv --sparse -c > tmpOutSparse
+zstd tmpSparse -c | zstd -dv --sparse -c > tmpOutSparse
 $DIFF -s tmpSparse tmpOutSparse
-$ZSTD tmpSparse -c | $ZSTD -dv --no-sparse -c > tmpOutNoSparse
+zstd tmpSparse -c | zstd -dv --no-sparse -c > tmpOutNoSparse
 $DIFF -s tmpSparse tmpOutNoSparse
 ls -ls tmpSparse*  # look at file size and block size on disk
-$DATAGEN -s1 -g1200007 -P100 | $ZSTD | $ZSTD -dv --sparse -c > tmpSparseOdd   # Odd size file (to not finish on an exact nb of blocks)
-$DATAGEN -s1 -g1200007 -P100 | $DIFF -s - tmpSparseOdd
+datagen -s1 -g1200007 -P100 | zstd | zstd -dv --sparse -c > tmpSparseOdd   # Odd size file (to not finish on an exact nb of blocks)
+datagen -s1 -g1200007 -P100 | $DIFF -s - tmpSparseOdd
 ls -ls tmpSparseOdd  # look at file size and block size on disk
 println "\n Sparse Compatibility with Console :"
-println "Hello World 1 !" | $ZSTD | $ZSTD -d -c
-println "Hello World 2 !" | $ZSTD | $ZSTD -d | cat
+println "Hello World 1 !" | zstd | zstd -d -c
+println "Hello World 2 !" | zstd | zstd -d | cat
 println "\n Sparse Compatibility with Append :"
-$DATAGEN -P100 -g1M > tmpSparse1M
+datagen -P100 -g1M > tmpSparse1M
 cat tmpSparse1M tmpSparse1M > tmpSparse2M
-$ZSTD -v -f tmpSparse1M -o tmpSparseCompressed
-$ZSTD -d -v -f tmpSparseCompressed -o tmpSparseRegenerated
-$ZSTD -d -v -f tmpSparseCompressed -c >> tmpSparseRegenerated
+zstd -v -f tmpSparse1M -o tmpSparseCompressed
+zstd -d -v -f tmpSparseCompressed -o tmpSparseRegenerated
+zstd -d -v -f tmpSparseCompressed -c >> tmpSparseRegenerated
 ls -ls tmpSparse*  # look at file size and block size on disk
 $DIFF tmpSparse2M tmpSparseRegenerated
 rm tmpSparse*
@@ -616,25 +633,25 @@ rm tmpSparse*
 
 println "\n===>  stream-size mode"
 
-$DATAGEN -g11000 > tmp
+datagen -g11000 > tmp
 println "test : basic file compression vs sized streaming compression"
-file_size=$($ZSTD -14 -f tmp -o tmp.zst && wc -c < tmp.zst)
-stream_size=$(cat tmp | $ZSTD -14 --stream-size=11000 | wc -c)
+file_size=$(zstd -14 -f tmp -o tmp.zst && wc -c < tmp.zst)
+stream_size=$(cat tmp | zstd -14 --stream-size=11000 | wc -c)
 if [ "$stream_size" -gt "$file_size" ]; then
   die "hinted compression larger than expected"
 fi
 println "test : sized streaming compression and decompression"
-cat tmp | $ZSTD -14 -f tmp -o --stream-size=11000 tmp.zst
-$ZSTD -df tmp.zst -o tmp_decompress
+cat tmp | zstd -14 -f tmp -o --stream-size=11000 tmp.zst
+zstd -df tmp.zst -o tmp_decompress
 cmp tmp tmp_decompress || die "difference between original and decompressed file"
 println "test : incorrect stream size"
-cat tmp | $ZSTD -14 -f -o tmp.zst --stream-size=11001 && die "should fail with incorrect stream size"
+cat tmp | zstd -14 -f -o tmp.zst --stream-size=11001 && die "should fail with incorrect stream size"
 
 println "\n===>  zstd zero weight dict test "
 rm -f tmp*
 cp "$TESTDIR/dict-files/zero-weight-dict" tmp_input
-$ZSTD -D "$TESTDIR/dict-files/zero-weight-dict" tmp_input
-$ZSTD -D "$TESTDIR/dict-files/zero-weight-dict" -d tmp_input.zst -o tmp_decomp
+zstd -D "$TESTDIR/dict-files/zero-weight-dict" tmp_input
+zstd -D "$TESTDIR/dict-files/zero-weight-dict" -d tmp_input.zst -o tmp_decomp
 $DIFF tmp_decomp tmp_input
 rm -rf tmp*
 
@@ -642,87 +659,87 @@ println "\n===>  zstd (valid) zero weight dict test "
 rm -f tmp*
 # 0 has a non-zero weight in the dictionary
 echo "0000000000000000000000000" > tmp_input
-$ZSTD -D "$TESTDIR/dict-files/zero-weight-dict" tmp_input
-$ZSTD -D "$TESTDIR/dict-files/zero-weight-dict" -d tmp_input.zst -o tmp_decomp
+zstd -D "$TESTDIR/dict-files/zero-weight-dict" tmp_input
+zstd -D "$TESTDIR/dict-files/zero-weight-dict" -d tmp_input.zst -o tmp_decomp
 $DIFF tmp_decomp tmp_input
 rm -rf tmp*
 
 println "\n===>  size-hint mode"
 
-$DATAGEN -g11000 > tmp
-$DATAGEN -g11000 > tmp2
-$DATAGEN > tmpDict
+datagen -g11000 > tmp
+datagen -g11000 > tmp2
+datagen > tmpDict
 println "test : basic file compression vs hinted streaming compression"
-file_size=$($ZSTD -14 -f tmp -o tmp.zst && wc -c < tmp.zst)
-stream_size=$(cat tmp | $ZSTD -14 --size-hint=11000 | wc -c)
+file_size=$(zstd -14 -f tmp -o tmp.zst && wc -c < tmp.zst)
+stream_size=$(cat tmp | zstd -14 --size-hint=11000 | wc -c)
 if [ "$stream_size" -ge "$file_size" ]; then
   die "hinted compression larger than expected"
 fi
 println "test : hinted streaming compression and decompression"
-cat tmp | $ZSTD -14 -f -o tmp.zst --size-hint=11000
-$ZSTD -df tmp.zst -o tmp_decompress
+cat tmp | zstd -14 -f -o tmp.zst --size-hint=11000
+zstd -df tmp.zst -o tmp_decompress
 cmp tmp tmp_decompress || die "difference between original and decompressed file"
 println "test : hinted streaming compression with dictionary"
-cat tmp | $ZSTD -14 -f -D tmpDict --size-hint=11000 | $ZSTD -t -D tmpDict
+cat tmp | zstd -14 -f -D tmpDict --size-hint=11000 | zstd -t -D tmpDict
 println "test : multiple file compression with hints and dictionary"
-$ZSTD -14 -f -D tmpDict --size-hint=11000 tmp tmp2
-$ZSTD -14 -f -o tmp1_.zst -D tmpDict --size-hint=11000 tmp
-$ZSTD -14 -f -o tmp2_.zst -D tmpDict --size-hint=11000 tmp2
+zstd -14 -f -D tmpDict --size-hint=11000 tmp tmp2
+zstd -14 -f -o tmp1_.zst -D tmpDict --size-hint=11000 tmp
+zstd -14 -f -o tmp2_.zst -D tmpDict --size-hint=11000 tmp2
 cmp tmp.zst tmp1_.zst || die "first file's output differs"
 cmp tmp2.zst tmp2_.zst || die "second file's output differs"
 println "test : incorrect hinted stream sizes"
-cat tmp | $ZSTD -14 -f --size-hint=11050 | $ZSTD -t  # slightly too high
-cat tmp | $ZSTD -14 -f --size-hint=10950 | $ZSTD -t  # slightly too low
-cat tmp | $ZSTD -14 -f --size-hint=22000 | $ZSTD -t  # considerably too high
-cat tmp | $ZSTD -14 -f --size-hint=5500  | $ZSTD -t  # considerably too low
+cat tmp | zstd -14 -f --size-hint=11050 | zstd -t  # slightly too high
+cat tmp | zstd -14 -f --size-hint=10950 | zstd -t  # slightly too low
+cat tmp | zstd -14 -f --size-hint=22000 | zstd -t  # considerably too high
+cat tmp | zstd -14 -f --size-hint=5500  | zstd -t  # considerably too low
 
 
 println "\n===>  dictionary tests "
 
 println "- test with raw dict (content only) "
-$DATAGEN > tmpDict
-$DATAGEN -g1M | $MD5SUM > tmp1
-$DATAGEN -g1M | $ZSTD -D tmpDict | $ZSTD -D tmpDict -dvq | $MD5SUM > tmp2
+datagen > tmpDict
+datagen -g1M | $MD5SUM > tmp1
+datagen -g1M | zstd -D tmpDict | zstd -D tmpDict -dvq | $MD5SUM > tmp2
 $DIFF -q tmp1 tmp2
 println "- Create first dictionary "
 TESTFILE="$PRGDIR"/zstdcli.c
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
 cp "$TESTFILE" tmp
 println "- Test dictionary compression with tmpDict as an input file and dictionary"
-$ZSTD -f tmpDict -D tmpDict && die "compression error not detected!"
+zstd -f tmpDict -D tmpDict && die "compression error not detected!"
 println "- Dictionary compression roundtrip"
-$ZSTD -f tmp -D tmpDict
-$ZSTD -d tmp.zst -D tmpDict -fo result
+zstd -f tmp -D tmpDict
+zstd -d tmp.zst -D tmpDict -fo result
 $DIFF "$TESTFILE" result
 println "- Dictionary compression with btlazy2 strategy"
-$ZSTD -f tmp -D tmpDict --zstd=strategy=6
-$ZSTD -d tmp.zst -D tmpDict -fo result
+zstd -f tmp -D tmpDict --zstd=strategy=6
+zstd -d tmp.zst -D tmpDict -fo result
 $DIFF "$TESTFILE" result
 if [ -n "$hasMT" ]
 then
     println "- Test dictionary compression with multithreading "
-    $DATAGEN -g5M | $ZSTD -T2 -D tmpDict | $ZSTD -t -D tmpDict   # fails with v1.3.2
+    datagen -g5M | zstd -T2 -D tmpDict | zstd -t -D tmpDict   # fails with v1.3.2
 fi
 println "- Create second (different) dictionary "
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
-$ZSTD -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
+zstd -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
 println "- Create dictionary with short dictID"
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
 cmp tmpDict tmpDict1 && die "dictionaries should have different ID !"
 println "- Create dictionary with wrong dictID parameter order (must fail)"
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID -o 1 tmpDict1 && die "wrong order : --dictID must be followed by argument "
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID -o 1 tmpDict1 && die "wrong order : --dictID must be followed by argument "
 println "- Create dictionary with size limit"
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K -v
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K -v
 println "- Create dictionary with small size limit"
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict3 --maxdict=1K -v
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict3 --maxdict=1K -v
 println "- Create dictionary with wrong parameter order (must fail)"
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict3 --maxdict -v 4K && die "wrong order : --maxdict must be followed by argument "
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict3 --maxdict -v 4K && die "wrong order : --maxdict must be followed by argument "
 println "- Compress without dictID"
-$ZSTD -f tmp -D tmpDict1 --no-dictID
-$ZSTD -d tmp.zst -D tmpDict -fo result
+zstd -f tmp -D tmpDict1 --no-dictID
+zstd -d tmp.zst -D tmpDict -fo result
 $DIFF "$TESTFILE" result
 println "- Compress with wrong argument order (must fail)"
-$ZSTD tmp -Df tmpDict1 -c > $INTOVOID && die "-D must be followed by dictionary name "
+zstd tmp -Df tmpDict1 -c > $INTOVOID && die "-D must be followed by dictionary name "
 println "- Compress multiple files with dictionary"
 rm -rf dirTestDict
 mkdir dirTestDict
@@ -730,8 +747,8 @@ cp "$TESTDIR"/*.c dirTestDict
 cp "$PRGDIR"/*.c dirTestDict
 cp "$PRGDIR"/*.h dirTestDict
 $MD5SUM dirTestDict/* > tmph1
-$ZSTD -f --rm dirTestDict/* -D tmpDictC
-$ZSTD -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by default
+zstd -f --rm dirTestDict/* -D tmpDictC
+zstd -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by default
 case "$UNAME" in
   Darwin) println "md5sum -c not supported on OS-X : test skipped" ;;  # not compatible with OS-X's md5
   *) $MD5SUM -c tmph1 ;;
@@ -739,65 +756,65 @@ esac
 rm -rf dirTestDict
 println "- dictionary builder on bogus input"
 println "Hello World" > tmp
-$ZSTD --train-legacy -q tmp && die "Dictionary training should fail : not enough input source"
-$DATAGEN -P0 -g10M > tmp
-$ZSTD --train-legacy -q tmp && die "Dictionary training should fail : source is pure noise"
+zstd --train-legacy -q tmp && die "Dictionary training should fail : not enough input source"
+datagen -P0 -g10M > tmp
+zstd --train-legacy -q tmp && die "Dictionary training should fail : source is pure noise"
 println "- Test -o before --train"
 rm -f tmpDict dictionary
-$ZSTD -o tmpDict --train "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd -o tmpDict --train "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f tmpDict
-$ZSTD --train "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f dictionary
 println "- Test dictionary training fails"
 echo "000000000000000000000000000000000" > tmpz
-$ZSTD --train tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz && die "Dictionary training should fail : source is all zeros"
+zstd --train tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz && die "Dictionary training should fail : source is all zeros"
 if [ -n "$hasMT" ]
 then
-  $ZSTD --train -T0 tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz && die "Dictionary training should fail : source is all zeros"
+  zstd --train -T0 tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz tmpz && die "Dictionary training should fail : source is all zeros"
   println "- Create dictionary with multithreading enabled"
-  $ZSTD --train -T0 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
+  zstd --train -T0 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
 fi
 rm tmp* dictionary
 
 
 println "\n===>  fastCover dictionary builder : advanced options "
 TESTFILE="$PRGDIR"/zstdcli.c
-$DATAGEN > tmpDict
+datagen > tmpDict
 println "- Create first dictionary"
-$ZSTD --train-fastcover=k=46,d=8,f=15,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
+zstd --train-fastcover=k=46,d=8,f=15,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
 cp "$TESTFILE" tmp
-$ZSTD -f tmp -D tmpDict
-$ZSTD -d tmp.zst -D tmpDict -fo result
+zstd -f tmp -D tmpDict
+zstd -d tmp.zst -D tmpDict -fo result
 $DIFF "$TESTFILE" result
 println "- Create second (different) dictionary"
-$ZSTD --train-fastcover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
-$ZSTD -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
-$ZSTD --train-fastcover=k=56,d=8 && die "Create dictionary without input file"
+zstd --train-fastcover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
+zstd -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
+zstd --train-fastcover=k=56,d=8 && die "Create dictionary without input file"
 println "- Create dictionary with short dictID"
-$ZSTD --train-fastcover=k=46,d=8,f=15,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
+zstd --train-fastcover=k=46,d=8,f=15,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
 cmp tmpDict tmpDict1 && die "dictionaries should have different ID !"
 println "- Create dictionaries with shrink-dict flag enabled"
-$ZSTD --train-fastcover=steps=1,shrink "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpShrinkDict
-$ZSTD --train-fastcover=steps=1,shrink=1 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpShrinkDict1
-$ZSTD --train-fastcover=steps=1,shrink=5 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpShrinkDict2
+zstd --train-fastcover=steps=1,shrink "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpShrinkDict
+zstd --train-fastcover=steps=1,shrink=1 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpShrinkDict1
+zstd --train-fastcover=steps=1,shrink=5 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpShrinkDict2
 println "- Create dictionary with size limit"
-$ZSTD --train-fastcover=steps=1 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K
+zstd --train-fastcover=steps=1 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K
 println "- Create dictionary using all samples for both training and testing"
-$ZSTD --train-fastcover=k=56,d=8,split=100 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-fastcover=k=56,d=8,split=100 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
 println "- Create dictionary using f=16"
-$ZSTD --train-fastcover=k=56,d=8,f=16 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
-$ZSTD --train-fastcover=k=56,d=8,accel=15 -r "$TESTDIR"/*.c "$PRGDIR"/*.c && die "Created dictionary using accel=15"
+zstd --train-fastcover=k=56,d=8,f=16 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-fastcover=k=56,d=8,accel=15 -r "$TESTDIR"/*.c "$PRGDIR"/*.c && die "Created dictionary using accel=15"
 println "- Create dictionary using accel=2"
-$ZSTD --train-fastcover=k=56,d=8,accel=2 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-fastcover=k=56,d=8,accel=2 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
 println "- Create dictionary using accel=10"
-$ZSTD --train-fastcover=k=56,d=8,accel=10 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-fastcover=k=56,d=8,accel=10 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
 println "- Create dictionary with multithreading"
-$ZSTD --train-fastcover -T4 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-fastcover -T4 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
 println "- Test -o before --train-fastcover"
 rm -f tmpDict dictionary
-$ZSTD -o tmpDict --train-fastcover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd -o tmpDict --train-fastcover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f tmpDict
-$ZSTD --train-fastcover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-fastcover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f dictionary
 rm tmp* dictionary
 
@@ -805,27 +822,27 @@ rm tmp* dictionary
 println "\n===>  legacy dictionary builder "
 
 TESTFILE="$PRGDIR"/zstdcli.c
-$DATAGEN > tmpDict
+datagen > tmpDict
 println "- Create first dictionary"
-$ZSTD --train-legacy=selectivity=8 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
+zstd --train-legacy=selectivity=8 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
 cp "$TESTFILE" tmp
-$ZSTD -f tmp -D tmpDict
-$ZSTD -d tmp.zst -D tmpDict -fo result
+zstd -f tmp -D tmpDict
+zstd -d tmp.zst -D tmpDict -fo result
 $DIFF "$TESTFILE" result
-$ZSTD --train-legacy=s=8 && die "Create dictionary without input files (should error)"
+zstd --train-legacy=s=8 && die "Create dictionary without input files (should error)"
 println "- Create second (different) dictionary"
-$ZSTD --train-legacy=s=5 "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
-$ZSTD -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
+zstd --train-legacy=s=5 "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
+zstd -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
 println "- Create dictionary with short dictID"
-$ZSTD --train-legacy -s5 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
+zstd --train-legacy -s5 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
 cmp tmpDict tmpDict1 && die "dictionaries should have different ID !"
 println "- Create dictionary with size limit"
-$ZSTD --train-legacy -s9 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K
+zstd --train-legacy -s9 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K
 println "- Test -o before --train-legacy"
 rm -f tmpDict dictionary
-$ZSTD -o tmpDict --train-legacy "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd -o tmpDict --train-legacy "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f tmpDict
-$ZSTD --train-legacy "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-legacy "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f dictionary
 rm tmp* dictionary
 
@@ -833,71 +850,71 @@ rm tmp* dictionary
 println "\n===>  integrity tests "
 
 println "test one file (tmp1.zst) "
-$DATAGEN > tmp1
-$ZSTD tmp1
-$ZSTD -t tmp1.zst
-$ZSTD --test tmp1.zst
+datagen > tmp1
+zstd tmp1
+zstd -t tmp1.zst
+zstd --test tmp1.zst
 println "test multiple files (*.zst) "
-$ZSTD -t ./*.zst
+zstd -t ./*.zst
 println "test bad files (*) "
-$ZSTD -t ./* && die "bad files not detected !"
-$ZSTD -t tmp1 && die "bad file not detected !"
+zstd -t ./* && die "bad files not detected !"
+zstd -t tmp1 && die "bad file not detected !"
 cp tmp1 tmp2.zst
-$ZSTD -t tmp2.zst && die "bad file not detected !"
-$DATAGEN -g0 > tmp3
-$ZSTD -t tmp3 && die "bad file not detected !"   # detects 0-sized files as bad
+zstd -t tmp2.zst && die "bad file not detected !"
+datagen -g0 > tmp3
+zstd -t tmp3 && die "bad file not detected !"   # detects 0-sized files as bad
 println "test --rm and --test combined "
-$ZSTD -t --rm tmp1.zst
+zstd -t --rm tmp1.zst
 test -f tmp1.zst   # check file is still present
 split -b16384 tmp1.zst tmpSplit.
-$ZSTD -t tmpSplit.* && die "bad file not detected !"
-$DATAGEN | $ZSTD -c | $ZSTD -t
+zstd -t tmpSplit.* && die "bad file not detected !"
+datagen | zstd -c | zstd -t
 
 
 println "\n===>  golden files tests "
 
-$ZSTD -t -r "$TESTDIR/golden-compression"
-$ZSTD -c -r "$TESTDIR/golden-compression" | $ZSTD -t
+zstd -t -r "$TESTDIR/golden-compression"
+zstd -c -r "$TESTDIR/golden-compression" | zstd -t
 
 
 println "\n===>  benchmark mode tests "
 
 println "bench one file"
-$DATAGEN > tmp1
-$ZSTD -bi0 tmp1
+datagen > tmp1
+zstd -bi0 tmp1
 println "bench multiple levels"
-$ZSTD -i0b0e3 tmp1
+zstd -i0b0e3 tmp1
 println "bench negative level"
-$ZSTD -bi0 --fast tmp1
+zstd -bi0 --fast tmp1
 println "with recursive and quiet modes"
-$ZSTD -rqi0b1e2 tmp1
+zstd -rqi0b1e2 tmp1
 println "benchmark decompression only"
-$ZSTD -f tmp1
-$ZSTD -b -d -i0 tmp1.zst
+zstd -f tmp1
+zstd -b -d -i0 tmp1.zst
 
 
 println "\n===>  zstd compatibility tests "
 
-$DATAGEN > tmp
+datagen > tmp
 rm -f tmp.zst
-$ZSTD --format=zstd -f tmp
+zstd --format=zstd -f tmp
 test -f tmp.zst
 
 
 println "\n===>  gzip compatibility tests "
 
 GZIPMODE=1
-$ZSTD --format=gzip -V || GZIPMODE=0
+zstd --format=gzip -V || GZIPMODE=0
 if [ $GZIPMODE -eq 1 ]; then
     println "gzip support detected"
     GZIPEXE=1
     gzip -V || GZIPEXE=0
     if [ $GZIPEXE -eq 1 ]; then
-        $DATAGEN > tmp
-        $ZSTD --format=gzip -f tmp
+        datagen > tmp
+        zstd --format=gzip -f tmp
         gzip -t -v tmp.gz
         gzip -f tmp
-        $ZSTD -d -f -v tmp.gz
+        zstd -d -f -v tmp.gz
         rm tmp*
     else
         println "gzip binary not detected"
@@ -910,50 +927,50 @@ fi
 println "\n===>  gzip frame tests "
 
 if [ $GZIPMODE -eq 1 ]; then
-    $DATAGEN > tmp
-    $ZSTD -f --format=gzip tmp
-    $ZSTD -f tmp
-    cat tmp.gz tmp.zst tmp.gz tmp.zst | $ZSTD -d -f -o tmp
-    truncateLastByte tmp.gz | $ZSTD -t > $INTOVOID && die "incomplete frame not detected !"
+    datagen > tmp
+    zstd -f --format=gzip tmp
+    zstd -f tmp
+    cat tmp.gz tmp.zst tmp.gz tmp.zst | zstd -d -f -o tmp
+    truncateLastByte tmp.gz | zstd -t > $INTOVOID && die "incomplete frame not detected !"
     rm tmp*
 else
     println "gzip mode not supported"
 fi
 
 if [ $GZIPMODE -eq 1 ]; then
-    $DATAGEN > tmp
+    datagen > tmp
     rm -f tmp.zst
-    $ZSTD --format=gzip --format=zstd -f tmp
+    zstd --format=gzip --format=zstd -f tmp
     test -f tmp.zst
 fi
 
 println "\n===>  xz compatibility tests "
 
 LZMAMODE=1
-$ZSTD --format=xz -V || LZMAMODE=0
+zstd --format=xz -V || LZMAMODE=0
 if [ $LZMAMODE -eq 1 ]; then
     println "xz support detected"
     XZEXE=1
     xz -Q -V && lzma -Q -V || XZEXE=0
     if [ $XZEXE -eq 1 ]; then
         println "Testing zstd xz and lzma support"
-        $DATAGEN > tmp
-        $ZSTD --format=lzma -f tmp
-        $ZSTD --format=xz -f tmp
+        datagen > tmp
+        zstd --format=lzma -f tmp
+        zstd --format=xz -f tmp
         xz -Q -t -v tmp.xz
         xz -Q -t -v tmp.lzma
         xz -Q -f -k tmp
         lzma -Q -f -k --lzma1 tmp
-        $ZSTD -d -f -v tmp.xz
-        $ZSTD -d -f -v tmp.lzma
+        zstd -d -f -v tmp.xz
+        zstd -d -f -v tmp.lzma
         rm tmp*
         println "Creating symlinks"
-        ln -s $ZSTD ./xz
-        ln -s $ZSTD ./unxz
-        ln -s $ZSTD ./lzma
-        ln -s $ZSTD ./unlzma
+        ln -s "$ZSTD_BIN" ./xz
+        ln -s "$ZSTD_BIN" ./unxz
+        ln -s "$ZSTD_BIN" ./lzma
+        ln -s "$ZSTD_BIN" ./unlzma
         println "Testing xz and lzma symlinks"
-        $DATAGEN > tmp
+        datagen > tmp
         ./xz tmp
         xz -Q -d tmp.xz
         ./lzma tmp
@@ -976,13 +993,13 @@ fi
 println "\n===>  xz frame tests "
 
 if [ $LZMAMODE -eq 1 ]; then
-    $DATAGEN > tmp
-    $ZSTD -f --format=xz tmp
-    $ZSTD -f --format=lzma tmp
-    $ZSTD -f tmp
-    cat tmp.xz tmp.lzma tmp.zst tmp.lzma tmp.xz tmp.zst | $ZSTD -d -f -o tmp
-    truncateLastByte tmp.xz | $ZSTD -t > $INTOVOID && die "incomplete frame not detected !"
-    truncateLastByte tmp.lzma | $ZSTD -t > $INTOVOID && die "incomplete frame not detected !"
+    datagen > tmp
+    zstd -f --format=xz tmp
+    zstd -f --format=lzma tmp
+    zstd -f tmp
+    cat tmp.xz tmp.lzma tmp.zst tmp.lzma tmp.xz tmp.zst | zstd -d -f -o tmp
+    truncateLastByte tmp.xz | zstd -t > $INTOVOID && die "incomplete frame not detected !"
+    truncateLastByte tmp.lzma | zstd -t > $INTOVOID && die "incomplete frame not detected !"
     rm tmp*
 else
     println "xz mode not supported"
@@ -991,17 +1008,17 @@ fi
 println "\n===>  lz4 compatibility tests "
 
 LZ4MODE=1
-$ZSTD --format=lz4 -V || LZ4MODE=0
+zstd --format=lz4 -V || LZ4MODE=0
 if [ $LZ4MODE -eq 1 ]; then
     println "lz4 support detected"
     LZ4EXE=1
     lz4 -V || LZ4EXE=0
     if [ $LZ4EXE -eq 1 ]; then
-        $DATAGEN > tmp
-        $ZSTD --format=lz4 -f tmp
+        datagen > tmp
+        zstd --format=lz4 -f tmp
         lz4 -t -v tmp.lz4
         lz4 -f tmp
-        $ZSTD -d -f -v tmp.lz4
+        zstd -d -f -v tmp.lz4
         rm tmp*
     else
         println "lz4 binary not detected"
@@ -1013,11 +1030,11 @@ fi
 
 if [ $LZ4MODE -eq 1 ]; then
     println "\n===>  lz4 frame tests "
-    $DATAGEN > tmp
-    $ZSTD -f --format=lz4 tmp
-    $ZSTD -f tmp
-    cat tmp.lz4 tmp.zst tmp.lz4 tmp.zst | $ZSTD -d -f -o tmp
-    truncateLastByte tmp.lz4 | $ZSTD -t > $INTOVOID && die "incomplete frame not detected !"
+    datagen > tmp
+    zstd -f --format=lz4 tmp
+    zstd -f tmp
+    cat tmp.lz4 tmp.zst tmp.lz4 tmp.zst | zstd -d -f -o tmp
+    truncateLastByte tmp.lz4 | zstd -t > $INTOVOID && die "incomplete frame not detected !"
     rm tmp*
 else
     println "\nlz4 mode not supported"
@@ -1026,7 +1043,7 @@ fi
 
 println "\n===> suffix list test"
 
-! $ZSTD -d tmp.abc 2> tmplg
+! zstd -d tmp.abc 2> tmplg
 
 if [ $GZIPMODE -ne 1 ]; then
     grep ".gz" tmplg > $INTOVOID && die "Unsupported suffix listed"
@@ -1046,39 +1063,39 @@ println "\n===>  tar extension tests "
 
 rm -f tmp tmp.tar tmp.tzst tmp.tgz tmp.txz tmp.tlz4
 
-$DATAGEN > tmp
+datagen > tmp
 tar cf tmp.tar tmp
-$ZSTD tmp.tar -o tmp.tzst
+zstd tmp.tar -o tmp.tzst
 rm tmp.tar
-$ZSTD -d tmp.tzst
+zstd -d tmp.tzst
 [ -e tmp.tar ] || die ".tzst failed to decompress to .tar!"
 rm -f tmp.tar tmp.tzst
 
 if [ $GZIPMODE -eq 1 ]; then
     tar czf tmp.tgz tmp
-    $ZSTD -d tmp.tgz
+    zstd -d tmp.tgz
     [ -e tmp.tar ] || die ".tgz failed to decompress to .tar!"
     rm -f tmp.tar tmp.tgz
 fi
 
 if [ $LZMAMODE -eq 1 ]; then
-    tar c tmp | $ZSTD --format=xz > tmp.txz
-    $ZSTD -d tmp.txz
+    tar c tmp | zstd --format=xz > tmp.txz
+    zstd -d tmp.txz
     [ -e tmp.tar ] || die ".txz failed to decompress to .tar!"
     rm -f tmp.tar tmp.txz
 fi
 
 if [ $LZ4MODE -eq 1 ]; then
-    tar c tmp | $ZSTD --format=lz4 > tmp.tlz4
-    $ZSTD -d tmp.tlz4
+    tar c tmp | zstd --format=lz4 > tmp.tlz4
+    zstd -d tmp.tlz4
     [ -e tmp.tar ] || die ".tlz4 failed to decompress to .tar!"
     rm -f tmp.tar tmp.tlz4
 fi
 
 touch tmp.t tmp.tz tmp.tzs
-! $ZSTD -d tmp.t
-! $ZSTD -d tmp.tz
-! $ZSTD -d tmp.tzs
+! zstd -d tmp.t
+! zstd -d tmp.tz
+! zstd -d tmp.tzs
 
 
 println "\n===>  zstd round-trip tests "
@@ -1116,10 +1133,10 @@ then
     roundTripTest -g8M "3 --long=24 -T2"
 
     println "\n===>  ovLog tests "
-    $DATAGEN -g2MB > tmp
-    refSize=$($ZSTD tmp -6 -c --zstd=wlog=18         | wc -c)
-    ov9Size=$($ZSTD tmp -6 -c --zstd=wlog=18,ovlog=9 | wc -c)
-    ov1Size=$($ZSTD tmp -6 -c --zstd=wlog=18,ovlog=1 | wc -c)
+    datagen -g2MB > tmp
+    refSize=$(zstd tmp -6 -c --zstd=wlog=18         | wc -c)
+    ov9Size=$(zstd tmp -6 -c --zstd=wlog=18,ovlog=9 | wc -c)
+    ov1Size=$(zstd tmp -6 -c --zstd=wlog=18,ovlog=1 | wc -c)
     if [ "$refSize" -eq "$ov9Size" ]; then
         echo ov9Size should be different from refSize
         exit 1
@@ -1140,66 +1157,66 @@ fi
 rm tmp*
 
 println "\n===>  zstd --list/-l single frame tests "
-$DATAGEN > tmp1
-$DATAGEN > tmp2
-$DATAGEN > tmp3
-$ZSTD tmp*
-$ZSTD -l ./*.zst
-$ZSTD -lv ./*.zst | grep "Decompressed Size:"  # check that decompressed size is present in header
-$ZSTD --list ./*.zst
-$ZSTD --list -v ./*.zst
+datagen > tmp1
+datagen > tmp2
+datagen > tmp3
+zstd tmp*
+zstd -l ./*.zst
+zstd -lv ./*.zst | grep "Decompressed Size:"  # check that decompressed size is present in header
+zstd --list ./*.zst
+zstd --list -v ./*.zst
 
 println "\n===>  zstd --list/-l multiple frame tests "
 cat tmp1.zst tmp2.zst > tmp12.zst
 cat tmp12.zst tmp3.zst > tmp123.zst
-$ZSTD -l ./*.zst
-$ZSTD -lv ./*.zst
+zstd -l ./*.zst
+zstd -lv ./*.zst
 
 println "\n===>  zstd --list/-l error detection tests "
-$ZSTD -l tmp1 tmp1.zst && die "-l must fail on non-zstd file"
-$ZSTD --list tmp* && die "-l must fail on non-zstd file"
-$ZSTD -lv tmp1* && die "-l must fail on non-zstd file"
-$ZSTD --list -v tmp2 tmp12.zst && die "-l must fail on non-zstd file"
+zstd -l tmp1 tmp1.zst && die "-l must fail on non-zstd file"
+zstd --list tmp* && die "-l must fail on non-zstd file"
+zstd -lv tmp1* && die "-l must fail on non-zstd file"
+zstd --list -v tmp2 tmp12.zst && die "-l must fail on non-zstd file"
 
 println "test : detect truncated compressed file "
 TEST_DATA_FILE=truncatable-input.txt
 FULL_COMPRESSED_FILE=${TEST_DATA_FILE}.zst
 TRUNCATED_COMPRESSED_FILE=truncated-input.txt.zst
-$DATAGEN -g50000 > $TEST_DATA_FILE
-$ZSTD -f $TEST_DATA_FILE -o $FULL_COMPRESSED_FILE
+datagen -g50000 > $TEST_DATA_FILE
+zstd -f $TEST_DATA_FILE -o $FULL_COMPRESSED_FILE
 dd bs=1 count=100 if=$FULL_COMPRESSED_FILE of=$TRUNCATED_COMPRESSED_FILE
-$ZSTD --list $TRUNCATED_COMPRESSED_FILE && die "-l must fail on truncated file"
+zstd --list $TRUNCATED_COMPRESSED_FILE && die "-l must fail on truncated file"
 
 rm $TEST_DATA_FILE
 rm $FULL_COMPRESSED_FILE
 rm $TRUNCATED_COMPRESSED_FILE
 
 println "\n===>  zstd --list/-l errors when presented with stdin / no files"
-$ZSTD -l && die "-l must fail on empty list of files"
-$ZSTD -l - && die "-l does not work on stdin"
-$ZSTD -l < tmp1.zst && die "-l does not work on stdin"
-$ZSTD -l - < tmp1.zst && die "-l does not work on stdin"
-$ZSTD -l - tmp1.zst && die "-l does not work on stdin"
-$ZSTD -l - tmp1.zst < tmp1.zst && die "-l does not work on stdin"
-$ZSTD -l tmp1.zst < tmp2.zst # this will check tmp1.zst, but not tmp2.zst, which is not an error : zstd simply doesn't read stdin in this case. It must not error just because stdin is not a tty
+zstd -l && die "-l must fail on empty list of files"
+zstd -l - && die "-l does not work on stdin"
+zstd -l < tmp1.zst && die "-l does not work on stdin"
+zstd -l - < tmp1.zst && die "-l does not work on stdin"
+zstd -l - tmp1.zst && die "-l does not work on stdin"
+zstd -l - tmp1.zst < tmp1.zst && die "-l does not work on stdin"
+zstd -l tmp1.zst < tmp2.zst # this will check tmp1.zst, but not tmp2.zst, which is not an error : zstd simply doesn't read stdin in this case. It must not error just because stdin is not a tty
 
 println "\n===>  zstd --list/-l test with null files "
-$DATAGEN -g0 > tmp5
-$ZSTD tmp5
-$ZSTD -l tmp5.zst
-$ZSTD -l tmp5* && die "-l must fail on non-zstd file"
-$ZSTD -lv tmp5.zst | grep "Decompressed Size: 0.00 KB (0 B)"  # check that 0 size is present in header
-$ZSTD -lv tmp5* && die "-l must fail on non-zstd file"
+datagen -g0 > tmp5
+zstd tmp5
+zstd -l tmp5.zst
+zstd -l tmp5* && die "-l must fail on non-zstd file"
+zstd -lv tmp5.zst | grep "Decompressed Size: 0.00 KB (0 B)"  # check that 0 size is present in header
+zstd -lv tmp5* && die "-l must fail on non-zstd file"
 
 println "\n===>  zstd --list/-l test with no content size field "
-$DATAGEN -g513K | $ZSTD > tmp6.zst
-$ZSTD -l tmp6.zst
-$ZSTD -lv tmp6.zst | grep "Decompressed Size:"  && die "Field :Decompressed Size: should not be available in this compressed file"
+datagen -g513K | zstd > tmp6.zst
+zstd -l tmp6.zst
+zstd -lv tmp6.zst | grep "Decompressed Size:"  && die "Field :Decompressed Size: should not be available in this compressed file"
 
 println "\n===>   zstd --list/-l test with no checksum "
-$ZSTD -f --no-check tmp1
-$ZSTD -l tmp1.zst
-$ZSTD -lv tmp1.zst
+zstd -f --no-check tmp1
+zstd -l tmp1.zst
+zstd -lv tmp1.zst
 
 rm tmp*
 
@@ -1231,22 +1248,22 @@ then
     roundTripTest -g270000000 " --adapt"
     roundTripTest -g27000000 " --adapt=min=1,max=4"
     println "===>   test: --adapt must fail on incoherent bounds "
-    $DATAGEN > tmp
-    $ZSTD -f -vv --adapt=min=10,max=9 tmp && die "--adapt must fail on incoherent bounds"
+    datagen > tmp
+    zstd -f -vv --adapt=min=10,max=9 tmp && die "--adapt must fail on incoherent bounds"
 
     println "\n===>   rsyncable mode "
     roundTripTest -g10M " --rsyncable"
     roundTripTest -g10M " --rsyncable -B100K"
     println "===>   test: --rsyncable must fail with --single-thread"
-    $ZSTD -f -vv --rsyncable --single-thread tmp && die "--rsyncable must fail with --single-thread"
+    zstd -f -vv --rsyncable --single-thread tmp && die "--rsyncable must fail with --single-thread"
 fi
 
 println "\n===> patch-from tests"
 
-$DATAGEN -g1000 -P50 > tmp_dict
-$DATAGEN -g1000 -P10 > tmp_patch
-$ZSTD --memory=10000 --patch-from=tmp_dict tmp_patch -o tmp_patch_diff
-$ZSTD -d --memory=10000 --patch-from=tmp_dict tmp_patch_diff -o tmp_patch_recon
+datagen -g1000 -P50 > tmp_dict
+datagen -g1000 -P10 > tmp_patch
+zstd --memory=10000 --patch-from=tmp_dict tmp_patch -o tmp_patch_diff
+zstd -d --memory=10000 --patch-from=tmp_dict tmp_patch_diff -o tmp_patch_recon
 $DIFF -s tmp_patch_recon tmp_patch
 rm -rf tmp_*
 
@@ -1312,36 +1329,36 @@ fi
 println "\n===>  cover dictionary builder : advanced options "
 
 TESTFILE="$PRGDIR"/zstdcli.c
-$DATAGEN > tmpDict
+datagen > tmpDict
 println "- Create first dictionary"
-$ZSTD --train-cover=k=46,d=8,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
+zstd --train-cover=k=46,d=8,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict
 cp "$TESTFILE" tmp
-$ZSTD -f tmp -D tmpDict
-$ZSTD -d tmp.zst -D tmpDict -fo result
+zstd -f tmp -D tmpDict
+zstd -d tmp.zst -D tmpDict -fo result
 $DIFF "$TESTFILE" result
-$ZSTD --train-cover=k=56,d=8 && die "Create dictionary without input file (should error)"
+zstd --train-cover=k=56,d=8 && die "Create dictionary without input file (should error)"
 println "- Create second (different) dictionary"
-$ZSTD --train-cover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
-$ZSTD -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
+zstd --train-cover=k=56,d=8 "$TESTDIR"/*.c "$PRGDIR"/*.c "$PRGDIR"/*.h -o tmpDictC
+zstd -d tmp.zst -D tmpDictC -fo result && die "wrong dictionary not detected!"
 println "- Create dictionary using shrink-dict flag"
-$ZSTD --train-cover=steps=256,shrink "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpShrinkDict
-$ZSTD --train-cover=steps=256,shrink=1 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpShrinkDict1
-$ZSTD --train-cover=steps=256,shrink=5 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpShrinkDict2
+zstd --train-cover=steps=256,shrink "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpShrinkDict
+zstd --train-cover=steps=256,shrink=1 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpShrinkDict1
+zstd --train-cover=steps=256,shrink=5 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpShrinkDict2
 println "- Create dictionary with short dictID"
-$ZSTD --train-cover=k=46,d=8,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
+zstd --train-cover=k=46,d=8,split=80 "$TESTDIR"/*.c "$PRGDIR"/*.c --dictID=1 -o tmpDict1
 cmp tmpDict tmpDict1 && die "dictionaries should have different ID !"
 println "- Create dictionary with size limit"
-$ZSTD --train-cover=steps=8 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K
+zstd --train-cover=steps=8 "$TESTDIR"/*.c "$PRGDIR"/*.c -o tmpDict2 --maxdict=4K
 println "- Compare size of dictionary from 90% training samples with 80% training samples"
-$ZSTD --train-cover=split=90 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
-$ZSTD --train-cover=split=80 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-cover=split=90 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-cover=split=80 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
 println "- Create dictionary using all samples for both training and testing"
-$ZSTD --train-cover=split=100 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-cover=split=100 -r "$TESTDIR"/*.c "$PRGDIR"/*.c
 println "- Test -o before --train-cover"
 rm -f tmpDict dictionary
-$ZSTD -o tmpDict --train-cover "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd -o tmpDict --train-cover "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f tmpDict
-$ZSTD --train-cover "$TESTDIR"/*.c "$PRGDIR"/*.c
+zstd --train-cover "$TESTDIR"/*.c "$PRGDIR"/*.c
 test -f dictionary
 rm -f tmp* dictionary
 


### PR DESCRIPTION
playTests.sh didn't work when `ZSTD_BIN` or `DATAGEN_BIN` had a space in
the path name. This happens for me because I split the cmake build
directory by compiler name, like "Clang 9.0.0".

The fix is to replace all instances of `$ZSTD` with the `zstd()`
function, and the replace `$DATAGEN` with `datagen()`. This will allow
us to change how we call zstd/datagen in the future without having to
change every callsite.

Note: I changed some tmp file suffixes from `.zstd` to `.zst` because they got messed up with my find and replace.