### PR TITLE
Change --patch-from limit from 4gb to 2gb

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -771,9 +771,10 @@ static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
                                     unsigned long long const maxSrcFileSize)
 {
     unsigned long long maxSize = MAX(prefs->memLimit, MAX(dictSize, maxSrcFileSize));
+    unsigned const maxWindowSize = (1U << ZSTD_WINDOWLOG_MAX);
     assert(maxSize != UTIL_FILESIZE_UNKNOWN);
-    if (maxSize > INT_MAX)
-        EXM_THROW(42, "Can't handle files larger than %u GB\n", INT_MAX/(1 GB) + 1);
+    if (maxSize > maxWindowSize)
+        EXM_THROW(42, "Can't handle files larger than %u GB\n", maxWindowSize/(1 GB));
     FIO_setMemLimit(prefs, (unsigned)maxSize);
 }
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -772,8 +772,8 @@ static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
 {
     unsigned long long maxSize = MAX(prefs->memLimit, MAX(dictSize, maxSrcFileSize));
     assert(maxSize != UTIL_FILESIZE_UNKNOWN);
-    if (maxSize > UINT_MAX)
-        EXM_THROW(42, "Can't handle files larger than %u GB\n", UINT_MAX/(1 GB) + 1);
+    if (maxSize > INT_MAX)
+        EXM_THROW(42, "Can't handle files larger than %u GB\n", INT_MAX/(1 GB) + 1);
     FIO_setMemLimit(prefs, (unsigned)maxSize);
 }
 


### PR DESCRIPTION
The effective limit was 2GB but the enforced limit was 4GB. Fixing the inconsistency. I see that there is another issue (https://github.com/facebook/zstd/issues/2173) open about increasing the limit all together. If we go down that route, that'll be a different pr. 

Test plan
```
$ make -C tests datagen
$ tests/datagen -g3000000000 > large-data
$ cp large-data large-dict
$ make -j
$ ./zstd --patch-from=large-dict large-data -o /dev/null
zstd: error 42 : Can't handle files larger than 2 GB
```