### PR TITLE
[greedy] Fix performance instability

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -681,6 +681,12 @@ ZSTD_compressBlock_lazy_generic(
     }
 
     /* Match Loop */
+#if defined(__GNUC__) && defined(__x86_64__)
+    /* I've measured random a 5% speed loss on levels 5 & 6 (greedy) when the
+     * code alignment is perturbed. To fix the instability align the loop on 32-bytes.
+     */
+    __asm__(".p2align 5");
+#endif
     while (ip < ilimit) {
         size_t matchLength=0;
         size_t offset=0;
@@ -952,6 +958,12 @@ size_t ZSTD_compressBlock_lazy_extDict_generic(
     ip += (ip == prefixStart);
 
     /* Match Loop */
+#if defined(__GNUC__) && defined(__x86_64__)
+    /* I've measured random a 5% speed loss on levels 5 & 6 (greedy) when the
+     * code alignment is perturbed. To fix the instability align the loop on 32-bytes.
+     */
+    __asm__(".p2align 5");
+#endif
     while (ip < ilimit) {
         size_t matchLength=0;
         size_t offset=0;


### PR DESCRIPTION
PR #2131 caused a 5% loss in speed for levels 5 and 6. This is caused by code alignment. This PR gets the speed back up to par.

I've measured speed with clang and gcc levels 5-9 and the performance is now approximately neutral with performance before the PR (within 1 MB/s either way).

This is the same alignment command that we are using in `decompressSequences()` so we're not adding anything new right before the release.