### PR TITLE
[fuzz+bug] running mt compression every time when fuzzing (even on small files)

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2813,7 +2813,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
 
         ZSTD_overflowCorrectIfNeeded(ms, ws, params, ip, ichunk);
 
-        if (params->ldmParams.enableLdm && ls != NULL && srcSize >= params->ldmParams.minMatchLength)
+        if (params->ldmParams.enableLdm && ls != NULL && srcSize > params->ldmParams.minMatchLength)
             ZSTD_ldm_fillHashTable(ls, (const BYTE*)src, (const BYTE*)src + srcSize, &params->ldmParams);
 
         switch(params->cParams.strategy)

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3950,9 +3950,14 @@ size_t ZSTD_compressStream2( ZSTD_CCtx* cctx,
 
 
 #ifdef ZSTD_MULTITHREAD
+
+/* Invoke fuzzing every time for mt even on small files */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         if ((cctx->pledgedSrcSizePlusOne-1) <= ZSTDMT_JOBSIZE_MIN) {
             params.nbWorkers = 0; /* do not invoke multi-threading when src size is too small */
         }
+#endif
+
         if (params.nbWorkers > 0) {
             /* mt context creation */
             if (cctx->mtctx == NULL) {

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -228,7 +228,8 @@ void ZSTD_ldm_fillHashTable(
             ldmState_t* state, const BYTE* ip,
             const BYTE* iend, ldmParams_t const* params)
 {
-    U64 startingHash = ZSTD_rollingHash_compute(ip, params->minMatchLength);
+    int const space = (U32)(iend - ip) > params->minMatchLength;
+    U64 const startingHash = space ? ZSTD_rollingHash_compute(ip, params->minMatchLength) : 0;
     ZSTD_ldm_fillLdmHashTable(
         state, startingHash, ip, iend - params->minMatchLength, state->window.base,
         params->hashLog - params->bucketSizeLog,

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1261,7 +1261,9 @@ static size_t ZSTDMT_compress_advanced_internal(
     unsigned const compressWithinDst = (dstCapacity >= ZSTD_compressBound(srcSize)) ? nbJobs : (unsigned)(dstCapacity / ZSTD_compressBound(avgJobSize));  /* presumes avgJobSize >= 256 KB, which should be the case */
     size_t frameStartPos = 0, dstBufferPos = 0;
     assert(jobParams.nbWorkers == 0);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     assert(mtctx->cctxPool->totalCCtx == params.nbWorkers);
+#endif
 
     params.jobSize = (U32)avgJobSize;
     DEBUGLOG(4, "ZSTDMT_compress_advanced_internal: nbJobs=%2u (rawSize=%u bytes; fixedSize=%u) ",

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -461,8 +461,8 @@ typedef struct {
     ZSTD_window_t ldmWindow;  /* A thread-safe copy of ldmState.window */
 } serialState_t;
 
-static int ZSTDMT_serialState_reset(serialState_t* serialState, 
-                        ZSTDMT_seqPool* seqPool, ZSTD_CCtx_params params, 
+static int ZSTDMT_serialState_reset(serialState_t* serialState,
+                        ZSTDMT_seqPool* seqPool, ZSTD_CCtx_params params,
                         size_t jobSize, const void* dict, size_t const dictSize)
 {
     /* Adjust parameters */
@@ -1417,7 +1417,10 @@ size_t ZSTDMT_initCStream_internal(
     if (params.jobSize != 0 && params.jobSize < ZSTDMT_JOBSIZE_MIN) params.jobSize = ZSTDMT_JOBSIZE_MIN;
     if (params.jobSize > (size_t)ZSTDMT_JOBSIZE_MAX) params.jobSize = (size_t)ZSTDMT_JOBSIZE_MAX;
 
+/* always trigger mt when fuzzing */
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     mtctx->singleBlockingThread = (pledgedSrcSize <= ZSTDMT_JOBSIZE_MIN);  /* do not trigger multi-threading when srcSize is too small */
+#endif
     if (mtctx->singleBlockingThread) {
         ZSTD_CCtx_params const singleThreadParams = ZSTDMT_initJobCCtxParams(&params);
         DEBUGLOG(5, "ZSTDMT_initCStream_internal: switch to single blocking thread mode");


### PR DESCRIPTION
Originally, I thought the first commit exposed a bug but it turns but it turns out there was another place where mt was being manually turned off when the input size <= ZSTDMT_JOBSIZE_MIN. So we needed another ifndef there.

Still, I don't think it would hurt to have this new path exposed to the fuzzer. 
