### PR TITLE
DDSS For Lazy: Implement a Dedicated Dictionary Hash Table

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2892,7 +2892,9 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
         case ZSTD_greedy:
         case ZSTD_lazy:
         case ZSTD_lazy2:
-            if (chunk >= HASH_READ_SIZE)
+            if (chunk >= HASH_READ_SIZE && params->enableDedicatedDictSearch)
+                ZSTD_lazy_loadDictionary(ms, ichunk-HASH_READ_SIZE);
+            else if (chunk >= HASH_READ_SIZE)
                 ZSTD_insertAndFindFirstIndex(ms, ichunk-HASH_READ_SIZE);
             break;
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2914,7 +2914,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
         case ZSTD_greedy:
         case ZSTD_lazy:
         case ZSTD_lazy2:
-            if (chunk >= HASH_READ_SIZE && params->enableDedicatedDictSearch)
+            if (chunk >= HASH_READ_SIZE && ms->dedicatedDictSearch)
                 ZSTD_dedicatedDictSearch_lazy_loadDictionary(ms, ichunk-HASH_READ_SIZE);
             else if (chunk >= HASH_READ_SIZE)
                 ZSTD_insertAndFindFirstIndex(ms, ichunk-HASH_READ_SIZE);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1640,10 +1640,8 @@ static int ZSTD_shouldAttachDict(const ZSTD_CDict* cdict,
                                  U64 pledgedSrcSize)
 {
     size_t cutoff = attachDictSizeCutoffs[cdict->matchState.cParams.strategy];
-    int const useDedicatedDictSearch =
-        params->enableDedicatedDictSearch &&
-        ZSTD_dedicatedDictSearch_isSupported(params->compressionLevel, cdict->dictContentSize);
-    return ( useDedicatedDictSearch
+    int const dedicatedDictSearch = cdict->matchState.dedicatedDictSearch;
+    return ( dedicatedDictSearch
           || pledgedSrcSize <= cutoff
           || pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN
           || params->attachDictPref == ZSTD_dictForceAttach )
@@ -1708,6 +1706,8 @@ static size_t ZSTD_resetCCtx_byCopyingCDict(ZSTD_CCtx* cctx,
                             ZSTD_buffered_policy_e zbuff)
 {
     const ZSTD_compressionParameters *cdict_cParams = &cdict->matchState.cParams;
+
+    assert(!cdict->matchState.dedicatedDictSearch);
 
     DEBUGLOG(4, "copying dictionary into context");
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3588,6 +3588,7 @@ const ZSTD_CDict* ZSTD_initStaticCDict(
                             + ZSTD_cwksp_alloc_size(HUF_WORKSPACE_SIZE)
                             + matchStateSize;
     ZSTD_CDict* cdict;
+    ZSTD_CCtx_params params;
 
     if ((size_t)workspace & 7) return NULL;  /* 8-aligned */
 
@@ -3603,7 +3604,6 @@ const ZSTD_CDict* ZSTD_initStaticCDict(
         (unsigned)workspaceSize, (unsigned)neededSize, (unsigned)(workspaceSize < neededSize));
     if (workspaceSize < neededSize) return NULL;
 
-    ZSTD_CCtx_params params;
     ZSTD_memset(&params, 0, sizeof(params));
 
     if (ZSTD_isError( ZSTD_initCDict_internal(cdict,
@@ -4315,107 +4315,107 @@ static const ZSTD_compressionParameters
 ZSTD_dedicatedDictSearch_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
 {   /* "default" - for any dictSize > 256 KB */
     /* W,  C,  H,  S,  L, TL, strat */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  4 (not adjusted) */
-    { 21, 18, 19 + DD_BLOG,  2,  5,  2, ZSTD_greedy  },  /* level  5 */
-    { 21, 19, 19 + DD_BLOG,  3,  5,  4, ZSTD_greedy  },  /* level  6 */
-    { 21, 19, 19 + DD_BLOG,  3,  5,  8, ZSTD_lazy    },  /* level  7 */
-    { 21, 19, 19 + DD_BLOG,  3,  5, 16, ZSTD_lazy2   },  /* level  8 */
-    { 21, 19, 20 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level  9 */
-    { 22, 20, 21 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level 10 */
-    { 22, 21, 22 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level 11 */
-    { 22, 21, 22 + DD_BLOG,  5,  5, 16, ZSTD_lazy2   },  /* level 12 */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  4 (not adjusted) */
+    { 21, 18, 19 + DD_BLOG,  2,  5,  2, ZSTD_greedy      },  /* level  5 */
+    { 21, 19, 19 + DD_BLOG,  3,  5,  4, ZSTD_greedy      },  /* level  6 */
+    { 21, 19, 19 + DD_BLOG,  3,  5,  8, ZSTD_lazy        },  /* level  7 */
+    { 21, 19, 19 + DD_BLOG,  3,  5, 16, ZSTD_lazy2       },  /* level  8 */
+    { 21, 19, 20 + DD_BLOG,  4,  5, 16, ZSTD_lazy2       },  /* level  9 */
+    { 22, 20, 21 + DD_BLOG,  4,  5, 16, ZSTD_lazy2       },  /* level 10 */
+    { 22, 21, 22 + DD_BLOG,  4,  5, 16, ZSTD_lazy2       },  /* level 11 */
+    { 22, 21, 22 + DD_BLOG,  5,  5, 16, ZSTD_lazy2       },  /* level 12 */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
 },
 {   /* for dictSize <= 256 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
-    { 18, 16, 17 + DD_BLOG,  2,  5,  2, ZSTD_greedy  },  /* level  4 */
-    { 18, 18, 18 + DD_BLOG,  3,  5,  2, ZSTD_greedy  },  /* level  5 */
-    { 18, 18, 19 + DD_BLOG,  3,  5,  4, ZSTD_lazy    },  /* level  6 */
-    { 18, 18, 19 + DD_BLOG,  4,  4,  4, ZSTD_lazy    },  /* level  7 */
-    { 18, 18, 19 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
-    { 18, 18, 19 + DD_BLOG,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 18, 18, 19 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 11 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 12 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 18, 16, 17 + DD_BLOG,  2,  5,  2, ZSTD_greedy      },  /* level  4 */
+    { 18, 18, 18 + DD_BLOG,  3,  5,  2, ZSTD_greedy      },  /* level  5 */
+    { 18, 18, 19 + DD_BLOG,  3,  5,  4, ZSTD_lazy        },  /* level  6 */
+    { 18, 18, 19 + DD_BLOG,  4,  4,  4, ZSTD_lazy        },  /* level  7 */
+    { 18, 18, 19 + DD_BLOG,  4,  4,  8, ZSTD_lazy2       },  /* level  8 */
+    { 18, 18, 19 + DD_BLOG,  5,  4,  8, ZSTD_lazy2       },  /* level  9 */
+    { 18, 18, 19 + DD_BLOG,  6,  4,  8, ZSTD_lazy2       },  /* level 10 */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
 },
 {   /* for dictSize <= 128 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  4 (not adjusted) */
-    { 17, 16, 17 + DD_BLOG,  3,  4,  2, ZSTD_greedy  },  /* level  5 */
-    { 17, 17, 17 + DD_BLOG,  3,  4,  4, ZSTD_lazy    },  /* level  6 */
-    { 17, 17, 17 + DD_BLOG,  3,  4,  8, ZSTD_lazy2   },  /* level  7 */
-    { 17, 17, 17 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
-    { 17, 17, 17 + DD_BLOG,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 17, 17, 17 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 11 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 12 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  4 (not adjusted) */
+    { 17, 16, 17 + DD_BLOG,  3,  4,  2, ZSTD_greedy      },  /* level  5 */
+    { 17, 17, 17 + DD_BLOG,  3,  4,  4, ZSTD_lazy        },  /* level  6 */
+    { 17, 17, 17 + DD_BLOG,  3,  4,  8, ZSTD_lazy2       },  /* level  7 */
+    { 17, 17, 17 + DD_BLOG,  4,  4,  8, ZSTD_lazy2       },  /* level  8 */
+    { 17, 17, 17 + DD_BLOG,  5,  4,  8, ZSTD_lazy2       },  /* level  9 */
+    { 17, 17, 17 + DD_BLOG,  6,  4,  8, ZSTD_lazy2       },  /* level 10 */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
 },
 {   /* for dictSize <= 16 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
-    { 14, 14, 14 + DD_BLOG,  4,  4,  2, ZSTD_greedy  },  /* level  4 */
-    { 14, 14, 14 + DD_BLOG,  3,  4,  4, ZSTD_lazy    },  /* level  5 */
-    { 14, 14, 14 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  6 */
-    { 14, 14, 14 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level  7 */
-    { 14, 14, 14 + DD_BLOG,  8,  4,  8, ZSTD_lazy2   },  /* level  8 */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  9 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  10 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  11 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  12 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            },  /* level  21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, 0            }   /* level  22 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 14, 14, 14 + DD_BLOG,  4,  4,  2, ZSTD_greedy      },  /* level  4 */
+    { 14, 14, 14 + DD_BLOG,  3,  4,  4, ZSTD_lazy        },  /* level  5 */
+    { 14, 14, 14 + DD_BLOG,  4,  4,  8, ZSTD_lazy2       },  /* level  6 */
+    { 14, 14, 14 + DD_BLOG,  6,  4,  8, ZSTD_lazy2       },  /* level  7 */
+    { 14, 14, 14 + DD_BLOG,  8,  4,  8, ZSTD_lazy2       },  /* level  8 */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  9 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  10 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level  22 (not adjusted) */
 },
 };
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4323,107 +4323,107 @@ static const ZSTD_compressionParameters
 ZSTD_dedicatedDictSearch_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
 {   /* "default" - for any dictSize > 256 KB */
     /* W,  C,  H,  S,  L, TL, strat */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  4 (not adjusted) */
-    { 21, 18, 19 + DD_BLOG,  2,  5,  2, ZSTD_greedy      },  /* level  5 */
-    { 21, 19, 19 + DD_BLOG,  3,  5,  4, ZSTD_greedy      },  /* level  6 */
-    { 21, 19, 19 + DD_BLOG,  3,  5,  8, ZSTD_lazy        },  /* level  7 */
-    { 21, 19, 19 + DD_BLOG,  3,  5, 16, ZSTD_lazy2       },  /* level  8 */
-    { 21, 19, 20 + DD_BLOG,  4,  5, 16, ZSTD_lazy2       },  /* level  9 */
-    { 22, 20, 21 + DD_BLOG,  4,  5, 16, ZSTD_lazy2       },  /* level 10 */
-    { 22, 21, 22 + DD_BLOG,  4,  5, 16, ZSTD_lazy2       },  /* level 11 */
-    { 22, 21, 22 + DD_BLOG,  5,  5, 16, ZSTD_lazy2       },  /* level 12 */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  4 (not adjusted) */
+    { 21, 18, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  2,  5,  2, ZSTD_greedy      },  /* level  5 */
+    { 21, 19, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  5,  4, ZSTD_greedy      },  /* level  6 */
+    { 21, 19, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  5,  8, ZSTD_lazy        },  /* level  7 */
+    { 21, 19, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  5, 16, ZSTD_lazy2       },  /* level  8 */
+    { 21, 19, 20 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  5, 16, ZSTD_lazy2       },  /* level  9 */
+    { 22, 20, 21 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  5, 16, ZSTD_lazy2       },  /* level 10 */
+    { 22, 21, 22 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  5, 16, ZSTD_lazy2       },  /* level 11 */
+    { 22, 21, 22 + ZSTD_LAZY_DDSS_BUCKET_LOG,  5,  5, 16, ZSTD_lazy2       },  /* level 12 */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
 },
 {   /* for dictSize <= 256 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
-    { 18, 16, 17 + DD_BLOG,  2,  5,  2, ZSTD_greedy      },  /* level  4 */
-    { 18, 18, 18 + DD_BLOG,  3,  5,  2, ZSTD_greedy      },  /* level  5 */
-    { 18, 18, 19 + DD_BLOG,  3,  5,  4, ZSTD_lazy        },  /* level  6 */
-    { 18, 18, 19 + DD_BLOG,  4,  4,  4, ZSTD_lazy        },  /* level  7 */
-    { 18, 18, 19 + DD_BLOG,  4,  4,  8, ZSTD_lazy2       },  /* level  8 */
-    { 18, 18, 19 + DD_BLOG,  5,  4,  8, ZSTD_lazy2       },  /* level  9 */
-    { 18, 18, 19 + DD_BLOG,  6,  4,  8, ZSTD_lazy2       },  /* level 10 */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 11 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 12 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 18, 16, 17 + ZSTD_LAZY_DDSS_BUCKET_LOG,  2,  5,  2, ZSTD_greedy      },  /* level  4 */
+    { 18, 18, 18 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  5,  2, ZSTD_greedy      },  /* level  5 */
+    { 18, 18, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  5,  4, ZSTD_lazy        },  /* level  6 */
+    { 18, 18, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  4,  4, ZSTD_lazy        },  /* level  7 */
+    { 18, 18, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  4,  8, ZSTD_lazy2       },  /* level  8 */
+    { 18, 18, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  5,  4,  8, ZSTD_lazy2       },  /* level  9 */
+    { 18, 18, 19 + ZSTD_LAZY_DDSS_BUCKET_LOG,  6,  4,  8, ZSTD_lazy2       },  /* level 10 */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 11 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 12 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
 },
 {   /* for dictSize <= 128 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  4 (not adjusted) */
-    { 17, 16, 17 + DD_BLOG,  3,  4,  2, ZSTD_greedy      },  /* level  5 */
-    { 17, 17, 17 + DD_BLOG,  3,  4,  4, ZSTD_lazy        },  /* level  6 */
-    { 17, 17, 17 + DD_BLOG,  3,  4,  8, ZSTD_lazy2       },  /* level  7 */
-    { 17, 17, 17 + DD_BLOG,  4,  4,  8, ZSTD_lazy2       },  /* level  8 */
-    { 17, 17, 17 + DD_BLOG,  5,  4,  8, ZSTD_lazy2       },  /* level  9 */
-    { 17, 17, 17 + DD_BLOG,  6,  4,  8, ZSTD_lazy2       },  /* level 10 */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 11 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 12 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  4 (not adjusted) */
+    { 17, 16, 17 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  4,  2, ZSTD_greedy      },  /* level  5 */
+    { 17, 17, 17 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  4,  4, ZSTD_lazy        },  /* level  6 */
+    { 17, 17, 17 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  4,  8, ZSTD_lazy2       },  /* level  7 */
+    { 17, 17, 17 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  4,  8, ZSTD_lazy2       },  /* level  8 */
+    { 17, 17, 17 + ZSTD_LAZY_DDSS_BUCKET_LOG,  5,  4,  8, ZSTD_lazy2       },  /* level  9 */
+    { 17, 17, 17 + ZSTD_LAZY_DDSS_BUCKET_LOG,  6,  4,  8, ZSTD_lazy2       },  /* level 10 */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 11 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 12 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 13 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 14 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 15 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 16 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 17 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 18 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 19 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 20 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level 21 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 }   /* level 22 (not adjusted) */
 },
 {   /* for dictSize <= 16 KB */
     /* W,  C,  H,  S,  L,  T, strat */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
-    { 14, 14, 14 + DD_BLOG,  4,  4,  2, ZSTD_greedy      },  /* level  4 */
-    { 14, 14, 14 + DD_BLOG,  3,  4,  4, ZSTD_lazy        },  /* level  5 */
-    { 14, 14, 14 + DD_BLOG,  4,  4,  8, ZSTD_lazy2       },  /* level  6 */
-    { 14, 14, 14 + DD_BLOG,  6,  4,  8, ZSTD_lazy2       },  /* level  7 */
-    { 14, 14, 14 + DD_BLOG,  8,  4,  8, ZSTD_lazy2       },  /* level  8 */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  9 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  10 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  11 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  12 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  13 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  14 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  15 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  16 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  17 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  18 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  19 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  20 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 },  /* level  21 (not adjusted) */
-    { 0,  0,  0,             0,  0,  0, (ZSTD_strategy)0 }   /* level  22 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* base (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  1 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  2 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  3 (not adjusted) */
+    { 14, 14, 14 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  4,  2, ZSTD_greedy      },  /* level  4 */
+    { 14, 14, 14 + ZSTD_LAZY_DDSS_BUCKET_LOG,  3,  4,  4, ZSTD_lazy        },  /* level  5 */
+    { 14, 14, 14 + ZSTD_LAZY_DDSS_BUCKET_LOG,  4,  4,  8, ZSTD_lazy2       },  /* level  6 */
+    { 14, 14, 14 + ZSTD_LAZY_DDSS_BUCKET_LOG,  6,  4,  8, ZSTD_lazy2       },  /* level  7 */
+    { 14, 14, 14 + ZSTD_LAZY_DDSS_BUCKET_LOG,  8,  4,  8, ZSTD_lazy2       },  /* level  8 */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  9 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  10 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  11 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  12 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  13 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  14 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  15 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  16 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  17 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  18 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  19 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  20 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 },  /* level  21 (not adjusted) */
+    { 0,  0,  0,                               0,  0,  0, (ZSTD_strategy)0 }   /* level  22 (not adjusted) */
 },
 };
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -353,6 +353,11 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
 #endif
         return bounds;
 
+    case ZSTD_c_enableDedicatedDictSearch:
+        bounds.lowerBound = 0;
+        bounds.upperBound = 1;
+        return bounds;
+
     case ZSTD_c_enableLongDistanceMatching:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
@@ -464,6 +469,7 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     case ZSTD_c_jobSize:
     case ZSTD_c_overlapLog:
     case ZSTD_c_rsyncable:
+    case ZSTD_c_enableDedicatedDictSearch:
     case ZSTD_c_enableLongDistanceMatching:
     case ZSTD_c_ldmHashLog:
     case ZSTD_c_ldmMinMatch:
@@ -514,6 +520,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
     case ZSTD_c_jobSize:
     case ZSTD_c_overlapLog:
     case ZSTD_c_rsyncable:
+    case ZSTD_c_enableDedicatedDictSearch:
     case ZSTD_c_enableLongDistanceMatching:
     case ZSTD_c_ldmHashLog:
     case ZSTD_c_ldmMinMatch:
@@ -667,6 +674,10 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
         return CCtxParams->rsyncable;
 #endif
 
+    case ZSTD_c_enableDedicatedDictSearch :
+        CCtxParams->enableDedicatedDictSearch = (value!=0);
+        return CCtxParams->enableDedicatedDictSearch;
+
     case ZSTD_c_enableLongDistanceMatching :
         CCtxParams->ldmParams.enableLdm = (value!=0);
         return CCtxParams->ldmParams.enableLdm;
@@ -794,6 +805,9 @@ size_t ZSTD_CCtxParams_getParameter(
         *value = CCtxParams->rsyncable;
         break;
 #endif
+    case ZSTD_c_enableDedicatedDictSearch :
+        *value = CCtxParams->enableDedicatedDictSearch;
+        break;
     case ZSTD_c_enableLongDistanceMatching :
         *value = CCtxParams->ldmParams.enableLdm;
         break;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3476,6 +3476,26 @@ ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t dictSize,
     }
 }
 
+ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
+                                                  ZSTD_dictLoadMethod_e dictLoadMethod,
+                                                  ZSTD_dictContentType_e dictContentType,
+                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_customMem customMem)
+{
+    int const enableDedicatedDictSearch = cctxParams.enableDedicatedDictSearch &&
+        ZSTD_dedicatedDictSearch_isSupported(cctxParams.compressionLevel, dictSize);
+    if (!enableDedicatedDictSearch)
+        return ZSTD_createCDict_advanced(dict, dictSize,
+            dictLoadMethod, dictContentType, cctxParams.cParams,
+            customMem);
+    {
+        ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
+            cctxParams.compressionLevel, dictSize);
+        return ZSTD_createCDict_advanced(dict, dictSize,
+            dictLoadMethod, dictContentType, cParams, customMem);
+    }
+}
+
 ZSTD_CDict* ZSTD_createCDict(const void* dict, size_t dictSize, int compressionLevel)
 {
     ZSTD_compressionParameters cParams = ZSTD_getCParams_internal(compressionLevel, ZSTD_CONTENTSIZE_UNKNOWN, dictSize);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1640,7 +1640,11 @@ static int ZSTD_shouldAttachDict(const ZSTD_CDict* cdict,
                                  U64 pledgedSrcSize)
 {
     size_t cutoff = attachDictSizeCutoffs[cdict->matchState.cParams.strategy];
-    return ( pledgedSrcSize <= cutoff
+    int const useDedicatedDictSearch =
+        params->enableDedicatedDictSearch &&
+        ZSTD_dedicatedDictSearch_isSupported(params->compressionLevel, cdict->dictContentSize);
+    return ( useDedicatedDictSearch
+          || pledgedSrcSize <= cutoff
           || pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN
           || params->attachDictPref == ZSTD_dictForceAttach )
         && params->attachDictPref != ZSTD_dictForceCopy

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -875,8 +875,6 @@ static int ZSTD_dedicatedDictSearch_isSupported(int const compressionLevel, size
 static size_t ZSTD_initLocalDict(ZSTD_CCtx* cctx)
 {
     ZSTD_localDict* const dl = &cctx->localDict;
-    ZSTD_compressionParameters const cParams = ZSTD_getCParamsFromCCtxParams(
-            &cctx->requestedParams, ZSTD_CONTENTSIZE_UNKNOWN, dl->dictSize);
     if (dl->dict == NULL) {
         /* No local dictionary. */
         assert(dl->dictBuffer == NULL);
@@ -893,12 +891,12 @@ static size_t ZSTD_initLocalDict(ZSTD_CCtx* cctx)
     assert(cctx->cdict == NULL);
     assert(cctx->prefixDict.dict == NULL);
 
-    dl->cdict = ZSTD_createCDict_advanced(
+    dl->cdict = ZSTD_createCDict_advanced2(
             dl->dict,
             dl->dictSize,
             ZSTD_dlm_byRef,
             dl->dictContentType,
-            cParams,
+            &cctx->requestedParams,
             cctx->customMem);
     RETURN_ERROR_IF(!dl->cdict, memory_allocation, "ZSTD_createCDict_advanced failed");
     cctx->cdict = dl->cdict;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3481,18 +3481,18 @@ ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t dictSize,
 ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,
                                                   ZSTD_dictContentType_e dictContentType,
-                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_CCtx_params* cctxParams,
                                                   ZSTD_customMem customMem)
 {
-    int const enableDedicatedDictSearch = cctxParams.enableDedicatedDictSearch &&
-        ZSTD_dedicatedDictSearch_isSupported(cctxParams.compressionLevel, dictSize);
+    int const enableDedicatedDictSearch = cctxParams->enableDedicatedDictSearch &&
+        ZSTD_dedicatedDictSearch_isSupported(cctxParams->compressionLevel, dictSize);
     if (!enableDedicatedDictSearch)
         return ZSTD_createCDict_advanced(dict, dictSize,
-            dictLoadMethod, dictContentType, cctxParams.cParams,
+            dictLoadMethod, dictContentType, cctxParams->cParams,
             customMem);
     {
         ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
-            cctxParams.compressionLevel, dictSize);
+            cctxParams->compressionLevel, dictSize);
         ZSTD_CDict* const cdict = ZSTD_createCDict_advanced(dict, dictSize,
             dictLoadMethod, dictContentType, cParams, customMem);
         cdict->matchState.enableDedicatedDictSearch = enableDedicatedDictSearch;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2212,7 +2212,7 @@ ZSTD_compressSequences(seqStore_t* seqStorePtr,
  * assumption : strat is a valid strategy */
 ZSTD_blockCompressor ZSTD_selectBlockCompressor(ZSTD_strategy strat, ZSTD_dictMode_e dictMode)
 {
-    static const ZSTD_blockCompressor blockCompressor[3][ZSTD_STRATEGY_MAX+1] = {
+    static const ZSTD_blockCompressor blockCompressor[4][ZSTD_STRATEGY_MAX+1] = {
         { ZSTD_compressBlock_fast  /* default for 0 */,
           ZSTD_compressBlock_fast,
           ZSTD_compressBlock_doubleFast,
@@ -2242,7 +2242,17 @@ ZSTD_blockCompressor ZSTD_selectBlockCompressor(ZSTD_strategy strat, ZSTD_dictMo
           ZSTD_compressBlock_btlazy2_dictMatchState,
           ZSTD_compressBlock_btopt_dictMatchState,
           ZSTD_compressBlock_btultra_dictMatchState,
-          ZSTD_compressBlock_btultra_dictMatchState }
+          ZSTD_compressBlock_btultra_dictMatchState },
+        { NULL  /* default for 0 */,
+          NULL,
+          NULL,
+          ZSTD_compressBlock_greedy_dedicatedDictSearch,
+          ZSTD_compressBlock_lazy_dedicatedDictSearch,
+          ZSTD_compressBlock_lazy2_dedicatedDictSearch,
+          NULL,
+          NULL,
+          NULL,
+          NULL }
     };
     ZSTD_blockCompressor selectedCompressor;
     ZSTD_STATIC_ASSERT((unsigned)ZSTD_fast == 1);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4248,6 +4248,114 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
 },
 };
 
+static const ZSTD_compressionParameters
+ZSTD_dedicatedDictSearch_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
+{   /* "default" - for any dictSize > 256 KB */
+    /* W,  C,  H,  S,  L, TL, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  4 (not adjusted) */
+    { 21, 18, 19 + DD_BLOG,  2,  5,  2, ZSTD_greedy  },  /* level  5 */
+    { 21, 19, 19 + DD_BLOG,  3,  5,  4, ZSTD_greedy  },  /* level  6 */
+    { 21, 19, 19 + DD_BLOG,  3,  5,  8, ZSTD_lazy    },  /* level  7 */
+    { 21, 19, 19 + DD_BLOG,  3,  5, 16, ZSTD_lazy2   },  /* level  8 */
+    { 21, 19, 20 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level  9 */
+    { 22, 20, 21 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level 10 */
+    { 22, 21, 22 + DD_BLOG,  4,  5, 16, ZSTD_lazy2   },  /* level 11 */
+    { 22, 21, 22 + DD_BLOG,  5,  5, 16, ZSTD_lazy2   },  /* level 12 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+},
+{   /* for dictSize <= 256 KB */
+    /* W,  C,  H,  S,  L,  T, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 18, 16, 17 + DD_BLOG,  2,  5,  2, ZSTD_greedy  },  /* level  4 */
+    { 18, 18, 18 + DD_BLOG,  3,  5,  2, ZSTD_greedy  },  /* level  5 */
+    { 18, 18, 19 + DD_BLOG,  3,  5,  4, ZSTD_lazy    },  /* level  6 */
+    { 18, 18, 19 + DD_BLOG,  4,  4,  4, ZSTD_lazy    },  /* level  7 */
+    { 18, 18, 19 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 18, 18, 19 + DD_BLOG,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 18, 18, 19 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+},
+{   /* for dictSize <= 128 KB */
+    /* W,  C,  H,  S,  L,  T, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  4 (not adjusted) */
+    { 17, 16, 17 + DD_BLOG,  3,  4,  2, ZSTD_greedy  },  /* level  5 */
+    { 17, 17, 17 + DD_BLOG,  3,  4,  4, ZSTD_lazy    },  /* level  6 */
+    { 17, 17, 17 + DD_BLOG,  3,  4,  8, ZSTD_lazy2   },  /* level  7 */
+    { 17, 17, 17 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 17, 17, 17 + DD_BLOG,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 17, 17, 17 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level 21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level 22 (not adjusted) */
+},
+{   /* for dictSize <= 16 KB */
+    /* W,  C,  H,  S,  L,  T, strat */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* base (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  1 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  2 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  3 (not adjusted) */
+    { 14, 14, 14 + DD_BLOG,  4,  4,  2, ZSTD_greedy  },  /* level  4 */
+    { 14, 14, 14 + DD_BLOG,  3,  4,  4, ZSTD_lazy    },  /* level  5 */
+    { 14, 14, 14 + DD_BLOG,  4,  4,  8, ZSTD_lazy2   },  /* level  6 */
+    { 14, 14, 14 + DD_BLOG,  6,  4,  8, ZSTD_lazy2   },  /* level  7 */
+    { 14, 14, 14 + DD_BLOG,  8,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  9 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  10 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  11 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  12 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  13 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  14 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  15 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  16 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  17 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  18 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  19 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  20 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            },  /* level  21 (not adjusted) */
+    { 0,  0,  0,             0,  0,  0, 0            }   /* level  22 (not adjusted) */
+},
+};
+
 /*! ZSTD_getCParams_internal() :
  * @return ZSTD_compressionParameters structure for a selected compression level, srcSize and dictSize.
  *  Note: srcSizeHint 0 means 0, use ZSTD_CONTENTSIZE_UNKNOWN for unknown.

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4392,8 +4392,8 @@ ZSTD_dedicatedDictSearch_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
 
 static ZSTD_compressionParameters ZSTD_dedicatedDictSearch_getCParams(int const compressionLevel, size_t const dictSize)
 {
-    size_t const tableID = (dictSize <= 256 KB) + (dictSize <= 128 KB) + (dictSize <= 16 KB);
-    size_t const row = compressionLevel;
+    int const tableID = (dictSize <= 256 KB) + (dictSize <= 128 KB) + (dictSize <= 16 KB);
+    int const row = compressionLevel;
     return ZSTD_dedicatedDictSearch_defaultCParameters[tableID][row];
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3491,8 +3491,10 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dict
     {
         ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
             cctxParams.compressionLevel, dictSize);
-        return ZSTD_createCDict_advanced(dict, dictSize,
+        ZSTD_CDict* const cdict = ZSTD_createCDict_advanced(dict, dictSize,
             dictLoadMethod, dictContentType, cParams, customMem);
+        cdict->matchState.enableDedicatedDictSearch = enableDedicatedDictSearch;
+        return cdict;
     }
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3403,7 +3403,7 @@ static size_t ZSTD_initCDict_internal(
     DEBUGLOG(3, "ZSTD_initCDict_internal (dictContentType:%u)", (unsigned)dictContentType);
     assert(!ZSTD_checkCParams(cParams));
     cdict->matchState.cParams = cParams;
-    cdict->matchState.enableDedicatedDictSearch = params.enableDedicatedDictSearch;
+    cdict->matchState.dedicatedDictSearch = params.enableDedicatedDictSearch;
     if ((dictLoadMethod == ZSTD_dlm_byRef) || (!dictBuffer) || (!dictSize)) {
         cdict->dictContent = dictBuffer;
     } else {
@@ -3512,9 +3512,9 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dict
                                                   ZSTD_CCtx_params* cctxParams,
                                                   ZSTD_customMem customMem)
 {
-    int const enableDedicatedDictSearch = cctxParams->enableDedicatedDictSearch &&
+    int const dedicatedDictSearch = cctxParams->enableDedicatedDictSearch &&
         ZSTD_dedicatedDictSearch_isSupported(cctxParams->compressionLevel, dictSize);
-    if (!enableDedicatedDictSearch) {
+    if (!dedicatedDictSearch) {
         ZSTD_compressionParameters cParams = ZSTD_getCParams_internal(
             cctxParams->compressionLevel, ZSTD_CONTENTSIZE_UNKNOWN, dictSize);
         return ZSTD_createCDict_advanced(dict, dictSize,

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2893,7 +2893,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
         case ZSTD_lazy:
         case ZSTD_lazy2:
             if (chunk >= HASH_READ_SIZE && params->enableDedicatedDictSearch)
-                ZSTD_lazy_loadDictionary(ms, ichunk-HASH_READ_SIZE);
+                ZSTD_dedicatedDictSearch_lazy_loadDictionary(ms, ichunk-HASH_READ_SIZE);
             else if (chunk >= HASH_READ_SIZE)
                 ZSTD_insertAndFindFirstIndex(ms, ichunk-HASH_READ_SIZE);
             break;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3403,6 +3403,7 @@ static size_t ZSTD_initCDict_internal(
     DEBUGLOG(3, "ZSTD_initCDict_internal (dictContentType:%u)", (unsigned)dictContentType);
     assert(!ZSTD_checkCParams(cParams));
     cdict->matchState.cParams = cParams;
+    cdict->matchState.enableDedicatedDictSearch = params.enableDedicatedDictSearch;
     if ((dictLoadMethod == ZSTD_dlm_byRef) || (!dictBuffer) || (!dictSize)) {
         cdict->dictContent = dictBuffer;
     } else {
@@ -3525,7 +3526,6 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dict
         ZSTD_CDict* cdict = ZSTD_createCDict_advanced_internal(dictSize,
                             dictLoadMethod, cParams,
                             customMem);
-        cdict->matchState.enableDedicatedDictSearch = enableDedicatedDictSearch;
 
         if (ZSTD_isError( ZSTD_initCDict_internal(cdict,
                                         dict, dictSize,

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -401,7 +401,7 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
         return bounds;
 
     case ZSTD_c_forceAttachDict:
-        ZSTD_STATIC_ASSERT(ZSTD_dictDefaultAttach < ZSTD_dictForceCopy);
+        ZSTD_STATIC_ASSERT(ZSTD_dictDefaultAttach < ZSTD_dictForceLoad);
         bounds.lowerBound = ZSTD_dictDefaultAttach;
         bounds.upperBound = ZSTD_dictForceLoad;       /* note : how to ensure at compile time that this is the highest value enum ? */
         return bounds;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3486,10 +3486,13 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dict
 {
     int const enableDedicatedDictSearch = cctxParams->enableDedicatedDictSearch &&
         ZSTD_dedicatedDictSearch_isSupported(cctxParams->compressionLevel, dictSize);
-    if (!enableDedicatedDictSearch)
+    if (!enableDedicatedDictSearch) {
+        ZSTD_compressionParameters cParams = ZSTD_getCParams_internal(
+            cctxParams->compressionLevel, ZSTD_CONTENTSIZE_UNKNOWN, dictSize);
         return ZSTD_createCDict_advanced(dict, dictSize,
-            dictLoadMethod, dictContentType, cctxParams->cParams,
+            dictLoadMethod, dictContentType, cParams,
             customMem);
+    }
     {
         ZSTD_compressionParameters const cParams = ZSTD_dedicatedDictSearch_getCParams(
             cctxParams->compressionLevel, dictSize);

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -153,6 +153,7 @@ struct ZSTD_matchState_t {
     U32* hashTable;
     U32* hashTable3;
     U32* chainTable;
+    int enableDedicatedDictSearch;
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -28,13 +28,6 @@
 extern "C" {
 #endif
 
-
-/* Dedicated dict search bucket log:
- * ---------------------------------
- * This determines the additional space we need for the hash table.
- * We will have 2^DD_BLOG slots in our bucket. */
-#define DD_BLOG 2
-
 /*-*************************************
 *  Constants
 ***************************************/

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -29,6 +29,12 @@ extern "C" {
 #endif
 
 
+/* Dedicated dict search bucket log:
+ * ---------------------------------
+ * This determines the additional space we need for the hash table.
+ * We will have 2^DD_BLOG slots in our bucket. */
+#define DD_BLOG 2
+
 /*-*************************************
 *  Constants
 ***************************************/

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -299,7 +299,12 @@ struct ZSTD_CCtx_s {
 
 typedef enum { ZSTD_dtlm_fast, ZSTD_dtlm_full } ZSTD_dictTableLoadMethod_e;
 
-typedef enum { ZSTD_noDict = 0, ZSTD_extDict = 1, ZSTD_dictMatchState = 2 } ZSTD_dictMode_e;
+typedef enum {
+    ZSTD_noDict = 0,
+    ZSTD_extDict = 1,
+    ZSTD_dictMatchState = 2,
+    ZSTD_dedicatedDictSearch = 3
+} ZSTD_dictMode_e;
 
 
 typedef size_t (*ZSTD_blockCompressor) (
@@ -763,7 +768,7 @@ MEM_STATIC ZSTD_dictMode_e ZSTD_matchState_dictMode(const ZSTD_matchState_t *ms)
     return ZSTD_window_hasExtDict(ms->window) ?
         ZSTD_extDict :
         ms->dictMatchState != NULL ?
-            ZSTD_dictMatchState :
+            (ms->dictMatchState->enableDedicatedDictSearch ? ZSTD_dedicatedDictSearch : ZSTD_dictMatchState) :
             ZSTD_noDict;
 }
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -153,7 +153,9 @@ struct ZSTD_matchState_t {
     U32* hashTable;
     U32* hashTable3;
     U32* chainTable;
-    int enableDedicatedDictSearch;
+    int dedicatedDictSearch;  /* Indicates whether this matchState is using the
+                               * dedicated dictionary search structure.
+                               */
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;
@@ -768,7 +770,7 @@ MEM_STATIC ZSTD_dictMode_e ZSTD_matchState_dictMode(const ZSTD_matchState_t *ms)
     return ZSTD_window_hasExtDict(ms->window) ?
         ZSTD_extDict :
         ms->dictMatchState != NULL ?
-            (ms->dictMatchState->enableDedicatedDictSearch ? ZSTD_dedicatedDictSearch : ZSTD_dictMatchState) :
+            (ms->dictMatchState->dedicatedDictSearch ? ZSTD_dedicatedDictSearch : ZSTD_dictMatchState) :
             ZSTD_noDict;
 }
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -228,6 +228,9 @@ struct ZSTD_CCtx_params_s {
     /* Long distance matching parameters */
     ldmParams_t ldmParams;
 
+    /* Dedicated dict search algorithm trigger */
+    int enableDedicatedDictSearch;
+
     /* Internal use, for createCCtxParams() and freeCCtxParams() only */
     ZSTD_customMem customMem;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -574,8 +574,7 @@ size_t ZSTD_HcFindBestMatch_generic (
         const U32 ddsIndexDelta        = dictLimit - ddsSize;
         const U32 ddsMinChain = ddsSize > ddsChainSize ? ddsSize - ddsChainSize : 0;
         const U32 bucketSize           = (1 << DD_BLOG);
-
-        U32 attemptNb = 1;
+        U32 attemptNb;
 
         matchIndex = dms->hashTable[ddsIdx];
 
@@ -583,7 +582,11 @@ size_t ZSTD_HcFindBestMatch_generic (
         if (!matchIndex)
             return ml;
 
-        for ( ; (matchIndex>ddsLowestIndex) & (nbAttempts>0) ; nbAttempts--, attemptNb++) {
+        for (attemptNb = 0; attemptNb < bucketSize; attemptNb++) {
+            PREFETCH_L1(ddsBase + dms->hashTable[ddsIdx + attemptNb]);
+        }
+
+        for (attemptNb = 1; (matchIndex>ddsLowestIndex) & (nbAttempts>0) ; nbAttempts--, attemptNb++) {
             size_t currentMl=0;
             const BYTE* const match = ddsBase + matchIndex;
             assert(match+4 <= ddsEnd);

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -475,7 +475,7 @@ U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip) {
     return ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, ms->cParams.minMatch);
 }
 
-void ZSTD_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip)
+void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip)
 {
     U32 const target = (U32)(ip - ms->window.base);
     U32* const chainTable = ms->chainTable;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -484,12 +484,12 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
     for (U32 idx = ms->nextToUpdate; idx < target; idx++) {
         U32 const h = ZSTD_hashPtr(
             ms->window.base + idx,
-            ms->cParams.hashLog - DD_BLOG,
-            ms->cParams.minMatch) << DD_BLOG;
+            ms->cParams.hashLog - ZSTD_LAZY_DDSS_BUCKET_LOG,
+            ms->cParams.minMatch) << ZSTD_LAZY_DDSS_BUCKET_LOG;
         chainTable[idx & chainMask] = ms->hashTable[h];
         ms->hashTable[h] = idx;
         /* Same logic as before. But now, just copy the chain into the bucket */
-        for (U32 i = 0; i < (1 << DD_BLOG) - 1; i++)
+        for (U32 i = 0; i < (1 << ZSTD_LAZY_DDSS_BUCKET_LOG) - 1; i++)
             ms->hashTable[h + i + 1] = chainTable[ms->hashTable[h + i] & chainMask];
     }
     ms->nextToUpdate = target;
@@ -525,9 +525,9 @@ size_t ZSTD_HcFindBestMatch_generic (
 
     const ZSTD_matchState_t* const dms = ms->dictMatchState;
     const U32 ddsHashLog = dictMode == ZSTD_dedicatedDictSearch
-                         ? dms->cParams.hashLog - DD_BLOG : 0;
+                         ? dms->cParams.hashLog - ZSTD_LAZY_DDSS_BUCKET_LOG : 0;
     const U32 ddsIdx = dictMode == ZSTD_dedicatedDictSearch
-                     ? ZSTD_hashPtr(ip, ddsHashLog, mls) << DD_BLOG : 0;
+                     ? ZSTD_hashPtr(ip, ddsHashLog, mls) << ZSTD_LAZY_DDSS_BUCKET_LOG : 0;
 
     U32 matchIndex;
 
@@ -573,7 +573,7 @@ size_t ZSTD_HcFindBestMatch_generic (
         const U32 ddsSize              = (U32)(ddsEnd - ddsBase);
         const U32 ddsIndexDelta        = dictLimit - ddsSize;
         const U32 ddsMinChain = ddsSize > ddsChainSize ? ddsSize - ddsChainSize : 0;
-        const U32 bucketSize           = (1 << DD_BLOG);
+        const U32 bucketSize           = (1 << ZSTD_LAZY_DDSS_BUCKET_LOG);
         U32 attemptNb;
 
         matchIndex = dms->hashTable[ddsIdx];

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -525,6 +525,11 @@ size_t ZSTD_HcFindBestMatch_generic (
     /* HC4 match finder */
     U32 matchIndex = ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, mls);
 
+    if (dictMode == ZSTD_dictMatchState && ms->dictMatchState->enableDedicatedDictSearch)
+        PREFETCH_L1(ms->dictMatchState->hashTable +
+            (ZSTD_hashPtr(ip, ms->dictMatchState->cParams.hashLog - DD_BLOG,
+            ms->dictMatchState->cParams.minMatch) << DD_BLOG));
+
     for ( ; (matchIndex>lowLimit) & (nbAttempts>0) ; nbAttempts--) {
         size_t currentMl=0;
         if ((dictMode != ZSTD_extDict) || matchIndex >= dictLimit) {

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -580,7 +580,7 @@ size_t ZSTD_HcFindBestMatch_generic (
             /* save best solution */
             if (currentMl > ml) {
                 ml = currentMl;
-                *offsetPtr = current - (matchIndex + dmsIndexDelta) + ZSTD_REP_MOVE;
+                *offsetPtr = curr - (matchIndex + dmsIndexDelta) + ZSTD_REP_MOVE;
                 if (ip+currentMl == iLimit) break; /* best possible, avoids read overflow on next attempt */
             }
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -567,7 +567,8 @@ size_t ZSTD_HcFindBestMatch_generic (
         const U32 dmsMinChain = dmsSize > dmsChainSize ? dmsSize - dmsChainSize : 0;
         const U32 bucketSize           = (1 << DD_BLOG);
 
-        U32 hash = ZSTD_hashPtr(ip, dms->cParams.hashLog - DD_BLOG, mls) << DD_BLOG;
+        U32 hash = ZSTD_hashPtr(ip, dms->cParams.hashLog - DD_BLOG,
+            dms->cParams.minMatch) << DD_BLOG;
         U32 attemptNb = 0;
         matchIndex = dms->hashTable[hash];
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -447,7 +447,7 @@ static size_t ZSTD_BtFindBestMatch_extDict_selectMLS (
 
 /* Update chains up to ip (excluded)
    Assumption : always within prefix (i.e. not within extDict) */
-static U32 ZSTD_insertAndFindFirstIndex_internal(
+FORCE_INLINE_TEMPLATE U32 ZSTD_insertAndFindFirstIndex_internal(
                         ZSTD_matchState_t* ms,
                         const ZSTD_compressionParameters* const cParams,
                         const BYTE* ip, U32 const mls)

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -544,7 +544,7 @@ size_t ZSTD_HcFindBestMatch_generic (
     /* HC4 match finder */
     matchIndex = ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, mls);
 
-    for ( ; (matchIndex>lowLimit) & (nbAttempts>0) ; nbAttempts--) {
+    for ( ; (matchIndex>=lowLimit) & (nbAttempts>0) ; nbAttempts--) {
         size_t currentMl=0;
         if ((dictMode != ZSTD_extDict) || matchIndex >= dictLimit) {
             const BYTE* const match = base + matchIndex;
@@ -649,7 +649,7 @@ size_t ZSTD_HcFindBestMatch_generic (
 
         matchIndex = dms->hashTable[ZSTD_hashPtr(ip, dms->cParams.hashLog, mls)];
 
-        for ( ; (matchIndex>dmsLowestIndex) & (nbAttempts>0) ; nbAttempts--) {
+        for ( ; (matchIndex>=dmsLowestIndex) & (nbAttempts>0) ; nbAttempts--) {
             size_t currentMl=0;
             const BYTE* const match = dmsBase + matchIndex;
             assert(match+4 <= dmsEnd);

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -575,7 +575,7 @@ size_t ZSTD_HcFindBestMatch_generic (
         const U32 ddsMinChain = ddsSize > ddsChainSize ? ddsSize - ddsChainSize : 0;
         const U32 bucketSize           = (1 << DD_BLOG);
 
-        U32 attemptNb = 0;
+        U32 attemptNb = 1;
 
         matchIndex = dms->hashTable[ddsIdx];
 
@@ -603,7 +603,7 @@ size_t ZSTD_HcFindBestMatch_generic (
                 break;
             }
 
-            if (attemptNb < bucketSize - 1) {
+            if (attemptNb < bucketSize) {
                 matchIndex = dms->hashTable[ddsIdx + attemptNb];
             } else {
                 matchIndex = dms->chainTable[matchIndex & ddsChainMask];

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -611,10 +611,6 @@ size_t ZSTD_HcFindBestMatch_generic (
                     return ml;
                 }
             }
-
-            if (matchIndex <= ddsMinChain) {
-                return ml;
-            }
         }
 
         for ( ; (ddsAttempt < nbAttempts) & (matchIndex >= ddsMinChain); ddsAttempt++) {

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -485,7 +485,7 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
     U32 bucketSize = 1 << ZSTD_LAZY_DDSS_BUCKET_LOG;
     for ( ; idx < target; idx++) {
         U32 i;
-        U32 const h = ZSTD_hashPtr(
+        size_t const h = ZSTD_hashPtr(
             ms->window.base + idx,
             ms->cParams.hashLog - ZSTD_LAZY_DDSS_BUCKET_LOG,
             ms->cParams.minMatch) << ZSTD_LAZY_DDSS_BUCKET_LOG;
@@ -531,8 +531,8 @@ size_t ZSTD_HcFindBestMatch_generic (
     const ZSTD_matchState_t* const dms = ms->dictMatchState;
     const U32 ddsHashLog = dictMode == ZSTD_dedicatedDictSearch
                          ? dms->cParams.hashLog - ZSTD_LAZY_DDSS_BUCKET_LOG : 0;
-    const U32 ddsIdx = dictMode == ZSTD_dedicatedDictSearch
-                     ? ZSTD_hashPtr(ip, ddsHashLog, mls) << ZSTD_LAZY_DDSS_BUCKET_LOG : 0;
+    const size_t ddsIdx = dictMode == ZSTD_dedicatedDictSearch
+                        ? ZSTD_hashPtr(ip, ddsHashLog, mls) << ZSTD_LAZY_DDSS_BUCKET_LOG : 0;
 
     U32 matchIndex;
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -523,13 +523,21 @@ size_t ZSTD_HcFindBestMatch_generic (
     U32 nbAttempts = 1U << cParams->searchLog;
     size_t ml=4-1;
 
-    /* HC4 match finder */
-    U32 matchIndex = ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, mls);
+    const ZSTD_matchState_t* const dms = ms->dictMatchState;
+    const U32 ddsHashLog = dictMode == ZSTD_dedicatedDictSearch
+                         ? dms->cParams.hashLog - DD_BLOG : 0;
+    const U32 ddsIdx = dictMode == ZSTD_dedicatedDictSearch
+                     ? ZSTD_hashPtr(ip, ddsHashLog, mls) << DD_BLOG : 0;
 
-    if (dictMode == ZSTD_dedicatedDictSearch)
-        PREFETCH_L1(ms->dictMatchState->hashTable +
-            (ZSTD_hashPtr(ip, ms->dictMatchState->cParams.hashLog - DD_BLOG,
-            ms->dictMatchState->cParams.minMatch) << DD_BLOG));
+    U32 matchIndex;
+
+    /* HC4 match finder */
+    matchIndex = ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, mls);
+
+    if (dictMode == ZSTD_dedicatedDictSearch) {
+        const U32* entry = &dms->hashTable[ddsIdx];
+        PREFETCH_L1(entry);
+    }
 
     for ( ; (matchIndex>lowLimit) & (nbAttempts>0) ; nbAttempts--) {
         size_t currentMl=0;
@@ -557,47 +565,51 @@ size_t ZSTD_HcFindBestMatch_generic (
     }
 
     if (dictMode == ZSTD_dedicatedDictSearch) {
-        const ZSTD_matchState_t* const dms = ms->dictMatchState;
-        const U32 dmsChainSize         = (1 << dms->cParams.chainLog);
-        const U32 dmsChainMask         = dmsChainSize - 1;
-        const U32 dmsLowestIndex       = dms->window.dictLimit;
-        const BYTE* const dmsBase      = dms->window.base;
-        const BYTE* const dmsEnd       = dms->window.nextSrc;
-        const U32 dmsSize              = (U32)(dmsEnd - dmsBase);
-        const U32 dmsIndexDelta        = dictLimit - dmsSize;
-        const U32 dmsMinChain = dmsSize > dmsChainSize ? dmsSize - dmsChainSize : 0;
+        const U32 ddsChainSize         = (1 << dms->cParams.chainLog);
+        const U32 ddsChainMask         = ddsChainSize - 1;
+        const U32 ddsLowestIndex       = dms->window.dictLimit;
+        const BYTE* const ddsBase      = dms->window.base;
+        const BYTE* const ddsEnd       = dms->window.nextSrc;
+        const U32 ddsSize              = (U32)(ddsEnd - ddsBase);
+        const U32 ddsIndexDelta        = dictLimit - ddsSize;
+        const U32 ddsMinChain = ddsSize > ddsChainSize ? ddsSize - ddsChainSize : 0;
         const U32 bucketSize           = (1 << DD_BLOG);
 
-        U32 hash = ZSTD_hashPtr(ip, dms->cParams.hashLog - DD_BLOG,
-            dms->cParams.minMatch) << DD_BLOG;
         U32 attemptNb = 0;
-        matchIndex = dms->hashTable[hash];
+
+        matchIndex = dms->hashTable[ddsIdx];
 
         /* Empty chain */
         if (!matchIndex)
             return ml;
 
-        for ( ; (matchIndex>dmsLowestIndex) & (nbAttempts>0) ; nbAttempts--, attemptNb++) {
+        for ( ; (matchIndex>ddsLowestIndex) & (nbAttempts>0) ; nbAttempts--, attemptNb++) {
             size_t currentMl=0;
-            const BYTE* const match = dmsBase + matchIndex;
-            assert(match+4 <= dmsEnd);
-            if (MEM_read32(match) == MEM_read32(ip))   /* assumption : matchIndex <= dictLimit-4 (by table construction) */
-                currentMl = ZSTD_count_2segments(ip+4, match+4, iLimit, dmsEnd, prefixStart) + 4;
+            const BYTE* const match = ddsBase + matchIndex;
+            assert(match+4 <= ddsEnd);
+            if (MEM_read32(match) == MEM_read32(ip)) {
+                /* assumption : matchIndex <= dictLimit-4 (by table construction) */
+                currentMl = ZSTD_count_2segments(ip+4, match+4, iLimit, ddsEnd, prefixStart) + 4;
+            }
 
             /* save best solution */
             if (currentMl > ml) {
                 ml = currentMl;
-                *offsetPtr = curr - (matchIndex + dmsIndexDelta) + ZSTD_REP_MOVE;
+                *offsetPtr = curr - (matchIndex + ddsIndexDelta) + ZSTD_REP_MOVE;
                 if (ip+currentMl == iLimit) break; /* best possible, avoids read overflow on next attempt */
             }
 
-            if (matchIndex <= dmsMinChain) break;
+            if (matchIndex <= ddsMinChain) {
+                break;
+            }
 
-            if (attemptNb < bucketSize - 1) matchIndex = dms->hashTable[++hash];
-            else matchIndex = dms->chainTable[matchIndex & dmsChainMask];
+            if (attemptNb < bucketSize - 1) {
+                matchIndex = dms->hashTable[ddsIdx + attemptNb];
+            } else {
+                matchIndex = dms->chainTable[matchIndex & ddsChainMask];
+            }
         }
     } else if (dictMode == ZSTD_dictMatchState) {
-        const ZSTD_matchState_t* const dms = ms->dictMatchState;
         const U32* const dmsChainTable = dms->chainTable;
         const U32 dmsChainSize         = (1 << dms->cParams.chainLog);
         const U32 dmsChainMask         = dmsChainSize - 1;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -531,13 +531,13 @@ size_t ZSTD_HcFindBestMatch_generic (
 
     U32 matchIndex;
 
-    /* HC4 match finder */
-    matchIndex = ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, mls);
-
     if (dictMode == ZSTD_dedicatedDictSearch) {
         const U32* entry = &dms->hashTable[ddsIdx];
         PREFETCH_L1(entry);
     }
+
+    /* HC4 match finder */
+    matchIndex = ZSTD_insertAndFindFirstIndex_internal(ms, cParams, ip, mls);
 
     for ( ; (matchIndex>lowLimit) & (nbAttempts>0) ; nbAttempts--) {
         size_t currentMl=0;

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -19,7 +19,7 @@ extern "C" {
 
 U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip);
 
-void ZSTD_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip);
+void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip);
 
 void ZSTD_preserveUnsortedMark (U32* const table, U32 const size, U32 const reducerValue);  /*! used in ZSTD_reduceIndex(). preemptively increase value of ZSTD_DUBT_UNSORTED_MARK */
 

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -49,6 +49,16 @@ size_t ZSTD_compressBlock_greedy_dictMatchState(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize);
 
+size_t ZSTD_compressBlock_lazy2_dedicatedDictSearch(
+        ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
+        void const* src, size_t srcSize);
+size_t ZSTD_compressBlock_lazy_dedicatedDictSearch(
+        ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
+        void const* src, size_t srcSize);
+size_t ZSTD_compressBlock_greedy_dedicatedDictSearch(
+        ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
+        void const* src, size_t srcSize);
+
 size_t ZSTD_compressBlock_greedy_extDict(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize);

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -17,6 +17,14 @@ extern "C" {
 
 #include "zstd_compress_internal.h"
 
+/**
+ * Dedicated Dictionary Search Structure bucket log. In the
+ * ZSTD_dedicatedDictSearch mode, the hashTable has
+ * 2 ** ZSTD_LAZY_DDSS_BUCKET_LOG entries in each bucket, rather than just
+ * one.
+ */
+#define ZSTD_LAZY_DDSS_BUCKET_LOG 2
+
 U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip);
 
 void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip);

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -19,6 +19,8 @@ extern "C" {
 
 U32 ZSTD_insertAndFindFirstIndex(ZSTD_matchState_t* ms, const BYTE* ip);
 
+void ZSTD_lazy_loadDictionary(ZSTD_matchState_t* ms, const BYTE* const ip);
+
 void ZSTD_preserveUnsortedMark (U32* const table, U32 const size, U32 const reducerValue);  /*! used in ZSTD_reduceIndex(). preemptively increase value of ZSTD_DUBT_UNSORTED_MARK */
 
 size_t ZSTD_compressBlock_btlazy2(

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1405,13 +1405,14 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced(const void* dict, size_t dictS
                                                   ZSTD_customMem customMem);
 
 /**
- * TODO: document!
+ * This API is temporary and is expected to change or disappear in the future!
  */
-ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
-                                                  ZSTD_dictLoadMethod_e dictLoadMethod,
-                                                  ZSTD_dictContentType_e dictContentType,
-                                                  ZSTD_CCtx_params* cctxParams,
-                                                  ZSTD_customMem customMem);
+ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(
+    const void* dict, size_t dictSize,
+    ZSTD_dictLoadMethod_e dictLoadMethod,
+    ZSTD_dictContentType_e dictContentType,
+    ZSTD_CCtx_params* cctxParams,
+    ZSTD_customMem customMem);
 
 ZSTDLIB_API ZSTD_DDict* ZSTD_createDDict_advanced(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1546,7 +1546,51 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
  * but compression ratio may regress significantly if guess considerably underestimates */
 #define ZSTD_c_srcSizeHint ZSTD_c_experimentalParam7
 
-/* TODO: document.
+/* Controls whether the new and experimental "dedicated dictionary search
+ * structure" can be used.
+ *
+ * How to use it:
+ *
+ * When using a CDict, whether to use this feature or not is controlled at
+ * CDict creation, and it must be set in a CCtxParams set passed into that
+ * construction. A compression will then use the feature or not based on how
+ * the CDict was constructed; the value of this param, set in the CCtx, will
+ * have no effect.
+ *
+ * However, when a dictionary buffer is passed into a CCtx, such as via
+ * ZSTD_CCtx_loadDictionary(), this param can be set on the CCtx to control
+ * whether the CDict that is created internally can use the feature or not.
+ *
+ * What it does:
+ *
+ * Normally, the internal data structures of the CDict are analogous to what
+ * would be stored in a CCtx after compressing the contents of a dictionary.
+ * To an approximation, a compression using a dictionary can then use those
+ * data structures to simply continue what is effectively a streaming
+ * compression where the simulated compression of the dictionary left off.
+ * Which is to say, the search structures in the CDict are normally the same
+ * format as in the CCtx.
+ *
+ * It is possible to do better, since the CDict is not like a CCtx: the search
+ * structures are written once during CDict creation, and then are only read
+ * after that, while the search structures in the CCtx are both read and
+ * written as the compression goes along. This means we can choose a search
+ * structure for the dictionary that is read-optimized.
+ *
+ * This feature enables the use of that different structure. Note that this
+ * means that the CDict tables can no longer be copied into the CCtx, so
+ * the dict attachment mode ZSTD_dictForceCopy will no longer be useable. The
+ * dictionary can only be attached or reloaded.
+ *
+ * Effects:
+ *
+ * This will only have any effect when the selected ZSTD_strategy
+ * implementation supports this feature. Currently, that's limited to
+ * ZSTD_greedy, ZSTD_lazy, and ZSTD_lazy2.
+ *
+ * In general, you should expect compression to be faster, and CDict creation
+ * to be slightly slower. Eventually, we will probably make this mode the
+ * default.
  */
 #define ZSTD_c_enableDedicatedDictSearch ZSTD_c_experimentalParam8
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -361,20 +361,7 @@ typedef enum {
                               * Deviating far from default value will likely result in a compression ratio decrease.
                               * Special: value 0 means "automatically determine hashRateLog". */
 
-    ZSTD_c_enableDedicatedDictSearch=170, /* Enable the use of the match finder specifically for
-                                           * dictionaries. This has several implications:
-                                           * 1) We may override cDict params supplied using
-                                           *    ZSTD_refCDict because the dedicated match finder
-                                           *    needs to enforce some unique invariants on the
-                                           *    hashLog and chainLog.
-                                           * 2) We will force the dict to be attached
-                                           * 3) We will pick cParams based on ZSTD_c_compressionLevel
-                                           *    and the size of the dictionary which will increase
-                                           *    the cDict memory usage.
-                                           * 4) We will only do this for certain supported levels.
-                                           *    The exact levels which are supported are determined
-                                           *    by ZSTD_c_compressionLevel and dictionary size.
-                                           *    (only ZSTD_greedy, ZSTD_lazy and ZSTD_lazy2) */
+    ZSTD_c_enableDedicatedDictSearch=170,
 
     /* frame parameters */
     ZSTD_c_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1404,6 +1404,9 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced(const void* dict, size_t dictS
                                                   ZSTD_compressionParameters cParams,
                                                   ZSTD_customMem customMem);
 
+/**
+ * TODO: document!
+ */
 ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,
                                                   ZSTD_dictContentType_e dictContentType,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1417,6 +1417,12 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced(const void* dict, size_t dictS
                                                   ZSTD_compressionParameters cParams,
                                                   ZSTD_customMem customMem);
 
+ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
+                                                  ZSTD_dictLoadMethod_e dictLoadMethod,
+                                                  ZSTD_dictContentType_e dictContentType,
+                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_customMem customMem);
+
 ZSTDLIB_API ZSTD_DDict* ZSTD_createDDict_advanced(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,
                                                   ZSTD_dictContentType_e dictContentType,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -361,8 +361,6 @@ typedef enum {
                               * Deviating far from default value will likely result in a compression ratio decrease.
                               * Special: value 0 means "automatically determine hashRateLog". */
 
-    ZSTD_c_enableDedicatedDictSearch=170,
-
     /* frame parameters */
     ZSTD_c_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)
                               * Content size must be known at the beginning of compression.
@@ -414,6 +412,7 @@ typedef enum {
      * ZSTD_c_literalCompressionMode
      * ZSTD_c_targetCBlockSize
      * ZSTD_c_srcSizeHint
+     * ZSTD_c_enableDedicatedDictSearch
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -424,7 +423,8 @@ typedef enum {
      ZSTD_c_experimentalParam4=1001,
      ZSTD_c_experimentalParam5=1002,
      ZSTD_c_experimentalParam6=1003,
-     ZSTD_c_experimentalParam7=1004
+     ZSTD_c_experimentalParam7=1004,
+     ZSTD_c_experimentalParam8=1005
 } ZSTD_cParameter;
 
 typedef struct {
@@ -1545,6 +1545,10 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
  * There is no guarantee that hint is close to actual source size,
  * but compression ratio may regress significantly if guess considerably underestimates */
 #define ZSTD_c_srcSizeHint ZSTD_c_experimentalParam7
+
+/* TODO: document.
+ */
+#define ZSTD_c_enableDedicatedDictSearch ZSTD_c_experimentalParam8
 
 /*! ZSTD_CCtx_getParameter() :
  *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1420,7 +1420,7 @@ ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced(const void* dict, size_t dictS
 ZSTDLIB_API ZSTD_CDict* ZSTD_createCDict_advanced2(const void* dict, size_t dictSize,
                                                   ZSTD_dictLoadMethod_e dictLoadMethod,
                                                   ZSTD_dictContentType_e dictContentType,
-                                                  ZSTD_CCtx_params cctxParams,
+                                                  ZSTD_CCtx_params* cctxParams,
                                                   ZSTD_customMem customMem);
 
 ZSTDLIB_API ZSTD_DDict* ZSTD_createDDict_advanced(const void* dict, size_t dictSize,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -361,6 +361,21 @@ typedef enum {
                               * Deviating far from default value will likely result in a compression ratio decrease.
                               * Special: value 0 means "automatically determine hashRateLog". */
 
+    ZSTD_c_enableDedicatedDictSearch=170, /* Enable the use of the match finder specifically for
+                                           * dictionaries. This has several implications:
+                                           * 1) We may override cDict params supplied using
+                                           *    ZSTD_refCDict because the dedicated match finder
+                                           *    needs to enforce some unique invariants on the
+                                           *    hashLog and chainLog.
+                                           * 2) We will force the dict to be attached
+                                           * 3) We will pick cParams based on ZSTD_c_compressionLevel
+                                           *    and the size of the dictionary which will increase
+                                           *    the cDict memory usage.
+                                           * 4) We will only do this for certain supported levels.
+                                           *    The exact levels which are supported are determined
+                                           *    by ZSTD_c_compressionLevel and dictionary size.
+                                           *    (only ZSTD_greedy, ZSTD_lazy and ZSTD_lazy2) */
+
     /* frame parameters */
     ZSTD_c_contentSizeFlag=200, /* Content size will be written into frame header _whenever known_ (default:1)
                               * Content size must be known at the beginning of compression.

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -931,6 +931,7 @@ static cRess_t FIO_createCResources(FIO_prefs_t* const prefs,
     CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_targetLength, (int)comprParams.targetLength) );
     CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_strategy, comprParams.strategy) );
     CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_literalCompressionMode, (int)prefs->literalCompressionMode) );
+    CHECK( ZSTD_CCtx_setParameter(ress.cctx, ZSTD_c_enableDedicatedDictSearch, 1) );
     /* multi-threading */
 #ifdef ZSTD_MULTITHREAD
     DISPLAYLEVEL(5,"set nb workers = %u \n", prefs->nbWorkers);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2963,7 +2963,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
             cSize = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, CNBuffer, CNBuffSize);
             CHECK_Z(cSize);
-            CHECK_Z(ZSTD_decompress_usingDict(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize, dict, CNBuffSize));
+            CHECK_Z(ZSTD_decompress_usingDict(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize, dict, dictSize));
 
             CHECK_Z(ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters));
             ZSTD_freeCDict(cdict);


### PR DESCRIPTION
Builds on top of @bimbashrestha's #2201 to implement a new search structure for dictionaries in the greedy, lazy, and lazy2 
strategies. This is a work-in-progress.

Expected performance increases are approximately as follows:

Level | Hot Dict | Cold Dict
----- | -------- | ---------
  5   |   ~+10%  |    ~+35%
  6   |   ~+10%  |    ~+30%
  7   |   ~+ 8%  |    ~+25%
  8   |   ~+ 6%  |    ~+17%
  9   |   ~+ 6%  |    ~+14%
 10   |   ~+ 5%  |    ~+12%

The improvement degrades as the input gets large. Compression ratio is slightly improved at level 5 (~0.05%). Benchmarked on an Intel Xeon E5-1650 v3 @ 3.50GHz (Haswell), with gcc 8.4.0. With recent fixes, I'm not aware of any scenario where perf is worse with the DDSS than without.

To-Do:

- [x] Document performance impacts, including corpora other than `http`.
- [x] Remove `ZSTD_dedicatedDictSearch_defaultCParameters` and replace with a lookup in the regular params, that is then adjusted?
- [x] Settle on a signature for `ZSTD_createCDict_advanced2()` and document it.