### PR TITLE
[fuzz] Fix oss-fuzz test problems

### DIFF
--- a/tests/fuzz/fuzz_data_producer.c
+++ b/tests/fuzz/fuzz_data_producer.c
@@ -66,6 +66,10 @@ size_t FUZZ_dataProducer_remainingBytes(FUZZ_dataProducer_t *producer){
     return producer->size;
 }
 
+int FUZZ_dataProducer_empty(FUZZ_dataProducer_t *producer) {
+    return producer->size == 0;
+}
+
 size_t FUZZ_dataProducer_contract(FUZZ_dataProducer_t *producer, size_t newSize)
 {
     newSize = newSize > producer->size ? producer->size : newSize;

--- a/tests/fuzz/fuzz_data_producer.h
+++ b/tests/fuzz/fuzz_data_producer.h
@@ -49,6 +49,9 @@ int32_t FUZZ_dataProducer_int32Range(FUZZ_dataProducer_t *producer,
 /* Returns the size of the remaining bytes of data in the producer */
 size_t FUZZ_dataProducer_remainingBytes(FUZZ_dataProducer_t *producer);
 
+/* Returns true if the data producer is out of bytes */
+int FUZZ_dataProducer_empty(FUZZ_dataProducer_t *producer);
+
 /* Restricts the producer to only the last newSize bytes of data.
 If newSize > current data size, nothing happens. Returns the number of bytes
 the producer won't use anymore, after contracting. */

--- a/tests/fuzz/simple_round_trip.c
+++ b/tests/fuzz/simple_round_trip.c
@@ -47,8 +47,12 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
     FUZZ_ZASSERT(cSize);
     dSize = ZSTD_decompressDCtx(dctx, result, resultCapacity, compressed, cSize);
     FUZZ_ZASSERT(dSize);
-    /* When superblock is enabled make sure we don't expand the block more than expected. */
-    if (targetCBlockSize != 0) {
+    /* When superblock is enabled make sure we don't expand the block more than expected.
+     * NOTE: This test is currently disabled because superblock mode can arbitrarily
+     * expand the block in the worst case. Once superblock mode has been improved we can
+     * re-enable this test.
+     */
+    if (0 && targetCBlockSize != 0) {
         size_t normalCSize;
         FUZZ_ZASSERT(ZSTD_CCtx_setParameter(cctx, ZSTD_c_targetCBlockSize, 0));
         normalCSize = ZSTD_compress2(cctx, compressed, compressedCapacity, src, srcSize);


### PR DESCRIPTION
* Disable the superblock expansion test, since there isn't effectively a bound in the worst case.
* Fix `stream_decompress` to avoid timeouts by passing the whole buffers when out of control bytes in the data producer.