### PR TITLE
fix generalization of pattern rules in lib/Makefile

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -221,14 +221,14 @@ libzstd : $(LIBZSTD)
 lib : libzstd.a libzstd
 
 .PHONY: lib-mt
-%-mt : CPPFLAGS += -DZSTD_MULTITHREAD
-%-mt : LDFLAGS  += -pthread
-%-mt : %
+% : CPPFLAGS += -DZSTD_MULTITHREAD
+% : LDFLAGS  += -pthread
+% : lib
 	@echo multi-threading build completed
 
 .PHONY: lib-release
-%-release : DEBUGFLAGS :=
-%-release : %
+% : DEBUGFLAGS :=
+% : lib
 	@echo release build completed
 
 


### PR DESCRIPTION
This was introduced in v1.4.4-383-gf77fd5ce
and results in the default rule in lib/ doing nothing.