### PR TITLE
DDSS for Lazy: Implement a Dedicated Dictionary Chain Table

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1647,13 +1647,13 @@ static int ZSTD_shouldAttachDict(const ZSTD_CDict* cdict,
 {
     size_t cutoff = attachDictSizeCutoffs[cdict->matchState.cParams.strategy];
     int const dedicatedDictSearch = cdict->matchState.dedicatedDictSearch;
-    return ( dedicatedDictSearch
-          || pledgedSrcSize <= cutoff
-          || pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN
-          || params->attachDictPref == ZSTD_dictForceAttach )
-        && params->attachDictPref != ZSTD_dictForceCopy
-        && !params->forceWindow; /* dictMatchState isn't correctly
-                                 * handled in _enforceMaxDist */
+    return dedicatedDictSearch
+        || ( ( pledgedSrcSize <= cutoff
+            || pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN
+            || params->attachDictPref == ZSTD_dictForceAttach )
+          && params->attachDictPref != ZSTD_dictForceCopy
+          && !params->forceWindow ); /* dictMatchState isn't correctly
+                                      * handled in _enforceMaxDist */
 }
 
 static size_t

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -872,6 +872,12 @@ ZSTD_compressBlock_lazy_generic(
                         ZSTD_matchState_t* ms,
                         const BYTE* ip, const BYTE* iLimit, size_t* offsetPtr);
 
+    /**
+     * This table is indexed first by the four ZSTD_dictMode_e values, and then
+     * by the two searchMethod_e values. NULLs are placed for configurations
+     * that should never occur (extDict modes go to the other implementation
+     * below and there is no DDSS for binary tree search yet).
+     */
     const searchMax_f searchFuncs[4][2] = {
         {
             ZSTD_HcFindBestMatch_selectMLS,

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -497,7 +497,7 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
      */
     U32 const hashLog = ms->cParams.hashLog - ZSTD_LAZY_DDSS_BUCKET_LOG;
     U32* const tmpHashTable = hashTable;
-    U32* const tmpChainTable = hashTable + (1 << hashLog);
+    U32* const tmpChainTable = hashTable + ((size_t)1 << hashLog);
     U32 const tmpChainSize = ((1 << ZSTD_LAZY_DDSS_BUCKET_LOG) - 1) << hashLog;
     U32 const tmpMinChain = tmpChainSize < target ? target - tmpChainSize : idx;
 
@@ -510,7 +510,7 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
 
     /* fill conventional hash table and conventional chain table */
     for ( ; idx < target; idx++) {
-        U32 const h = ZSTD_hashPtr(base + idx, hashLog, ms->cParams.minMatch);
+        U32 const h = (U32)ZSTD_hashPtr(base + idx, hashLog, ms->cParams.minMatch);
         if (idx >= tmpMinChain) {
             tmpChainTable[idx - tmpMinChain] = hashTable[h];
         }
@@ -579,7 +579,7 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
 
     /* fill the buckets of the hash table */
     for (idx = ms->nextToUpdate; idx < target; idx++) {
-        U32 const h = ZSTD_hashPtr(base + idx, hashLog, ms->cParams.minMatch)
+        U32 const h = (U32)ZSTD_hashPtr(base + idx, hashLog, ms->cParams.minMatch)
                    << ZSTD_LAZY_DDSS_BUCKET_LOG;
         U32 i;
         /* Shift hash cache down 1. */

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -487,7 +487,9 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
     U32 const chainMask = chainSize - 1;
     U32 idx = ms->nextToUpdate;
     U32 const minChain = chainSize < target ? target - chainSize : idx;
-    U32 bucketSize = 1 << ZSTD_LAZY_DDSS_BUCKET_LOG;
+    U32 const bucketSize = 1 << ZSTD_LAZY_DDSS_BUCKET_LOG;
+    U32 const nbAttempts = (1 << ms->cParams.searchLog) - bucketSize + 1;
+    U32 const chainLimit = nbAttempts > 255 ? 255 : nbAttempts;
     U32* const chains = (U32*)malloc(chainSize * sizeof(U32));
     assert(chains != NULL);
     assert(idx != 0);
@@ -517,7 +519,7 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
             while (i) {
                 chainTable[chainPos++] = i;
                 count++;
-                if (i < minChain || count >= 255) {
+                if (i < minChain || count >= chainLimit) {
                     break;
                 }
                 i = chains[i & chainMask];

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -535,8 +535,7 @@ void ZSTD_dedicatedDictSearch_lazy_loadDictionary(ZSTD_matchState_t* ms, const B
             if (count == cacheSize) {
                 for (count = 0; count < chainLimit;) {
                     if (i < minChain) {
-                        countBeyondMinChain++;
-                        if (countBeyondMinChain > cacheSize) {
+                        if (!i || countBeyondMinChain++ > cacheSize) {
                             /* only allow pulling `cacheSize` number of entries
                              * into the cache or chainTable beyond `minChain`,
                              * to replace the entries pulled out of the
@@ -688,10 +687,13 @@ size_t ZSTD_HcFindBestMatch_generic (
             matchIndex = dms->hashTable[ddsIdx + ddsAttempt];
             match = ddsBase + matchIndex;
 
-            if (matchIndex < ddsLowestIndex) {
+            if (!matchIndex) {
                 return ml;
             }
 
+            /* guaranteed by table construction */
+            (void)ddsLowestIndex;
+            assert(matchIndex >= ddsLowestIndex);
             assert(match+4 <= ddsEnd);
             if (MEM_read32(match) == MEM_read32(ip)) {
                 /* assumption : matchIndex <= dictLimit-4 (by table construction) */
@@ -727,10 +729,8 @@ size_t ZSTD_HcFindBestMatch_generic (
                 matchIndex = dms->chainTable[chainIndex];
                 match = ddsBase + matchIndex;
 
-                if (matchIndex < ddsLowestIndex) {
-                    break;
-                }
-
+                /* guaranteed by table construction */
+                assert(matchIndex >= ddsLowestIndex);
                 assert(match+4 <= ddsEnd);
                 if (MEM_read32(match) == MEM_read32(ip)) {
                     /* assumption : matchIndex <= dictLimit-4 (by table construction) */

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -653,9 +653,13 @@ size_t ZSTD_HcFindBestMatch_generic (
             U32 const chainLength = chainPackedPointer & 0xFF;
             U32 const chainAttempts = nbAttempts - ddsAttempt;
             U32 const chainLimit = chainAttempts > chainLength ? chainLength : chainAttempts;
-            U32 chainAttempt = 0;
+            U32 chainAttempt;
 
-            for ( ; chainAttempt < chainLimit; chainAttempt++, chainIndex++) {
+            for (chainAttempt = 0 ; chainAttempt < chainLimit; chainAttempt++) {
+                PREFETCH_L1(ddsBase + dms->chainTable[chainIndex + chainAttempt]);
+            }
+
+            for (chainAttempt = 0 ; chainAttempt < chainLimit; chainAttempt++, chainIndex++) {
                 size_t currentMl=0;
                 const BYTE* match;
                 matchIndex = dms->chainTable[chainIndex];

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1548,15 +1548,16 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
 #define ZSTD_c_srcSizeHint ZSTD_c_experimentalParam7
 
 /* Controls whether the new and experimental "dedicated dictionary search
- * structure" can be used.
+ * structure" can be used. This feature is still rough around the edges, be
+ * prepared for surprising behavior!
  *
  * How to use it:
  *
  * When using a CDict, whether to use this feature or not is controlled at
  * CDict creation, and it must be set in a CCtxParams set passed into that
- * construction. A compression will then use the feature or not based on how
- * the CDict was constructed; the value of this param, set in the CCtx, will
- * have no effect.
+ * construction (via ZSTD_createCDict_advanced2()). A compression will then
+ * use the feature or not based on how the CDict was constructed; the value of
+ * this param, set in the CCtx, will have no effect.
  *
  * However, when a dictionary buffer is passed into a CCtx, such as via
  * ZSTD_CCtx_loadDictionary(), this param can be set on the CCtx to control
@@ -1578,10 +1579,13 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
  * written as the compression goes along. This means we can choose a search
  * structure for the dictionary that is read-optimized.
  *
- * This feature enables the use of that different structure. Note that this
- * means that the CDict tables can no longer be copied into the CCtx, so
- * the dict attachment mode ZSTD_dictForceCopy will no longer be useable. The
- * dictionary can only be attached or reloaded.
+ * This feature enables the use of that different structure.
+ *
+ * Note that some of the members of the ZSTD_compressionParameters struct have
+ * different semantics and constraints in the dedicated search structure. It is
+ * highly recommended that you simply set a compression level in the CCtxParams
+ * you pass into the CDict creation call, and avoid messing with the cParams
+ * directly.
  *
  * Effects:
  *
@@ -1589,9 +1593,13 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
  * implementation supports this feature. Currently, that's limited to
  * ZSTD_greedy, ZSTD_lazy, and ZSTD_lazy2.
  *
- * In general, you should expect compression to be faster, and CDict creation
- * to be slightly slower. Eventually, we will probably make this mode the
- * default.
+ * Note that this means that the CDict tables can no longer be copied into the
+ * CCtx, so the dict attachment mode ZSTD_dictForceCopy will no longer be
+ * useable. The dictionary can only be attached or reloaded.
+ *
+ * In general, you should expect compression to be faster--sometimes very much
+ * so--and CDict creation to be slightly slower. Eventually, we will probably
+ * make this mode the default.
  */
 #define ZSTD_c_enableDedicatedDictSearch ZSTD_c_experimentalParam8
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2948,8 +2948,8 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
         CHECK(cctx_params != NULL);
 
-        for (dictSize = CNBuffSize; dictSize; dictSize = dictSize >> 1) {
-            for (cLevel = 4; cLevel < 12; cLevel++) {
+        for (dictSize = CNBuffSize; dictSize; dictSize = dictSize >> 3) {
+            for (cLevel = 4; cLevel < 13; cLevel++) {
                 for (i = 0; i < 8; ++i) {
                     ZSTD_dictAttachPref_e const attachPref = attachPrefs[i];
                     int const enableDDS = enableDedicatedDictSearch[i];

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2955,7 +2955,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
                     int const enableDDS = enableDedicatedDictSearch[i];
                     ZSTD_CDict* cdict;
 
-                    DISPLAYLEVEL(5, "\n  dictSize %lu cLevel %d iter %d ", dictSize, cLevel, i);
+                    DISPLAYLEVEL(5, "\n  dictSize %u cLevel %d iter %d ", (U32)dictSize, cLevel, i);
 
                     ZSTD_CCtxParams_init(cctx_params, cLevel);
                     CHECK_Z(ZSTD_CCtxParams_setParameter(cctx_params, ZSTD_c_enableDedicatedDictSearch, enableDDS));
@@ -2970,7 +2970,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
                     CHECK_Z(cSize);
                     CHECK_Z(ZSTD_decompress_usingDict(dctx, decodedBuffer, CNBuffSize, compressedBuffer, cSize, dict, dictSize));
 
-                    DISPLAYLEVEL(5, "compressed to %lu bytes ", cSize);
+                    DISPLAYLEVEL(5, "compressed to %u bytes ", (U32)cSize);
 
                     CHECK_Z(ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters));
                     ZSTD_freeCDict(cdict);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2949,13 +2949,14 @@ static int basicUnitTests(U32 const seed, double compressibility)
         CHECK(cctx_params != NULL);
 
         for (dictSize = CNBuffSize; dictSize; dictSize = dictSize >> 3) {
+            DISPLAYLEVEL(3, "\n    Testing with dictSize %u ", (U32)dictSize);
             for (cLevel = 4; cLevel < 13; cLevel++) {
                 for (i = 0; i < 8; ++i) {
                     ZSTD_dictAttachPref_e const attachPref = attachPrefs[i];
                     int const enableDDS = enableDedicatedDictSearch[i];
                     ZSTD_CDict* cdict;
 
-                    DISPLAYLEVEL(5, "\n  dictSize %u cLevel %d iter %d ", (U32)dictSize, cLevel, i);
+                    DISPLAYLEVEL(5, "\n      dictSize %u cLevel %d iter %d ", (U32)dictSize, cLevel, i);
 
                     ZSTD_CCtxParams_init(cctx_params, cLevel);
                     CHECK_Z(ZSTD_CCtxParams_setParameter(cctx_params, ZSTD_c_enableDedicatedDictSearch, enableDDS));


### PR DESCRIPTION
This PR builds on #2276 to also restructure the chain table for the strategies `ZSTD_greedy`, `ZSTD_lazy`, and `ZSTD_lazy2`.

With this PR, the cumulative perf improvement seen for the Dedicated Dictionary Search Structure stack, for the HTTP test corpus, is:

Level | Hot Dict | Cold Dict
----- | -------- | ---------
  5   |   ~+17%  |    ~+30%
  6   |   ~+12%  |    ~+45%
  7   |   ~+13%  |    ~+40%
  8   |   ~+16%  |    ~+50%
  9   |   ~+19%  |    ~+65%
 10   |   ~+24%  |    ~+70%