### PR TITLE
MSVC: switch BitScanForward/Reverse to _lzcnt/_tzcnt_u32/64 when BMI2 is available. Added STATIC_BMI2 for detecting BMI2 based on build settings.

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -192,13 +192,15 @@
 #  endif
 #endif
 
+#ifndef STATIC_BMI2
+    #define STATIC_BMI2 0
+#endif
+
 /* If STATIC_BMI2 was enabled force DYNAMIC_BMI2 on */
 #if STATIC_BMI2 == 1
 #   ifndef DYNAMIC_BMI2
 #       define DYNAMIC_BMI2 1 //Build it statically targeting BMI2, so enable DYNAMIC_BMI2 if it wasn't already on
 #   endif
 #else
-    #define STATIC_BMI2 0
-#endif
 
 #endif /* ZSTD_COMPILER_H */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -188,7 +188,6 @@
 #  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  
 #    ifdef __AVX2__  //MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2
 #       define STATIC_BMI2 1
-
 #    endif
 #  endif
 #endif

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -201,6 +201,6 @@
 #   ifndef DYNAMIC_BMI2
 #       define DYNAMIC_BMI2 1 //Build it statically targeting BMI2, so enable DYNAMIC_BMI2 if it wasn't already on
 #   endif
-#else
+#endif
 
 #endif /* ZSTD_COMPILER_H */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -193,10 +193,12 @@
 #endif
 
 /* If STATIC_BMI2 was enabled force DYNAMIC_BMI2 on */
-#if STATIC_BMI2
+#if STATIC_BMI2 == 1
 #   ifndef DYNAMIC_BMI2
 #       define DYNAMIC_BMI2 1 //Build it statically targeting BMI2, so enable DYNAMIC_BMI2 if it wasn't already on
 #   endif
+#else
+    #define STATIC_BMI2 0
 #endif
 
 #endif /* ZSTD_COMPILER_H */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -183,4 +183,21 @@
 #  pragma warning(disable : 4324)        /* disable: C4324: padded structure */
 #endif
 
+/*Like DYNAMIC_BMI2 but for compile time determination of BMI2 support*/
+#ifndef STATIC_BMI2
+#  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))  
+#    ifdef __AVX2__  //MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2
+#       define STATIC_BMI2 1
+
+#    endif
+#  endif
+#endif
+
+/* If STATIC_BMI2 was enabled force DYNAMIC_BMI2 on */
+#if STATIC_BMI2
+#   ifndef DYNAMIC_BMI2
+#       define DYNAMIC_BMI2 1 //Build it statically targeting BMI2, so enable DYNAMIC_BMI2 if it wasn't already on
+#   endif
+#endif
+
 #endif /* ZSTD_COMPILER_H */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -199,7 +199,7 @@
 /* If STATIC_BMI2 was enabled force DYNAMIC_BMI2 on */
 #if STATIC_BMI2 == 1
 #   ifndef DYNAMIC_BMI2
-#       define DYNAMIC_BMI2 1 //Build it statically targeting BMI2, so enable DYNAMIC_BMI2 if it wasn't already on
+#       define DYNAMIC_BMI2 1 //Build it statically targeting BMI2, so enable DYNAMIC_BMI2
 #   endif
 #endif
 

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -394,8 +394,12 @@ MEM_STATIC U32 ZSTD_highbit32(U32 val)   /* compress, dictBuilder, decodeCorpus 
     assert(val != 0);
     {
 #   if defined(_MSC_VER)   /* Visual */
-        unsigned long r=0;
-        return _BitScanReverse(&r, val) ? (unsigned)r : 0;
+#       if STATIC_BMI2 == 1
+            return _lzcnt_u32(val);
+#       else
+            unsigned long r=0;
+            return _BitScanReverse(&r, val) ? (unsigned)r : 0;
+#       endif
 #   elif defined(__GNUC__) && (__GNUC__ >= 3)   /* GCC Intrinsic */
         return __builtin_clz (val) ^ 31;
 #   elif defined(__ICCARM__)    /* IAR Intrinsic */

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -498,8 +498,12 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
     if (MEM_isLittleEndian()) {
         if (MEM_64bits()) {
 #       if defined(_MSC_VER) && defined(_WIN64)
-            unsigned long r = 0;
-            return _BitScanForward64( &r, (U64)val ) ? (unsigned)(r >> 3) : 0;
+#           if STATIC_BMI2
+                return _tzcnt_u64(val) >> 3;
+#           else
+                unsigned long r = 0;
+                return _BitScanForward64( &r, (U64)val ) ? (unsigned)(r >> 3) : 0;
+#           endif
 #       elif defined(__GNUC__) && (__GNUC__ >= 4)
             return (__builtin_ctzll((U64)val) >> 3);
 #       else
@@ -530,8 +534,12 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
     } else {  /* Big Endian CPU */
         if (MEM_64bits()) {
 #       if defined(_MSC_VER) && defined(_WIN64)
-            unsigned long r = 0;
-            return _BitScanReverse64( &r, val ) ? (unsigned)(r >> 3) : 0;
+#           if STATIC_BMI2
+			    return _lzcnt_u64(val) >> 3;
+#           else
+			    unsigned long r = 0;
+			    return _BitScanReverse64(&r, (U64)val) ? (unsigned)(r >> 3) : 0;
+#           endif
 #       elif defined(__GNUC__) && (__GNUC__ >= 4)
             return (__builtin_clzll(val) >> 3);
 #       else

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -535,10 +535,10 @@ static unsigned ZSTD_NbCommonBytes (size_t val)
         if (MEM_64bits()) {
 #       if defined(_MSC_VER) && defined(_WIN64)
 #           if STATIC_BMI2
-			    return _lzcnt_u64(val) >> 3;
+		return _lzcnt_u64(val) >> 3;
 #           else
-			    unsigned long r = 0;
-			    return _BitScanReverse64(&r, (U64)val) ? (unsigned)(r >> 3) : 0;
+		unsigned long r = 0;
+		return _BitScanReverse64(&r, (U64)val) ? (unsigned)(r >> 3) : 0;
 #           endif
 #       elif defined(__GNUC__) && (__GNUC__ >= 4)
             return (__builtin_clzll(val) >> 3);


### PR DESCRIPTION
This adds a define for STATIC_BMI2 that is similar to DYNAMIC_BMI2 but for statically determining BMI2 support.

It is only targeting MSVC here.

When STATIC_BMI2 is on, many of the calls to BitScanForward/Reverse are replaced with calls to _lzcnt/_tzcnt. 
The codegen for the BitScanForward/Reverse calls was not great on MSVC.

Also if STATIC_BMI2 is enabled, which means the binary is targeting BMI2, DYNAMIC_BMI2 is forced on.   

**Compiler Explorer using _lzcnt_u32:** https://godbolt.org/z/sEqTEE

   cmp     ecx, 63                             ; 0000003fH
        jbe     SHORT $LN3@ZSTD_LLcod
        lzcnt   eax, ecx
        add     eax, 19
        ret     0

**Compiler Explorer using BitScanForward**:https://godbolt.org/z/W8TxT9

   cmp     ecx, 63                             ; 0000003fH
        jbe     SHORT $LN3@ZSTD_LLcod
        xor     eax, eax
        bsr     ecx, ecx
        cmovne  eax, ecx
        add     eax, 19
        ret     0
