### PR TITLE
[WIP] Add new ZSTD_customJobControl settings.

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -255,6 +255,7 @@ struct ZSTD_CCtx_s {
     unsigned long long producedCSize;
     XXH64_state_t xxhState;
     ZSTD_customMem customMem;
+    ZSTD_customJobControl customJobControl;
     size_t staticSize;
     SeqCollector seqCollector;
     int isFirstBlock;

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -60,7 +60,8 @@ typedef struct ZSTDMT_CCtx_s ZSTDMT_CCtx;
 ZSTDMT_API ZSTDMT_CCtx* ZSTDMT_createCCtx(unsigned nbWorkers);
 /* Requires ZSTD_MULTITHREAD to be defined during compilation, otherwise it will return NULL. */
 ZSTDMT_API ZSTDMT_CCtx* ZSTDMT_createCCtx_advanced(unsigned nbWorkers,
-                                                    ZSTD_customMem cMem);
+                                                    ZSTD_customMem cMem,
+                                                    ZSTD_customJobControl cJobControl);
 ZSTDMT_API size_t ZSTDMT_freeCCtx(ZSTDMT_CCtx* mtctx);
 
 ZSTDMT_API size_t ZSTDMT_sizeof_CCtx(ZSTDMT_CCtx* mtctx);


### PR DESCRIPTION
As mentioned in #1097, I see it handy to have a mechanism that can limit threading among ZSTD contexts.
My motivation example comes from `rpm` where it does:
```
#omp parallel
foreach (package in packages)
   package->compress()
```

where each package can use threading compression of `zstd`. It is common that you can have a single file package (like Firefox) where you want to utilize threading compression. And you can also have very many sub-packages (like for gcc) where you can't spawn N threads for each of them.

I know the suggested code is not portable right now. It's a POC and I would like to see comments from community?