### PR TITLE
Fix -Wunused-variable under FUZZING_BUILD_MODE...

### DIFF
--- a/lib/common/debug.h
+++ b/lib/common/debug.h
@@ -79,7 +79,7 @@ extern "C" {
 #  include <assert.h>
 #else
 #  ifndef assert   /* assert may be already defined, due to prior #include <assert.h> */
-#    define assert(condition) ((void)0)   /* disable assert (default) */
+#    define assert(condition) ((void) (condition))   /* disable assert (default) */
 #  endif
 #endif
 


### PR DESCRIPTION
Fuzzing build modes (FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) doesn't
necessarily imply that assert() is enabled, according to the manual.

When the current do-nothing is expanded under -Wunused-variable (-Wall),
it results in unused variables in some of the FUZZING_BUILD_MODE...
blocks.

This patch extends the do-nothing to avoid the unused variable.