### PR TITLE
[bug] handling case where prefix is NULL or 0 sized in refPrefix_advanced 

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -945,9 +945,11 @@ size_t ZSTD_CCtx_refPrefix_advanced(
 {
     RETURN_ERROR_IF(cctx->streamStage != zcss_init, stage_wrong);
     ZSTD_clearAllDicts(cctx);
-    cctx->prefixDict.dict = prefix;
-    cctx->prefixDict.dictSize = prefixSize;
-    cctx->prefixDict.dictContentType = dictContentType;
+    if (prefix != NULL && prefixSize > 0) {
+        cctx->prefixDict.dict = prefix;
+        cctx->prefixDict.dictSize = prefixSize;
+        cctx->prefixDict.dictContentType = dictContentType;
+    }
     return 0;
 }
 

--- a/tests/fuzz/dictionary_round_trip.c
+++ b/tests/fuzz/dictionary_round_trip.c
@@ -32,6 +32,7 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
 {
     ZSTD_dictContentType_e dictContentType = ZSTD_dct_auto;
     FUZZ_dict_t dict = FUZZ_train(src, srcSize, producer);
+    int const refPrefix = FUZZ_dataProducer_uint32Range(producer, 0, 1) != 0;
     size_t cSize;
     if (FUZZ_dataProducer_uint32Range(producer, 0, 15) == 0) {
         int const cLevel = FUZZ_dataProducer_int32Range(producer, kMinClevel, kMaxClevel);
@@ -46,17 +47,27 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
         FUZZ_setRandomParameters(cctx, srcSize, producer);
         /* Disable checksum so we can use sizes smaller than compress bound. */
         FUZZ_ZASSERT(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 0));
-        FUZZ_ZASSERT(ZSTD_CCtx_loadDictionary_advanced(
+        if (refPrefix)
+            FUZZ_ZASSERT(ZSTD_CCtx_refPrefix_advanced(
+                cctx, dict.buff, dict.size,
+                dictContentType));
+        else 
+            FUZZ_ZASSERT(ZSTD_CCtx_loadDictionary_advanced(
                 cctx, dict.buff, dict.size,
                 (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
                 dictContentType));
         cSize = ZSTD_compress2(cctx, compressed, compressedCapacity, src, srcSize);
     }
     FUZZ_ZASSERT(cSize);
-    FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
-        dctx, dict.buff, dict.size,
-        (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
-        dictContentType));
+    if (refPrefix)
+        FUZZ_ZASSERT(ZSTD_DCtx_refPrefix_advanced(
+            dctx, dict.buff, dict.size,
+            dictContentType));
+    else
+        FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
+            dctx, dict.buff, dict.size,
+            (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
+            dictContentType));
     {
         size_t const ret = ZSTD_decompressDCtx(
                 dctx, result, resultCapacity, compressed, cSize);


### PR DESCRIPTION
Adding refPrefix to our dictionary_round_trip fuzzer caused it to crash on 

https://github.com/facebook/zstd/blob/dde98d833db693020130996de4750e8052dfcc1c/lib/compress/zstd_compress.c#L3003-L3007

handling null case on refPrefix advanced like in loadDictionary.  I'll rebase the patch-from pr on top of this after it lands.