### PR TITLE
Dedicated dict search rough draft 1

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3479,10 +3479,13 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dict
 {
     int const enableDedicatedDictSearch = cctxParams->enableDedicatedDictSearch &&
         ZSTD_dedicatedDictSearch_isSupported(cctxParams->compressionLevel, dictSize);
-    if (!enableDedicatedDictSearch)
+    if (!enableDedicatedDictSearch) {
+        ZSTD_compressionParameters cParams = ZSTD_getCParams_internal(
+            cctxParams->compressionLevel, ZSTD_CONTENTSIZE_UNKNOWN, dictSize);
         return ZSTD_createCDict_advanced(dict, dictSize,
-            dictLoadMethod, dictContentType, cctxParams->cParams,
+            dictLoadMethod, dictContentType, cParams,
             customMem);
+    }
     {
         ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
             cctxParams->compressionLevel, dictSize);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2887,7 +2887,9 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
         case ZSTD_greedy:
         case ZSTD_lazy:
         case ZSTD_lazy2:
-            if (chunk >= HASH_READ_SIZE)
+            if (chunk >= HASH_READ_SIZE && params->enableDedicatedDictSearch)
+                ZSTD_lazy_loadDictionary(ms, ichunk-HASH_READ_SIZE);
+            else if (chunk >= HASH_READ_SIZE)
                 ZSTD_insertAndFindFirstIndex(ms, ichunk-HASH_READ_SIZE);
             break;
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3469,6 +3469,26 @@ ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t dictSize,
     }
 }
 
+ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
+                                                  ZSTD_dictLoadMethod_e dictLoadMethod,
+                                                  ZSTD_dictContentType_e dictContentType,
+                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_customMem customMem)
+{
+    int const enableDedicatedDictSearch = cctxParams.enableDedicatedDictSearch &&
+        ZSTD_dedicatedDictSearch_isSupported(cctxParams.compressionLevel, dictSize);
+    if (!enableDedicatedDictSearch)
+        return ZSTD_createCDict_advanced(dict, dictSize,
+            dictLoadMethod, dictContentType, cctxParams.cParams,
+            customMem);
+    {
+        ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
+            cctxParams.compressionLevel, dictSize);
+        return ZSTD_createCDict_advanced(dict, dictSize,
+            dictLoadMethod, dictContentType, cParams, customMem);
+    }
+}
+
 ZSTD_CDict* ZSTD_createCDict(const void* dict, size_t dictSize, int compressionLevel)
 {
     ZSTD_compressionParameters cParams = ZSTD_getCParams_internal(compressionLevel, ZSTD_CONTENTSIZE_UNKNOWN, dictSize);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3380,7 +3380,8 @@ static size_t ZSTD_initCDict_internal(
               const void* dictBuffer, size_t dictSize,
                     ZSTD_dictLoadMethod_e dictLoadMethod,
                     ZSTD_dictContentType_e dictContentType,
-                    ZSTD_compressionParameters cParams)
+                    ZSTD_compressionParameters cParams,
+                    ZSTD_CCtx_params params)
 {
     DEBUGLOG(3, "ZSTD_initCDict_internal (dictContentType:%u)", (unsigned)dictContentType);
     assert(!ZSTD_checkCParams(cParams));
@@ -3410,9 +3411,7 @@ static size_t ZSTD_initCDict_internal(
     /* (Maybe) load the dictionary
      * Skips loading the dictionary if it is < 8 bytes.
      */
-    {   ZSTD_CCtx_params params;
-        memset(&params, 0, sizeof(params));
-        params.compressionLevel = ZSTD_CLEVEL_DEFAULT;
+    {   params.compressionLevel = ZSTD_CLEVEL_DEFAULT;
         params.fParams.contentSizeFlag = 1;
         params.cParams = cParams;
         {   size_t const dictID = ZSTD_compress_insertDictionary(
@@ -3428,12 +3427,10 @@ static size_t ZSTD_initCDict_internal(
     return 0;
 }
 
-ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t dictSize,
+static ZSTD_CDict* ZSTD_createCDict_advanced_internal(size_t dictSize,
                                       ZSTD_dictLoadMethod_e dictLoadMethod,
-                                      ZSTD_dictContentType_e dictContentType,
                                       ZSTD_compressionParameters cParams, ZSTD_customMem customMem)
 {
-    DEBUGLOG(3, "ZSTD_createCDict_advanced, mode %u", (unsigned)dictContentType);
     if (!customMem.customAlloc ^ !customMem.customFree) return NULL;
 
     {   size_t const workspaceSize =
@@ -3459,16 +3456,36 @@ ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t dictSize,
         cdict->customMem = customMem;
         cdict->compressionLevel = 0; /* signals advanced API usage */
 
+        return cdict;
+    }
+}
+
+ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t dictSize,
+                                      ZSTD_dictLoadMethod_e dictLoadMethod,
+                                      ZSTD_dictContentType_e dictContentType,
+                                      ZSTD_compressionParameters cParams, ZSTD_customMem customMem)
+{
+    DEBUGLOG(3, "ZSTD_createCDict_advanced, mode %u", (unsigned)dictContentType);
+    if (!customMem.customAlloc ^ !customMem.customFree) return NULL;
+
+    {   ZSTD_CDict* cdict = ZSTD_createCDict_advanced_internal(dictSize,
+                            dictLoadMethod, cParams,
+                            customMem);
+
+        ZSTD_CCtx_params params;
+        memset(&params, 0, sizeof(params));
+
         if (ZSTD_isError( ZSTD_initCDict_internal(cdict,
                                         dictBuffer, dictSize,
                                         dictLoadMethod, dictContentType,
-                                        cParams) )) {
+                                        cParams, params) )) {
             ZSTD_freeCDict(cdict);
             return NULL;
         }
 
         return cdict;
     }
+
 }
 
 ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
@@ -3486,12 +3503,21 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dict
             dictLoadMethod, dictContentType, cParams,
             customMem);
     }
-    {
-        ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
+    {   ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
             cctxParams->compressionLevel, dictSize);
-        ZSTD_CDict* const cdict = ZSTD_createCDict_advanced(dict, dictSize,
-            dictLoadMethod, dictContentType, cParams, customMem);
+        ZSTD_CDict* cdict = ZSTD_createCDict_advanced_internal(dictSize,
+                            dictLoadMethod, cParams,
+                            customMem);
         cdict->matchState.enableDedicatedDictSearch = enableDedicatedDictSearch;
+
+        if (ZSTD_isError( ZSTD_initCDict_internal(cdict,
+                                        dict, dictSize,
+                                        dictLoadMethod, dictContentType,
+                                        cParams, *cctxParams) )) {
+            ZSTD_freeCDict(cdict);
+            return NULL;
+        }
+
         return cdict;
     }
 }
@@ -3570,10 +3596,13 @@ const ZSTD_CDict* ZSTD_initStaticCDict(
         (unsigned)workspaceSize, (unsigned)neededSize, (unsigned)(workspaceSize < neededSize));
     if (workspaceSize < neededSize) return NULL;
 
+    ZSTD_CCtx_params params;
+    memset(&params, 0, sizeof(params));
+
     if (ZSTD_isError( ZSTD_initCDict_internal(cdict,
                                               dict, dictSize,
                                               dictLoadMethod, dictContentType,
-                                              cParams) ))
+                                              cParams, params) ))
         return NULL;
 
     return cdict;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3484,8 +3484,10 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dict
     {
         ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
             cctxParams.compressionLevel, dictSize);
-        return ZSTD_createCDict_advanced(dict, dictSize,
+        ZSTD_CDict* const cdict = ZSTD_createCDict_advanced(dict, dictSize,
             dictLoadMethod, dictContentType, cParams, customMem);
+        cdict->matchState.enableDedicatedDictSearch = enableDedicatedDictSearch;
+        return cdict;
     }
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4241,6 +4241,114 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
 },
 };
 
+static const ZSTD_compressionParameters
+ZSTD_dedicatedDictSearch_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
+{   /* "default" - for any dictSize > 256 KB */
+    /* W,  C,  H,  S,  L, TL, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  4 (not adjusted) */
+    { 21, 18, 19 + DD_BLOG,  2,  5,  2, ZSTD_greedy  },  /* level  5 */
+    { 21, 19, 19 + DD_BLOG,  3,  5,  4, ZSTD_greedy  },  /* level  6 */
+    { 21, 19, 19 + DD_BLOG,  3,  5,  8, ZSTD_lazy    },  /* level  7 */
+    { 21, 19, 19 + DD_BLOG,  3,  5, 16, ZSTD_lazy2   },  /* level  8 */
+    { 21, 19, 20 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level  9 */
+    { 22, 20, 21 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level 10 */
+    { 22, 21, 22 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level 11 */
+    { 22, 21, 22 + DD_BLOG,  5,  5, 16, ZSTD_lazy2   },  /* level 12 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+},
+{   /* for dictSize <= 256 KB */
+    /* W,  C,  H,  S,  L,  T, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 18, 16, 17 + DD_BLOG,  2,  5,  2, ZSTD_greedy  },  /* level  4 */
+    { 18, 18, 18 + DD_BLOG,  3,  5,  2, ZSTD_greedy  },  /* level  5 */
+    { 18, 18, 19 + DD_BLOG,  3,  5,  4, ZSTD_lazy    },  /* level  6 */
+    { 18, 18, 19 + DD_BLOG,  4,  4,  4, ZSTD_lazy    },  /* level  7 */
+    { 18, 18, 19 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 18, 18, 19 + DD_BLOG,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 18, 18, 19 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+},
+{   /* for dictSize <= 128 KB */
+    /* W,  C,  H,  S,  L,  T, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  4 (not adjusted) */
+    { 17, 16, 17 + DD_BLOG,  3,  4,  2, ZSTD_greedy  },  /* level  5 */
+    { 17, 17, 17 + DD_BLOG,  3,  4,  4, ZSTD_lazy    },  /* level  6 */
+    { 17, 17, 17 + DD_BLOG,  3,  4,  8, ZSTD_lazy2   },  /* level  7 */
+    { 17, 17, 17 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 17, 17, 17 + DD_BLOG,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 17, 17, 17 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+},
+{   /* for dictSize <= 16 KB */
+    /* W,  C,  H,  S,  L,  T, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 14, 14, 14 + DD_BLOG,  4,  4,  2, ZSTD_greedy  },  /* level  4 */
+    { 14, 14, 14 + DD_BLOG,  3,  4,  4, ZSTD_lazy    },  /* level  5 */
+    { 14, 14, 14 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  6 */
+    { 14, 14, 14 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level  7 */
+    { 14, 14, 14 + DD_BLOG,  8,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  9 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  10 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level  22 (not adjusted) */
+},
+};
+
 /*! ZSTD_getCParams_internal() :
  * @return ZSTD_compressionParameters structure for a selected compression level, srcSize and dictSize.
  *  Note: srcSizeHint 0 means 0, use ZSTD_CONTENTSIZE_UNKNOWN for unknown.

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2888,7 +2888,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
         case ZSTD_lazy:
         case ZSTD_lazy2:
             if (chunk >= HASH_READ_SIZE && params->enableDedicatedDictSearch)
-                ZSTD_lazy_loadDictionary(ms, ichunk-HASH_READ_SIZE);
+                ZSTD_dedicatedDictSearch_lazy_loadDictionary(ms, ichunk-HASH_READ_SIZE);
             else if (chunk >= HASH_READ_SIZE)
                 ZSTD_insertAndFindFirstIndex(ms, ichunk-HASH_READ_SIZE);
             break;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3474,18 +3474,18 @@ ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t dictSize,
 ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,
                                                   ZSTD_dictContentType_e dictContentType,
-                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_CCtx_params* cctxParams,
                                                   ZSTD_customMem customMem)
 {
-    int const enableDedicatedDictSearch = cctxParams.enableDedicatedDictSearch &&
-        ZSTD_dedicatedDictSearch_isSupported(cctxParams.compressionLevel, dictSize);
+    int const enableDedicatedDictSearch = cctxParams->enableDedicatedDictSearch &&
+        ZSTD_dedicatedDictSearch_isSupported(cctxParams->compressionLevel, dictSize);
     if (!enableDedicatedDictSearch)
         return ZSTD_createCDict_advanced(dict, dictSize,
-            dictLoadMethod, dictContentType, cctxParams.cParams,
+            dictLoadMethod, dictContentType, cctxParams->cParams,
             customMem);
     {
         ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
-            cctxParams.compressionLevel, dictSize);
+            cctxParams->compressionLevel, dictSize);
         ZSTD_CDict* const cdict = ZSTD_createCDict_advanced(dict, dictSize,
             dictLoadMethod, dictContentType, cParams, customMem);
         cdict->matchState.enableDedicatedDictSearch = enableDedicatedDictSearch;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -354,6 +354,11 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
 #endif
         return bounds;
 
+    case ZSTD_c_enableDedicatedDictSearch:
+        bounds.lowerBound = 0;
+        bounds.upperBound = 1;
+        return bounds;
+
     case ZSTD_c_enableLongDistanceMatching:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
@@ -465,6 +470,7 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     case ZSTD_c_jobSize:
     case ZSTD_c_overlapLog:
     case ZSTD_c_rsyncable:
+    case ZSTD_c_enableDedicatedDictSearch:
     case ZSTD_c_enableLongDistanceMatching:
     case ZSTD_c_ldmHashLog:
     case ZSTD_c_ldmMinMatch:
@@ -515,6 +521,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
     case ZSTD_c_jobSize:
     case ZSTD_c_overlapLog:
     case ZSTD_c_rsyncable:
+    case ZSTD_c_enableDedicatedDictSearch:
     case ZSTD_c_enableLongDistanceMatching:
     case ZSTD_c_ldmHashLog:
     case ZSTD_c_ldmMinMatch:
@@ -667,6 +674,10 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
         return CCtxParams->rsyncable;
 #endif
 
+    case ZSTD_c_enableDedicatedDictSearch :
+        CCtxParams->enableDedicatedDictSearch = (value!=0);
+        return CCtxParams->enableDedicatedDictSearch;
+
     case ZSTD_c_enableLongDistanceMatching :
         CCtxParams->ldmParams.enableLdm = (value!=0);
         return CCtxParams->ldmParams.enableLdm;
@@ -794,6 +805,9 @@ size_t ZSTD_CCtxParams_getParameter(
         *value = CCtxParams->rsyncable;
         break;
 #endif
+    case ZSTD_c_enableDedicatedDictSearch :
+        *value = CCtxParams->enableDedicatedDictSearch;
+        break;
     case ZSTD_c_enableLongDistanceMatching :
         *value = CCtxParams->ldmParams.enableLdm;
         break;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4385,8 +4385,8 @@ ZSTD_dedicatedDictSearch_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
 
 static ZSTD_compressionParameters ZSTD_dedicatedDictSearch_getCParams(int const compressionLevel, size_t const dictSize)
 {
-    size_t const tableID = (dictSize <= 256 KB) + (dictSize <= 128 KB) + (dictSize <= 16 KB);
-    size_t const row = compressionLevel;
+    int const tableID = (dictSize <= 256 KB) + (dictSize <= 128 KB) + (dictSize <= 16 KB);
+    int const row = compressionLevel;
     return ZSTD_dedicatedDictSearch_defaultCParameters[tableID][row];
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -864,6 +864,9 @@ ZSTDLIB_API size_t ZSTD_CCtx_setPledgedSrcSize(ZSTD_CCtx* cctx, unsigned long lo
     return 0;
 }
 
+static ZSTD_compressionParameters ZSTD_dedicatedDictSearch_getCParams(int const compressionLevel, size_t const dictSize);
+static int ZSTD_dedicatedDictSearch_isSupported(int const compressionLevel, size_t const dictSize);
+
 /**
  * Initializes the local dict using the requested parameters.
  * NOTE: This does not use the pledged src size, because it may be used for more
@@ -4348,6 +4351,19 @@ ZSTD_dedicatedDictSearch_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
     { 0,  0,  0,             0,  0,  0, 0            }   /* level  22 (not adjusted) */
 },
 };
+
+static ZSTD_compressionParameters ZSTD_dedicatedDictSearch_getCParams(int const compressionLevel, size_t const dictSize)
+{
+    size_t const tableID = (dictSize <= 256 KB) + (dictSize <= 128 KB) + (dictSize <= 16 KB);
+    size_t const row = compressionLevel;
+    return ZSTD_dedicatedDictSearch_defaultCParameters[tableID][row];
+}
+
+static int ZSTD_dedicatedDictSearch_isSupported(int const compressionLevel, size_t const dictSize)
+{
+    ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(compressionLevel, dictSize);
+    return (cParams.strategy >= ZSTD_greedy) && (cParams.strategy <= ZSTD_lazy2);
+}
 
 /*! ZSTD_getCParams_internal() :
  * @return ZSTD_compressionParameters structure for a selected compression level, srcSize and dictSize.

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1639,7 +1639,11 @@ static int ZSTD_shouldAttachDict(const ZSTD_CDict* cdict,
                                  U64 pledgedSrcSize)
 {
     size_t cutoff = attachDictSizeCutoffs[cdict->matchState.cParams.strategy];
-    return ( pledgedSrcSize <= cutoff
+    int const useDedicatedDictSearch =
+        params->enableDedicatedDictSearch &&
+        ZSTD_dedicatedDictSearch_isSupported(params->compressionLevel, cdict->dictContentSize);
+    return ( useDedicatedDictSearch
+          || pledgedSrcSize <= cutoff
           || pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN
           || params->attachDictPref == ZSTD_dictForceAttach )
         && params->attachDictPref != ZSTD_dictForceCopy

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -153,6 +153,7 @@ struct ZSTD_matchState_t {
     U32* hashTable;
     U32* hashTable3;
     U32* chainTable;
+    int enableDedicatedDictSearch;
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -29,6 +29,12 @@ extern "C" {
 #endif
 
 
+/* Dedicated dict search bucket log:
+ * ---------------------------------
+ * This determines the additional space we need for the hash table.
+ * We will have 2^DD_BLOG slots in our bucket. */
+#define DD_BLOG 2
+
 /*-*************************************
 *  Constants
 ***************************************/

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -228,6 +228,9 @@ struct ZSTD_CCtx_params_s {
     /* Long distance matching parameters */
     ldmParams_t ldmParams;
 
+    /* Dedicated dict search algorithm trigger */
+    int enableDedicatedDictSearch;
+
     /* Internal use, for createCCtxParams() and freeCCtxParams() only */
     ZSTD_customMem customMem;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -475,7 +475,7 @@ U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip) {
     return ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, ms->cParams.minMatch);
 }
 
-void ZSTD_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip)
+void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip)
 {
     U32 const target = (U32)(ip - ms->window.base);
     U32* const chainTable = ms->chainTable;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -525,6 +525,11 @@ size_t ZSTD_HcFindBestMatch_generic (
     /* HC4 match finder */
     U32 matchIndex = ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, mls);
 
+    if (dictMode == ZSTD_dictMatchState && ms->dictMatchState->enableDedicatedDictSearch)
+        PREFETCH_L1(ms->dictMatchState->hashTable +
+            (ZSTD_hashPtr(ip, ms->dictMatchState->cParams.hashLog - DD_BLOG,
+            ms->dictMatchState->cParams.minMatch) << DD_BLOG));
+
     for ( ; (matchIndex>lowLimit) & (nbAttempts>0) ; nbAttempts--) {
         size_t currentMl=0;
         if ((dictMode != ZSTD_extDict) || matchIndex >= dictLimit) {

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -567,7 +567,8 @@ size_t ZSTD_HcFindBestMatch_generic (
         const U32 dmsMinChain = dmsSize > dmsChainSize ? dmsSize - dmsChainSize : 0;
         const U32 bucketSize           = (1 << DD_BLOG);
 
-        U32 hash = ZSTD_hashPtr(ip, dms->cParams.hashLog - DD_BLOG, mls) << DD_BLOG;
+        U32 hash = ZSTD_hashPtr(ip, dms->cParams.hashLog - DD_BLOG,
+            dms->cParams.minMatch) << DD_BLOG;
         U32 attemptNb = 0;
         matchIndex = dms->hashTable[hash];
 

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -19,7 +19,7 @@ extern "C" {
 
 U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip);
 
-void ZSTD_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip);
+void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip);
 
 void ZSTD_preserveUnsortedMark (U32* const table, U32 const size, U32 const reducerValue);  /*! used in ZSTD_reduceIndex(). preemptively increase value of ZSTD_DUBT_UNSORTED_MARK */
 

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -19,6 +19,8 @@ extern "C" {
 
 U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip);
 
+void ZSTD_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip);
+
 void ZSTD_preserveUnsortedMark (U32* const table, U32 const size, U32 const reducerValue);  /*! used in ZSTD_reduceIndex(). preemptively increase value of ZSTD_DUBT_UNSORTED_MARK */
 
 size_t ZSTD_compressBlock_btlazy2(

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1400,6 +1400,12 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced(const void* dict, size_t dictS
                                                   ZSTD_compressionParameters cParams,
                                                   ZSTD_customMem customMem);
 
+ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
+                                                  ZSTD_dictLoadMethod_e dictLoadMethod,
+                                                  ZSTD_dictContentType_e dictContentType,
+                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_customMem customMem);
+
 ZSTDLIB_API ZSTD_DDict* ZSTD_createDDict_advanced(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,
                                                   ZSTD_dictContentType_e dictContentType,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1403,7 +1403,7 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced(const void* dict, size_t dictS
 ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,
                                                   ZSTD_dictContentType_e dictContentType,
-                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_CCtx_params* cctxParams,
                                                   ZSTD_customMem customMem);
 
 ZSTDLIB_API ZSTD_DDict* ZSTD_createDDict_advanced(const void* dict, size_t dictSize,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -356,6 +356,21 @@ typedef enum {
                               * Deviating far from default value will likely result in a compression ratio decrease.
                               * Special: value 0 means "automatically determine hashRateLog". */
 
+    ZSTD_c_enableDedicatedDictSearch=170, /* Enable the use of the match finder specifically for
+                                           * dictionaries. This has several implications:
+                                           * 1) We may override cDict params supplied using
+                                           *    ZSTD_refCDict because the dedicated match finder
+                                           *    needs to enforce some unique invariants on the
+                                           *    hashLog and chainLog.
+                                           * 2) We will force the dict to be attached
+                                           * 3) We will pick cParams based on ZSTD_c_compressionLevel
+                                           *    and the size of the dictionary which will increase
+                                           *    the cDict memory usage.
+                                           * 4) We will only do this for certain supported levels.
+                                           *    The exact levels which are supported are determined
+                                           *    by ZSTD_c_compressionLevel and dictionary size.
+                                           *    (only ZSTD_greedy, ZSTD_lazy and ZSTD_lazy2) */
+
     /* frame parameters */
     ZSTD_c_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)
                               * Content size must be known at the beginning of compression.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -356,20 +356,7 @@ typedef enum {
                               * Deviating far from default value will likely result in a compression ratio decrease.
                               * Special: value 0 means "automatically determine hashRateLog". */
 
-    ZSTD_c_enableDedicatedDictSearch=170, /* Enable the use of the match finder specifically for
-                                           * dictionaries. This has several implications:
-                                           * 1) We may override cDict params supplied using
-                                           *    ZSTD_refCDict because the dedicated match finder
-                                           *    needs to enforce some unique invariants on the
-                                           *    hashLog and chainLog.
-                                           * 2) We will force the dict to be attached
-                                           * 3) We will pick cParams based on ZSTD_c_compressionLevel
-                                           *    and the size of the dictionary which will increase
-                                           *    the cDict memory usage.
-                                           * 4) We will only do this for certain supported levels.
-                                           *    The exact levels which are supported are determined
-                                           *    by ZSTD_c_compressionLevel and dictionary size.
-                                           *    (only ZSTD_greedy, ZSTD_lazy and ZSTD_lazy2) */
+    ZSTD_c_enableDedicatedDictSearch=170,
 
     /* frame parameters */
     ZSTD_c_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)


### PR DESCRIPTION
PR just for review.

This is a first take at trying integrate the dict search optimizations. 

The idea behind this approach was to allow for a way to create a CDict with cParams specifically for the dedicated dict search algorithm (namely special hashLogs and chainLogs). So I introduced a new API method called `ZSTD_createCDict_advanced2(..)`. The difference between it and `ZSTD_createCDict_advanced` is that it takes a `ZSTD_CCtx_params` instead of `ZSTD_compressionParameters`. This way I can pass in the new parameter `ZSTD_c_enableDedicatdDictSearch` and select a set of dedicated defaults from the new `ZSTD_dedicatedDictSearch_defaultCompressionParameters`.

When the strategy picked by the new `ZSTD_dedicatedDictSearch_defaultCompressionParameters` falls outside `ZSTD_greedy`, `ZSTD_lazy` and `ZSTD_lazy2`, using the new param will have no effect. When the strategy picked is one of those and we have `ZSTD_c_enableDedicatedDictSearch` enabled, we force a dict to be attached instead of copied. 

The actual dedicated dict search algorithm needs to be tuned later but the one I have in right now has hash table buckets of size 4 and the remaining entries in the chainTable (used exactly as before so no reduction in size). It only prefetches the first hash entry into L1.

Also updated largeNbDicts.c. You can test the changes with --dedicated-dict-search. Here are some crude results for level 6 with http data (+ ~25-28% is where the wins plateau). I haven't property benchmarked or optimized yet so I'd expect this to be better.

![plot](https://i.imgur.com/lupVH3F.png)