### PR TITLE
[doc] Add ZSTD_versionString() to manual

### DIFF
--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -73,15 +73,20 @@ extern "C" {
 #define ZSTD_VERSION_MAJOR    1
 #define ZSTD_VERSION_MINOR    4
 #define ZSTD_VERSION_RELEASE  5
-
 #define ZSTD_VERSION_NUMBER  (ZSTD_VERSION_MAJOR *100*100 + ZSTD_VERSION_MINOR *100 + ZSTD_VERSION_RELEASE)
-ZSTDLIB_API unsigned ZSTD_versionNumber(void);   /**< to check runtime library version */
+
+/*! ZSTD_versionNumber() :
+ *  Return runtime library version, the value is (MAJOR*100*100 + MINOR*100 + RELEASE). */
+ZSTDLIB_API unsigned ZSTD_versionNumber(void);
 
 #define ZSTD_LIB_VERSION ZSTD_VERSION_MAJOR.ZSTD_VERSION_MINOR.ZSTD_VERSION_RELEASE
 #define ZSTD_QUOTE(str) #str
 #define ZSTD_EXPAND_AND_QUOTE(str) ZSTD_QUOTE(str)
 #define ZSTD_VERSION_STRING ZSTD_EXPAND_AND_QUOTE(ZSTD_LIB_VERSION)
-ZSTDLIB_API const char* ZSTD_versionString(void);   /* requires v1.3.0+ */
+
+/*! ZSTD_versionString() :
+ *  Return runtime library version, like "1.4.5". Requires v1.3.0+. */
+ZSTDLIB_API const char* ZSTD_versionString(void);
 
 /* *************************************
  *  Default constant


### PR DESCRIPTION
`ZSTD_versionString(void)` function is missing from the manual.
Below is the display effect in the Edge browser.

Before:
![before](https://github.com/animalize/pics/blob/master/issues/zstdver0.PNG?raw=true)

After:
![after](https://github.com/animalize/pics/blob/master/issues/zstdver1.PNG?raw=true)