### PR TITLE
minor refactor of `fileio.c`

### DIFF
--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -20,7 +20,7 @@
 #include "timefn.h"      /* UTIL_clockSpanNano, UTIL_getTime */
 #include "mem.h"         /* U32 */
 #ifndef ZSTD_DLL_IMPORT
-    #include "zstd_internal.h"   /* ZSTD_decodeSeqHeaders, ZSTD_blockHeaderSize, blockType_e, KB, MB */
+    #include "zstd_internal.h"   /* ZSTD_decodeSeqHeaders, ZSTD_blockHeaderSize, ZSTD_getcBlockSize, blockType_e, KB, MB */
 #else
     #define KB *(1 <<10)
     #define MB *(1 <<20)


### PR DESCRIPTION
Made a few minor improvements to `fileio.c` :

- fix or clarify a few comments
- reorder some parameters, to enforce "mutable references first" rule
- simplified `fwriteSparse()`