### PR TITLE
Fix legacy build after #2103

### DIFF
--- a/lib/legacy/zstd_v04.c
+++ b/lib/legacy/zstd_v04.c
@@ -74,7 +74,7 @@ extern "C" {
 /*-*************************************
 *  Debug
 ***************************************/
-#include "debug.h"
+#include "../common/debug.h"
 #ifndef assert
 #  define assert(condition) ((void)0)
 #endif


### PR DESCRIPTION
Fixes this error when building with `make ZSTD_LEGACY_SUPPORT=1`:

```
legacy/zstd_v04.c:77:10: fatal error: debug.h: No such file or directory                                                     
   77 | #include "debug.h"                                                                                                   
```