### PR TITLE
Reduced single file lib size on macOS

### DIFF
--- a/contrib/single_file_libs/README.md
+++ b/contrib/single_file_libs/README.md
@@ -12,7 +12,7 @@ This is the most common use case. The decompression library is small, adding, fo
 Create `zstddeclib.c` from the Zstd source using:
 ```
 cd zstd/contrib/single_file_libs
-./combine.sh -r ../../lib -r ../../lib/common -r ../../lib/decompress -o zstddeclib.c zstddeclib-in.c
+./combine.sh -r ../../lib -o zstddeclib.c zstddeclib-in.c
 ```
 Then add the resulting file to your project (see the [example files](examples)).
 
@@ -21,12 +21,12 @@ Then add the resulting file to your project (see the [example files](examples)).
 Full Library
 ------------
 
-The same tool can amalgamate the entire Zstd library for ease of adding both compression and decompression to a project. The [roundtrip example](examples/roundtrip.c) uses the original `zstd.h` with the remaining source files combined into `zstd.c` (currently just over 1MB) created from `zstd-in.c`. As with the standalone decoder the most useful compile flags have already been rolled-in and the resulting file can be added to a project as-is.
+The same tool can amalgamate the entire Zstd library for ease of adding both compression and decompression to a project. The [roundtrip example](examples/roundtrip.c) uses the original `zstd.h` with the remaining source files combined into `zstd.c` (currently just over 1.2MB) created from `zstd-in.c`. As with the standalone decoder the most useful compile flags have already been rolled-in and the resulting file can be added to a project as-is.
 
 Create `zstd.c` from the Zstd source using:
 ```
 cd zstd/contrib/single_file_libs
-combine.sh -r ../../lib -r ../../lib/common -r ../../lib/compress -r ../../lib/decompress -k zstd.h -o zstd.c zstd-in.c
+./combine.sh -r ../../lib -o zstd.c zstd-in.c
 ```
 It's possible to create a compressor-only library but since the decompressor is so small in comparison this doesn't bring much of a gain (but for the curious, simply remove the files in the _decompress_ section at the end of `zstd-in.c`).
 

--- a/contrib/single_file_libs/combine.sh
+++ b/contrib/single_file_libs/combine.sh
@@ -93,6 +93,12 @@ resolve_include() {
         echo "$relpath"
         return 0
       fi
+      # Fallback on Python to reduce the path if the above fails.
+      local relpath=$(python -c "import os,sys; print os.path.relpath(sys.argv[1])" "$root/$inc" 2>/dev/null)
+      if [ "$relpath" != "" ]; then # not all distros have realpath...
+        echo "$relpath"
+        return 0
+      fi
       # Worst case, fall back to just the root + relative include path. The
       # problem with this is that it is possible to emit multiple different
       # resolved paths to the same file, depending on exactly how its included.

--- a/contrib/single_file_libs/create_single_file_library.sh
+++ b/contrib/single_file_libs/create_single_file_library.sh
@@ -5,7 +5,7 @@ ZSTD_SRC_ROOT="../../lib"
 
 # Amalgamate the sources
 echo "Amalgamating files... this can take a while"
-./combine.sh -r "$ZSTD_SRC_ROOT" -k zstd.h -o zstd.c zstd-in.c
+./combine.sh -r "$ZSTD_SRC_ROOT" -o zstd.c zstd-in.c
 # Did combining work?
 if [ $? -ne 0 ]; then
   echo "Combine script: FAILED"

--- a/contrib/single_file_libs/zstd-in.c
+++ b/contrib/single_file_libs/zstd-in.c
@@ -4,7 +4,7 @@
  *
  * Generate using:
  * \code
- *	combine.sh -r ../../lib -k zstd.h -o zstd.c zstd-in.c
+ *	combine.sh -r ../../lib -o zstd.c zstd-in.c
  * \endcode
  */
 /*


### PR DESCRIPTION
Since #2103 the generated file sizes are much larger on macOS (and any other environment where `realpath` is missing). This adds a Python fallback to bring the file sizes back to what they were.