### PR TITLE
[ldm][mt] Fix loadedDictEnd

### DIFF
--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -513,6 +513,7 @@ ZSTDMT_serialState_reset(serialState_t* serialState,
         memset(serialState->ldmState.bucketOffsets, 0, bucketSize);
 
         /* Update window state and fill hash table with dict */
+        serialState->ldmState.loadedDictEnd = 0;
         if (dictSize > 0) {
             if (dictContentType == ZSTD_dct_rawContent) {
                 BYTE const* const dictEnd = (const BYTE*)dict + dictSize;
@@ -526,9 +527,6 @@ ZSTDMT_serialState_reset(serialState_t* serialState,
 
         /* Initialize serialState's copy of ldmWindow. */
         serialState->ldmWindow = serialState->ldmState.window;
-    }
-
-    if (params.ldmParams.enableLdm && dict) {
     }
 
     serialState->params = params;


### PR DESCRIPTION
Missed 1 place to reset the `loadedDictEnd` in PR #2150.

Test Plan:
```
./zstreamtest --newapi -vv -i75205 -s4067 -t75156
./zstreamtest --newapi -vv -i1861 -s5681 -t1792
./zstreamtest --newapi -vv -i1937 -s7232 -t1845
```