### PR TITLE
programs/util.c: fix build without st_mtime

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -28,7 +28,7 @@ extern "C" {
 #  include <io.h>         /* _chmod */
 #else
 #  include <unistd.h>     /* chown, stat */
-#  if PLATFORM_POSIX_VERSION < 200809L
+#  if PLATFORM_POSIX_VERSION < 200809L || !defined(st_mtime)
 #    include <utime.h>    /* utime */
 #  else
 #    include <fcntl.h>    /* AT_FDCWD */


### PR DESCRIPTION
Since version 1.4.5 and commit 5af8cb7aea8d890b4801e50e5274371510f2cf33, if st_mtime is not defined, programs/util.c uses utime without including utime.h which will raise the following build failure on some of the buildroot autobuilders:

```
util.c: In function 'UTIL_setFileStat':
util.c:161:24: error: storage size of 'timebuf' isn't known
         struct utimbuf timebuf;
                        ^~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/be902c5d110f37bce622a2215191f155b7d3e7e0

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>