### PR TITLE
CMake: Fix DESTDIR installs and the Package Config file

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -158,3 +158,39 @@ add_custom_target(clean-all
    COMMAND ${CMAKE_BUILD_TOOL} clean
    COMMAND rm -rf ${CMAKE_BINARY_DIR}/
 )
+
+#-----------------------------------------------------------------------------
+# Generate Package Config files
+#
+# This section is based on the boiler plate code from:
+# https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-packages
+#-----------------------------------------------------------------------------
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/zstdConfigVersion.cmake"
+    VERSION ${zstd_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+
+# A Package Config file that works from the build directory
+export(EXPORT zstdExports
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/zstdTargets.cmake"
+    NAMESPACE zstd::
+    )
+configure_file(zstdConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/zstdConfig.cmake"
+    COPYONLY
+    )
+
+# A Package Config file that works from the installation directory
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/zstd)
+install(EXPORT zstdExports
+    FILE zstdTargets.cmake
+    NAMESPACE zstd::
+    DESTINATION ${ConfigPackageLocation}
+    )
+install(FILES
+    zstdConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/zstdConfigVersion.cmake"
+    DESTINATION ${ConfigPackageLocation}
+    )

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -142,7 +142,7 @@ if (UNIX)
             -P "${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig.cmake"
             COMMENT "Creating pkg-config file")
 
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libzstd.pc" DESTINATION "${LIBDIR}/pkgconfig")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libzstd.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif ()
 
 # install target

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -169,21 +169,6 @@ if (ZSTD_BUILD_STATIC)
     )
 endif ()
 
-# export targets + find config
-configure_file(
-  "config.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/zstdConfig.cmake"
-  @ONLY
-)
-install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/zstdConfig.cmake"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zstd"
-)
-install(EXPORT zstdExports
-  NAMESPACE zstd::
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zstd"
-)
-
 # uninstall target
 if (NOT TARGET uninstall)
     configure_file(

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -77,8 +77,10 @@ if (MSVC)
 endif ()
 
 # Split project to static and shared libraries build
+set(library_targets)
 if (ZSTD_BUILD_SHARED)
     add_library(libzstd_shared SHARED ${Sources} ${Headers} ${PlatformDependResources})
+    list(APPEND library_targets libzstd_shared)
     if (ZSTD_MULTITHREAD_SUPPORT)
         set_property(TARGET libzstd_shared APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_MULTITHREAD")
         if (UNIX)
@@ -88,6 +90,7 @@ if (ZSTD_BUILD_SHARED)
 endif ()
 if (ZSTD_BUILD_STATIC)
     add_library(libzstd_static STATIC ${Sources} ${Headers})
+    list(APPEND library_targets libzstd_static)
     if (ZSTD_MULTITHREAD_SUPPORT)
         set_property(TARGET libzstd_static APPEND PROPERTY COMPILE_DEFINITIONS "ZSTD_MULTITHREAD")
         if (UNIX)
@@ -135,7 +138,7 @@ if (UNIX)
     # pkg-config
     set(PREFIX "${CMAKE_INSTALL_PREFIX}")
     set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
-    set(VERSION "${zstd_VERSION_MAJOR}.${zstd_VERSION_MINOR}.${zstd_VERSION_PATCH}")
+    set(VERSION "${zstd_VERSION}")
     add_custom_target(libzstd.pc ALL
             ${CMAKE_COMMAND} -DIN="${LIBRARY_DIR}/libzstd.pc.in" -DOUT="libzstd.pc"
             -DPREFIX="${PREFIX}" -DVERSION="${VERSION}"
@@ -154,20 +157,12 @@ install(FILES
     "${LIBRARY_DIR}/common/zstd_errors.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-if (ZSTD_BUILD_SHARED)
-    install(TARGETS libzstd_shared EXPORT zstdExports
-                                   INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-                                   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-                                   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+install(TARGETS ${library_targets}
+    EXPORT zstdExports
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     )
-endif()
-if (ZSTD_BUILD_STATIC)
-    install(TARGETS libzstd_static EXPORT zstdExports
-                                   INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-                                   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-                                   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    )
-endif ()
 
 # uninstall target
 if (NOT TARGET uninstall)

--- a/build/cmake/lib/config.cmake.in
+++ b/build/cmake/lib/config.cmake.in
@@ -1,7 +1,0 @@
-include(FindPackageHandleStandardArgs)
-set(${CMAKE_FIND_PACKAGE_NAME}_CONFIG ${CMAKE_CURRENT_LIST_FILE})
-find_package_handle_standard_args(zstd CONFIG_MODE)
-
-if(NOT TARGET zstd::libzstd_shared)
-    include("${CMAKE_CURRENT_LIST_DIR}/zstdExports.cmake")
-endif()

--- a/build/cmake/zstdConfig.cmake
+++ b/build/cmake/zstdConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/zstdTargets.cmake")


### PR DESCRIPTION
- Generate a better CMake Package Config file
  - Doesn't give an error if a version is specified to `find_package` (e.g. `find_package(zstd 1.4.3)`)
  - Works from both a build directory and installation directory
- Fix that installation of the libzstd.pc does not respect DESTDIR installations (e.g. `make DESTDIR=/tmp/staging install`)
- Minor CMake refactoring/simplification
