### PR TITLE
[actions] removing broken icc test from travis and adding working version to actions

### DIFF
--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -182,3 +182,22 @@ jobs:
         wget https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz
         tar -xf shellcheck-v0.7.1.linux.x86_64.tar.xz
         shellcheck-v0.7.1/shellcheck --shell=sh --severity=warning --exclude=SC2010 tests/playTests.sh
+
+  icc:
+    name: icc-check
+    runs-on: ubuntu-latest
+    steps:
+    - name: install icc
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get -qqq update
+        sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+        sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+        sudo apt-get install -y intel-oneapi-icc
+    - uses: actions/checkout@v2
+    - name: make check
+      run: |
+        make CC=/opt/intel/oneapi/compiler/latest/linux/bin/intel64/icc check

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,22 +25,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - name: icc
-      compiler: icc
-      env:
-      - C_COMPILER=icc
-      - CXX_COMPILER=icpc
-      install:
-      - source /opt/intel/inteloneapi/compiler/latest/env/vars.sh
-      addons:
-        apt:
-          sources:
-          - sourceline: 'deb https://apt.repos.intel.com/oneapi all main'
-            key_url: 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB'
-          packages:
-          - intel-oneapi-icc
-      script: make check
-
     - name: arm64    # ~2.5 mn
       os: linux
       arch: arm64


### PR DESCRIPTION
The directory structure for icc's installation had changed so it couldn't find he setvars.sh it needed. I now just reference the compiler path for the latest icc directly which shouldn't change. 