### PR TITLE
[cmake] Generate libzstd.pc everywhere pkg-config is found

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -134,7 +134,8 @@ if (ZSTD_BUILD_STATIC)
             OUTPUT_NAME ${STATIC_LIBRARY_BASE_NAME})
 endif ()
 
-if (UNIX)
+find_package (PkgConfig)
+if (PkgConfig_FOUND)
     # pkg-config
     set(PREFIX "${CMAKE_INSTALL_PREFIX}")
     set(LIBDIR "${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
Else it wont generate it when cross-compiling with mingw (target is WIN32, not UNIX)
Another solution would have been "if (NOT MSVC)" as MSVC is the only I can think of where pc files are useless, but it may be incomplete.
This is the cleanest idea I could think of.