### PR TITLE
New advanced decompression param to ignore checksums

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1398,9 +1398,9 @@ size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format)
     return ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, format);
 }
 
-size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_format_e format)
+size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_forceIgnoreChecksum_e shouldIgnore)
 {
-    return ZSTD_DCtx_setParameter(dctx, ZSTD_d_forceIgnoreChecksum, format);
+    return ZSTD_DCtx_setParameter(dctx, ZSTD_d_forceIgnoreChecksum, shouldIgnore);
 }
 
 ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam)
@@ -1423,6 +1423,7 @@ ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam)
         case ZSTD_d_forceIgnoreChecksum:
             bounds.lowerBound = (int)ZSTD_d_validateChecksum;
             bounds.upperBound = (int)ZSTD_d_ignoreChecksum;
+            return bounds;
         default:;
     }
     bounds.error = ERROR(parameter_unsupported);
@@ -1465,6 +1466,7 @@ size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter dParam, int value
         case ZSTD_d_forceIgnoreChecksum:
             CHECK_DBOUNDS(ZSTD_d_forceIgnoreChecksum, value);
             dctx->forceIgnoreChecksum = (ZSTD_forceIgnoreChecksum_e)value;
+            return 0;
         default:;
     }
     RETURN_ERROR(parameter_unsupported, "");

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1543,7 +1543,7 @@ static void ZSTD_DCtx_updateOversizedDuration(ZSTD_DStream* zds, size_t const ne
 {
     if (ZSTD_DCtx_isOverflow(zds, neededInBuffSize, neededOutBuffSize))
         zds->oversizedDuration++;
-    else
+    else 
         zds->oversizedDuration = 0;
 }
 
@@ -1750,7 +1750,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
 
                 {   int const tooSmall = (zds->inBuffSize < neededInBuffSize) || (zds->outBuffSize < neededOutBuffSize);
                     int const tooLarge = ZSTD_DCtx_isOversizedTooLong(zds);
-
+                    
                     if (tooSmall || tooLarge) {
                         size_t const bufferSize = neededInBuffSize + neededOutBuffSize;
                         DEBUGLOG(4, "inBuff  : from %u to %u",

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1398,7 +1398,7 @@ size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format)
     return ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, format);
 }
 
-size_t ZSTD_DCtx_setForceSkipChecksum(ZSTD_DCtx* dctx, ZSTD_format_e format)
+size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_format_e format)
 {
     return ZSTD_DCtx_setParameter(dctx, ZSTD_d_forceIgnoreChecksum, format);
 }

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -677,10 +677,10 @@ static size_t ZSTD_decompressFrame(ZSTD_DCtx* dctx,
                         corruption_detected, "");
     }
     if (dctx->fParams.checksumFlag) { /* Frame content checksum verification */
+        RETURN_ERROR_IF(remainingSrcSize<4, checksum_wrong, "");
         if (!dctx->forceIgnoreChecksum) {
             U32 const checkCalc = (U32)XXH64_digest(&dctx->xxhState);
             U32 checkRead;
-            RETURN_ERROR_IF(remainingSrcSize<4, checksum_wrong, "");
             checkRead = MEM_readLE32(ip);
             RETURN_ERROR_IF(checkRead != checkCalc, checksum_wrong, "");
         }
@@ -1401,11 +1401,6 @@ size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowSize)
 size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format)
 {
     return ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, format);
-}
-
-size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_forceIgnoreChecksum_e value)
-{
-    return ZSTD_DCtx_setParameter(dctx, ZSTD_d_forceIgnoreChecksum, value);
 }
 
 ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam)

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -103,7 +103,7 @@ typedef enum {
 typedef enum {
     ZSTD_d_validateChecksum = 0,
     ZSTD_d_ignoreChecksum = 1
-} ZSTD_ignoreChecksumMode_e;
+} ZSTD_forceIgnoreChecksum_e;
 
 struct ZSTD_DCtx_s
 {
@@ -127,7 +127,7 @@ struct ZSTD_DCtx_s
     XXH64_state_t xxhState;
     size_t headerSize;
     ZSTD_format_e format;
-    ZSTD_ignoreChecksumMode_e forceIgnoreChecksum;   /* if enabled, will ignore checksums in compressed frame */
+    ZSTD_forceIgnoreChecksum_e forceIgnoreChecksum;   /* if == 1, will ignore checksums in compressed frame */
     const BYTE* litPtr;
     ZSTD_customMem customMem;
     size_t litSize;

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -100,6 +100,11 @@ typedef enum {
     ZSTD_obm_stable = 1     /* ZSTD_outBuffer is stable */
 } ZSTD_outBufferMode_e;
 
+typedef enum {
+    ZSTD_d_validateChecksum = 0,
+    ZSTD_d_ignoreChecksum = 1
+} ZSTD_ignoreChecksumMode_e;
+
 struct ZSTD_DCtx_s
 {
     const ZSTD_seqSymbol* LLTptr;
@@ -122,6 +127,7 @@ struct ZSTD_DCtx_s
     XXH64_state_t xxhState;
     size_t headerSize;
     ZSTD_format_e format;
+    ZSTD_ignoreChecksumMode_e forceIgnoreChecksum;   /* if enabled, will ignore checksums in compressed frame */
     const BYTE* litPtr;
     ZSTD_customMem customMem;
     size_t litSize;

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -100,11 +100,6 @@ typedef enum {
     ZSTD_obm_stable = 1     /* ZSTD_outBuffer is stable */
 } ZSTD_outBufferMode_e;
 
-typedef enum {
-    ZSTD_d_validateChecksum = 0,
-    ZSTD_d_ignoreChecksum = 1
-} ZSTD_forceIgnoreChecksum_e;
-
 struct ZSTD_DCtx_s
 {
     const ZSTD_seqSymbol* LLTptr;

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -122,7 +122,8 @@ struct ZSTD_DCtx_s
     XXH64_state_t xxhState;
     size_t headerSize;
     ZSTD_format_e format;
-    ZSTD_forceIgnoreChecksum_e forceIgnoreChecksum;   /* if == 1, will ignore checksums in compressed frame */
+    ZSTD_forceIgnoreChecksum_e forceIgnoreChecksum;   /* User specified: if == 1, will ignore checksums in compressed frame. Default == 0 */
+    U32 validateChecksum;         /* if == 1, will validate checksum. Is == 1 if (fParams.checksumFlag == 1) and (forceIgnoreChecksum == 0). */
     const BYTE* litPtr;
     ZSTD_customMem customMem;
     size_t litSize;

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1701,8 +1701,8 @@ ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowS
  * Experimental parameter.
  * Default is 0 == disabled. Set to 1 to enable
  *
- * Tells the decompressor to skip checksum validation during decompression, regardless.
- * of whether or not checksumming was specified during decompression. This offers some
+ * Tells the decompressor to skip checksum validation during decompression, regardless
+ * of whether checksumming was specified during compression. This offers some
  * slight performance benefits, and may be useful for debugging.
  */
 #define ZSTD_d_forceIgnoreChecksum ZSTD_d_experimentalParam3

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1163,6 +1163,7 @@ typedef enum {
 } ZSTD_format_e;
 
 typedef enum {
+    /* Note: this enum controls ZSTD_d_forceIgnoreChecksum */
     ZSTD_d_validateChecksum = 0,
     ZSTD_d_ignoreChecksum = 1
 } ZSTD_forceIgnoreChecksum_e;
@@ -1704,6 +1705,7 @@ ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowS
  * Tells the decompressor to skip checksum validation during decompression, regardless
  * of whether checksumming was specified during compression. This offers some
  * slight performance benefits, and may be useful for debugging.
+ * Param has values of type ZSTD_forceIgnoreChecksum_e
  */
 #define ZSTD_d_forceIgnoreChecksum ZSTD_d_experimentalParam3
 
@@ -1713,11 +1715,6 @@ ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowS
  *  such ZSTD_f_zstd1_magicless for example.
  * @return : 0, or an error code (which can be tested using ZSTD_isError()). */
 ZSTDLIB_API size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format);
-
-/*! ZSTD_DCtx_setForceIgnoreChecksum() :
- *  Instruct the decoder context to ignore checksums in compressed frame.
- * @return : 0, or an error code (which can be tested using ZSTD_isError()). */
-ZSTDLIB_API size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_forceIgnoreChecksum_e value);
 
 /*! ZSTD_decompressStream_simpleArgs() :
  *  Same as ZSTD_decompressStream(),

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1709,6 +1709,11 @@ ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowS
  * @return : 0, or an error code (which can be tested using ZSTD_isError()). */
 ZSTDLIB_API size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format);
 
+/*! ZSTD_DCtx_setForceIgnoreChecksum() :
+ *  Instruct the decoder context to ignore checksums in compressed frame.
+ * @return : 0, or an error code (which can be tested using ZSTD_isError()). */
+ZSTDLIB_API size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_format_e format);
+
 /*! ZSTD_decompressStream_simpleArgs() :
  *  Same as ZSTD_decompressStream(),
  *  but using only integral types as arguments.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1163,6 +1163,11 @@ typedef enum {
 } ZSTD_format_e;
 
 typedef enum {
+    ZSTD_d_validateChecksum = 0,
+    ZSTD_d_ignoreChecksum = 1
+} ZSTD_forceIgnoreChecksum_e;
+
+typedef enum {
     /* Note: this enum and the behavior it controls are effectively internal
      * implementation details of the compressor. They are expected to continue
      * to evolve and should be considered only in the context of extremely
@@ -1712,7 +1717,7 @@ ZSTDLIB_API size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format);
 /*! ZSTD_DCtx_setForceIgnoreChecksum() :
  *  Instruct the decoder context to ignore checksums in compressed frame.
  * @return : 0, or an error code (which can be tested using ZSTD_isError()). */
-ZSTDLIB_API size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_format_e format);
+ZSTDLIB_API size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_forceIgnoreChecksum_e format);
 
 /*! ZSTD_decompressStream_simpleArgs() :
  *  Same as ZSTD_decompressStream(),

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -528,7 +528,7 @@ typedef enum {
      * At the time of this writing, they include :
      * ZSTD_d_format
      * ZSTD_d_stableOutBuffer
-     * ZSTD_d_forceSkipChecksum
+     * ZSTD_d_forceIgnoreChecksum
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
@@ -1692,7 +1692,7 @@ ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowS
  */
 #define ZSTD_d_stableOutBuffer ZSTD_d_experimentalParam2
 
-/* ZSTD_d_forceSkipChecksum
+/* ZSTD_d_forceIgnoreChecksum
  * Experimental parameter.
  * Default is 0 == disabled. Set to 1 to enable
  *
@@ -1700,7 +1700,7 @@ ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowS
  * of whether or not checksumming was specified during decompression. This offers some
  * slight performance benefits, and may be useful for debugging.
  */
-#define ZSTD_d_forceSkipChecksum ZSTD_d_experimentalParam3
+#define ZSTD_d_forceIgnoreChecksum ZSTD_d_experimentalParam3
 
 /*! ZSTD_DCtx_setFormat() :
  *  Instruct the decoder context about what kind of data to decode next.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -528,11 +528,13 @@ typedef enum {
      * At the time of this writing, they include :
      * ZSTD_d_format
      * ZSTD_d_stableOutBuffer
+     * ZSTD_d_forceSkipChecksum
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
      ZSTD_d_experimentalParam1=1000,
-     ZSTD_d_experimentalParam2=1001
+     ZSTD_d_experimentalParam2=1001,
+     ZSTD_d_experimentalParam3=1002
 
 } ZSTD_dParameter;
 
@@ -1689,6 +1691,16 @@ ZSTDLIB_API size_t ZSTD_DCtx_setMaxWindowSize(ZSTD_DCtx* dctx, size_t maxWindowS
  * this flag tells zstd to use the user provided buffer.
  */
 #define ZSTD_d_stableOutBuffer ZSTD_d_experimentalParam2
+
+/* ZSTD_d_forceSkipChecksum
+ * Experimental parameter.
+ * Default is 0 == disabled. Set to 1 to enable
+ *
+ * Tells the decompressor to skip checksum validation during decompression, regardless.
+ * of whether or not checksumming was specified during decompression. This offers some
+ * slight performance benefits, and may be useful for debugging.
+ */
+#define ZSTD_d_forceSkipChecksum ZSTD_d_experimentalParam3
 
 /*! ZSTD_DCtx_setFormat() :
  *  Instruct the decoder context about what kind of data to decode next.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1717,7 +1717,7 @@ ZSTDLIB_API size_t ZSTD_DCtx_setFormat(ZSTD_DCtx* dctx, ZSTD_format_e format);
 /*! ZSTD_DCtx_setForceIgnoreChecksum() :
  *  Instruct the decoder context to ignore checksums in compressed frame.
  * @return : 0, or an error code (which can be tested using ZSTD_isError()). */
-ZSTDLIB_API size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_forceIgnoreChecksum_e format);
+ZSTDLIB_API size_t ZSTD_DCtx_setForceIgnoreChecksum(ZSTD_DCtx* dctx, ZSTD_forceIgnoreChecksum_e value);
 
 /*! ZSTD_decompressStream_simpleArgs() :
  *  Same as ZSTD_decompressStream(),

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1754,8 +1754,12 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
     if (ress.dctx==NULL)
         EXM_THROW(60, "Error: %s : can't create ZSTD_DStream", strerror(errno));
     CHECK( ZSTD_DCtx_setMaxWindowSize(ress.dctx, prefs->memLimit) );
-    if (!prefs->checksumFlag)
-        CHECK( ZSTD_DCtx_setForceIgnoreChecksum(ress.dctx, ZSTD_d_ignoreChecksum));
+    if (!prefs->checksumFlag) {
+        CHECK( ZSTD_DCtx_setParameter(ress.dctx, ZSTD_d_forceIgnoreChecksum, ZSTD_d_ignoreChecksum));
+    } else {
+        CHECK( ZSTD_DCtx_setParameter(ress.dctx, ZSTD_d_forceIgnoreChecksum, ZSTD_d_validateChecksum));
+    }
+    
     ress.srcBufferSize = ZSTD_DStreamInSize();
     ress.srcBuffer = malloc(ress.srcBufferSize);
     ress.dstBufferSize = ZSTD_DStreamOutSize();

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1754,11 +1754,7 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
     if (ress.dctx==NULL)
         EXM_THROW(60, "Error: %s : can't create ZSTD_DStream", strerror(errno));
     CHECK( ZSTD_DCtx_setMaxWindowSize(ress.dctx, prefs->memLimit) );
-    if (!prefs->checksumFlag) {
-        CHECK( ZSTD_DCtx_setParameter(ress.dctx, ZSTD_d_forceIgnoreChecksum, ZSTD_d_ignoreChecksum));
-    } else {
-        CHECK( ZSTD_DCtx_setParameter(ress.dctx, ZSTD_d_forceIgnoreChecksum, ZSTD_d_validateChecksum));
-    }
+    CHECK( ZSTD_DCtx_setParameter(ress.dctx, ZSTD_d_forceIgnoreChecksum, !prefs->checksumFlag));
     
     ress.srcBufferSize = ZSTD_DStreamInSize();
     ress.srcBuffer = malloc(ress.srcBufferSize);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1754,6 +1754,10 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
     if (ress.dctx==NULL)
         EXM_THROW(60, "Error: %s : can't create ZSTD_DStream", strerror(errno));
     CHECK( ZSTD_DCtx_setMaxWindowSize(ress.dctx, prefs->memLimit) );
+    if (!prefs->checksumFlag) {
+        DISPLAY("Ignoring checksums...");
+        CHECK( ZSTD_DCtx_setForceIgnoreChecksum(ress.dctx, 1 /* ZSTD_d_ignoreChecksum */));
+    }
     ress.srcBufferSize = ZSTD_DStreamInSize();
     ress.srcBuffer = malloc(ress.srcBufferSize);
     ress.dstBufferSize = ZSTD_DStreamOutSize();

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1755,7 +1755,7 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
         EXM_THROW(60, "Error: %s : can't create ZSTD_DStream", strerror(errno));
     CHECK( ZSTD_DCtx_setMaxWindowSize(ress.dctx, prefs->memLimit) );
     if (!prefs->checksumFlag)
-        CHECK( ZSTD_DCtx_setForceIgnoreChecksum(ress.dctx, 1 /* ZSTD_d_ignoreChecksum */));
+        CHECK( ZSTD_DCtx_setForceIgnoreChecksum(ress.dctx, ZSTD_d_ignoreChecksum));
     ress.srcBufferSize = ZSTD_DStreamInSize();
     ress.srcBuffer = malloc(ress.srcBufferSize);
     ress.dstBufferSize = ZSTD_DStreamOutSize();

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1754,10 +1754,8 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
     if (ress.dctx==NULL)
         EXM_THROW(60, "Error: %s : can't create ZSTD_DStream", strerror(errno));
     CHECK( ZSTD_DCtx_setMaxWindowSize(ress.dctx, prefs->memLimit) );
-    if (!prefs->checksumFlag) {
-        DISPLAY("Ignoring checksums...");
+    if (!prefs->checksumFlag)
         CHECK( ZSTD_DCtx_setForceIgnoreChecksum(ress.dctx, 1 /* ZSTD_d_ignoreChecksum */));
-    }
     ress.srcBufferSize = ZSTD_DStreamInSize();
     ress.srcBuffer = malloc(ress.srcBufferSize);
     ress.dstBufferSize = ZSTD_DStreamOutSize();

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -196,6 +196,7 @@ static void usage_advanced(const char* programName)
     DISPLAYOUT( " -l     : print information about zstd compressed files \n");
     DISPLAYOUT( "--test  : test compressed file integrity \n");
     DISPLAYOUT( " -M#    : Set a memory usage limit for decompression \n");
+    DISPLAYOUT( "--no-check : disable validation of checksums in compressed frame \n");
 # if ZSTD_SPARSE_DEFAULT
     DISPLAYOUT( "--[no-]sparse : sparse mode (default: enabled on file, disabled on stdout) \n");
 # else

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -160,12 +160,11 @@ static void usage_advanced(const char* programName)
 #ifndef ZSTD_NODECOMPRESS
     DISPLAYOUT( ". If specified with -d, decompressor will ignore/validate checksums in compressed frame (default: validate).");
 #endif
-#endif /* ZSTD_NOCOMPRESS */
-#ifndef ZSTD_NODECOMPRESS
+#else
 #ifdef ZSTD_NOCOMPRESS
     DISPLAYOUT( "--[no-]check : during decompression, ignore/validate checksums in compressed frame (default: validate).");
 #endif
-#endif /* ZSTD_NODECOMPRESS */
+#endif /* ZSTD_NOCOMPRESS */
     DISPLAYOUT( "\n");
 
     DISPLAYOUT( "--      : All arguments after \"--\" are treated as files \n");

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -154,6 +154,20 @@ static void usage_advanced(const char* programName)
     DISPLAYOUT( "--output-dir-mirror DIR : processed files are stored into DIR respecting original directory structure \n");
 #endif
 
+
+#ifndef ZSTD_NOCOMPRESS
+    DISPLAYOUT( "--[no-]check : during compression, add XXH64 integrity checksum to frame (default: enabled)");
+#ifndef ZSTD_NODECOMPRESS
+    DISPLAYOUT( ". If specified with -d, decompressor will ignore/validate checksums in compressed frame (default: validate).");
+#endif
+#endif /* ZSTD_NOCOMPRESS */
+#ifndef ZSTD_NODECOMPRESS
+#ifdef ZSTD_NOCOMPRESS
+    DISPLAYOUT( "--[no-]check : during decompression, ignore/validate checksums in compressed frame (default: validate).");
+#endif
+#endif /* ZSTD_NODECOMPRESS */
+    DISPLAYOUT( "\n");
+
     DISPLAYOUT( "--      : All arguments after \"--\" are treated as files \n");
 
 #ifndef ZSTD_NOCOMPRESS
@@ -174,7 +188,6 @@ static void usage_advanced(const char* programName)
     DISPLAYOUT( "--size-hint=# optimize compression parameters for streaming input of approximately this size \n");
     DISPLAYOUT( "--target-compressed-block-size=# : generate compressed block of approximately targeted size \n");
     DISPLAYOUT( "--no-dictID : don't write dictID into header (dictionary compression only) \n");
-    DISPLAYOUT( "--[no-]check : add XXH64 integrity checksum to frame (default: enabled) \n");
     DISPLAYOUT( "--[no-]compress-literals : force (un)compressed literals \n");
 
     DISPLAYOUT( "--format=zstd : compress files to the .zst format (default) \n");
@@ -196,7 +209,6 @@ static void usage_advanced(const char* programName)
     DISPLAYOUT( " -l     : print information about zstd compressed files \n");
     DISPLAYOUT( "--test  : test compressed file integrity \n");
     DISPLAYOUT( " -M#    : Set a memory usage limit for decompression \n");
-    DISPLAYOUT( "--no-check : disable validation of checksums in compressed frame \n");
 # if ZSTD_SPARSE_DEFAULT
     DISPLAYOUT( "--[no-]sparse : sparse mode (default: enabled on file, disabled on stdout) \n");
 # else

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2354,9 +2354,6 @@ static int basicUnitTests(U32 const seed, double compressibility)
         {   size_t const sr = ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, (ZSTD_format_e)888);
             if (!ZSTD_isError(sr)) goto _output_error;
         }
-        {   size_t const sr = ZSTD_DCtx_setParameter(dctx, ZSTD_d_forceIgnoreChecksum, (ZSTD_forceIgnoreChecksum_e)888);
-            if (!ZSTD_isError(sr)) goto _output_error;
-        }
         DISPLAYLEVEL(3, "OK \n");
 
         ZSTD_freeDCtx(dctx);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -571,8 +571,8 @@ static int basicUnitTests(U32 const seed, double compressibility)
         r = ZSTD_decompress(decodedBuffer, CNBuffSize, compressedBuffer, cSize);
         if (!ZSTD_isError(r)) goto _output_error;
         if (ZSTD_getErrorCode(r) != ZSTD_error_checksum_wrong) goto _output_error;
-
-        CHECK_Z(ZSTD_DCtx_setForceIgnoreChecksum(dctx, ZSTD_d_ignoreChecksum));
+        
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_forceIgnoreChecksum, ZSTD_d_ignoreChecksum));
         r = ZSTD_decompressDCtx(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize-1);
         if (!ZSTD_isError(r)) goto _output_error;   /* wrong checksum size should still throw error */
         r = ZSTD_decompressDCtx(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2354,6 +2354,9 @@ static int basicUnitTests(U32 const seed, double compressibility)
         {   size_t const sr = ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, (ZSTD_format_e)888);
             if (!ZSTD_isError(sr)) goto _output_error;
         }
+        {   size_t const sr = ZSTD_DCtx_setParameter(dctx, ZSTD_d_forceIgnoreChecksum, (ZSTD_forceIgnoreChecksum_e)888);
+            if (!ZSTD_isError(sr)) goto _output_error;
+        }
         DISPLAYLEVEL(3, "OK \n");
 
         ZSTD_freeDCtx(dctx);

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -261,8 +261,9 @@ zstd tmp -c --compress-literals    -19      | zstd -t
 zstd -b --fast=1 -i0e1 tmp --compress-literals
 zstd -b --fast=1 -i0e1 tmp --no-compress-literals
 println "test: --no-check for decompression"
-zstd -f tmp --check
+zstd -f tmp -o tmp.zst --check
 zstd -f tmp -o tmp1.zst --no-check
+printf '\xDE\xAD\xBE\xEF' | dd of=tmp.zst bs=1 seek=$(($(wc -c <"tmp.zst") - 4)) count=4 conv=notrunc # corrupt checksum in tmp
 zstd -d -f tmp.zst --no-check
 zstd -d -f tmp1.zst --no-check
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -260,6 +260,11 @@ zstd tmp -c --compress-literals    --fast=1 | zstd -t
 zstd tmp -c --compress-literals    -19      | zstd -t
 zstd -b --fast=1 -i0e1 tmp --compress-literals
 zstd -b --fast=1 -i0e1 tmp --no-compress-literals
+println "test: --no-check for decompression"
+zstd -f tmp --check
+zstd -f tmp -o tmp1.zst --no-check
+zstd -d -f tmp.zst --no-check
+zstd -d -f tmp1.zst --no-check
 
 println "\n===> zstdgrep tests"
 ln -sf "$ZSTD_BIN" zstdcat

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -261,11 +261,12 @@ zstd tmp -c --compress-literals    -19      | zstd -t
 zstd -b --fast=1 -i0e1 tmp --compress-literals
 zstd -b --fast=1 -i0e1 tmp --no-compress-literals
 println "test: --no-check for decompression"
-zstd -f tmp -o tmp.zst --check
-zstd -f tmp -o tmp1.zst --no-check
-printf '\xDE\xAD\xBE\xEF' | dd of=tmp.zst bs=1 seek=$(($(wc -c <"tmp.zst") - 4)) count=4 conv=notrunc # corrupt checksum in tmp
+zstd -f tmp -o tmp_corrupt.zst --check
+zstd -f tmp -o tmp.zst --no-check
+printf '\xDE\xAD\xBE\xEF' | dd of=tmp_corrupt.zst bs=1 seek=$(($(wc -c < "tmp_corrupt.zst") - 4)) count=4 conv=notrunc # corrupt checksum in tmp
+zstd -d -f tmp_corrupt.zst --no-check
+zstd -d -f tmp_corrupt.zst --check --no-check # final flag overrides
 zstd -d -f tmp.zst --no-check
-zstd -d -f tmp1.zst --no-check
 
 println "\n===> zstdgrep tests"
 ln -sf "$ZSTD_BIN" zstdcat


### PR DESCRIPTION
This adds the advanced parameter `ZSTD_d_forceIgnoreChecksum` as a new experimental decompression parameter. If enabled, then decompression will ignore checksums, whether or not they were enabled during compression.

A few considerations/points of discussion:
- Open to other naming suggestions - not sure if there’s a general consensus against negative actions in param names (ignore), but I wanted to emphasize that we’re going out of our way to ignore the checksum behavior that the compressor specified, and that this isn't typical behavior, hence `forceIgnore`. But, done the other way, we avoid all the `!` in the logic implementing this.
- This strictly ignores the value of the checksum, i.e. if the checksum flag is enabled in the compressed stream, but the checksum size is not 4 bytes, enabling `ZSTD_d_forceIgnoreChecksum` will not prevent decompression from throwing an error. In my mind, the checksum size somehow being wrong seems like a very serious error, and the new functionality probably shouldn't ignore that - but, let me know what your thoughts are
- I noticed `--no-check` was a compression CLI flag. I’ve added support for `--no-check` to be used as as decompression parameter to enable this new advanced param. We can add a different one, but I think the overload makes sense since it's documented and seems a little less bloat-y.
- In addition to testing the new functionality, the added unit test in fuzzer.c also tests that if checksums are corrupt, they should fail to decompress under normal circumstances - I couldn't find an explicit test for this already