### PR TITLE
Make --version respect -q for ouptut a shorter version string

### DIFF
--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -238,6 +238,7 @@ the last one takes effect.
     display version number and exit.
     Advanced : `-vV` also displays supported formats.
     `-vvV` also displays POSIX support.
+    `-q` will only display the version number, suitable for machine reading.
 * `-v`, `--verbose`:
     verbose mode
 * `--show-default-cparams`:

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -544,6 +544,11 @@ static unsigned parseCompressionParameters(const char* stringPtr, ZSTD_compressi
 
 static void printVersion(void)
 {
+    if (g_displayLevel < DISPLAY_LEVEL_DEFAULT) {
+        DISPLAYOUT("%s\n", ZSTD_VERSION_STRING);
+        return;
+    }
+
     DISPLAYOUT(WELCOME_MESSAGE);
     if (g_displayLevel >= 3) {
     /* format support */


### PR DESCRIPTION
This makes it easier to parse the version of zstd
we have instead of having to run a regex to parse
the WELCOME_MESSAGE

This was needed because we wanted to detect if
--patch-from was supported or not.