### PR TITLE
Refreshing progress bar for processing multiple files

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -624,9 +624,10 @@ FIO_openDstFile(FIO_prefs_t* const prefs,
                 {   int ch = getchar();
                     if ((ch!='Y') && (ch!='y')) {
                         DISPLAY("    not overwritten  \n");
+                        /* flush rest of input line */
+                        while ((ch!=EOF) && (ch!='\n')) ch = getchar();
                         return NULL;
                     }
-                    /* flush rest of input line */
                     while ((ch!=EOF) && (ch!='\n')) ch = getchar();
             }   }
             /* need to unlink */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1261,7 +1261,7 @@ FIO_compressZstdFrame(FIO_prefs_t* const prefs,
 
                 /* display progress notifications */
                 if (g_display_prefs.displayLevel >= 3) {
-                    DISPLAYUPDATE(3, "\r(L%i) Buffered :%4u MB - Consumed :%4u MB - Compressed :%4u MB => %.2f%%\033 ",
+                    DISPLAYUPDATE(3, "\r(L%i) Buffered :%4u MB - Consumed :%4u MB - Compressed :%4u MB => %.2f%% ",
                                 compressionLevel,
                                 (unsigned)((zfp.ingested - zfp.consumed) >> 20),
                                 (unsigned)(zfp.consumed >> 20),
@@ -1725,8 +1725,6 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
                 dstFileName = FIO_determineCompressedName(srcFileName, outDirName, suffix);  /* cannot fail */
             }
 
-            /* No status message in pipe mode (stdin - stdout) or multi-files mode */
-            // if (!strcmp(inFileNamesTable[0], stdinmark) && outFileName && !strcmp(outFileName,stdoutmark) && (g_display_prefs.displayLevel==2)) g_displayLevel=1;
             if (nbFiles > 1)
                 DISPLAYLEVEL(2, "\rCompressing %u/%u files. Current source: %s | ", u+1, nbFiles, srcFileName);
             error |= FIO_compressFilename_srcFile(prefs, ress, dstFileName, srcFileName, compressionLevel);
@@ -2614,7 +2612,7 @@ FIO_decompressMultipleFilenames(FIO_prefs_t* const prefs,
             }
             if (dstFileName == NULL) { error=1; continue; }
             if (nbFiles > 1)
-                DISPLAYLEVEL(2, "\rDecompressing %u/%u files. Current source: %s | ", u+1, nbFiles, srcFileName[u]);
+                DISPLAYLEVEL(2, "\rDecompressing %u/%u files. Current source: %s | ", u+1, nbFiles, srcFileName);
             error |= FIO_decompressSrcFile(prefs, ress, dstFileName, srcFileName);
         }
         if (outDirName)

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1695,7 +1695,7 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
             unsigned u;
             for (u=0; u<nbFiles; u++) {
                 if (nbFiles > 1)
-                    DISPLAYLEVEL(2, "\rCompressing %u/%u files. Current source: %s | ", u+1, nbFiles, inFileNamesTable[u]);
+                    DISPLAYLEVEL(2, "\rCompressing %u/%u files. Current source: %s ", u+1, nbFiles, inFileNamesTable[u]);
                 error |= FIO_compressFilename_srcFile(prefs, ress, outFileName, inFileNamesTable[u], compressionLevel);
             }
             if (fclose(ress.dstFile))
@@ -1726,7 +1726,7 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
             }
 
             if (nbFiles > 1)
-                DISPLAYLEVEL(2, "\rCompressing %u/%u files. Current source: %s | ", u+1, nbFiles, srcFileName);
+                DISPLAYLEVEL(2, "\rCompressing %u/%u files. Current source: %s ", u+1, nbFiles, srcFileName);
             error |= FIO_compressFilename_srcFile(prefs, ress, dstFileName, srcFileName, compressionLevel);
         }
 

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1437,7 +1437,7 @@ FIO_compressFilename_internal(FIO_prefs_t* const prefs,
     
     DISPLAYLEVEL(2, "\r%79s\r", "");
     /* No status message in pipe mode (stdin - stdout) or multi-files mode */
-    if (prefs->nbFiles == 1 && !((!strcmp(srcFileName, stdinmark) && dstFileName && !strcmp(dstFileName,stdoutmark)))) {
+    if (g_display_prefs.displayLevel > 2 || (prefs->nbFiles == 1 && !((!strcmp(srcFileName, stdinmark) && dstFileName && !strcmp(dstFileName,stdoutmark))))) {
         if (readsize == 0) {
             DISPLAYLEVEL(2,"%-20s :  (%6llu => %6llu bytes, %s) \n",
                 srcFileName,
@@ -2332,7 +2332,9 @@ static int FIO_decompressFrames(dRess_t ress, FILE* srcFile,
 
     /* Final Status */
     DISPLAYLEVEL(2, "\r%79s\r", "");
-    DISPLAYLEVEL(2, "%-20s: %llu bytes \n", srcFileName, filesize);
+    /* No status message in pipe mode (stdin - stdout) or multi-files mode */
+    if (g_display_prefs.displayLevel > 2 || (prefs->nbFiles == 1 && !((!strcmp(srcFileName, stdinmark) && dstFileName && !strcmp(dstFileName,stdoutmark)))))
+        DISPLAYLEVEL(2, "%-20s: %llu bytes \n", srcFileName, filesize);
 
     return 0;
 }
@@ -2585,7 +2587,7 @@ FIO_decompressMultipleFilenames(FIO_prefs_t* const prefs,
             if (ress.dstFile == 0) EXM_THROW(19, "cannot open %s", outFileName);
         }
         for (u=0; u<nbFiles; u++) {
-            DISPLAYLEVEL(2, "\rDecompressing %u/%u files. Current source: %s | ", u+1, nbFiles, srcNamesTable[u]);
+            DISPLAYLEVEL(2, "\rDecompressing %u/%u files. Current source: ", u+1, nbFiles);
             error |= FIO_decompressSrcFile(prefs, ress, outFileName, srcNamesTable[u]);
         }
         if ((!prefs->testMode) && (fclose(ress.dstFile)))
@@ -2612,7 +2614,7 @@ FIO_decompressMultipleFilenames(FIO_prefs_t* const prefs,
             }
             if (dstFileName == NULL) { error=1; continue; }
             if (nbFiles > 1)
-                DISPLAYLEVEL(2, "\rDecompressing %u/%u files. Current source: %s | ", u+1, nbFiles, srcFileName);
+                DISPLAYLEVEL(2, "\rDecompressing %u/%u files. Current source: ", u+1, nbFiles);
             error |= FIO_decompressSrcFile(prefs, ress, dstFileName, srcFileName);
         }
         if (outDirName)

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -97,6 +97,7 @@ void FIO_setExcludeCompressedFile(FIO_prefs_t* const prefs, int excludeCompresse
 void FIO_setPatchFromMode(FIO_prefs_t* const prefs, int value);
 void FIO_setContentSize(FIO_prefs_t* const prefs, int value);
 void FIO_setNbFiles(FIO_prefs_t* const prefs, int value);
+void FIO_setCurrFileIdx(FIO_prefs_t* const prefs, int value);
 
 /*-*************************************
 *  Single File functions
@@ -122,7 +123,7 @@ int FIO_listMultipleFiles(unsigned numFiles, const char** filenameTable, int dis
 /** FIO_compressMultipleFilenames() :
  * @return : nb of missing files */
 int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
-                                  const char** inFileNamesTable, unsigned nbFiles,
+                                  const char** inFileNamesTable,
                                   const char* outMirroredDirName,
                                   const char* outDirName,
                                   const char* outFileName, const char* suffix,
@@ -132,7 +133,7 @@ int FIO_compressMultipleFilenames(FIO_prefs_t* const prefs,
 /** FIO_decompressMultipleFilenames() :
  * @return : nb of missing or skipped files */
 int FIO_decompressMultipleFilenames(FIO_prefs_t* const prefs,
-                                    const char** srcNamesTable, unsigned nbFiles,
+                                    const char** srcNamesTable,
                                     const char* outMirroredDirName,
                                     const char* outDirName,
                                     const char* outFileName,

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -96,6 +96,7 @@ void FIO_setNotificationLevel(int level);
 void FIO_setExcludeCompressedFile(FIO_prefs_t* const prefs, int excludeCompressedFiles);
 void FIO_setPatchFromMode(FIO_prefs_t* const prefs, int value);
 void FIO_setContentSize(FIO_prefs_t* const prefs, int value);
+void FIO_setNbFiles(FIO_prefs_t* const prefs, int value);
 
 /*-*************************************
 *  Single File functions

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1319,7 +1319,6 @@ int main(int const argCount, const char* argv[])
         if (filenames->tableSize == 1 && outFileName) {
             operationResult = FIO_decompressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName);
         } else {
-            FIO_setNbFiles(prefs, (int)filenames->tableSize);
             operationResult = FIO_decompressMultipleFilenames(prefs, filenames->fileNames, outMirroredDirName, outDirName, outFileName, dictFileName);
         }
 #else

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1243,8 +1243,12 @@ int main(int const argCount, const char* argv[])
         DISPLAY("error : can't use --patch-from=# on multiple files \n");
         CLEAN_RETURN(1);
     }
+    
+    /* No status message in pipe mode (stdin - stdout) */	
+    if (!strcmp(filenames->fileNames[0], stdinmark) && outFileName && !strcmp(outFileName,stdoutmark) && (g_displayLevel==2)) g_displayLevel=1;
 
     /* IO Stream/File */
+    FIO_setNbFiles(prefs, (int)filenames->tableSize); 
     FIO_setNotificationLevel(g_displayLevel);
     FIO_setPatchFromMode(prefs, patchFromDictFileName != NULL);
     if (memLimit == 0) {
@@ -1302,12 +1306,10 @@ int main(int const argCount, const char* argv[])
             }
         }
 
-        if ((filenames->tableSize==1) && outFileName) {
+        if ((filenames->tableSize==1) && outFileName)
             operationResult = FIO_compressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName, cLevel, compressionParams);
-        } else {
-            FIO_setNbFiles(prefs, (int)filenames->tableSize);
-            operationResult = FIO_compressMultipleFilenames(prefs, filenames->fileNames, (unsigned)filenames->tableSize, outMirroredDirName, outDirName, outFileName, suffix, dictFileName, cLevel, compressionParams);
-        }
+        else
+            operationResult = FIO_compressMultipleFilenames(prefs, filenames->fileNames, outMirroredDirName, outDirName, outFileName, suffix, dictFileName, cLevel, compressionParams);
 #else
         (void)contentSize; (void)suffix; (void)adapt; (void)rsyncable; (void)ultra; (void)cLevel; (void)ldmFlag; (void)literalCompressionMode; (void)targetCBlockSize; (void)streamSrcSize; (void)srcSizeHint; (void)ZSTD_strategyMap; /* not used when ZSTD_NOCOMPRESS set */
         DISPLAY("Compression not supported \n");
@@ -1318,7 +1320,7 @@ int main(int const argCount, const char* argv[])
             operationResult = FIO_decompressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName);
         } else {
             FIO_setNbFiles(prefs, (int)filenames->tableSize);
-            operationResult = FIO_decompressMultipleFilenames(prefs, filenames->fileNames, (unsigned)filenames->tableSize, outMirroredDirName, outDirName, outFileName, dictFileName);
+            operationResult = FIO_decompressMultipleFilenames(prefs, filenames->fileNames, outMirroredDirName, outDirName, outFileName, dictFileName);
         }
 #else
         DISPLAY("Decompression not supported \n");

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1244,10 +1244,6 @@ int main(int const argCount, const char* argv[])
         CLEAN_RETURN(1);
     }
 
-    /* No status message in pipe mode (stdin - stdout) or multi-files mode */
-    if (!strcmp(filenames->fileNames[0], stdinmark) && outFileName && !strcmp(outFileName,stdoutmark) && (g_displayLevel==2)) g_displayLevel=1;
-    if ((filenames->tableSize > 1) & (g_displayLevel==2)) g_displayLevel=1;
-
     /* IO Stream/File */
     FIO_setNotificationLevel(g_displayLevel);
     FIO_setPatchFromMode(prefs, patchFromDictFileName != NULL);
@@ -1306,10 +1302,12 @@ int main(int const argCount, const char* argv[])
             }
         }
 
-        if ((filenames->tableSize==1) && outFileName)
-          operationResult = FIO_compressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName, cLevel, compressionParams);
-        else
-          operationResult = FIO_compressMultipleFilenames(prefs, filenames->fileNames, (unsigned)filenames->tableSize, outMirroredDirName, outDirName, outFileName, suffix, dictFileName, cLevel, compressionParams);
+        if ((filenames->tableSize==1) && outFileName) {
+            operationResult = FIO_compressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName, cLevel, compressionParams);
+        } else {
+            FIO_setNbFiles(prefs, (int)filenames->tableSize);
+            operationResult = FIO_compressMultipleFilenames(prefs, filenames->fileNames, (unsigned)filenames->tableSize, outMirroredDirName, outDirName, outFileName, suffix, dictFileName, cLevel, compressionParams);
+        }
 #else
         (void)contentSize; (void)suffix; (void)adapt; (void)rsyncable; (void)ultra; (void)cLevel; (void)ldmFlag; (void)literalCompressionMode; (void)targetCBlockSize; (void)streamSrcSize; (void)srcSizeHint; (void)ZSTD_strategyMap; /* not used when ZSTD_NOCOMPRESS set */
         DISPLAY("Compression not supported \n");
@@ -1319,6 +1317,7 @@ int main(int const argCount, const char* argv[])
         if (filenames->tableSize == 1 && outFileName) {
             operationResult = FIO_decompressFilename(prefs, outFileName, filenames->fileNames[0], dictFileName);
         } else {
+            FIO_setNbFiles(prefs, (int)filenames->tableSize);
             operationResult = FIO_decompressMultipleFilenames(prefs, filenames->fileNames, (unsigned)filenames->tableSize, outMirroredDirName, outDirName, outFileName, dictFileName);
         }
 #else

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -361,7 +361,7 @@ zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
 zstd -d tmp1.zst tmp2.zst -o tmp
 touch tmpexists
 zstd tmp1 tmp2 -f -o tmpexists
-zstd tmp1 tmp2 -o tmpexists && die "should have refused to overwrite"
+zstd tmp1 tmp2 -q -o tmpexists && die "should have refused to overwrite"
 # Bug: PR #972
 if [ "$?" -eq 139 ]; then
   die "should not have segfaulted"


### PR DESCRIPTION
video of how it works: https://vimeo.com/451651373

Summary:
Now, instead of line by line output, we have a single, live updating progress feed when compressing/decompressing multiple files.

```
zstd tmp1 tmp2 tmp3 tmp4.       # uses refreshing status line, displayLevel = 2
zstd tmp1 tmp2 tmp3 tmp4.  -v   # same as before, prints status updates on each line and more info, displayLevel = 3
zstd tmp1 tmp2 tmp3 tmp4   -q.  # same as before, emits nothing, displayLevel = 1
```

We add two new parameters in `FIO_prefs_t`: `int nbFiles` and `int currFileIdx`. Also, the function signature of `FIO_(de)compressMultipleFilenames()` no longer has a `nbFiles` field, since we already have one in `FIO_prefs_t`.
Now, we only force `displayLevel=1` in pipe mode which is actually desirable, as opposed to the previous situation where this was forced during multiple files mode too.

One small side effect of this correction of multi-file `displayLevel`: if we input `zstd file1 file2 -o conflictingOutfile.zst`, previously zstd would simply bail (due to `displayLevel=1`), but now it will trigger user confirmation prompt (due to `displayLevel=2`). We also trigger the prompt if we invoke `zstd file1 file2` in the presence of `file1.zst file2.zst`. This the exact same behavior as single file operations: `zstd file1 -o conflictingOutfile.zst`.

This PR also corrects a bug in the user prompt that caused it to skip over every other file if you answered "no" each time when prompting overwrite for multiple files.

Followup:
- Add a summary of total compression ratio of all files `totalBytes/compressedBytes` in a followup PR.