### PR TITLE
Share stat() Calls Where Convenient

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1486,7 +1486,8 @@ static int FIO_compressFilename_dstFile(FIO_prefs_t* const prefs,
         addHandler(dstFileName);
 
         if ( strcmp (srcFileName, stdinmark)
-          && UTIL_statFile(srcFileName, &statbuf))
+          && UTIL_stat(srcFileName, &statbuf)
+          && UTIL_isRegularFileStat(&statbuf) )
             transfer_permissions = 1;
     }
 
@@ -2352,7 +2353,8 @@ static int FIO_decompressDstFile(FIO_prefs_t* const prefs,
         addHandler(dstFileName);
 
         if ( strcmp(srcFileName, stdinmark)   /* special case : don't transfer permissions from stdin */
-          && UTIL_statFile(srcFileName, &statbuf) )
+          && UTIL_stat(srcFileName, &statbuf)
+          && UTIL_isRegularFileStat(&statbuf) )
             transfer_permissions = 1;
     }
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -519,6 +519,7 @@ static int FIO_remove(const char* path)
  * @result : FILE* to `srcFileName`, or NULL if it fails */
 static FILE* FIO_openSrcFile(const char* srcFileName)
 {
+    stat_t statbuf;
     assert(srcFileName != NULL);
     if (!strcmp (srcFileName, stdinmark)) {
         DISPLAYLEVEL(4,"Using stdin for input \n");
@@ -526,14 +527,14 @@ static FILE* FIO_openSrcFile(const char* srcFileName)
         return stdin;
     }
 
-    if (!UTIL_fileExist(srcFileName)) {
+    if (!UTIL_stat(srcFileName, &statbuf)) {
         DISPLAYLEVEL(1, "zstd: can't stat %s : %s -- ignored \n",
                         srcFileName, strerror(errno));
         return NULL;
     }
 
-    if (!UTIL_isRegularFile(srcFileName)
-     && !UTIL_isFIFO(srcFileName)
+    if (!UTIL_isRegularFileStat(&statbuf)
+     && !UTIL_isFIFOStat(&statbuf)
     ) {
         DISPLAYLEVEL(1, "zstd: %s is not a regular file -- ignored \n",
                         srcFileName);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -509,7 +509,7 @@ static int FIO_remove(const char* path)
 #if defined(_WIN32) || defined(WIN32)
     /* windows doesn't allow remove read-only files,
      * so try to make it writable first */
-    UTIL_chmod(path, _S_IWRITE);
+    UTIL_chmod(path, NULL, _S_IWRITE);
 #endif
     return remove(path);
 }
@@ -619,7 +619,7 @@ FIO_openDstFile(FIO_prefs_t* const prefs,
                && strcmp (srcFileName, stdinmark)
                && strcmp(dstFileName, nulmark) ) {
             /* reduce rights on newly created dst file while compression is ongoing */
-            UTIL_chmod(dstFileName, 00600);
+            UTIL_chmod(dstFileName, NULL, 00600);
         }
         return f;
     }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1478,7 +1478,7 @@ static int FIO_compressFilename_dstFile(FIO_prefs_t* const prefs,
         addHandler(dstFileName);
 
         if ( strcmp (srcFileName, stdinmark)
-          && UTIL_getFileStat(srcFileName, &statbuf))
+          && UTIL_statFile(srcFileName, &statbuf))
             transfer_permissions = 1;
     }
 
@@ -2344,7 +2344,7 @@ static int FIO_decompressDstFile(FIO_prefs_t* const prefs,
         addHandler(dstFileName);
 
         if ( strcmp(srcFileName, stdinmark)   /* special case : don't transfer permissions from stdin */
-          && UTIL_getFileStat(srcFileName, &statbuf) )
+          && UTIL_statFile(srcFileName, &statbuf) )
             transfer_permissions = 1;
     }
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -514,7 +514,7 @@ static int FIO_removeFile(const char* path)
 #if defined(_WIN32) || defined(WIN32)
     /* windows doesn't allow remove read-only files,
      * so try to make it writable first */
-    if (!(statbuf.mode & _S_IWRITE)) {
+    if (!(statbuf.st_mode & _S_IWRITE)) {
         UTIL_chmod(path, &statbuf, _S_IWRITE);
     }
 #endif

--- a/programs/util.c
+++ b/programs/util.c
@@ -209,8 +209,8 @@ int UTIL_isSameFile(const char* fName1, const char* fName2)
 #else
     {   stat_t file1Stat;
         stat_t file2Stat;
-        return UTIL_getFileStat(fName1, &file1Stat)
-            && UTIL_getFileStat(fName2, &file2Stat)
+        return UTIL_stat(fName1, &file1Stat)
+            && UTIL_stat(fName2, &file2Stat)
             && (file1Stat.st_dev == file2Stat.st_dev)
             && (file1Stat.st_ino == file2Stat.st_ino);
     }
@@ -223,8 +223,8 @@ int UTIL_isFIFO(const char* infilename)
 /* macro guards, as defined in : https://linux.die.net/man/2/lstat */
 #if PLATFORM_POSIX_VERSION >= 200112L
     stat_t statbuf;
-    int const r = UTIL_getFileStat(infilename, &statbuf);
-    if (!r && S_ISFIFO(statbuf.st_mode)) return 1;
+    int const r = UTIL_stat(infilename, &statbuf);
+    if (r && S_ISFIFO(statbuf.st_mode)) return 1;
 #endif
     (void)infilename;
     return 0;

--- a/programs/util.c
+++ b/programs/util.c
@@ -99,6 +99,17 @@ int g_utilDisplayLevel;
 *  Functions
 ***************************************/
 
+int UTIL_stat(const char* filename, stat_t* statbuf)
+{
+#if defined(_MSC_VER)
+    return !_stat64(filename, statbuf);
+#elif defined(__MINGW32__) && defined (__MSVCRT__)
+    return !_stati64(filename, statbuf);
+#else
+    return !stat(filename, statbuf);
+#endif
+}
+
 int UTIL_fileExist(const char* filename)
 {
     stat_t statbuf;

--- a/programs/util.c
+++ b/programs/util.c
@@ -110,12 +110,6 @@ int UTIL_stat(const char* filename, stat_t* statbuf)
 #endif
 }
 
-int UTIL_fileExist(const char* filename)
-{
-    stat_t statbuf;
-    return UTIL_stat(filename, &statbuf);
-}
-
 int UTIL_isRegularFile(const char* infilename)
 {
     stat_t statbuf;

--- a/programs/util.c
+++ b/programs/util.c
@@ -119,10 +119,10 @@ int UTIL_fileExist(const char* filename)
 int UTIL_isRegularFile(const char* infilename)
 {
     stat_t statbuf;
-    return UTIL_getFileStat(infilename, &statbuf); /* Only need to know whether it is a regular file */
+    return UTIL_statFile(infilename, &statbuf); /* Only need to know whether it is a regular file */
 }
 
-int UTIL_getFileStat(const char* infilename, stat_t *statbuf)
+int UTIL_statFile(const char* infilename, stat_t *statbuf)
 {
     const int r = UTIL_stat(infilename, statbuf);
 #if defined(_MSC_VER)
@@ -132,7 +132,7 @@ int UTIL_getFileStat(const char* infilename, stat_t *statbuf)
 #endif
 }
 
-int UTIL_getDirectoryStat(const char* infilename, stat_t *statbuf)
+int UTIL_statDir(const char* infilename, stat_t *statbuf)
 {
     const int r = UTIL_stat(infilename, statbuf);
 #if defined(_MSC_VER)
@@ -190,7 +190,7 @@ int UTIL_setFileStat(const char *filename, const stat_t *statbuf)
 int UTIL_isDirectory(const char* infilename)
 {
     stat_t statbuf;
-    return UTIL_getDirectoryStat(infilename, &statbuf);
+    return UTIL_statDir(infilename, &statbuf);
 }
 
 int UTIL_compareStr(const void *p1, const void *p2) {
@@ -647,7 +647,7 @@ static int isFileNameValidForMirroredOutput(const char *filename)
 static mode_t getDirMode(const char *dirName)
 {
     stat_t st;
-    int ret = UTIL_getDirectoryStat(dirName, &st);
+    int ret = UTIL_statDir(dirName, &st);
     if (!ret) {
         UTIL_DISPLAY("zstd: failed to get DIR stats %s: %s\n", dirName, strerror(errno));
         return DIR_DEFAULT_MODE;

--- a/programs/util.c
+++ b/programs/util.c
@@ -354,11 +354,12 @@ UTIL_createFileNamesTable_fromFileName(const char* inputFileName)
     char* buf;
     size_t bufSize;
     size_t pos = 0;
+    stat_t statbuf;
 
-    if (!UTIL_fileExist(inputFileName) || !UTIL_isRegularFile(inputFileName))
+    if (!UTIL_stat(inputFileName, &statbuf) || !UTIL_isRegularFileStat(&statbuf))
         return NULL;
 
-    {   U64 const inputFileSize = UTIL_getFileSize(inputFileName);
+    {   U64 const inputFileSize = UTIL_getFileSizeStat(&statbuf);
         if(inputFileSize > MAX_FILE_OF_FILE_NAMES_SIZE)
             return NULL;
         bufSize = (size_t)(inputFileSize + 1); /* (+1) to add '\0' at the end of last filename */

--- a/programs/util.c
+++ b/programs/util.c
@@ -149,7 +149,7 @@ int UTIL_chmod(char const* filename, mode_t permissions)
     return chmod(filename, permissions);
 }
 
-int UTIL_setFileStat(const char *filename, stat_t *statbuf)
+int UTIL_setFileStat(const char *filename, const stat_t *statbuf)
 {
     int res = 0;
 

--- a/programs/util.c
+++ b/programs/util.c
@@ -157,7 +157,8 @@ int UTIL_setFileStat(const char *filename, const stat_t *statbuf)
 {
     int res = 0;
 
-    if (!UTIL_isRegularFile(filename))
+    stat_t curStatBuf;
+    if (!UTIL_stat(filename, &curStatBuf) || !UTIL_isRegularFileStat(&curStatBuf))
         return -1;
 
     /* set access and modification times */
@@ -185,7 +186,7 @@ int UTIL_setFileStat(const char *filename, const stat_t *statbuf)
     res += chown(filename, statbuf->st_uid, statbuf->st_gid);  /* Copy ownership */
 #endif
 
-    res += UTIL_chmod(filename, NULL, statbuf->st_mode & 07777);  /* Copy file permissions */
+    res += UTIL_chmod(filename, &curStatBuf, statbuf->st_mode & 07777);  /* Copy file permissions */
 
     errno = 0;
     return -res; /* number of errors is returned */

--- a/programs/util.h
+++ b/programs/util.h
@@ -155,7 +155,6 @@ int UTIL_chmod(char const* filename, const stat_t* statbuf, mode_t permissions);
  * compute the needed information.
  */
 
-int UTIL_fileExist(const char* filename);
 int UTIL_isRegularFile(const char* infilename);
 int UTIL_isDirectory(const char* infilename);
 int UTIL_isSameFile(const char* file1, const char* file2);

--- a/programs/util.h
+++ b/programs/util.h
@@ -120,18 +120,24 @@ extern int g_utilDisplayLevel;
  * Returns success (1) or failure (0).
  */
 int UTIL_stat(const char* filename, stat_t* statbuf);
-int UTIL_statFile(const char* infilename, stat_t* statbuf); /* also check it's a file */
-int UTIL_statDir(const char* infilename, stat_t* statbuf); /* also check it's a directory */
+/** Also checks that the target is a regular file. */
+int UTIL_statFile(const char* infilename, stat_t* statbuf);
+/** Also checks that the target is a directory. */
+int UTIL_statDir(const char* infilename, stat_t* statbuf);
 int UTIL_fileExist(const char* filename);
 int UTIL_isRegularFile(const char* infilename);
+int UTIL_isRegularFileStat(const stat_t* statbuf); /* same but takes existing statbuf */
 int UTIL_isDirectory(const char* infilename);
+int UTIL_isDirectoryStat(const stat_t* statbuf); /* same but takes existing statbuf */
 int UTIL_isSameFile(const char* file1, const char* file2);
 int UTIL_isCompressedFile(const char* infilename, const char *extensionList[]);
 int UTIL_isLink(const char* infilename);
 int UTIL_isFIFO(const char* infilename);
+int UTIL_isFIFOStat(const stat_t* statbuf); /* same but takes existing statbuf */
 
 #define UTIL_FILESIZE_UNKNOWN  ((U64)(-1))
 U64 UTIL_getFileSize(const char* infilename);
+U64 UTIL_getFileSizeStat(const stat_t* statbuf);
 U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
 int UTIL_setFileStat(const char* filename, const stat_t* statbuf);
 int UTIL_chmod(char const* filename, mode_t permissions);   /*< like chmod, but avoid changing permission of /dev/null */

--- a/programs/util.h
+++ b/programs/util.h
@@ -140,7 +140,12 @@ U64 UTIL_getFileSize(const char* infilename);
 U64 UTIL_getFileSizeStat(const stat_t* statbuf);
 U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
 int UTIL_setFileStat(const char* filename, const stat_t* statbuf);
-int UTIL_chmod(char const* filename, mode_t permissions);   /*< like chmod, but avoid changing permission of /dev/null */
+/**
+ * Like chmod, but only modifies regular files. Provided statbuf may be NULL,
+ * in which case this function will stat() the file internally, in order to
+ * check that it should be modified.
+ */
+int UTIL_chmod(char const* filename, const stat_t* statbuf, mode_t permissions);
 int UTIL_compareStr(const void *p1, const void *p2);
 const char* UTIL_getFileExtension(const char* infilename);
 void  UTIL_mirrorSourceFilesDirectories(const char** fileNamesTable, unsigned int nbFiles, const char *outDirName);

--- a/programs/util.h
+++ b/programs/util.h
@@ -100,6 +100,8 @@ extern int g_utilDisplayLevel;
 #if defined(_MSC_VER)
     typedef struct __stat64 stat_t;
     typedef int mode_t;
+#elif defined(__MINGW32__) && defined (__MSVCRT__)
+    typedef struct _stati64 stat_t;
 #else
     typedef struct stat stat_t;
 #endif
@@ -113,6 +115,11 @@ extern int g_utilDisplayLevel;
 #define STRDUP(s) strdup(s)
 #endif
 
+/**
+ * Calls platform's equivalent of stat() on filename and writes info to statbuf.
+ * Returns success (1) or failure (0).
+ */
+int UTIL_stat(const char* filename, stat_t* statbuf);
 int UTIL_fileExist(const char* filename);
 int UTIL_isRegularFile(const char* infilename);
 int UTIL_isDirectory(const char* infilename);

--- a/programs/util.h
+++ b/programs/util.h
@@ -120,10 +120,6 @@ extern int g_utilDisplayLevel;
  * Returns success (1) or failure (0).
  */
 int UTIL_stat(const char* filename, stat_t* statbuf);
-/** Also checks that the target is a regular file. */
-int UTIL_statFile(const char* infilename, stat_t* statbuf);
-/** Also checks that the target is a directory. */
-int UTIL_statDir(const char* infilename, stat_t* statbuf);
 
 /**
  * Instead of getting a file's stats, this updates them with the info in the

--- a/programs/util.h
+++ b/programs/util.h
@@ -124,28 +124,49 @@ int UTIL_stat(const char* filename, stat_t* statbuf);
 int UTIL_statFile(const char* infilename, stat_t* statbuf);
 /** Also checks that the target is a directory. */
 int UTIL_statDir(const char* infilename, stat_t* statbuf);
+
+/**
+ * Instead of getting a file's stats, this updates them with the info in the
+ * provided stat_t. Currently sets owner, group, atime, and mtime. Will only
+ * update this info for regular files.
+ */
+int UTIL_setFileStat(const char* filename, const stat_t* statbuf);
+
+/*
+ * These helpers operate on a pre-populated stat_t, i.e., the result of
+ * calling one of the above functions.
+ */
+
+int UTIL_isRegularFileStat(const stat_t* statbuf);
+int UTIL_isDirectoryStat(const stat_t* statbuf);
+int UTIL_isFIFOStat(const stat_t* statbuf);
+U64 UTIL_getFileSizeStat(const stat_t* statbuf);
+
+/**
+ * Like chmod(), but only modifies regular files. Provided statbuf may be NULL,
+ * in which case this function will stat() the file internally, in order to
+ * check whether it should be modified.
+ */
+int UTIL_chmod(char const* filename, const stat_t* statbuf, mode_t permissions);
+
+/*
+ * In the absence of a pre-existing stat result on the file in question, these
+ * functions will do a stat() call internally and then use that result to
+ * compute the needed information.
+ */
+
 int UTIL_fileExist(const char* filename);
 int UTIL_isRegularFile(const char* infilename);
-int UTIL_isRegularFileStat(const stat_t* statbuf); /* same but takes existing statbuf */
 int UTIL_isDirectory(const char* infilename);
-int UTIL_isDirectoryStat(const stat_t* statbuf); /* same but takes existing statbuf */
 int UTIL_isSameFile(const char* file1, const char* file2);
 int UTIL_isCompressedFile(const char* infilename, const char *extensionList[]);
 int UTIL_isLink(const char* infilename);
 int UTIL_isFIFO(const char* infilename);
-int UTIL_isFIFOStat(const stat_t* statbuf); /* same but takes existing statbuf */
 
 #define UTIL_FILESIZE_UNKNOWN  ((U64)(-1))
 U64 UTIL_getFileSize(const char* infilename);
-U64 UTIL_getFileSizeStat(const stat_t* statbuf);
 U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
-int UTIL_setFileStat(const char* filename, const stat_t* statbuf);
-/**
- * Like chmod, but only modifies regular files. Provided statbuf may be NULL,
- * in which case this function will stat() the file internally, in order to
- * check that it should be modified.
- */
-int UTIL_chmod(char const* filename, const stat_t* statbuf, mode_t permissions);
+
 int UTIL_compareStr(const void *p1, const void *p2);
 const char* UTIL_getFileExtension(const char* infilename);
 void  UTIL_mirrorSourceFilesDirectories(const char** fileNamesTable, unsigned int nbFiles, const char *outDirName);

--- a/programs/util.h
+++ b/programs/util.h
@@ -120,6 +120,8 @@ extern int g_utilDisplayLevel;
  * Returns success (1) or failure (0).
  */
 int UTIL_stat(const char* filename, stat_t* statbuf);
+int UTIL_statFile(const char* infilename, stat_t* statbuf); /* also check it's a file */
+int UTIL_statDir(const char* infilename, stat_t* statbuf); /* also check it's a directory */
 int UTIL_fileExist(const char* filename);
 int UTIL_isRegularFile(const char* infilename);
 int UTIL_isDirectory(const char* infilename);
@@ -131,9 +133,7 @@ int UTIL_isFIFO(const char* infilename);
 #define UTIL_FILESIZE_UNKNOWN  ((U64)(-1))
 U64 UTIL_getFileSize(const char* infilename);
 U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
-int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
 int UTIL_setFileStat(const char* filename, const stat_t* statbuf);
-int UTIL_getDirectoryStat(const char* infilename, stat_t* statbuf);
 int UTIL_chmod(char const* filename, mode_t permissions);   /*< like chmod, but avoid changing permission of /dev/null */
 int UTIL_compareStr(const void *p1, const void *p2);
 const char* UTIL_getFileExtension(const char* infilename);

--- a/programs/util.h
+++ b/programs/util.h
@@ -132,7 +132,7 @@ int UTIL_isFIFO(const char* infilename);
 U64 UTIL_getFileSize(const char* infilename);
 U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
 int UTIL_getFileStat(const char* infilename, stat_t* statbuf);
-int UTIL_setFileStat(const char* filename, stat_t* statbuf);
+int UTIL_setFileStat(const char* filename, const stat_t* statbuf);
 int UTIL_getDirectoryStat(const char* infilename, stat_t* statbuf);
 int UTIL_chmod(char const* filename, mode_t permissions);   /*< like chmod, but avoid changing permission of /dev/null */
 int UTIL_compareStr(const void *p1, const void *p2);


### PR DESCRIPTION
This stack introduces variants of various `UTIL_...()` functions that take an already prepared result of a `stat()` call, rather than making a `stat()` call themselves. In situations where several of these calls are made in sequence, it's easy to use these new functions to refactor the code to reuse the result of a single `stat()` call rather than make several.

This causes zstd to make 37% fewer `stat()` calls:

```
felixh@vali:~/prog/zstd (dev)$ strace ./zstd -r lib -o /dev/null |& grep -E '^stat\(' | wc -l
730
felixh@vali:~/prog/zstd (fewer-stat-syscalls)$ strace ./zstd -r lib -o /dev/null |& grep -E '^stat\(' | wc -l
460
```