### PR TITLE
Explicitly use __cdecl for qsort, to avoid warning when default calling convention is not __cdecl

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -27,7 +27,6 @@
 #  define FORCE_INLINE_ATTR __attribute__((always_inline))
 #elif defined(_MSC_VER)
 #  define FORCE_INLINE_ATTR __forceinline
-
 #else
 #  define FORCE_INLINE_ATTR
 #endif

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -38,6 +38,11 @@
 
 #endif
 
+/**
+  On MSVC qsort requires functions passed to it use the __cdecl calling conversion(CC). 
+  This explictly marks such functions as __cdecl so that the code will still compile 
+  if a CC other than __cdecl has been made the default.
+*/
 #if  defined(_MSC_VER)
 #  define WIN_CDECL __cdecl
 #else

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -39,7 +39,7 @@
 #endif
 
 /**
-  On MSVC qsort requires functions passed to it use the __cdecl calling conversion(CC). 
+  On MSVC qsort requires that functions passed into it use the __cdecl calling conversion(CC). 
   This explictly marks such functions as __cdecl so that the code will still compile 
   if a CC other than __cdecl has been made the default.
 */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -27,6 +27,7 @@
 #  define FORCE_INLINE_ATTR __attribute__((always_inline))
 #elif defined(_MSC_VER)
 #  define FORCE_INLINE_ATTR __forceinline
+
 #else
 #  define FORCE_INLINE_ATTR
 #endif
@@ -36,6 +37,12 @@
 #define INLINE_KEYWORD
 #define FORCE_INLINE_ATTR
 
+#endif
+
+#if  defined(_MSC_VER)
+#  define WIN_CDECL __cdecl
+#else
+#  define WIN_CDECL 
 #endif
 
 /**

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -261,7 +261,7 @@ static int COVER_cmp8(COVER_ctx_t *ctx, const void *lp, const void *rp) {
  * NOTE: g_ctx must be set to call this function.  A global is required because
  * qsort doesn't take an opaque pointer.
  */
-static int COVER_strict_cmp(const void *lp, const void *rp) {
+static int WIN_CDECL COVER_strict_cmp(const void *lp, const void *rp) {
   int result = COVER_cmp(g_ctx, lp, rp);
   if (result == 0) {
     result = lp < rp ? -1 : 1;
@@ -271,7 +271,7 @@ static int COVER_strict_cmp(const void *lp, const void *rp) {
 /**
  * Faster version for d <= 8.
  */
-static int COVER_strict_cmp8(const void *lp, const void *rp) {
+static int WIN_CDECL COVER_strict_cmp8(const void *lp, const void *rp) {
   int result = COVER_cmp8(g_ctx, lp, rp);
   if (result == 0) {
     result = lp < rp ? -1 : 1;


### PR DESCRIPTION
 On MSVC there are other calling conventions such as __vectorcall, which may be enabled as the default. When this is done, zstd will not compile as it attempts to pass a __vectorcall sort function to qsort, which expects a __cdecl function.

 This explicitly marks those functions intended for usage with qsort as being __cdecl.