### PR TITLE
[doc-bug] Updating the recommended max chainlog for patch-from

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -816,7 +816,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
         DISPLAYLEVEL(1, "[Optimal parser notes] Consider the following to improve patch size at the cost of speed:\n");
         DISPLAYLEVEL(1, "- Use --single-thread mode in the zstd cli\n");
         DISPLAYLEVEL(1, "- Set a larger targetLength (eg. --zstd=targetLength=4096)\n");
-        DISPLAYLEVEL(1, "- Set a larger chainLog (eg. --zstd=chainLog=31)\n");
+        DISPLAYLEVEL(1, "- Set a larger chainLog (eg. --zstd=chainLog=%u)\n", ZSTD_CHAINLOG_MAX);
         DISPLAYLEVEL(1, "Also consdier playing around with searchLog and hashLog\n");
     }
 }


### PR DESCRIPTION
https://github.com/facebook/zstd/issues/2081
```
[Optimal parser notes] Consider the following to improve patch size at the cost of speed:
- Use --single-thread mode in the zstd cli
- Set a larger targetLength (eg. --zstd=targetLength=4096)
- Set a larger chainLog (eg. --zstd=chainLog=30)
```