### PR TITLE
do not install zbuff.h

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -152,9 +152,7 @@ endif ()
 # install target
 install(FILES
     "${LIBRARY_DIR}/zstd.h"
-    "${LIBRARY_DIR}/deprecated/zbuff.h"
     "${LIBRARY_DIR}/dictBuilder/zdict.h"
-    "${LIBRARY_DIR}/dictBuilder/cover.h"
     "${LIBRARY_DIR}/common/zstd_errors.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 

--- a/build/meson/lib/meson.build
+++ b/build/meson/lib/meson.build
@@ -127,6 +127,5 @@ pkgconfig.generate(libzstd,
   url: 'http://www.zstd.net/')
 
 install_headers(join_paths(zstd_rootdir, 'lib/zstd.h'),
-  join_paths(zstd_rootdir, 'lib/deprecated/zbuff.h'),
   join_paths(zstd_rootdir, 'lib/dictBuilder/zdict.h'),
   join_paths(zstd_rootdir, 'lib/common/zstd_errors.h'))

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -336,7 +336,6 @@ install-includes:
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(INCLUDEDIR)/
 	$(Q)$(INSTALL_DATA) zstd.h $(DESTDIR)$(INCLUDEDIR)
 	$(Q)$(INSTALL_DATA) common/zstd_errors.h $(DESTDIR)$(INCLUDEDIR)
-	$(Q)$(INSTALL_DATA) deprecated/zbuff.h $(DESTDIR)$(INCLUDEDIR)     # prototypes generate deprecation warnings
 	$(Q)$(INSTALL_DATA) dictBuilder/zdict.h $(DESTDIR)$(INCLUDEDIR)
 
 uninstall:
@@ -347,7 +346,6 @@ uninstall:
 	$(Q)$(RM) $(DESTDIR)$(PKGCONFIGDIR)/libzstd.pc
 	$(Q)$(RM) $(DESTDIR)$(INCLUDEDIR)/zstd.h
 	$(Q)$(RM) $(DESTDIR)$(INCLUDEDIR)/zstd_errors.h
-	$(Q)$(RM) $(DESTDIR)$(INCLUDEDIR)/zbuff.h   # Deprecated streaming functions
 	$(Q)$(RM) $(DESTDIR)$(INCLUDEDIR)/zdict.h
 	@echo zstd libraries successfully uninstalled
 


### PR DESCRIPTION
this API is deprecated, for a loong time now,
all related symbols will be removed in a future version (likely v1.5.0)
and the header `zbuff.h` doesn't compile from `include/` anyway,
because it needs to be positioned one directory below `zstd.h`.

Also removed `cover.h` from `cmake` installer,
as it should have never been part of this list to begin with.

Fix #2161