### PR TITLE
[contrib][linux-kernel] Add decompress_sources.h

### DIFF
--- a/contrib/linux-kernel/Makefile
+++ b/contrib/linux-kernel/Makefile
@@ -49,6 +49,7 @@ libzstd:
 	mv linux/lib/zstd/common/zstd_errors.h linux/include/linux
 	cp zstd_compress_module.c linux/lib/zstd
 	cp zstd_decompress_module.c linux/lib/zstd
+	cp decompress_sources.h linux/lib/zstd
 	cp linux.mk linux/lib/zstd/Makefile
 
 LINUX ?= $(HOME)/repos/linux

--- a/contrib/linux-kernel/decompress_sources.h
+++ b/contrib/linux-kernel/decompress_sources.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * This file includes every .c file needed for decompression.
+ * It is used by lib/decompress_unzstd.c to include the decompression
+ * source into the translation-unit, so it can be used for kernel
+ * decompression.
+ */
+
+#include "common/debug.c"
+#include "common/entropy_common.c"
+#include "common/error_private.c"
+#include "common/fse_decompress.c"
+#include "common/zstd_common.c"
+#include "decompress/huf_decompress.c"
+#include "decompress/zstd_ddict.c"
+#include "decompress/zstd_decompress.c"
+#include "decompress/zstd_decompress_block.c"

--- a/contrib/linux-kernel/test/Makefile
+++ b/contrib/linux-kernel/test/Makefile
@@ -18,9 +18,13 @@ liblinuxzstd.a: $(LINUX_ZSTD_OBJECTS)
 test: test.c liblinuxzstd.a
 	$(CC) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $^ -o $@
 
-run-test: test
+static_test: static_test.c
+	$(CC) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $^ -o $@
+
+run-test: test static_test
 	./macro-test.sh
 	./test
+	./static_test
 
 .PHONY:
 clean:

--- a/contrib/linux-kernel/test/static_test.c
+++ b/contrib/linux-kernel/test/static_test.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "decompress_sources.h"
+#include <linux/zstd.h>
+
+#define CONTROL(x)                                                             \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      fprintf(stderr, "%s:%u: %s failed!\n", __FUNCTION__, __LINE__, #x);      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+
+static const char kEmptyZstdFrame[] = {
+    0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x00, 0x01, 0x00, 0x00, 0x99, 0xe9, 0xd8, 0x51
+};
+
+static void test_decompress_unzstd() {
+    fprintf(stderr, "Testing decompress unzstd... ");
+    {
+        size_t const wkspSize = ZSTD_estimateDCtxSize();
+        void* wksp = malloc(wkspSize);
+        CONTROL(wksp != NULL);
+        ZSTD_DCtx* dctx = ZSTD_initStaticDCtx(wksp, wkspSize);
+        CONTROL(dctx != NULL);
+        size_t const dSize = ZSTD_decompressDCtx(dctx, NULL, 0, kEmptyZstdFrame, sizeof(kEmptyZstdFrame));
+        CONTROL(!ZSTD_isError(dSize));
+        CONTROL(dSize == 0);
+        free(wksp);
+    }
+    fprintf(stderr, "Ok\n");
+}
+
+int main(void) {
+  test_decompress_unzstd();
+  return 0;
+}


### PR DESCRIPTION
Add decompress_sources.h, which includes all the decompression .c files.
This is used for kernel decompression.

Also, add a test which checks that including decompress_sources.h works.