### PR TITLE
fixed default rule for lib/Makefile

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -220,13 +220,14 @@ libzstd : $(LIBZSTD)
 .PHONY: lib
 lib : libzstd.a libzstd
 
-.PHONY: lib-mt
+# note : do not define lib-mt or lib-release as .PHONY
+# make does not consider implicit pattern rule for .PHONY target
+
 %-mt : CPPFLAGS += -DZSTD_MULTITHREAD
 %-mt : LDFLAGS  += -pthread
 %-mt : %
 	@echo multi-threading build completed
 
-.PHONY: lib-release
 %-release : DEBUGFLAGS :=
 %-release : %
 	@echo release build completed


### PR DESCRIPTION
rule `lib-release` wasn't working : it was just skipped.
Same for `lib-mt`.

Removing them from the list of `.PHONY` targets fixes it.

fix #2175 
