### PR TITLE
Optimize ZSTD_wildcopy

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -290,8 +290,10 @@ void ZSTD_wildcopy(void* dst, const void* src, ptrdiff_t length, ZSTD_overlap_e 
         }
         while (op < oend);
 #else
-        COPY16(op, ip);
-        if (op >= oend) return;
+        memcpy(op, ip, 16);
+        if (16 >= length) return;
+        op += 16;
+        ip += 16;
         do {
             COPY16(op, ip);
             COPY16(op, ip);

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -290,7 +290,7 @@ void ZSTD_wildcopy(void* dst, const void* src, ptrdiff_t length, ZSTD_overlap_e 
         }
         while (op < oend);
 #else
-        memcpy(op, ip, 16);
+        ZSTD_copy16(op, ip);
         if (16 >= length) return;
         op += 16;
         ip += 16;


### PR DESCRIPTION
Use `memcpy` instead of `COPY16` so that the `add` instruction can be moved after the branch. This could save 1 instruction when compiling with gcc.

Codegen before this PR: in Basic Block 1, 4 instructions execute before jmp instruction.
<img width="660" alt="gcc-new-default" src="https://user-images.githubusercontent.com/18431130/88622005-a1e31480-d056-11ea-9b67-d54447a29398.png">

Codegen after this PR: in Basic Block 1, 3 instructions execute before jmp instruction. 
<img width="660" alt="gcc-new-proto" src="https://user-images.githubusercontent.com/18431130/88622039-b9ba9880-d056-11ea-8648-349f17db46ea.png">

