### PR TITLE
[bench] Extending largeNbDicts to compression 

### DIFF
--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -415,7 +415,7 @@ static void freeCDictCollection(cdict_collection_t cdictc)
 /* returns .buffers=NULL if operation fails */
 static cdict_collection_t createCDictCollection(const void* dictBuffer, size_t dictSize, size_t nbCDict, int cLevel)
 {
-    ZSTD_CDict** const cdicts = malloc(nbCDict * sizeof(ZSTD_DDict*));
+    ZSTD_CDict** const cdicts = malloc(nbCDict * sizeof(ZSTD_CDict*));
     assert(cdicts != NULL);
     if (cdicts==NULL) return kNullCDictCollection;
     for (size_t dictNb=0; dictNb < nbCDict; dictNb++) {

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -419,7 +419,7 @@ static cdict_collection_t createCDictCollection(const void* dictBuffer, size_t d
     if (cdicts==NULL) return kNullCDictCollection;
     for (size_t dictNb=0; dictNb < nbCDict; dictNb++) {
         cdicts[dictNb] = ZSTD_createCDict(dictBuffer, dictSize, cLevel);
-        assert(cdicts[dictNb] != NULL);
+        CONTROL(cdicts[dictNb] != NULL);
     }
     cdict_collection_t cdictc;
     cdictc.cdicts = cdicts;

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -334,6 +334,18 @@ createBufferCollection_fromSliceCollectionSizes(slice_collection_t sc)
     return result;
 }
 
+static buffer_collection_t
+createBufferCollection_fromSliceCollection(slice_collection_t sc)
+{
+    buffer_collection_t result = createBufferCollection_fromSliceCollectionSizes(sc);
+    for (size_t i = 0; i < sc.nbSlices; i++) {
+        if (result.slices.slicePtrs[i] != NULL) {
+            memcpy(result.slices.slicePtrs[i], sc.slicePtrs[i], sc.capacities[i]);
+            result.slices.capacities[i] = sc.capacities[i];
+        }
+    }
+    return result;
+}
 
 /* @return : kBuffNull if any error */
 static buffer_collection_t
@@ -776,15 +788,9 @@ int bench(const char** fileNameTable, unsigned nbFiles,
 
         shuffleCDictionaries(cdictionaries);
 
-        buffer_collection_t resultCollection = createBufferCollection_fromSliceCollectionSizes(srcSlices);
+        buffer_collection_t resultCollection = createBufferCollection_fromSliceCollection(srcSlices);
         CONTROL(resultCollection.buffer.ptr != NULL);
 
-        for (size_t i = 0; i < srcSlices.nbSlices; i++) {
-            if (resultCollection.slices.slicePtrs[i] != NULL) {
-                memcpy(resultCollection.slices.slicePtrs[i], srcSlices.slicePtrs[i], srcSlices.capacities[i]);
-                resultCollection.slices.capacities[i] = srcSlices.capacities[i];
-            }
-        }
         result = benchMem(dstSlices, resultCollection.slices, ddictionaries, cdictionaries, nbRounds, benchCompression);
 
         freeBufferCollection(resultCollection);

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -582,6 +582,22 @@ void freeDecompressInstructions(decompressInstructions di)
 }
 
 /* benched function */
+size_t compress(const void* src, size_t srcSize, void* dst, size_t dstCapacity, void* payload)
+{
+    compressInstructions* const ci = (compressInstructions*) payload;
+
+    size_t const result = ZSTD_compress_usingCDict(ci->cctx,
+                                        dst, dstCapacity,
+                                        src, srcSize,
+                                        ci->dictionaries.cdicts[ci->dictNb]);
+
+    ci->dictNb = ci->dictNb + 1;
+    if (ci->dictNb >= ci->nbDicts) ci->dictNb = 0;
+
+    return result;
+}
+
+/* benched function */
 size_t decompress(const void* src, size_t srcSize, void* dst, size_t dstCapacity, void* payload)
 {
     decompressInstructions* const di = (decompressInstructions*) payload;

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -339,7 +339,7 @@ createBufferCollection_fromSliceCollection(slice_collection_t sc)
 {
     buffer_collection_t result = createBufferCollection_fromSliceCollectionSizes(sc);
     for (size_t i = 0; i < sc.nbSlices; i++) {
-        if (result.slices.slicePtrs[i] != NULL) {
+        if (result.slices != NULL && result.slices.slicePtrs[i] != NULL) {
             memcpy(result.slices.slicePtrs[i], sc.slicePtrs[i], sc.capacities[i]);
             result.slices.capacities[i] = sc.capacities[i];
         }

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -781,8 +781,10 @@ int bench(const char** fileNameTable, unsigned nbFiles,
         CONTROL(resultCollection.buffer.ptr != NULL);
 
         for (size_t i = 0; i < srcSlices.nbSlices; i++) {
-            memcpy(resultCollection.slices.slicePtrs[i], srcSlices.slicePtrs[i], srcSlices.capacities[i]);
-            resultCollection.slices.capacities[i] = srcSlices.capacities[i];
+            if (resultCollection.slices.slicePtrs[i] != NULL) {
+                memcpy(resultCollection.slices.slicePtrs[i], srcSlices.slicePtrs[i], srcSlices.capacities[i]);
+                resultCollection.slices.capacities[i] = srcSlices.capacities[i];
+            }
         }
         result = benchMem(dstSlices, resultCollection.slices, ddictionaries, cdictionaries, nbRounds, benchCompression);
 

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -546,7 +546,7 @@ compressInstructions createCompressInstructions(cdict_collection_t dictionaries)
 {
     compressInstructions ci;
     ci.cctx = ZSTD_createCCtx();
-    assert(ci.cctx != NULL);
+    CONTROL(ci.cctx != NULL);
     ci.nbDicts = dictionaries.nbCDict;
     ci.dictNb = 0;
     ci.dictionaries = dictionaries;

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -536,6 +536,29 @@ static size_t compressBlocks(size_t* cSizes,   /* optional (can be NULL). If pre
 /* ---  Benchmark  --- */
 
 typedef struct {
+    ZSTD_CCtx* cctx;
+    size_t nbDicts;
+    size_t dictNb;
+    cdict_collection_t dictionaries;
+} compressInstructions;
+
+compressInstructions createCompressInstructions(cdict_collection_t dictionaries)
+{
+    compressInstructions ci;
+    ci.cctx = ZSTD_createCCtx();
+    assert(ci.cctx != NULL);
+    ci.nbDicts = dictionaries.nbCDict;
+    ci.dictNb = 0;
+    ci.dictionaries = dictionaries;
+    return ci;
+}
+
+void freeCompressInstructions(compressInstructions ci)
+{
+    ZSTD_freeCCtx(ci.cctx);
+}
+
+typedef struct {
     ZSTD_DCtx* dctx;
     size_t nbDicts;
     size_t dictNb;

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -339,7 +339,7 @@ createBufferCollection_fromSliceCollection(slice_collection_t sc)
 {
     buffer_collection_t result = createBufferCollection_fromSliceCollectionSizes(sc);
     for (size_t i = 0; i < sc.nbSlices; i++) {
-        if (result.slices != NULL && result.slices.slicePtrs[i] != NULL) {
+        if (result.slices.slicePtrs != NULL && result.slices.slicePtrs[i] != NULL) {
             memcpy(result.slices.slicePtrs[i], sc.slicePtrs[i], sc.capacities[i]);
             result.slices.capacities[i] = sc.capacities[i];
         }

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -416,7 +416,6 @@ static void freeCDictCollection(cdict_collection_t cdictc)
 static cdict_collection_t createCDictCollection(const void* dictBuffer, size_t dictSize, size_t nbCDict, int cLevel)
 {
     ZSTD_CDict** const cdicts = malloc(nbCDict * sizeof(ZSTD_CDict*));
-    assert(cdicts != NULL);
     if (cdicts==NULL) return kNullCDictCollection;
     for (size_t dictNb=0; dictNb < nbCDict; dictNb++) {
         cdicts[dictNb] = ZSTD_createCDict(dictBuffer, dictSize, cLevel);

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -456,7 +456,26 @@ static ddict_collection_t createDDictCollection(const void* dictBuffer, size_t d
 
 
 /* mess with addresses, so that linear scanning dictionaries != linear address scanning */
-void shuffleDictionaries(ddict_collection_t dicts)
+void shuffleCDictionaries(cdict_collection_t dicts)
+{
+    size_t const nbDicts = dicts.nbCDict;
+    for (size_t r=0; r<nbDicts; r++) {
+        size_t const d = (size_t)rand() % nbDicts;
+        ZSTD_CDict* tmpd = dicts.cdicts[d];
+        dicts.cdicts[d] = dicts.cdicts[r];
+        dicts.cdicts[r] = tmpd;
+    }
+    for (size_t r=0; r<nbDicts; r++) {
+        size_t const d1 = (size_t)rand() % nbDicts;
+        size_t const d2 = (size_t)rand() % nbDicts;
+        ZSTD_CDict* tmpd = dicts.cdicts[d1];
+        dicts.cdicts[d1] = dicts.cdicts[d2];
+        dicts.cdicts[d2] = tmpd;
+    }
+}
+
+/* mess with addresses, so that linear scanning dictionaries != linear address scanning */
+void shuffleDDictionaries(ddict_collection_t dicts)
 {
     size_t const nbDicts = dicts.nbDDict;
     for (size_t r=0; r<nbDicts; r++) {
@@ -702,7 +721,7 @@ int bench(const char** fileNameTable, unsigned nbFiles,
     ddict_collection_t const dictionaries = createDDictCollection(dictBuffer.ptr, dictBuffer.size, nbDicts);
     CONTROL(dictionaries.ddicts != NULL);
 
-    shuffleDictionaries(dictionaries);
+    shuffleDDictionaries(dictionaries);
 
     buffer_collection_t resultCollection = createBufferCollection_fromSliceCollectionSizes(srcSlices);
     CONTROL(resultCollection.buffer.ptr != NULL);


### PR DESCRIPTION
Benchmark compression (default) with -z now 
```
 ./largeNbDicts [Options] filename(s)

Options :
-z          : benchmark compression (default)
-d          : benchmark decompression
-r          : recursively load all files in subdirectories (default: off)
-B#         : split input into blocks of size # (default: no split)
-#          : use compression level # (default: 3)
-D #        : use # as a dictionary (default: create one)
-i#         : nb benchmark rounds (default: 6)
--nbBlocks=#: use # blocks for bench (default: one per file)
--nbDicts=# : create # dictionaries for bench (default: one per block)
-h          : help (this text)
```

Sanity check: largeNbDicts with one dict benchmarks the same as hot compression with -b

```
zstd -b6 -i1 -D ~/data/github_dict -r ~/data/github
 6# 9114 files       :   7484607 ->    723641 (10.34),  96.3 MB/s ,1146.7 MB/s

./largeNbDicts -6 -z -D ~/data/github_dict -r ~/data/github --nbDicts=1 
loading 9114 files...
created src buffer of size 7.1 MB
split input into 9114 blocks
loading dictionary /home/bimbashrestha/data/github_dict
compressing at level 6 without dictionary : Ratio=3.03  (2471189 bytes)
compressed using a 112640 bytes dictionary : Ratio=10.34  (723641 bytes)
generating 1 dictionaries, using 0.5 MB of memory
Compression Speed : 96.1 MB/s
```

and then performance drops steadily off as expected: 

```
./largeNbDicts -6 -z -D ~/data/github_dict -r ~/data/github --nbDicts=1 
...
Compression Speed : 96.1 MB/s


./largeNbDicts -6 -z -D ~/data/github_dict -r ~/data/github --nbDicts=10
...
Compression Speed : 84.0 MB/s

./largeNbDicts -6 -z -D ~/data/github_dict -r ~/data/github --nbDicts=30
...
Compression Speed : 77.7 MB/s

./largeNbDicts -6 -z -D ~/data/github_dict -r ~/data/github --nbDicts=100
...
Compression Speed : 71.4 MB/s
```
and so on 