### PR TITLE
Fix setParameter not falling back to default compression level

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -544,7 +544,6 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
             CCtxParams->compressionLevel = ZSTD_CLEVEL_DEFAULT; /* 0 == default */
         else
             CCtxParams->compressionLevel = value;
-        }
         if (CCtxParams->compressionLevel >= 0) return (size_t)CCtxParams->compressionLevel;
         return 0;  /* return type (size_t) cannot represent negative values */
     }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -540,7 +540,9 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
 
     case ZSTD_c_compressionLevel : {
         FORWARD_IF_ERROR(ZSTD_cParam_clampBounds(param, &value), "");
-        if (value) {  /* 0 : does not change current level */
+        if (value == 0)
+            CCtxParams->compressionLevel = ZSTD_CLEVEL_DEFAULT; /* 0 == default */
+        else
             CCtxParams->compressionLevel = value;
         }
         if (CCtxParams->compressionLevel >= 0) return (size_t)CCtxParams->compressionLevel;


### PR DESCRIPTION
`ZSTD_CCtx_setParameter` does not adhere to the documented behavior of setting `0` as `compressionLevel`:  
`Special: value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT`.  
Instead it does not change the compression level at all.  

This pull request adjusts the behavior to conform to the documentation.