### PR TITLE
fix 22294 & 22262

### DIFF
--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -398,7 +398,7 @@ static size_t ZSTD_compressBlock_fast_extDict_generic(
     const BYTE* const ilimit = iend - 8;
     U32 offset_1=rep[0], offset_2=rep[1];
 
-    DEBUGLOG(5, "ZSTD_compressBlock_fast_extDict_generic");
+    DEBUGLOG(5, "ZSTD_compressBlock_fast_extDict_generic (offset_1=%u)", offset_1);
 
     /* switch to "regular" variant if extDict is invalidated due to maxDistance */
     if (prefixStartIndex == dictStartIndex)
@@ -415,6 +415,7 @@ static size_t ZSTD_compressBlock_fast_extDict_generic(
         const BYTE* const repBase = repIndex < prefixStartIndex ? dictBase : base;
         const BYTE* const repMatch = repBase + repIndex;
         hashTable[h] = current;   /* update hash table */
+        DEBUGLOG(7, "offset_1 = %u , current = %u", offset_1, current);
         assert(offset_1 <= current +1);   /* check repIndex */
 
         if ( (((U32)((prefixStartIndex-1) - repIndex) >= 3) /* intentional underflow */ & (repIndex > dictStartIndex))

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -228,6 +228,7 @@ void ZSTD_ldm_fillHashTable(
             ldmState_t* state, const BYTE* ip,
             const BYTE* iend, ldmParams_t const* params)
 {
+    DEBUGLOG(5, "ZSTD_ldm_fillHashTable");
     if ((size_t)(iend - ip) >= params->minMatchLength) {
         U64 startingHash = ZSTD_rollingHash_compute(ip, params->minMatchLength);
         ZSTD_ldm_fillLdmHashTable(
@@ -594,7 +595,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         ZSTD_ldm_limitTableUpdate(ms, ip);
         ZSTD_ldm_fillFastTables(ms, ip);
         /* Run the block compressor */
-        DEBUGLOG(5, "calling block compressor on segment of size %u", sequence.litLength);
+        DEBUGLOG(5, "pos %u : calling block compressor on segment of size %u", (unsigned)(ip-istart), sequence.litLength);
         {
             size_t const newLitLength =
                 blockCompressor(ms, seqStore, rep, ip, sequence.litLength);

--- a/tests/fuzz/.gitignore
+++ b/tests/fuzz/.gitignore
@@ -5,6 +5,8 @@ block_round_trip
 dictionary_decompress
 dictionary_loader
 dictionary_round_trip
+dictionary_stream_round_trip
+raw_dictionary_round_trip
 simple_compress
 simple_decompress
 simple_round_trip
@@ -12,3 +14,7 @@ stream_decompress
 stream_round_trip
 zstd_frame_info
 fuzz-*.log
+
+# misc
+trace
+tmp*


### PR DESCRIPTION
Issue 22294, firing `assert(offset_1 <= current +1)` within `compress_fast_extDict()`,
and issue 22262, firing `assert(offset_1 <= dictAndPrefixLength)` within `compress_fast_dictMatchState()`,
are actually a consequence of a new behavior enabled within `ldm`, that has become possible since the new `--patch-from` capability (and therefore not present in earlier versions) : 

- Previously, `ldm` would not load any dictionary when in multithreading mode
   + This is still the case when using the "one-ingestion" strategy
- This has been updated as part of the [`--patch-from` capability](https://github.com/facebook/zstd/blame/dev/lib/compress/zstdmt_compress.c#L1519)
   + Loading the dictionary into the `ldm` is necessary in order to catch long-distance correlations
   + Note that only the "streaming" mode has been updated, as it's the only mode relevant for `--patch-from`
- However, there is a subtle twist : this patch makes the `ldm` ingest the full dictionary as a content, irrespective of being a "raw" dictionary (only content) or a "full" dictionary (header and entropy tables)
   + As a consequence, when the dictionary is "full", the `ldm` loads entropy tables as "content", and may be able to find matches into them (just as a matter of random luck)
   + Once the `ldm` has found such a match, it passes the following literals section to the _regular_ match finder (`compress_fast()` in this case), where the previous offset is passed as repeat code
   + the previous offset now leads _beyond_ the dictionary content, which was properly loaded into the regular match finder. As a consequence, the offset _underflows_ the index.
   + this is caught by the `assert()`. Without  the `assert()`, the resulting pointer is invalid, and result in a segfault.

This PR makes the minimum to control the damage : 
Now `ldm` only loads the dictionary _if_ it is labelled a "raw" dictionary, as it is the only case which matters for `--patch-from`. If the dictionary is labelled "auto" or "full", it is not loaded at all.
This was the behavior of `ldm` before the `--patch-from` mode.
It also avoids expanding the scope and creating new scenarios, that would have to be fuzzed.

This PR doesn't have a test case attached.
It's a bit tricky to generate, as it requires a "full" dictionary, with a matching pattern directly in the encoded entropy section of the header (which looks like random bytes), so it's unclear how to generate this case intentionally.

But we can add the known cases as "golden files" to our regression corpus.