### PR TITLE
[bug] Making compressStream2 fail when passing rawContent but claiming fullDict

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3965,7 +3965,7 @@ size_t ZSTD_compressStream2( ZSTD_CCtx* cctx,
             DEBUGLOG(4, "call ZSTDMT_initCStream_internal as nbWorkers=%u", params.nbWorkers);
             FORWARD_IF_ERROR( ZSTDMT_initCStream_internal(
                         cctx->mtctx,
-                        prefixDict.dict, prefixDict.dictSize, ZSTD_dct_rawContent,
+                        prefixDict.dict, prefixDict.dictSize, prefixDict.dictContentType,
                         cctx->cdict, params, cctx->pledgedSrcSizePlusOne-1) );
             cctx->streamStage = zcss_load;
             cctx->appliedParams.nbWorkers = params.nbWorkers;


### PR DESCRIPTION
Right now, when the user supplies a non-fullDict to compressStream2 with multi-threading on and claims that they're passing a fullDict, we don't fail. Instead we just convert the dict to a rawContent dict. 