### PR TITLE
Add ImpromptuNinjas.ZStd C# libzstd bindings link to GitHub Pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: alpine:3.7
+    steps:
+      - run:
+          name: Ignored
+          command: echo Ignored
+
+workflows:
+ gh-pages-wf:
+   when:
+    false
+   jobs:
+    - build:
+        filters:
+          branches:
+            ignore:
+              - gh-pages

--- a/index.html
+++ b/index.html
@@ -188,6 +188,7 @@ here is a list of known bindings and their authors :
 | __Rust__      | Alexandre Bury      | https://crates.io/crates/zstd         |
 | __C#__        | SKB Kontur          | https://github.com/skbkontur/ZstdNet  |
 | __C#__ (streaming) | Bernhard Pichler | https://github.com/bp74/Zstandard.Net
+| __C#__        | Tyler Young         | https://github.com/ImpromptuNinjas/ZStd
 | __Javascript__ (emscripten) | Yoshihito | https://www.npmjs.com/package/zstd-codec
 | __Node.js__ streams | albertdb      | https://www.npmjs.com/package/node-zstandard
 | __Node.js__ buffers | Zwb           | https://www.npmjs.com/package/node-zstd


### PR DESCRIPTION
Should I add something like (full) or (block, streaming, dictionary, training)?
I think it's the only C# binding that provides OSX .dylib and Linux Musl compatible .so versions as well.
It ships stripped statically linked O3 LTO builds of libzstd for the gamut of platforms that .NET / Fw / Core runs on.
It builds libzstd-mt from zstd version tags and does generic tests for all the platforms using docker images, incl. armv7-hf and arm64v8 via qemu.
It exposes friendly wrappers as well as direct bindings, it has decent testing and coverage.
Performance overhead is minimal as it performs direct `calli` cdecl call site bindings.
It's also signed now, so corpos that need that sort of thing can link their signed assemblies against it.