### PR TITLE
Fix clang -Wcomma warning (single file decoder)

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -499,7 +499,8 @@ size_t ZSTD_decodeSeqHeaders(ZSTD_DCtx* dctx, int* nbSeqPtr,
     if (nbSeq > 0x7F) {
         if (nbSeq == 0xFF) {
             RETURN_ERROR_IF(ip+2 > iend, srcSize_wrong, "");
-            nbSeq = MEM_readLE16(ip) + LONGNBSEQ, ip+=2;
+            nbSeq = MEM_readLE16(ip) + LONGNBSEQ;
+            ip+=2;
         } else {
             RETURN_ERROR_IF(ip >= iend, srcSize_wrong, "");
             nbSeq = ((nbSeq-0x80)<<8) + *ip++;


### PR DESCRIPTION
Minor change but newer Clang/Xcode projects seem to have the `-Wcomma` warning enabled by default.

There are more of these in the codebase in general, and it's a style I use myself, so wasn't sure whether adding the various compiler equivalents of `-Wno-comma` would be better? For the single file _decoder_ there's only one so it became a one-liner.