### PR TITLE
[ci] Adding bourne shell compatibility test

### DIFF
--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -170,3 +170,13 @@ jobs:
         # sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix; (doesn't work)
         sudo apt-get install gcc-mingw-w64
         CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CFLAGS="-Werror -O1" make zstd
+
+  bourne-shell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Bourne shell compatibility (shellcheck)
+      run: |
+        wget https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz
+        tar -xf shellcheck-v0.7.1.linux.x86_64.tar.xz
+        shellcheck-v0.7.1/shellcheck --shell=sh --severity=warning tests/playTests.sh

--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -6,20 +6,20 @@ on:
 
 jobs:
 
-# Dev PR jobs that still have to be migrated from travis 
-# 
+# Dev PR jobs that still have to be migrated from travis
+#
 # icc (need self-hosted)
 # arm/qemu-arm (need self-hosted)
-# versionTag 
+# versionTag
 # valgrindTest (keeps failing for some reason. need investigation)
 # staticAnalyze (need trusty so need self-hosted)
 # pcc-fuzz: (need trusty so need self-hosted)
 # arm-build-test (need self-hosted)
-# 
-# setting up self-hosted is pretty straightforward, but 
+#
+# setting up self-hosted is pretty straightforward, but
 # I need admins permissions to the repo for that it looks like
 # So I'm tabling that for now
-# 
+#
 # The master branch exclusive jobs will be in a separate
 # workflow file (the osx tests and meson build that is)
 
@@ -29,14 +29,14 @@ jobs:
     - uses: actions/checkout@v2
     - name: make benchmarking
       run: make benchmarking
-      
+
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: make test 
-      run: make test 
-  
+    - name: make test
+      run: make test
+
   gcc-6-7-libzstd:
     runs-on: ubuntu-latest
     steps:
@@ -50,18 +50,18 @@ jobs:
         make clean
         LDFLAGS=-Wl,--no-undefined make -C lib libzstd-mt
         make -C tests zbufftest-dll
-    
+
   gcc-8-asan-ubsan-testzstd:
-    runs-on: ubuntu-16.04 # fails on 18.04 
+    runs-on: ubuntu-16.04 # fails on 18.04
     steps:
     - uses: actions/checkout@v2
-    - name: gcc-8 + ASan + UBSan + Test Zstd 
-      run: | 
+    - name: gcc-8 + ASan + UBSan + Test Zstd
+      run: |
         make gcc8install
         CC=gcc-8 CFLAGS="-Werror" make -j all
         make clean
         CC=gcc-8 make -j uasan-test-zstd </dev/null
-        
+
   gcc-6-asan-ubsan-testzstd-32bit:
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
         CC=gcc-6 make -j uasan-test-zstd32
 
   clang-38-msan-testzstd:
-    runs-on: ubuntu-16.04 # fails on 18.04 
+    runs-on: ubuntu-16.04 # fails on 18.04
     steps:
     - uses: actions/checkout@v2
     - name: clang-3.8 + MSan + Test Zstd
@@ -86,7 +86,7 @@ jobs:
         CC=clang-3.8 make clean msan-test-zstd HAVE_ZLIB=0 HAVE_LZ4=0 HAVE_LZMA=0
 
   min-decomp-macros:
-    runs-on: ubuntu-16.04 # fails on 18.04 
+    runs-on: ubuntu-16.04 # fails on 18.04
     steps:
     - uses: actions/checkout@v2
     - name: Minimal Decompressor Macros
@@ -146,7 +146,7 @@ jobs:
         make -j uasanregressiontest
         make clean
         make -j msanregressiontest
-        
+
   cpp-gnu90-c99-compatibility:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -179,4 +179,4 @@ jobs:
       run: |
         wget https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz
         tar -xf shellcheck-v0.7.1.linux.x86_64.tar.xz
-        shellcheck-v0.7.1/shellcheck --shell=sh --severity=warning tests/playTests.sh
+        shellcheck-v0.7.1/shellcheck --shell=sh --severity=warning --exclude=SC2010 tests/playTests.sh

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -8,22 +8,22 @@ die() {
 }
 
 datagen() {
-    "$DATAGEN_BIN" $@
+    "$DATAGEN_BIN" "$@"
 }
 
 zstd() {
     if [ -z "$EXEC_PREFIX" ]; then
-        "$ZSTD_BIN" $@
+        "$ZSTD_BIN" "$@"
     else
-        "$EXEC_PREFIX" "$ZSTD_BIN" $@
+        "$EXEC_PREFIX" "$ZSTD_BIN" "$@"
     fi
 }
 
 sudoZstd() {
     if [ -z "$EXEC_PREFIX" ]; then
-        sudo "$ZSTD_BIN" $@
+        sudo "$ZSTD_BIN" "$@"
     else
-        sudo "$EXEC_PREFIX" "$ZSTD_BIN" $@
+        sudo "$EXEC_PREFIX" "$ZSTD_BIN" "$@"
     fi
 }
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -78,6 +78,11 @@ println() {
     printf '%b\n' "${*}"
 }
 
+if [ -z "${size}" ]; then
+    size=
+else
+    size=${size}
+fi
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PRGDIR="$SCRIPT_DIR/../programs"


### PR DESCRIPTION
Closes https://github.com/facebook/zstd/issues/2149

I'm using [shellcheck](https://github.com/koalaman/shellcheck#from-your-terminal) to check compatibility with bourne shell explicitly. I confirmed that this catches the incompatibility that was missed in the previous release (https://github.com/facebook/zstd/pull/2148): 

```
In tests/playTests.sh line 270:
if [[ $file2timestamp -ge $file1timestamp ]]; then
   ^-- SC2039: In POSIX sh, [[ ]] is undefined.
```

It also discovered 3 other warnings. Two of them were good suggestions so I fixed them. One of them isn't worth fixing imo so I suppressed it using shellcheck --exclude. This is the warning I excluded

```
In tests/playTests.sh line 401:
    ls -las $INTOVOID | grep "rw-rw-rw-"
    ^-- SC2010: Don't use ls | grep. Use a glob or a for loop with a condition to allow non-alphanumeric filenames.
``` 
