### PR TITLE
[cover] Remove unnecessary mask and dedup hash functions

### DIFF
--- a/lib/dictBuilder/fastcover.c
+++ b/lib/dictBuilder/fastcover.c
@@ -21,6 +21,7 @@
 #include "../common/threading.h"
 #include "cover.h"
 #include "../common/zstd_internal.h" /* includes zstd.h */
+#include "../compress/zstd_compress_internal.h" /* ZSTD_hash*() */
 #ifndef ZDICT_STATIC_LINKING_ONLY
 #define ZDICT_STATIC_LINKING_ONLY
 #endif
@@ -75,25 +76,16 @@ static clock_t g_time = 0;
 
 
 /*-*************************************
-* Hash Functions (matching zstd_compress_internal.h)
+* Hash Functions
 ***************************************/
-static const U64 FASTCOVER_prime6bytes = 227718039650203ULL;
-static size_t FASTCOVER_hash6(U64 u, U32 h) { return (size_t)(((u  << (64-48)) * FASTCOVER_prime6bytes) >> (64-h)) ; }
-static size_t FASTCOVER_hash6Ptr(const void* p, U32 h) { return FASTCOVER_hash6(MEM_readLE64(p), h); }
-
-static const U64 FASTCOVER_prime8bytes = 0xCF1BBCDCB7A56463ULL;
-static size_t FASTCOVER_hash8(U64 u, U32 h) { return (size_t)(((u) * FASTCOVER_prime8bytes) >> (64-h)) ; }
-static size_t FASTCOVER_hash8Ptr(const void* p, U32 h) { return FASTCOVER_hash8(MEM_readLE64(p), h); }
-
-
 /**
- * Hash the d-byte value pointed to by p and mod 2^f
+ * Hash the d-byte value pointed to by p and mod 2^f into the frequency vector
  */
-static size_t FASTCOVER_hashPtrToIndex(const void* p, U32 h, unsigned d) {
+static size_t FASTCOVER_hashPtrToIndex(const void* p, U32 f, unsigned d) {
   if (d == 6) {
-    return FASTCOVER_hash6Ptr(p, h) & ((1 << h) - 1);
+    return ZSTD_hash6Ptr(p, f);
   }
-  return FASTCOVER_hash8Ptr(p, h) & ((1 << h) - 1);
+  return ZSTD_hash8Ptr(p, f);
 }
 
 


### PR DESCRIPTION
* Remove the unnecessary mask, since `ZSTD_hash*()` already ensures
  the output is mod 2^h.
* Dedup the hash functions and use `ZSTD_hash*()` directly.