### PR TITLE
Fixes decompressor when using -Wshorten-64-to-32

### DIFF
--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -835,7 +835,7 @@ HUF_decompress4X2_usingDTable_internal_body(
             HUF_DECODE_SYMBOLX2_0(op2, &bitD2);
             HUF_DECODE_SYMBOLX2_0(op3, &bitD3);
             HUF_DECODE_SYMBOLX2_0(op4, &bitD4);
-            endSignal = LIKELY(
+            endSignal = (U32)LIKELY(
                         (BIT_reloadDStreamFast(&bitD1) == BIT_DStream_unfinished)
                       & (BIT_reloadDStreamFast(&bitD2) == BIT_DStream_unfinished)
                       & (BIT_reloadDStreamFast(&bitD3) == BIT_DStream_unfinished)


### PR DESCRIPTION
Spotted on iOS/Clang when building with the default `-Wshorten-64-to-32` (since `__builtin_expect` returns a `long`).