### PR TITLE
[build] removing -f test (grep usage not supported on mac)

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -254,14 +254,6 @@ ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep_bad.zst && die "Should have failed
 ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep_bad.zst | grep "No such file or directory" || true
 rm -f tmp_grep*
 
-println "\n===> zstdgrep pipe in with -f "
-echo "start" > tmp_grep
-echo "stop" >> tmp_grep
-echo "start" | ZCAT=./zstdcat $ZSTDGREP -f - tmp_grep > tmp_grep_out1
-echo "start" | grep -f - tmp_grep > tmp_grep_out2
-$DIFF tmp_grep_out1 tmp_grep_out2
-rm -f tmp_grep*
-
 println "\n===> zstdgrep --regexp= multiple"
 echo "start" > tmp_grep
 echo "stop" >> tmp_grep


### PR DESCRIPTION
```
echo "start" | grep -f - tmp_grep
```
doesn't work consistently on all greps (eg: fails on mac) so we shouldn't require that zstdgrep support that usage. Removing that test