### PR TITLE
Fixed VS variable shadowing warning (single file lib)

### DIFF
--- a/contrib/single_file_libs/build_decoder_test.sh
+++ b/contrib/single_file_libs/build_decoder_test.sh
@@ -12,7 +12,7 @@ IN_FILES="examples/emscripten.c"
 # Emscripten build using emcc.
 emscripten_emcc_build() {
   # Compile the the same example as above
-  CC_FLAGS="-Wall -Wextra -Werror -Os -g0 -flto"
+  CC_FLAGS="-Wall -Wextra -Wshadow -Werror -Os -g0 -flto"
   emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
   # Did compilation work?
   if [ $? -ne 0 ]; then
@@ -66,7 +66,7 @@ fi
 echo "Single file decoder creation script: PASSED"
 
 # Compile the generated output
-cc -Wall -Wextra -Werror -Os -g0 -o $OUT_FILE examples/simple.c
+cc -Wall -Wextra -Wshadow -Werror -Os -g0 -o $OUT_FILE examples/simple.c
 # Did compilation work?
 if [ $? -ne 0 ]; then
   echo "Compiling simple.c: FAILED"

--- a/contrib/single_file_libs/build_library_test.sh
+++ b/contrib/single_file_libs/build_library_test.sh
@@ -15,7 +15,7 @@ IN_FILES="zstd.c examples/roundtrip.c"
 # Emscripten build using emcc.
 emscripten_emcc_build() {
   # Compile the the same example as above
-  CC_FLAGS="-Wall -Wextra -Werror -Os -g0 -flto"
+  CC_FLAGS="-Wall -Wextra -Wshadow -Werror -Os -g0 -flto"
   emcc $CC_FLAGS -s WASM=1 -I. -o $OUT_WASM $IN_FILES
   # Did compilation work?
   if [ $? -ne 0 ]; then
@@ -72,7 +72,7 @@ echo "Single file library creation script: PASSED"
 cp "$ZSTD_SRC_ROOT/zstd.h" zstd.h
 
 # Compile the generated output
-cc -Wall -Wextra -Werror -pthread -I. -Os -g0 -o $OUT_FILE zstd.c examples/roundtrip.c
+cc -Wall -Wextra -Werror -Wshadow -pthread -I. -Os -g0 -o $OUT_FILE zstd.c examples/roundtrip.c
 # Did compilation work?
 if [ $? -ne 0 ]; then
   echo "Compiling roundtrip.c: FAILED"

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -63,13 +63,13 @@ static int g_displayLevel = 2;
 #define DISPLAYLEVEL(l, ...) LOCALDISPLAYLEVEL(g_displayLevel, l, __VA_ARGS__)
 
 #ifndef LOCALDISPLAYUPDATE
-static const clock_t refreshRate = CLOCKS_PER_SEC * 15 / 100;
+static const clock_t g_refreshRate = CLOCKS_PER_SEC * 15 / 100;
 static clock_t g_time = 0;
 #endif
 #undef  LOCALDISPLAYUPDATE
 #define LOCALDISPLAYUPDATE(displayLevel, l, ...)                               \
   if (displayLevel >= l) {                                                     \
-    if ((clock() - g_time > refreshRate) || (displayLevel >= 4)) {             \
+    if ((clock() - g_time > g_refreshRate) || (displayLevel >= 4)) {             \
       g_time = clock();                                                        \
       DISPLAY(__VA_ARGS__);                                                    \
     }                                                                          \

--- a/lib/dictBuilder/fastcover.c
+++ b/lib/dictBuilder/fastcover.c
@@ -60,13 +60,13 @@ static int g_displayLevel = 2;
 #define DISPLAYLEVEL(l, ...) LOCALDISPLAYLEVEL(g_displayLevel, l, __VA_ARGS__)
 
 #ifndef LOCALDISPLAYUPDATE
-static const clock_t refreshRate = CLOCKS_PER_SEC * 15 / 100;
+static const clock_t g_refreshRate = CLOCKS_PER_SEC * 15 / 100;
 static clock_t g_time = 0;
 #endif
 #undef  LOCALDISPLAYUPDATE
 #define LOCALDISPLAYUPDATE(displayLevel, l, ...)                               \
   if (displayLevel >= l) {                                                     \
-    if ((clock() - g_time > refreshRate) || (displayLevel >= 4)) {             \
+    if ((clock() - g_time > g_refreshRate) || (displayLevel >= 4)) {             \
       g_time = clock();                                                        \
       DISPLAY(__VA_ARGS__);                                                    \
     }                                                                          \


### PR DESCRIPTION
Visual Studio 2019 was generating a variable shadowing warning after the dict builder was rolled-in. This prefixes the affected global and adds `-Wshadow` to the build scripts.