### PR TITLE
[contrib] Fix single-file compilation error on Emscripten build.

### DIFF
--- a/contrib/single_file_libs/build_decoder_test.sh
+++ b/contrib/single_file_libs/build_decoder_test.sh
@@ -6,6 +6,56 @@ OUT_FILE="tempbin"
 # Optional temporary compiled WebAssembly
 OUT_WASM="temp.wasm"
 
+# Source files to compile using Emscripten.
+IN_FILES="examples/emscripten.c"
+
+# Emscripten build using emcc.
+emscripten_emcc_build() {
+  # Compile the the same example as above
+  CC_FLAGS="-Wall -Wextra -Werror -Os -g0 -flto"
+  emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
+  # Did compilation work?
+  if [ $? -ne 0 ]; then
+    echo "Compiling ${IN_FILES}: FAILED"
+    exit 1
+  fi
+  echo "Compiling ${IN_FILES}: PASSED"
+  rm -f $OUT_WASM
+}
+
+# Emscripten build using docker.
+emscripten_docker_build() {
+  docker container run --rm \
+    --volume $PWD:/code \
+    --workdir /code \
+    trzeci/emscripten \
+    emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
+  # Did compilation work?
+  if [ $? -ne 0 ]; then
+      echo "Compiling ${IN_FILES} (using docker): FAILED"
+    exit 1
+  fi
+  echo "Compiling ${IN_FILES} (using docker): PASSED"
+  rm -f $OUT_WASM
+}
+
+# Try Emscripten build using emcc or docker.
+try_emscripten_build() {
+  which emcc > /dev/null
+  if [ $? -eq 0 ]; then
+    emscripten_emcc_build
+    return $?
+  fi
+
+  which docker > /dev/null
+  if [ $? -eq 0 ]; then
+    emscripten_docker_build
+    return $?
+  fi
+
+  echo "(Skipping Emscripten test)"
+}
+
 # Amalgamate the sources
 ./create_single_file_decoder.sh
 # Did combining work?
@@ -35,21 +85,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Running simple.c: PASSED"
 
-# Is Emscripten available?
-which emcc > /dev/null
-if [ $? -ne 0 ]; then
-  echo "(Skipping Emscripten test)"
-else
-  # Compile the Emscripten example
-  CC_FLAGS="-Wall -Wextra -Werror -Os -g0 -flto --llvm-lto 3 -lGL -DNDEBUG=1"
-  emcc $CC_FLAGS -s WASM=1 -o $OUT_WASM examples/emscripten.c
-  # Did compilation work?
-  if [ $? -ne 0 ]; then
-    echo "Compiling emscripten.c: FAILED"
-    exit 1
-  fi
-  echo "Compiling emscripten.c: PASSED"
-  rm -f $OUT_WASM
-fi
+# Try Emscripten build if emcc or docker command is available.
+try_emscripten_build
 
 exit 0

--- a/contrib/single_file_libs/build_decoder_test.sh
+++ b/contrib/single_file_libs/build_decoder_test.sh
@@ -28,7 +28,7 @@ emscripten_docker_build() {
   docker container run --rm \
     --volume $PWD:/code \
     --workdir /code \
-    trzeci/emscripten \
+    emscripten/emsdk:latest \
     emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
   # Did compilation work?
   if [ $? -ne 0 ]; then

--- a/contrib/single_file_libs/build_library_test.sh
+++ b/contrib/single_file_libs/build_library_test.sh
@@ -31,7 +31,7 @@ emscripten_docker_build() {
   docker container run --rm \
     --volume $PWD:/code \
     --workdir /code \
-    trzeci/emscripten \
+    emscripten/emsdk:latest \
     emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
   # Did compilation work?
   if [ $? -ne 0 ]; then

--- a/contrib/single_file_libs/build_library_test.sh
+++ b/contrib/single_file_libs/build_library_test.sh
@@ -9,6 +9,56 @@ OUT_FILE="tempbin"
 # Optional temporary compiled WebAssembly
 OUT_WASM="temp.wasm"
 
+# Source files to compile using Emscripten.
+IN_FILES="zstd.c examples/roundtrip.c"
+
+# Emscripten build using emcc.
+emscripten_emcc_build() {
+  # Compile the the same example as above
+  CC_FLAGS="-Wall -Wextra -Werror -Os -g0 -flto"
+  emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
+  # Did compilation work?
+  if [ $? -ne 0 ]; then
+    echo "Compiling ${IN_FILES}: FAILED"
+    exit 1
+  fi
+  echo "Compiling ${IN_FILES}: PASSED"
+  rm -f $OUT_WASM
+}
+
+# Emscripten build using docker.
+emscripten_docker_build() {
+  docker container run --rm \
+    --volume $PWD:/code \
+    --workdir /code \
+    trzeci/emscripten \
+    emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
+  # Did compilation work?
+  if [ $? -ne 0 ]; then
+      echo "Compiling ${IN_FILES} (using docker): FAILED"
+    exit 1
+  fi
+  echo "Compiling ${IN_FILES} (using docker): PASSED"
+  rm -f $OUT_WASM
+}
+
+# Try Emscripten build using emcc or docker.
+try_emscripten_build() {
+  which emcc > /dev/null
+  if [ $? -eq 0 ]; then
+    emscripten_emcc_build
+    return $?
+  fi
+
+  which docker > /dev/null
+  if [ $? -eq 0 ]; then
+    emscripten_docker_build
+    return $?
+  fi
+
+  echo "(Skipping Emscripten test)"
+}
+
 # Amalgamate the sources
 ./create_single_file_library.sh
 # Did combining work?
@@ -41,21 +91,7 @@ if [ $retVal -ne 0 ]; then
 fi
 echo "Running roundtrip.c: PASSED"
 
-# Is Emscripten available?
-which emcc > /dev/null
-if [ $? -ne 0 ]; then
-  echo "(Skipping Emscripten test)"
-else
-  # Compile the the same example as above
-  CC_FLAGS="-Wall -Wextra -Werror -Os -g0 -flto"
-  emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM zstd.c examples/roundtrip.c
-  # Did compilation work?
-  if [ $? -ne 0 ]; then
-    echo "Compiling emscripten.c: FAILED"
-    exit 1
-  fi
-  echo "Compiling emscripten.c: PASSED"
-  rm -f $OUT_WASM
-fi
+# Try Emscripten build if emcc or docker command is available.
+try_emscripten_build
 
 exit 0

--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -301,7 +301,7 @@ int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque)
 struct POOL_ctx_s {
     int dummy;
 };
-static POOL_ctx g_ctx;
+static POOL_ctx g_poolCtx;
 
 POOL_ctx* POOL_create(size_t numThreads, size_t queueSize) {
     return POOL_create_advanced(numThreads, queueSize, ZSTD_defaultCMem);
@@ -311,11 +311,11 @@ POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize, ZSTD_customM
     (void)numThreads;
     (void)queueSize;
     (void)customMem;
-    return &g_ctx;
+    return &g_poolCtx;
 }
 
 void POOL_free(POOL_ctx* ctx) {
-    assert(!ctx || ctx == &g_ctx);
+    assert(!ctx || ctx == &g_poolCtx);
     (void)ctx;
 }
 
@@ -337,7 +337,7 @@ int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque) {
 
 size_t POOL_sizeof(POOL_ctx* ctx) {
     if (ctx==NULL) return 0;  /* supports sizeof NULL */
-    assert(ctx == &g_ctx);
+    assert(ctx == &g_poolCtx);
     return sizeof(*ctx);
 }
 

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -224,7 +224,7 @@ typedef struct {
 } COVER_ctx_t;
 
 /* We need a global context for qsort... */
-static COVER_ctx_t *g_ctx = NULL;
+static COVER_ctx_t *g_coverCtx = NULL;
 
 /*-*************************************
 *  Helper functions
@@ -267,11 +267,11 @@ static int COVER_cmp8(COVER_ctx_t *ctx, const void *lp, const void *rp) {
 
 /**
  * Same as COVER_cmp() except ties are broken by pointer value
- * NOTE: g_ctx must be set to call this function.  A global is required because
+ * NOTE: g_coverCtx must be set to call this function.  A global is required because
  * qsort doesn't take an opaque pointer.
  */
 static int WIN_CDECL COVER_strict_cmp(const void *lp, const void *rp) {
-  int result = COVER_cmp(g_ctx, lp, rp);
+  int result = COVER_cmp(g_coverCtx, lp, rp);
   if (result == 0) {
     result = lp < rp ? -1 : 1;
   }
@@ -281,7 +281,7 @@ static int WIN_CDECL COVER_strict_cmp(const void *lp, const void *rp) {
  * Faster version for d <= 8.
  */
 static int WIN_CDECL COVER_strict_cmp8(const void *lp, const void *rp) {
-  int result = COVER_cmp8(g_ctx, lp, rp);
+  int result = COVER_cmp8(g_coverCtx, lp, rp);
   if (result == 0) {
     result = lp < rp ? -1 : 1;
   }
@@ -612,7 +612,7 @@ static size_t COVER_ctx_init(COVER_ctx_t *ctx, const void *samplesBuffer,
     /* qsort doesn't take an opaque pointer, so pass as a global.
      * On OpenBSD qsort() is not guaranteed to be stable, their mergesort() is.
      */
-    g_ctx = ctx;
+    g_coverCtx = ctx;
 #if defined(__OpenBSD__)
     mergesort(ctx->suffix, ctx->suffixSize, sizeof(U32),
           (ctx->d <= 8 ? &COVER_strict_cmp8 : &COVER_strict_cmp));


### PR DESCRIPTION
The single-file library makes a compilation error on Emscripten build due to static variable names collisions, reported on #2211

- Rename a few static variables
- Try Emscripten build using `docker` if `emcc` command is not available

Error like this...
```bash
$ ./build_library_test.sh
Amalgamating files... this can take a while
Processing: zstd-in.c
...
Combine script: PASSED
Single file library creation script: PASSED
Compiling roundtrip.c: PASSED
Compression: PASSED (size: 3127, uncompressed: 32768)
Decompression: PASSED
Byte comparison: PASSED
Running roundtrip.c: PASSED
zstd.c:30822:21: error: redefinition of 'g_ctx' with a different type: 'COVER_ctx_t *' vs 'POOL_ctx' (aka 'struct POOL_ctx_s')
static COVER_ctx_t *g_ctx = NULL;
                    ^
zstd.c:7413:17: note: previous definition is here
static POOL_ctx g_ctx;
                ^
zstd.c:30869:26: error: passing 'POOL_ctx' (aka 'struct POOL_ctx_s') to parameter of incompatible type 'COVER_ctx_t *'
  int result = COVER_cmp(g_ctx, lp, rp);
                         ^~~~~
zstd.c:30845:35: note: passing argument to parameter 'ctx' here
static int COVER_cmp(COVER_ctx_t *ctx, const void *lp, const void *rp) {
                                  ^
zstd.c:30879:27: error: passing 'POOL_ctx' (aka 'struct POOL_ctx_s') to parameter of incompatible type 'COVER_ctx_t *'
  int result = COVER_cmp8(g_ctx, lp, rp);
                          ^~~~~
zstd.c:30853:36: note: passing argument to parameter 'ctx' here
static int COVER_cmp8(COVER_ctx_t *ctx, const void *lp, const void *rp) {
                                   ^
zstd.c:31210:11: error: assigning to 'POOL_ctx' (aka 'struct POOL_ctx_s') from incompatible type 'COVER_ctx_t *'
    g_ctx = ctx;
          ^ ~~~
4 errors generated.
emcc: error: '/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/bin/clang -target wasm32-unknown-emscripten -D__EMSCRIPTEN_major__=1 -D__EMSCRIPTEN_minor__=39 -D__EMSCRIPTEN_tiny__=18 -D_LIBCPP_ABI_VERSION=2 -Dunix -D__unix -D__unix__ -Werror=implicit-function-declaration -Xclang -nostdsysteminc -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/system/include/compat -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/system/include -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/system/include/libc -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/system/lib/libc/musl/arch/emscripten -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/system/local/include -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/system/include/SSE -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/cache/wasm-lto/include -DEMSCRIPTEN -fignore-exceptions -fno-inline-functions -Wall -Wextra -Werror -Os -flto -I. zstd.c -Xclang -isystem/Users/yoshihitoh/workspace/tools/sdk/emsdk/upstream/emscripten/system/include/SDL -c -o /var/folders/x7/xy9p7bj978sgz5b15_l26_4c0000gq/T/emscripten_temp_g31g5lty/zstd_0.o -flto=full' failed (1)
Compiling emscripten.c: FAILED
```

will be fixed like...
```
$ ./build_library_test.sh
Amalgamating files... this can take a while
Processing: zstd-in.c
...
Combine script: PASSED
Single file library creation script: PASSED
Compiling roundtrip.c: PASSED
Compression: PASSED (size: 3127, uncompressed: 32768)
Decompression: PASSED
Byte comparison: PASSED
Running roundtrip.c: PASSED
Compiling emscripten.c: PASSED
```