### PR TITLE
Check environmental variables in playTests.sh and add default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Going into `build` directory, you will find additional possibilities:
 You can build the zstd binary via buck by executing: `buck build programs:zstd` from the root of the repo.
 The output binary will be in `buck-out/gen/programs/`.
 
+## Testing
+
+You can run quick local smoke tests by executing the `playTest.sh` script from the `src/tests` directory.
+Two env variables `$ZSTD_BIN` and `$DATAGEN_BIN` are needed for the test script to locate the zstd and datagen binary.
+For information on CI testing, please refer to TESTING.md
+
 ## Status
 
 Zstandard is currently deployed within Facebook. It is used continuously to compress large amounts of data in multiple formats and use cases.

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -128,10 +128,25 @@ case "$UNAME" in
   SunOS) DIFF="gdiff" ;;
 esac
 
-println "\nStarting playTests.sh isWindows=$isWindows EXE_PREFIX='$EXE_PREFIX' ZSTD_BIN='$ZSTD_BIN' DATAGEN_BIN='$DATAGEN_BIN'"
 
-[ -n "$ZSTD_BIN" ] || die "\$ZSTD_BIN variable must be defined!"
-[ -n "$DATAGEN_BIN" ] || die "\$DATAGEN_BIN variable must be defined!"
+# check if ZSTD_BIN is defined. if not, use the default value
+if [[ -z "${ZSTD_BIN}" ]]; then
+  println "\nZSTD_BIN is not set. Using the default value..."
+  ZSTD_BIN="$PRGDIR/zstd"
+fi
+
+# check if DATAGEN_BIN is defined. if not, use the default value
+if [[ -z "${DATAGEN_BIN}" ]]; then
+  println "\nDATAGEN_BIN is not set. Using the default value..."
+  DATAGEN_BIN="$TESTDIR/datagen"
+fi
+
+ZSTD_BIN="$EXE_PREFIX$ZSTD_BIN"
+
+# assertions
+[ -n "$ZSTD_BIN" ] || die "zstd not found at $ZSTD_BIN! \n Please define ZSTD_BIN pointing to the zstd binary. You might also consider rebuilding zstd follwing the instructions in README.md"
+[ -n "$DATAGEN_BIN" ] || die "datagen not found at $DATAGEN_BIN! \n Please define DATAGEN_BIN pointing to the datagen binary. You might also consider rebuilding zstd tests following the instructions in README.md. "
+println "\nStarting playTests.sh isWindows=$isWindows EXE_PREFIX='$EXE_PREFIX' ZSTD_BIN='$ZSTD_BIN' DATAGEN_BIN='$DATAGEN_BIN'"
 
 if echo hello | zstd -v -T2 2>&1 > $INTOVOID | grep -q 'multi-threading is disabled'
 then

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -130,13 +130,13 @@ esac
 
 
 # check if ZSTD_BIN is defined. if not, use the default value
-if [[ -z "${ZSTD_BIN}" ]]; then
+if [ -z "${ZSTD_BIN}" ]; then
   println "\nZSTD_BIN is not set. Using the default value..."
   ZSTD_BIN="$PRGDIR/zstd"
 fi
 
 # check if DATAGEN_BIN is defined. if not, use the default value
-if [[ -z "${DATAGEN_BIN}" ]]; then
+if [ -z "${DATAGEN_BIN}" ]; then
   println "\nDATAGEN_BIN is not set. Using the default value..."
   DATAGEN_BIN="$TESTDIR/datagen"
 fi


### PR DESCRIPTION
Improved zstd test script by making it more intuitive.
- Provided default values for both ZSTD_BIN and DATAGEN_BIN
- Added more actionable error messages in the script
- Added instructions for local testing in README