### PR TITLE
Support .zstd suffix only for decompression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ zstdmt
 # Test artefacts
 tmp*
 *.zst
+*.zstd
 dictionary.
 dictionary
 NUL

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2555,6 +2555,9 @@ int FIO_decompressFilename(FIO_ctx_t* const fCtx, FIO_prefs_t* const prefs,
 static const char *suffixList[] = {
     ZSTD_EXTENSION,
     TZSTD_EXTENSION,
+#ifndef ZSTD_NODECOMPRESS
+    ZSTD_ALT_EXTENSION,
+#endif
 #ifdef ZSTD_GZDECOMPRESS
     GZ_EXTENSION,
     TGZ_EXTENSION,

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -44,6 +44,7 @@ extern "C" {
 
 #define ZSTD_EXTENSION  ".zst"
 #define TZSTD_EXTENSION ".tzst"
+#define ZSTD_ALT_EXTENSION  ".zstd" /* allow decompression of .zstd files */
 
 #define LZ4_EXTENSION   ".lz4"
 #define TLZ4_EXTENSION  ".tlz4"

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1128,10 +1128,13 @@ if [ $LZ4MODE -ne 1 ]; then
     grep ".lz4" tmplg > $INTOVOID && die "Unsupported suffix listed"
 fi
 
+touch tmp1
+zstd tmp1 -o tmp1.zstd
+zstd -d tmp1.zstd   # support .zstd suffix even though it's not the default suffix
 
 println "\n===>  tar extension tests "
 
-rm -f tmp tmp.tar tmp.tzst tmp.tgz tmp.txz tmp.tlz4
+rm -f tmp tmp.tar tmp.tzst tmp.tgz tmp.txz tmp.tlz4 tmp1.zstd
 
 datagen > tmp
 tar cf tmp.tar tmp

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1130,7 +1130,7 @@ fi
 
 touch tmp1
 zstd tmp1 -o tmp1.zstd
-zstd -d tmp1.zstd   # support .zstd suffix even though it's not the default suffix
+zstd -d -f tmp1.zstd   # support .zstd suffix even though it's not the default suffix
 
 println "\n===>  tar extension tests "
 


### PR DESCRIPTION
This PR adds support to decompress `*.zstd` files, silently.
Users might accidentally use that prefix instead of `.zst` so this seems nice to have. 

We don't include `.zstd` in `suffixListStr` (which prints out the supported suffixes when trying to decompress an invalid suffix), nor do we include this in the `README.md` cause `.zst` is still the correct suffix that should be used - this is just more for convenience.

Tests: in `playTests.sh` and manual spot-checking.