### PR TITLE
Fix using uninitialized value

### DIFF
--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -845,6 +845,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     assert(optLevel <= 2);
     ZSTD_rescaleFreqs(optStatePtr, (const BYTE*)src, srcSize, optLevel);
     ip += (ip==prefixStart);
+    memset(&lastSequence, 0, sizeof(lastSequence));
 
     /* Match Loop */
     while (ip < ilimit) {

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -905,6 +905,8 @@ ZSTD_decodeSequence(seqState_t* seqState, const ZSTD_longOffset_e longOffsets, c
         seq.match = matchBase + pos - seq.offset;  /* note : this operation can overflow when seq.offset is really too large, which can only happen when input is corrupted.
                                                     * No consequence though : no memory access will occur, offset is only used for prefetching */
         seqState->pos = pos + seq.matchLength;
+    } else {
+        seq.match = NULL;
     }
 
     /* ANS state update


### PR DESCRIPTION
This commit is to fix critical warning of probably using uninitialized fields of structures.