### PR TITLE
updated `zstd -h` 

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -213,13 +213,13 @@ zstd-noxz : LZMALD  :=
 zstd-noxz : LZMA_MSG := - xz/lzma support is disabled
 zstd-noxz : zstd
 
-# note : the following target doesn't build
+## zstd-dll: zstd executable linked to dynamic library libzstd (must already exist)
+# note : the following target doesn't link
 #        because zstd uses non-public symbols from libzstd
 #        such as XXH64 (for benchmark),
-#        ZDICT_trainFromBuffer_unsafe_legacy for dictionary builder
-#        and ZSTD_cycleLog (likely for --patch-from)
-#        It's unclear at this stage if this is a scenario we want to support
-## zstd-dll: zstd executable linked to dynamic library libzstd (must already exist)
+#        ZDICT_trainFromBuffer_unsafe_legacy (for dictionary builder)
+#        and ZSTD_cycleLog (likely for --patch-from).
+#        It's unclear at this stage if this is a scenario that must be supported
 .PHONY: zstd-dll
 zstd-dll : LDFLAGS+= -L$(ZSTDDIR) -lzstd
 zstd-dll : ZSTDLIB_FILES =
@@ -227,6 +227,7 @@ zstd-dll : $(ZSTD_CLI_OBJ)
 	$(CC) $(FLAGS) $^ -o $@$(EXT) $(LDFLAGS)
 
 
+## zstd-pgo: zstd executable optimized with pgo. `gcc` only.
 zstd-pgo :
 	$(MAKE) clean
 	$(MAKE) zstd MOREFLAGS=-fprofile-generate

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -123,7 +123,7 @@ static void usage(FILE* f, const char* programName)
     DISPLAY_F(f, " -d     : decompression \n");
 #endif
     DISPLAY_F(f, " -D DICT: use DICT as Dictionary for compression or decompression \n");
-    DISPLAY_F(f, " -o file: result stored into file \n");
+    DISPLAY_F(f, " -o file: result stored into `file` (only 1 output file) \n");
     DISPLAY_F(f, " -f     : overwrite output without prompting, also (de)compress links \n");
     DISPLAY_F(f, "--rm    : remove source file(s) after successful de/compression \n");
     DISPLAY_F(f, " -k     : preserve source file(s) (default) \n");


### PR DESCRIPTION
to help readability.

Group arguments into separated titled categories,
try to give better visibility to more commonly used arguments.