### PR TITLE
Fix multifile status bar and summary - clear out extraneous characters

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1338,14 +1338,23 @@ FIO_compressZstdFrame(FIO_ctx_t* const fCtx,
                                 cShare );
                 } else {   /* summarized notifications if == 2 */
                     if (fCtx->nbFilesTotal > 1) {
-                        DISPLAYLEVEL(2, "\rCompressing %u/%u files. Current source: %s ", fCtx->currFileIdx+1, fCtx->nbFilesTotal, srcFileName);
+                        size_t srcFileNameSize = strlen(srcFileName);
+                        /* Ensure that the string we print is roughly the same size each time */
+                        if (srcFileNameSize > 20) {
+                            const char* truncatedSrcFileName = srcFileName + srcFileNameSize - 17;
+                            DISPLAYLEVEL(2, "\rCompressing %2u / %2u files. Current source: ...%s ",
+                                         fCtx->currFileIdx+1, fCtx->nbFilesTotal, truncatedSrcFileName);
+                        } else {
+                            DISPLAYLEVEL(2, "\rCompressing %2u / %2u files. Current source: %*s ",
+                                         fCtx->currFileIdx+1, fCtx->nbFilesTotal, (int)(20-srcFileNameSize), srcFileName);
+                        }
                     } else {
                         DISPLAYLEVEL(2, "\r");
                     }
-                    DISPLAYLEVEL(2, "Read : %u ", (unsigned)(zfp.consumed >> 20));
+                    DISPLAYLEVEL(2, "Read : %2u ", (unsigned)(zfp.consumed >> 20));
                     if (fileSize != UTIL_FILESIZE_UNKNOWN)
-                        DISPLAYLEVEL(2, "/ %u ", (unsigned)(fileSize >> 20));
-                    DISPLAYLEVEL(2, "MB ==> %2.f%%", cShare);
+                        DISPLAYLEVEL(2, "/ %2u ", (unsigned)(fileSize >> 20));
+                    DISPLAYLEVEL(2, "MB ==> %2.f%%      ", cShare);
                     DELAY_NEXT_UPDATE();
                 }
 
@@ -1817,9 +1826,9 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
     }
 
     if (fCtx->nbFilesProcessed >= 1 && fCtx->nbFilesTotal > 1 && fCtx->totalBytesInput != 0)
-        DISPLAYLEVEL(2, "%d files compressed : %.2f%%  (%6zu => %6zu bytes)\n", fCtx->nbFilesProcessed,
+        DISPLAYLEVEL(2, "%d files compressed : %.2f%%  (%6zu => %6zu %-40s\n", fCtx->nbFilesProcessed,
                         (double)fCtx->totalBytesOutput/((double)fCtx->totalBytesInput)*100,
-                        fCtx->totalBytesInput, fCtx->totalBytesOutput);
+                        fCtx->totalBytesInput, fCtx->totalBytesOutput, "bytes)");
 
     FIO_freeCResources(ress);
     return error;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2743,7 +2743,7 @@ FIO_decompressMultipleFilenames(FIO_ctx_t* const fCtx,
             FIO_checkFilenameCollisions(srcNamesTable , fCtx->nbFilesTotal);
     }
     
-    if (fCtx->nbFilesProcessed >= 1  && fCtx->nbFilesTotal > 1 && fCtx->totalBytesInput != 0)
+    if (fCtx->nbFilesProcessed >= 1  && fCtx->nbFilesTotal > 1 && fCtx->totalBytesOutput != 0)
         DISPLAYLEVEL(2, "%d files decompressed : %6zu bytes total \n", fCtx->nbFilesProcessed, fCtx->totalBytesOutput);
 
     FIO_freeDResources(ress);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1343,10 +1343,10 @@ FIO_compressZstdFrame(FIO_ctx_t* const fCtx,
                         /* Ensure that the string we print is roughly the same size each time */
                         if (srcFileNameSize > 18) {
                             const char* truncatedSrcFileName = srcFileName + srcFileNameSize - 15;
-                            DISPLAYLEVEL(2, "Compress: %2u/%2u files. Current: ...%s ",
+                            DISPLAYLEVEL(2, "Compress: %u/%u files. Current: ...%s ",
                                          fCtx->currFileIdx+1, fCtx->nbFilesTotal, truncatedSrcFileName);
                         } else {
-                            DISPLAYLEVEL(2, "Compress: %2u/%2u files. Current: %*s ",
+                            DISPLAYLEVEL(2, "Compress: %u/%u files. Current: %*s ",
                                          fCtx->currFileIdx+1, fCtx->nbFilesTotal, (int)(18-srcFileNameSize), srcFileName);
                         }
                     }
@@ -2101,8 +2101,15 @@ FIO_decompressZstdFrame(FIO_ctx_t* const fCtx, dRess_t* ress, FILE* finput,
         storedSkips = FIO_fwriteSparse(ress->dstFile, ress->dstBuffer, outBuff.pos, prefs, storedSkips);
         frameSize += outBuff.pos;
         if (fCtx->nbFilesTotal > 1) {
-            DISPLAYUPDATE(2, "\rDecompress: %u/%u files. Current source: %-20.20s : %u MB...    ",
-                          fCtx->currFileIdx+1, fCtx->nbFilesTotal, srcFileName, (unsigned)((alreadyDecoded+frameSize)>>20) );
+            size_t srcFileNameSize = strlen(srcFileName);
+            if (srcFileNameSize > 18) {
+                const char* truncatedSrcFileName = srcFileName + srcFileNameSize - 15;
+                DISPLAYUPDATE(2, "\rDecompress: %2u/%2u files. Current: ...%s : %u MB...    ",
+                                fCtx->currFileIdx+1, fCtx->nbFilesTotal, truncatedSrcFileName, (unsigned)((alreadyDecoded+frameSize)>>20) );
+            } else {
+                DISPLAYUPDATE(2, "\rDecompress: %2u/%2u files. Current: %s : %u MB...    ",
+                            fCtx->currFileIdx+1, fCtx->nbFilesTotal, srcFileName, (unsigned)((alreadyDecoded+frameSize)>>20) );
+            }
         } else {
             DISPLAYUPDATE(2, "\r%-20.20s : %u MB...     ",
                             srcFileName, (unsigned)((alreadyDecoded+frameSize)>>20) );

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1337,24 +1337,23 @@ FIO_compressZstdFrame(FIO_ctx_t* const fCtx,
                                 (unsigned)(zfp.produced >> 20),
                                 cShare );
                 } else {   /* summarized notifications if == 2 */
+                    DISPLAYLEVEL(2, "\r%79s\r", "");    /* Clear out the current displayed line */
                     if (fCtx->nbFilesTotal > 1) {
                         size_t srcFileNameSize = strlen(srcFileName);
                         /* Ensure that the string we print is roughly the same size each time */
-                        if (srcFileNameSize > 20) {
-                            const char* truncatedSrcFileName = srcFileName + srcFileNameSize - 17;
-                            DISPLAYLEVEL(2, "\rCompressing %2u / %2u files. Current source: ...%s ",
+                        if (srcFileNameSize > 18) {
+                            const char* truncatedSrcFileName = srcFileName + srcFileNameSize - 15;
+                            DISPLAYLEVEL(2, "Compress: %2u/%2u files. Current: ...%s ",
                                          fCtx->currFileIdx+1, fCtx->nbFilesTotal, truncatedSrcFileName);
                         } else {
-                            DISPLAYLEVEL(2, "\rCompressing %2u / %2u files. Current source: %*s ",
-                                         fCtx->currFileIdx+1, fCtx->nbFilesTotal, (int)(20-srcFileNameSize), srcFileName);
+                            DISPLAYLEVEL(2, "Compress: %2u/%2u files. Current: %*s ",
+                                         fCtx->currFileIdx+1, fCtx->nbFilesTotal, (int)(18-srcFileNameSize), srcFileName);
                         }
-                    } else {
-                        DISPLAYLEVEL(2, "\r");
                     }
                     DISPLAYLEVEL(2, "Read : %2u ", (unsigned)(zfp.consumed >> 20));
                     if (fileSize != UTIL_FILESIZE_UNKNOWN)
                         DISPLAYLEVEL(2, "/ %2u ", (unsigned)(fileSize >> 20));
-                    DISPLAYLEVEL(2, "MB ==> %2.f%%      ", cShare);
+                    DISPLAYLEVEL(2, "MB ==> %2.f%%", cShare);
                     DELAY_NEXT_UPDATE();
                 }
 
@@ -1825,10 +1824,12 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
             FIO_checkFilenameCollisions(inFileNamesTable , fCtx->nbFilesTotal);
     }
 
-    if (fCtx->nbFilesProcessed >= 1 && fCtx->nbFilesTotal > 1 && fCtx->totalBytesInput != 0)
-        DISPLAYLEVEL(2, "%d files compressed : %.2f%%  (%6zu => %6zu %-40s\n", fCtx->nbFilesProcessed,
+    if (fCtx->nbFilesProcessed >= 1 && fCtx->nbFilesTotal > 1 && fCtx->totalBytesInput != 0) {
+        DISPLAYLEVEL(2, "\r%79s\r", "");
+        DISPLAYLEVEL(2, "%d files compressed : %.2f%%  (%6zu => %6zu bytes)\n", fCtx->nbFilesProcessed,
                         (double)fCtx->totalBytesOutput/((double)fCtx->totalBytesInput)*100,
-                        fCtx->totalBytesInput, fCtx->totalBytesOutput, "bytes)");
+                        fCtx->totalBytesInput, fCtx->totalBytesOutput);
+    }
 
     FIO_freeCResources(ress);
     return error;
@@ -2100,7 +2101,7 @@ FIO_decompressZstdFrame(FIO_ctx_t* const fCtx, dRess_t* ress, FILE* finput,
         storedSkips = FIO_fwriteSparse(ress->dstFile, ress->dstBuffer, outBuff.pos, prefs, storedSkips);
         frameSize += outBuff.pos;
         if (fCtx->nbFilesTotal > 1) {
-            DISPLAYUPDATE(2, "\rDecompressing %u/%u files. Current source: %-20.20s : %u MB...    ",
+            DISPLAYUPDATE(2, "\rDecompress: %u/%u files. Current source: %-20.20s : %u MB...    ",
                           fCtx->currFileIdx+1, fCtx->nbFilesTotal, srcFileName, (unsigned)((alreadyDecoded+frameSize)>>20) );
         } else {
             DISPLAYUPDATE(2, "\r%-20.20s : %u MB...     ",


### PR DESCRIPTION
To address #2309 

This PR will make it so that the lines printed throughout the multifile status bar update are roughly the same size each time, and adds a bit of padding at the end, so it will more successfully overwrite. We also add 40 characters of whitespace to the right of the printed summary, which would override any leftover characters from the status bar.

I'm not sure if there are better ways to do this. There are still theoretically rare/extreme cases in which we still may leave behind some leftover characters (if the number of megabytes read for a given file are more than tens of thousands, and then the next file is small). Escape codes would be a cleaner solution, but aren't portable.

Tested locally to make sure it works as intended, and that the leftover characters are overwritten with whitespace:
![image](https://user-images.githubusercontent.com/17059792/93243197-dec5b080-f755-11ea-9296-4c6827aea29f.png)
