### PR TITLE
[fuzz] adding dictionary stream round trip fuzzer

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2846,7 +2846,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
 
         ZSTD_overflowCorrectIfNeeded(ms, ws, params, ip, ichunk);
 
-        if (params->ldmParams.enableLdm && ls != NULL && srcSize >= params->ldmParams.minMatchLength)
+        if (params->ldmParams.enableLdm && ls != NULL)
             ZSTD_ldm_fillHashTable(ls, (const BYTE*)src, (const BYTE*)src + srcSize, &params->ldmParams);
 
         switch(params->cParams.strategy)

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -228,11 +228,13 @@ void ZSTD_ldm_fillHashTable(
             ldmState_t* state, const BYTE* ip,
             const BYTE* iend, ldmParams_t const* params)
 {
-    U64 startingHash = ZSTD_rollingHash_compute(ip, params->minMatchLength);
-    ZSTD_ldm_fillLdmHashTable(
-        state, startingHash, ip, iend - params->minMatchLength, state->window.base,
-        params->hashLog - params->bucketSizeLog,
-        *params);
+    if ((size_t)(iend - ip) >= params->minMatchLength) {
+        U64 startingHash = ZSTD_rollingHash_compute(ip, params->minMatchLength);
+        ZSTD_ldm_fillLdmHashTable(
+            state, startingHash, ip, iend - params->minMatchLength, state->window.base,
+            params->hashLog - params->bucketSizeLog,
+            *params);
+    }
 }
 
 

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -94,7 +94,8 @@ FUZZ_TARGETS :=       \
 	zstd_frame_info \
 	simple_compress \
 	dictionary_loader \
-	raw_dictionary_round_trip
+	raw_dictionary_round_trip \
+	dictionary_stream_round_trip
 
 all: $(FUZZ_TARGETS)
 
@@ -163,6 +164,9 @@ dictionary_round_trip: $(FUZZ_HEADERS) $(FUZZ_ROUND_TRIP_OBJ) rt_fuzz_dictionary
 
 raw_dictionary_round_trip: $(FUZZ_HEADERS) $(FUZZ_ROUND_TRIP_OBJ) rt_fuzz_raw_dictionary_round_trip.o
 	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_ROUND_TRIP_OBJ) rt_fuzz_raw_dictionary_round_trip.o $(LIB_FUZZING_ENGINE) -o $@
+
+dictionary_stream_round_trip: $(FUZZ_HEADERS) $(FUZZ_ROUND_TRIP_OBJ) rt_fuzz_dictionary_stream_round_trip.o
+	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_ROUND_TRIP_OBJ) rt_fuzz_dictionary_stream_round_trip.o $(LIB_FUZZING_ENGINE) -o $@
 
 dictionary_decompress: $(FUZZ_HEADERS) $(FUZZ_DECOMPRESS_OBJ) d_fuzz_dictionary_decompress.o
 	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_DECOMPRESS_OBJ) d_fuzz_dictionary_decompress.o $(LIB_FUZZING_ENGINE) -o $@

--- a/tests/fuzz/dictionary_stream_round_trip.c
+++ b/tests/fuzz/dictionary_stream_round_trip.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2016-2020, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+/**
+ * This fuzz target performs a zstd round-trip test (compress & decompress),
+ * compares the result with the original, and calls abort() on corruption.
+ */
+
+#define ZSTD_STATIC_LINKING_ONLY
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "fuzz_helpers.h"
+#include "zstd_helpers.h"
+#include "fuzz_data_producer.h"
+
+ZSTD_CCtx *cctx = NULL;
+static ZSTD_DCtx *dctx = NULL;
+static uint8_t* cBuf = NULL;
+static uint8_t* rBuf = NULL;
+static size_t bufSize = 0;
+
+static ZSTD_outBuffer makeOutBuffer(uint8_t *dst, size_t capacity,
+                                    FUZZ_dataProducer_t *producer)
+{
+    ZSTD_outBuffer buffer = { dst, 0, 0 };
+
+    FUZZ_ASSERT(capacity > 0);
+    buffer.size = (FUZZ_dataProducer_uint32Range(producer, 1, capacity));
+    FUZZ_ASSERT(buffer.size <= capacity);
+
+    return buffer;
+}
+
+static ZSTD_inBuffer makeInBuffer(const uint8_t **src, size_t *size,
+                                  FUZZ_dataProducer_t *producer)
+{
+    ZSTD_inBuffer buffer = { *src, 0, 0 };
+
+    FUZZ_ASSERT(*size > 0);
+    buffer.size = (FUZZ_dataProducer_uint32Range(producer, 1, *size));
+    FUZZ_ASSERT(buffer.size <= *size);
+    *src += buffer.size;
+    *size -= buffer.size;
+
+    return buffer;
+}
+
+static size_t compress(uint8_t *dst, size_t capacity,
+                        const uint8_t *src, size_t srcSize,
+                        const uint8_t* dict, size_t dictSize,
+                        FUZZ_dataProducer_t *producer, int refPrefix,
+                        ZSTD_dictContentType_e dictContentType)
+{
+    size_t dstSize = 0;
+    ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
+    FUZZ_setRandomParameters(cctx, srcSize, producer);
+
+    /* Disable checksum so we can use sizes smaller than compress bound. */
+    FUZZ_ZASSERT(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 0));
+    if (refPrefix)
+        FUZZ_ZASSERT(ZSTD_CCtx_refPrefix_advanced(
+            cctx, dict, dictSize,
+            dictContentType));
+    else
+        FUZZ_ZASSERT(ZSTD_CCtx_loadDictionary_advanced(
+            cctx, dict, dictSize,
+            (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
+            dictContentType));
+
+    while (srcSize > 0) {
+        ZSTD_inBuffer in = makeInBuffer(&src, &srcSize, producer);
+        /* Mode controls the action. If mode == -1 we pick a new mode */
+        int mode = -1;
+        while (in.pos < in.size || mode != -1) {
+            ZSTD_outBuffer out = makeOutBuffer(dst, capacity, producer);
+            /* Previous action finished, pick a new mode. */
+            if (mode == -1) mode = FUZZ_dataProducer_uint32Range(producer, 0, 9);
+            switch (mode) {
+                case 0: /* fall-through */
+                case 1: /* fall-through */
+                case 2: {
+                    size_t const ret =
+                        ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_flush);
+                    FUZZ_ZASSERT(ret);
+                    if (ret == 0)
+                        mode = -1;
+                    break;
+                }
+                case 3: {
+                    size_t ret =
+                        ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
+                    FUZZ_ZASSERT(ret);
+                    /* Reset the compressor when the frame is finished */
+                    if (ret == 0) {
+                        ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
+                        if (FUZZ_dataProducer_uint32Range(producer, 0, 7) == 0) {
+                            size_t const remaining = in.size - in.pos;
+                            FUZZ_setRandomParameters(cctx, remaining, producer);
+                        }
+                        mode = -1;
+                    }
+                    break;
+                }
+                case 4: {
+                    ZSTD_inBuffer nullIn = { NULL, 0, 0 };
+                    ZSTD_outBuffer nullOut = { NULL, 0, 0 };
+                    size_t const ret = ZSTD_compressStream2(cctx, &nullOut, &nullIn, ZSTD_e_continue);
+                    FUZZ_ZASSERT(ret);
+                }
+                /* fall-through */
+                default: {
+                    size_t const ret =
+                        ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_continue);
+                    FUZZ_ZASSERT(ret);
+                    mode = -1;
+                }
+            }
+            dst += out.pos;
+            dstSize += out.pos;
+            capacity -= out.pos;
+        }
+    }
+    for (;;) {
+        ZSTD_inBuffer in = {NULL, 0, 0};
+        ZSTD_outBuffer out = makeOutBuffer(dst, capacity, producer);
+        size_t const ret = ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end);
+        FUZZ_ZASSERT(ret);
+
+        dst += out.pos;
+        dstSize += out.pos;
+        capacity -= out.pos;
+        if (ret == 0)
+            break;
+    }
+    return dstSize;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
+{
+    size_t neededBufSize;
+
+    /* Give a random portion of src data to the producer, to use for
+    parameter generation. The rest will be used for (de)compression */
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(src, size);
+    size = FUZZ_dataProducer_reserveDataPrefix(producer);
+
+    neededBufSize = ZSTD_compressBound(size) * 15;
+
+    /* Allocate all buffers and contexts if not already allocated */
+    if (neededBufSize > bufSize) {
+        free(cBuf);
+        free(rBuf);
+        cBuf = (uint8_t*)FUZZ_malloc(neededBufSize);
+        rBuf = (uint8_t*)FUZZ_malloc(neededBufSize);
+        bufSize = neededBufSize;
+    }
+    if (!cctx) {
+        cctx = ZSTD_createCCtx();
+        FUZZ_ASSERT(cctx);
+    }
+    if (!dctx) {
+        dctx = ZSTD_createDCtx();
+        FUZZ_ASSERT(dctx);
+    }
+
+    {
+        ZSTD_dictContentType_e dictContentType = FUZZ_dataProducer_uint32Range(producer, 0, 2);
+        FUZZ_dict_t dict = FUZZ_train(src, size, producer);
+        int const refPrefix = FUZZ_dataProducer_uint32Range(producer, 0, 1) != 0;
+
+        size_t const cSize = compress(cBuf, neededBufSize, src, size, dict.buff, dict.size, producer, refPrefix, dictContentType);
+
+        if (refPrefix)
+            FUZZ_ZASSERT(ZSTD_DCtx_refPrefix_advanced(
+                dctx, dict.buff, dict.size,
+                dictContentType));
+        else
+            FUZZ_ZASSERT(ZSTD_DCtx_loadDictionary_advanced(
+                dctx, dict.buff, dict.size,
+                (ZSTD_dictLoadMethod_e)FUZZ_dataProducer_uint32Range(producer, 0, 1),
+                dictContentType));
+        size_t const rSize =
+            ZSTD_decompressDCtx(dctx, rBuf, neededBufSize, cBuf, cSize);
+        FUZZ_ZASSERT(rSize);
+        FUZZ_ASSERT_MSG(rSize == size, "Incorrect regenerated size");
+        FUZZ_ASSERT_MSG(!FUZZ_memcmp(src, rBuf, size), "Corruption!");
+    }
+
+    FUZZ_dataProducer_free(producer);
+#ifndef STATEFUL_FUZZING
+    ZSTD_freeCCtx(cctx); cctx = NULL;
+    ZSTD_freeDCtx(dctx); dctx = NULL;
+#endif
+    return 0;
+}

--- a/tests/fuzz/fuzz.py
+++ b/tests/fuzz/fuzz.py
@@ -58,6 +58,7 @@ TARGET_INFO = {
     'simple_compress': TargetInfo(InputType.RAW_DATA),
     'dictionary_loader': TargetInfo(InputType.DICTIONARY_DATA),
     'raw_dictionary_round_trip': TargetInfo(InputType.RAW_DATA),
+    'dictionary_stream_round_trip': TargetInfo(InputType.RAW_DATA),
 }
 TARGETS = list(TARGET_INFO.keys())
 ALL_TARGETS = TARGETS + ['all']


### PR DESCRIPTION
This exposes the bug mentioned in: 

https://github.com/facebook/zstd/pull/2138

```
$ ./dictionary_stream_round_trip corpora/dictionary_round_trip
...
../../lib/compress/zstdmt_compress.c: ZSTDMT_setBufferSize: bSize = 16236
../../lib/compress/zstd_compress_internal.h: ZSTD_window_update
../../lib/compress/zstd_compress_internal.h: Non contiguous blocks, new segment starts at 1
=================================================================
==25047==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61900000a480 at pc 0x00010a752f24 bp 0x7ffee569e640 sp 0x7ffee569e638
READ of size 1 at 0x61900000a480 thread T0
    #0 0x10a752f23 in ZSTD_rollingHash_append zstd_compress_internal.h:667
    #1 0x10a74c123 in ZSTD_rollingHash_compute zstd_compress_internal.h:677
    #2 0x10a74be53 in ZSTD_ldm_fillHashTable zstd_ldm.c:231
    #3 0x10a872295 in ZSTDMT_serialState_reset zstdmt_compress.c:516
    #4 0x10a86f3bf in ZSTDMT_initCStream_internal zstdmt_compress.c:1512
    #5 0x10a64ab78 in ZSTD_compressStream2 zstd_compress.c:4000
    #6 0x10a97e014 in compress dictionary_stream_round_trip.c:123
    #7 0x10a97cc32 in LLVMFuzzerTestOneInput dictionary_stream_round_trip.c:181
    #8 0x10a97f31a in main regression_driver.c:77
    #9 0x7fff68d3d3d4 in start (libdyld.dylib:x86_64+0x163d4)

0x61900000a480 is located 0 bytes to the right of 1024-byte region [0x61900000a080,0x61900000a480)
allocated by thread T0 here:
    #0 0x10aaee053 in wrap_malloc (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x5c053)
    #1 0x10a56631f in FUZZ_malloc fuzz_helpers.c:19
    #2 0x10a567a22 in FUZZ_train zstd_helpers.c:109
    #3 0x10a97ca34 in LLVMFuzzerTestOneInput dictionary_stream_round_trip.c:178
    #4 0x10a97f31a in main regression_driver.c:77
    #5 0x7fff68d3d3d4 in start (libdyld.dylib:x86_64+0x163d4)

SUMMARY: AddressSanitizer: heap-buffer-overflow zstd_compress_internal.h:667 in ZSTD_rollingHash_append
Shadow bytes around the buggy address:
  0x1c3200001440: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3200001450: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3200001460: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3200001470: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3200001480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x1c3200001490:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c32000014a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c32000014b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c32000014c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c32000014d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c32000014e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==25047==ABORTING
```