### PR TITLE
faster cygwin test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -249,7 +249,7 @@
       C:\cygwin64\bin\bash --login -c "
         set -e;
         cd build/cmake;
-        CFLAGS='-Werror' cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Debug -DZSTD_BUILD_TESTS:BOOL=ON -DZSTD_FUZZER_FLAGS=-T30s .;
+        CFLAGS='-Werror' cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Debug -DZSTD_BUILD_TESTS:BOOL=ON -DZSTD_FUZZER_FLAGS=-T30s -DZSTD_ZSTREAM_FLAGS=-T30s .;
         make -j4;
         ctest -V -L Medium;
       "

--- a/build/cmake/tests/CMakeLists.txt
+++ b/build/cmake/tests/CMakeLists.txt
@@ -70,7 +70,7 @@ AddTestFlagsOption(ZSTD_FUZZER_FLAGS "$ENV{FUZZERTEST} $ENV{FUZZER_FLAGS}"
 add_test(NAME fuzzer COMMAND fuzzer ${ZSTD_FUZZER_FLAGS})
 # Disable the timeout since the run time is too long for the default timeout of
 # 1500 seconds and varies considerably between low-end and high-end CPUs.
-set_tests_properties(fuzzer PROPERTIES TIMEOUT 0)
+# set_tests_properties(fuzzer PROPERTIES TIMEOUT 0)
 
 #
 # zstreamtest


### PR DESCRIPTION
The cygwin test on Appveyor is way too long (>30 mn).
The main issue is the very long `zstreamtest`, because no time out has been programmed.
Ensures that both `fuzzer` and `zstreamtest` receive a 30sec slot.
Should reduce cygwin tests duration by -30mn.