### PR TITLE
Add a warning whenever (de)compressing multiple files

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1722,8 +1722,10 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
     /* init */
     assert(outFileName != NULL || suffix != NULL);
     if (outFileName != NULL) {   /* output into a single destination (stdout typically) */
-        if (FIO_removeMultiFilesWarning(prefs, 1 /* displayLevelCutoff */, outFileName))
+        if (FIO_removeMultiFilesWarning(prefs, 1 /* displayLevelCutoff */, outFileName)) {
+            FIO_freeCResources(ress);
             return 1;
+        }
         ress.dstFile = FIO_openDstFile(prefs, NULL, outFileName);
         if (ress.dstFile == NULL) {  /* could not open outFileName */
             error = 1;
@@ -2618,8 +2620,10 @@ FIO_decompressMultipleFilenames(FIO_prefs_t* const prefs,
     dRess_t ress = FIO_createDResources(prefs, dictFileName);
 
     if (outFileName) {
-        if (FIO_removeMultiFilesWarning(prefs, 1 /* displayLevelCutoff */, outFileName))
+        if (FIO_removeMultiFilesWarning(prefs, 1 /* displayLevelCutoff */, outFileName)) {
+            FIO_freeDResources(ress);
             return 1;
+        }
         if (!prefs->testMode) {
             ress.dstFile = FIO_openDstFile(prefs, NULL, outFileName);
             if (ress.dstFile == 0) EXM_THROW(19, "cannot open %s", outFileName);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1677,6 +1677,29 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
     /* init */
     assert(outFileName != NULL || suffix != NULL);
     if (outFileName != NULL) {   /* output into a single destination (stdout typically) */
+        if (nbFiles > 1) {
+            if (!strcmp (outFileName, stdoutmark)) {
+                DISPLAY("zstd: WARNING: all input files will be processed and concatenated into stdout. ");
+            } else {
+                DISPLAY("zstd: WARNING: all input files will be processed and concatenated into a single output file: %s ", outFileName);
+            }
+            if (prefs->removeSrcFile && !prefs->overwrite) {
+                DISPLAY("\nYou must specify -f as well in order to execute this command with --rm. Aborting...");
+                return 1;
+            }
+            
+            DISPLAY("Proceed? (y/n): ");
+            {
+                int ch = getchar();
+                if ((ch != 'y') && (ch != 'Y')) {
+                    DISPLAY("zstd: aborting...\n");
+                    return 1;
+                }
+                /* flush the rest */
+                while ((ch!=EOF) && (ch!='\n'))
+                    ch = getchar();
+            }
+        }
         ress.dstFile = FIO_openDstFile(prefs, NULL, outFileName);
         if (ress.dstFile == NULL) {  /* could not open outFileName */
             error = 1;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1677,28 +1677,26 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
     /* init */
     assert(outFileName != NULL || suffix != NULL);
     if (outFileName != NULL) {   /* output into a single destination (stdout typically) */
-        if (nbFiles > 1) {
+        if (nbFiles > 1 && !prefs->overwrite) {
             if (!strcmp (outFileName, stdoutmark)) {
                 DISPLAY("zstd: WARNING: all input files will be processed and concatenated into stdout. ");
             } else {
                 DISPLAY("zstd: WARNING: all input files will be processed and concatenated into a single output file: %s ", outFileName);
             }
-            if (prefs->removeSrcFile && !prefs->overwrite) {
-                DISPLAY("\nYou must specify -f as well in order to execute this command with --rm. Aborting...");
-                return 1;
-            }
-            
-            DISPLAY("Proceed? (y/n): ");
-            {
-                int ch = getchar();
-                if ((ch != 'y') && (ch != 'Y')) {
-                    DISPLAY("zstd: aborting...\n");
-                    return 1;
+            if (prefs->removeSrcFile) {
+                DISPLAY("Proceed? (y/n): ");
+                {
+                    int ch = getchar();
+                    if ((ch != 'y') && (ch != 'Y')) {
+                        DISPLAY("zstd: aborting...\n");
+                        return 1;
+                    }
+                    /* flush the rest */
+                    while ((ch!=EOF) && (ch!='\n'))
+                        ch = getchar();
                 }
-                /* flush the rest */
-                while ((ch!=EOF) && (ch!='\n'))
-                    ch = getchar();
             }
+            DISPLAY("\n");
         }
         ress.dstFile = FIO_openDstFile(prefs, NULL, outFileName);
         if (ress.dstFile == NULL) {  /* could not open outFileName */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -798,7 +798,7 @@ static void FIO_adjustMemLimitForPatchFromMode(FIO_prefs_t* const prefs,
  *         If -f is specified with --rm, zstd will proceed as usual
  *         If -q is specified with --rm, zstd will abort pre-emptively
  *         If neither flag is specified, zstd will prompt the user for confirmation to proceed.
- * If --rm is not specified, then zstd may print a warning to the user.
+ * If --rm is not specified, then zstd will print a warning to the user (which can be silenced with -q).
  */
 static int FIO_removeMultiFilesWarning(const FIO_prefs_t* const prefs, int displayLevelCutoff, const char* outFileName)
 {
@@ -819,8 +819,8 @@ static int FIO_removeMultiFilesWarning(const FIO_prefs_t* const prefs, int displ
                 DISPLAYLEVEL(2, "\nThe concatenated output CANNOT regenerate the original directory tree. This is a destructive operation. ")
                 error = g_display_prefs.displayLevel > displayLevelCutoff && UTIL_requireUserConfirmation("Proceed? (y/n): ", "Aborting...", "yY");
             }
-            DISPLAY("\n");
         }
+        DISPLAY("\n");
     }
     return error;
 }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -605,16 +605,10 @@ FIO_openDstFile(FIO_prefs_t* const prefs,
                             dstFileName);
                     return NULL;
                 }
-                DISPLAY("zstd: %s already exists; overwrite (y/N) ? ",
-                        dstFileName);
-                {   int ch = getchar();
-                    if ((ch!='Y') && (ch!='y')) {
-                        DISPLAY("    not overwritten  \n");
-                        return NULL;
-                    }
-                    /* flush rest of input line */
-                    while ((ch!=EOF) && (ch!='\n')) ch = getchar();
-            }   }
+                DISPLAY("zstd: %s already exists; ", dstFileName);
+                if (UTIL_requireUserConfirmationToProceed("overwrite (y/n) ? ", "Not overwritten  \n", "yY"))
+                    return NULL;
+            }
             /* need to unlink */
             FIO_removeFile(dstFileName);
     }   }
@@ -1683,19 +1677,8 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
             } else {
                 DISPLAY("zstd: WARNING: all input files will be processed and concatenated into a single output file: %s ", outFileName);
             }
-            if (prefs->removeSrcFile) {
-                DISPLAY("Proceed? (y/n): ");
-                {
-                    int ch = getchar();
-                    if ((ch != 'y') && (ch != 'Y')) {
-                        DISPLAY("zstd: aborting...\n");
-                        return 1;
-                    }
-                    /* flush the rest */
-                    while ((ch!=EOF) && (ch!='\n'))
-                        ch = getchar();
-                }
-            }
+            if (prefs->removeSrcFile)
+                error = UTIL_requireUserConfirmationToProceed("Proceed? (y/n): ", "Aborting...", "yY");
             DISPLAY("\n");
         }
         ress.dstFile = FIO_openDstFile(prefs, NULL, outFileName);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -815,9 +815,9 @@ static int FIO_removeMultiFilesWarning(const FIO_prefs_t* const prefs, int displ
             } else {
                 DISPLAYLEVEL(2, "zstd: WARNING: all input files will be processed and concatenated into a single output file: %s ", outFileName);
             }
+            DISPLAYLEVEL(2, "\nThe concatenated output CANNOT regenerate the original directory tree. ")
             if (prefs->removeSrcFile) {
-                DISPLAYLEVEL(2, "\nThe concatenated output CANNOT regenerate the original directory tree. This is a destructive operation. ")
-                error = g_display_prefs.displayLevel > displayLevelCutoff && UTIL_requireUserConfirmation("Proceed? (y/n): ", "Aborting...", "yY");
+                error = g_display_prefs.displayLevel > displayLevelCutoff && UTIL_requireUserConfirmation("This is a destructive operation. Proceed? (y/n): ", "Aborting...", "yY");
             }
         }
         DISPLAY("\n");

--- a/programs/util.c
+++ b/programs/util.c
@@ -87,20 +87,20 @@ UTIL_STATIC void* UTIL_realloc(void *ptr, size_t size)
 ******************************************/
 int g_utilDisplayLevel;
 
-int UTIL_requireUserConfirmationToProceed(const char* prompt, const char* abortMsg,
+int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
                                           const char* acceptableLetters) {
-    int ch;
+    int ch, result;
     UTIL_DISPLAY("%s", prompt);
     ch = getchar();
+    result = 0;
     if (strchr(acceptableLetters, ch) == NULL) {
         UTIL_DISPLAY("%s", abortMsg);
-        return 1;
+        result = 1;
     }
     /* flush the rest */
     while ((ch!=EOF) && (ch!='\n'))
         ch = getchar();
-    
-    return 0;
+    return result;
 }
 
 

--- a/programs/util.c
+++ b/programs/util.c
@@ -87,6 +87,22 @@ UTIL_STATIC void* UTIL_realloc(void *ptr, size_t size)
 ******************************************/
 int g_utilDisplayLevel;
 
+int UTIL_requireUserConfirmationToProceed(const char* prompt, const char* abortMsg,
+                                          const char* acceptableLetters) {
+    int ch;
+    UTIL_DISPLAY("%s", prompt);
+    ch = getchar();
+    if (strchr(acceptableLetters, ch) == NULL) {
+        UTIL_DISPLAY("%s", abortMsg);
+        return 1;
+    }
+    /* flush the rest */
+    while ((ch!=EOF) && (ch!='\n'))
+        ch = getchar();
+    
+    return 0;
+}
+
 
 /*-*************************************
 *  Constants

--- a/programs/util.h
+++ b/programs/util.h
@@ -93,6 +93,12 @@ extern "C" {
 ******************************************/
 extern int g_utilDisplayLevel;
 
+/**
+ * Displays a message prompt and returns success (0) if first character from stdin
+ * matches any from acceptableLetters. Otherwise, returns failure (1) and displays abortMsg.
+ */
+int UTIL_requireUserConfirmationToProceed(const char* const prompt, const char* const abortMsg, const char* const acceptableLetters);
+
 
 /*-****************************************
 *  File functions

--- a/programs/util.h
+++ b/programs/util.h
@@ -97,7 +97,7 @@ extern int g_utilDisplayLevel;
  * Displays a message prompt and returns success (0) if first character from stdin
  * matches any from acceptableLetters. Otherwise, returns failure (1) and displays abortMsg.
  */
-int UTIL_requireUserConfirmation(const char* const prompt, const char* const abortMsg, const char* const acceptableLetters);
+int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const char* acceptableLetters);
 
 
 /*-****************************************

--- a/programs/util.h
+++ b/programs/util.h
@@ -97,7 +97,7 @@ extern int g_utilDisplayLevel;
  * Displays a message prompt and returns success (0) if first character from stdin
  * matches any from acceptableLetters. Otherwise, returns failure (1) and displays abortMsg.
  */
-int UTIL_requireUserConfirmationToProceed(const char* const prompt, const char* const abortMsg, const char* const acceptableLetters);
+int UTIL_requireUserConfirmation(const char* const prompt, const char* const abortMsg, const char* const acceptableLetters);
 
 
 /*-****************************************

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -213,7 +213,8 @@ the last one takes effect.
     and disabled when output is stdout.
     This setting overrides default and can force sparse mode over stdout.
 * `--rm`:
-    remove source file(s) after successful compression or decompression
+    remove source file(s) after successful compression or decompression. If used in combination with
+    -o, will trigger a confirmation prompt (which can be silenced with -f), as this is a destructive operation. 
 * `-k`, `--keep`:
     keep source file(s) after successful compression or decompression.
     This is the default behavior.

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -349,19 +349,25 @@ rm tmp*
 println "\n===>  compress multiple files"
 println hello > tmp1
 println world > tmp2
-zstd tmp1 tmp2 -o "$INTOVOID" -f
-zstd tmp1 tmp2 -c | zstd -t
-zstd tmp1 tmp2 -o tmp.zst
+echo 'y' | zstd tmp1 tmp2 -o "$INTOVOID" -f  # echo 'y' confirms the warning prompt
+echo 'y' | zstd tmp1 tmp2 -c | zstd -t
+echo 'y' | zstd tmp1 tmp2 -o tmp.zst
 test ! -f tmp1.zst
 test ! -f tmp2.zst
 zstd tmp1 tmp2
 zstd -t tmp1.zst tmp2.zst
 zstd -dc tmp1.zst tmp2.zst
-zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
-zstd -d tmp1.zst tmp2.zst -o tmp
+echo 'y' | zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
+echo 'y' | zstd -d tmp1.zst tmp2.zst -o tmp
 touch tmpexists
-zstd tmp1 tmp2 -f -o tmpexists
-zstd tmp1 tmp2 -o tmpexists && die "should have refused to overwrite"
+echo 'y' | zstd tmp1 tmp2 -f -o tmpexists
+echo 'y' | zstd tmp1 tmp2 -o tmpexists && die "should have refused to overwrite"
+zstd tmp1 tmp2 -o "$INTOVOID" --rm && die "should have refused to execute with --rm"
+println gooder > tmp_rm1
+println boi > tmp_rm2
+echo 'y' | zstd tmp_rm1 tmp_rm2 -o tmp_rm3.zst -f --rm
+rm tmp_rm3.zst
+
 # Bug: PR #972
 if [ "$?" -eq 139 ]; then
   die "should not have segfaulted"
@@ -382,7 +388,7 @@ test -f tmp1
 test -f tmp2
 test -f tmp3
 println "compress tmp* into stdout > tmpall : "
-zstd -c tmp1 tmp2 tmp3 > tmpall
+echo 'y' | zstd -c tmp1 tmp2 tmp3 > tmpall
 test -f tmpall  # should check size of tmpall (should be tmp1.zst + tmp2.zst + tmp3.zst)
 println "decompress tmpall* into stdout > tmpdec : "
 cp tmpall tmpall2
@@ -920,7 +926,7 @@ datagen | zstd -c | zstd -t
 println "\n===>  golden files tests "
 
 zstd -t -r "$TESTDIR/golden-decompression"
-zstd -c -r "$TESTDIR/golden-compression" | zstd -t
+echo 'y' | zstd -c -r "$TESTDIR/golden-compression" | zstd -t
 zstd -D "$TESTDIR/golden-dictionaries/http-dict-missing-symbols" "$TESTDIR/golden-compression/http" -c | zstd -D "$TESTDIR/golden-dictionaries/http-dict-missing-symbols" -t
 
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -349,24 +349,34 @@ rm tmp*
 println "\n===>  compress multiple files"
 println hello > tmp1
 println world > tmp2
-echo 'y' | zstd tmp1 tmp2 -o "$INTOVOID" -f  # echo 'y' confirms the warning prompt
-echo 'y' | zstd tmp1 tmp2 -c | zstd -t
-echo 'y' | zstd tmp1 tmp2 -o tmp.zst
+zstd tmp1 tmp2 -o "$INTOVOID" -f
+zstd tmp1 tmp2 -c | zstd -t
+zstd tmp1 tmp2 -o tmp.zst
 test ! -f tmp1.zst
 test ! -f tmp2.zst
 zstd tmp1 tmp2
 zstd -t tmp1.zst tmp2.zst
 zstd -dc tmp1.zst tmp2.zst
-echo 'y' | zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
-echo 'y' | zstd -d tmp1.zst tmp2.zst -o tmp
+zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
+zstd -d tmp1.zst tmp2.zst -o tmp
 touch tmpexists
-echo 'y' | zstd tmp1 tmp2 -f -o tmpexists
-echo 'y' | zstd tmp1 tmp2 -o tmpexists && die "should have refused to overwrite"
-zstd tmp1 tmp2 -o "$INTOVOID" --rm && die "should have refused to execute with --rm"
+zstd tmp1 tmp2 -f -o tmpexists
+zstd tmp1 tmp2 -o tmpexists && die "should have refused to overwrite"
 println gooder > tmp_rm1
 println boi > tmp_rm2
-echo 'y' | zstd tmp_rm1 tmp_rm2 -o tmp_rm3.zst -f --rm
-rm tmp_rm3.zst
+println worldly > tmp_rm3
+echo 'y' | zstd tmp_rm1 tmp_rm2 -o tmp_rm3.zst --rm     # tests the warning prompt for --rm with multiple inputs into once source
+test ! -f tmp_rm1
+test ! -f tmp_rm2
+cp tmp_rm3.zst tmp_rm4.zst
+echo 'Y' | zstd -d tmp_rm3.zst tmp_rm4.zst -o tmp_rm_out --rm
+test ! -f tmp_rm3.zst
+test ! -f tmp_rm4.zst
+echo 'yes' | zstd tmp_rm_out tmp_rm3 -c --rm
+test ! -f tmp_rm_out
+test ! -f tmp_rm3
+println gooder > tmpexists1
+zstd tmpexists1 tmpexists -c --rm -f
 
 # Bug: PR #972
 if [ "$?" -eq 139 ]; then
@@ -388,7 +398,7 @@ test -f tmp1
 test -f tmp2
 test -f tmp3
 println "compress tmp* into stdout > tmpall : "
-echo 'y' | zstd -c tmp1 tmp2 tmp3 > tmpall
+zstd -c tmp1 tmp2 tmp3 > tmpall
 test -f tmpall  # should check size of tmpall (should be tmp1.zst + tmp2.zst + tmp3.zst)
 println "decompress tmpall* into stdout > tmpdec : "
 cp tmpall tmpall2
@@ -926,7 +936,7 @@ datagen | zstd -c | zstd -t
 println "\n===>  golden files tests "
 
 zstd -t -r "$TESTDIR/golden-decompression"
-echo 'y' | zstd -c -r "$TESTDIR/golden-compression" | zstd -t
+zstd -c -r "$TESTDIR/golden-compression" | zstd -t
 zstd -D "$TESTDIR/golden-dictionaries/http-dict-missing-symbols" "$TESTDIR/golden-compression/http" -c | zstd -D "$TESTDIR/golden-dictionaries/http-dict-missing-symbols" -t
 
 


### PR DESCRIPTION
The following would trigger the warning:

`zstd tst/tmp1 tst/tmp2 tst/tmp3 -o out.zst`
`zstd tst/tmp1 tst/tmp2 tst/tmp3 -o out.zst --rm` (this one aborts fully)
`zstd tst/tmp1 tst/tmp2 tst/tmp3 -o out.zst --rm -f`
`zstd tst/tmp1 tst/tmp2 tst/tmp3 -o out.zst -f`
`zstd tst/tmp1 testfiles/tmp2 testfiles/tmp3 -c`
`zstd -r tst/ -o out.zst`
`zstd -r tst/ -c`
`zstd -r tst/ --rm -c` (this one aborts fully)
./zstd -r tst/ --rm -f`

For overwriting the file with `-f`, there's no warning triggered. Is that behavior that we want here as well? 

Some tests in `playTests.sh` had to be modified to work with the new warning.