### PR TITLE
Don't let warning messages consume input from stdin

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -662,7 +662,7 @@ FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
                     return NULL;
                 }
                 DISPLAY("zstd: %s already exists; ", dstFileName);
-                if (UTIL_requireUserConfirmation("overwrite (y/n) ? ", "Not overwritten  \n", "yY"))
+                if (UTIL_requireUserConfirmation("overwrite (y/n) ? ", "Not overwritten  \n", "yY", fCtx->hasStdinInput))
                     return NULL;
             }
             /* need to unlink */
@@ -859,7 +859,7 @@ static int FIO_removeMultiFilesWarning(FIO_ctx_t* const fCtx, const FIO_prefs_t*
             }
             DISPLAYLEVEL(2, "\nThe concatenated output CANNOT regenerate the original directory tree. ")
             if (prefs->removeSrcFile) {
-                error = g_display_prefs.displayLevel > displayLevelCutoff && UTIL_requireUserConfirmation("This is a destructive operation. Proceed? (y/n): ", "Aborting...", "yY");
+                error = g_display_prefs.displayLevel > displayLevelCutoff && UTIL_requireUserConfirmation("This is a destructive operation. Proceed? (y/n): ", "Aborting...", "yY", fCtx->hasStdinInput);
             }
         }
         DISPLAY("\n");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -542,7 +542,7 @@ void FIO_setNbFilesTotal(FIO_ctx_t* const fCtx, int value)
 }
 
 void FIO_determineHasStdinInput(FIO_ctx_t* const fCtx, const FileNamesTable* const filenames) {
-    int i = 0;
+    size_t i = 0;
     for ( ; i < filenames->tableSize; ++i) {
         if (!strcmp(stdinmark, filenames->fileNames[i])) {
             fCtx->hasStdinInput = 1;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -603,8 +603,8 @@ static FILE* FIO_openSrcFile(const char* srcFileName)
  *  condition : `dstFileName` must be non-NULL.
  * @result : FILE* to `dstFileName`, or NULL if it fails */
 static FILE*
-FIO_openDstFile(FIO_prefs_t* const prefs,
-          const char* srcFileName, const char* dstFileName)
+FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
+                const char* srcFileName, const char* dstFileName)
 {
     if (prefs->testMode) return NULL;  /* do not open file in test mode */
 
@@ -1566,7 +1566,7 @@ static int FIO_compressFilename_dstFile(FIO_ctx_t* const fCtx,
     if (ress.dstFile == NULL) {
         closeDstFile = 1;
         DISPLAYLEVEL(6, "FIO_compressFilename_dstFile: opening dst: %s \n", dstFileName);
-        ress.dstFile = FIO_openDstFile(prefs, srcFileName, dstFileName);
+        ress.dstFile = FIO_openDstFile(fCtx, prefs, srcFileName, dstFileName);
         if (ress.dstFile==NULL) return 1;  /* could not open dstFileName */
         /* Must only be added after FIO_openDstFile() succeeds.
          * Otherwise we may delete the destination file if it already exists,
@@ -1773,7 +1773,7 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
             FIO_freeCResources(ress);
             return 1;
         }
-        ress.dstFile = FIO_openDstFile(prefs, NULL, outFileName);
+        ress.dstFile = FIO_openDstFile(fCtx, prefs, NULL, outFileName);
         if (ress.dstFile == NULL) {  /* could not open outFileName */
             error = 1;
         } else {
@@ -2458,7 +2458,7 @@ static int FIO_decompressDstFile(FIO_ctx_t* const fCtx,
     if ((ress.dstFile == NULL) && (prefs->testMode==0)) {
         releaseDstFile = 1;
 
-        ress.dstFile = FIO_openDstFile(prefs, srcFileName, dstFileName);
+        ress.dstFile = FIO_openDstFile(fCtx, prefs, srcFileName, dstFileName);
         if (ress.dstFile==NULL) return 1;
 
         /* Must only be added after FIO_openDstFile() succeeds.
@@ -2688,7 +2688,7 @@ FIO_decompressMultipleFilenames(FIO_ctx_t* const fCtx,
             return 1;
         }
         if (!prefs->testMode) {
-            ress.dstFile = FIO_openDstFile(prefs, NULL, outFileName);
+            ress.dstFile = FIO_openDstFile(fCtx, prefs, NULL, outFileName);
             if (ress.dstFile == 0) EXM_THROW(19, "cannot open %s", outFileName);
         }
         for (; fCtx->currFileIdx < fCtx->nbFilesTotal; fCtx->currFileIdx++) {

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -330,6 +330,7 @@ struct FIO_ctx_s {
 
     /* file i/o info */
     int nbFilesTotal;
+    int hasStdinInput;
 
     /* file i/o state */
     int currFileIdx;
@@ -386,6 +387,7 @@ FIO_ctx_t* FIO_createContext(void)
     if (!ret) EXM_THROW(21, "Allocation error : not enough memory");
 
     ret->currFileIdx = 0;
+    ret->hasStdinInput = 0;
     ret->nbFilesTotal = 1;
     ret->nbFilesProcessed = 0;
     ret->totalBytesInput = 0;
@@ -537,6 +539,16 @@ void FIO_setContentSize(FIO_prefs_t* const prefs, int value)
 void FIO_setNbFilesTotal(FIO_ctx_t* const fCtx, int value)
 {
     fCtx->nbFilesTotal = value;
+}
+
+void FIO_determineHasStdinInput(FIO_ctx_t* const fCtx, const FileNamesTable* const filenames) {
+    int i = 0;
+    for ( ; i < filenames->tableSize; ++i) {
+        if (!strcmp(stdinmark, filenames->fileNames[i])) {
+            fCtx->hasStdinInput = 1;
+            return;
+        }
+    }
 }
 
 /*-*************************************

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -106,6 +106,7 @@ void FIO_setContentSize(FIO_prefs_t* const prefs, int value);
 
 /* FIO_ctx_t functions */
 void FIO_setNbFilesTotal(FIO_ctx_t* const fCtx, int value);
+void FIO_determineHasStdinInput(FIO_ctx_t* const fCtx, const FileNamesTable* const filenames);
 
 /*-*************************************
 *  Single File functions

--- a/programs/util.c
+++ b/programs/util.c
@@ -91,8 +91,10 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
                                  const char* acceptableLetters, int hasStdinInput) {
     int ch, result;
 
-    if (hasStdinInput)
+    if (hasStdinInput) {
+        UTIL_DISPLAY("Stdin is an input - not proceeding.\n");
         return 1;
+    }
 
     UTIL_DISPLAY("%s", prompt);
     ch = getchar();

--- a/programs/util.c
+++ b/programs/util.c
@@ -92,7 +92,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
     int ch, result;
 
     if (hasStdinInput) {
-        UTIL_DISPLAY("Stdin is an input - not proceeding.\n");
+        UTIL_DISPLAY("stdin is an input - not proceeding.\n");
         return 1;
     }
 

--- a/programs/util.c
+++ b/programs/util.c
@@ -90,9 +90,6 @@ int g_utilDisplayLevel;
 int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
                                           const char* acceptableLetters) {
     int ch, result;
-    /* If input is presented via stdin, dont use prompt as it may swallow characters */
-    if (!IS_CONSOLE(stdin))
-        return 0;
 
     UTIL_DISPLAY("%s", prompt);
     ch = getchar();

--- a/programs/util.c
+++ b/programs/util.c
@@ -90,6 +90,10 @@ int g_utilDisplayLevel;
 int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
                                           const char* acceptableLetters) {
     int ch, result;
+    /* If input is presented via stdin, dont use prompt as it may swallow characters */
+    if (!IS_CONSOLE(stdin))
+        return 0;
+
     UTIL_DISPLAY("%s", prompt);
     ch = getchar();
     result = 0;

--- a/programs/util.c
+++ b/programs/util.c
@@ -88,8 +88,11 @@ UTIL_STATIC void* UTIL_realloc(void *ptr, size_t size)
 int g_utilDisplayLevel;
 
 int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
-                                          const char* acceptableLetters) {
+                                 const char* acceptableLetters, int hasStdinInput) {
     int ch, result;
+
+    if (hasStdinInput)
+        return 1;
 
     UTIL_DISPLAY("%s", prompt);
     ch = getchar();

--- a/programs/util.h
+++ b/programs/util.h
@@ -96,8 +96,9 @@ extern int g_utilDisplayLevel;
 /**
  * Displays a message prompt and returns success (0) if first character from stdin
  * matches any from acceptableLetters. Otherwise, returns failure (1) and displays abortMsg.
+ * If any of the inputs are stdin itself, then automatically return failure (1).
  */
-int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const char* acceptableLetters);
+int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const char* acceptableLetters, int hasStdinInput);
 
 
 /*-****************************************

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1286,6 +1286,7 @@ int main(int const argCount, const char* argv[])
 
     /* IO Stream/File */
     FIO_setNbFilesTotal(fCtx, (int)filenames->tableSize); 
+    FIO_determineHasStdinInput(fCtx, filenames);
     FIO_setNotificationLevel(g_displayLevel);
     FIO_setPatchFromMode(prefs, patchFromDictFileName != NULL);
     if (memLimit == 0) {

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -309,6 +309,18 @@ test -f precompressedFilterTestDir/input.5.zst.zst
 test -f precompressedFilterTestDir/input.6.zst.zst
 println "Test completed"
 
+
+
+println "\n===>  warning prompt does not swallow characters"
+println "y" > tmpPrompt
+println "hello world" >> tmpPrompt
+zstd tmpPrompt
+zstd < tmpPrompt -o tmpPrompt.zst
+zstd -q -d tmpPrompt.zst -o tmpPromptRegenerated
+$DIFF tmpPromptRegenerated tmpPrompt
+println "Test completed"
+
+
 println "\n===>  recursive mode test "
 # combination of -r with empty list of input file
 zstd -c -r < tmp > tmp.zst

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -311,13 +311,19 @@ println "Test completed"
 
 
 
-println "\n===>  warning prompt does not swallow characters"
+println "\n===>  warning prompts should not occur if stdin is an input"
 println "y" > tmpPrompt
 println "hello world" >> tmpPrompt
-zstd tmpPrompt
-zstd < tmpPrompt -o tmpPrompt.zst
-zstd -q -d tmpPrompt.zst -o tmpPromptRegenerated
-$DIFF tmpPromptRegenerated tmpPrompt
+zstd tmpPrompt -f
+zstd < tmpPrompt -o tmpPrompt.zst && die "should have aborted immediately and failed to overwrite"
+zstd < tmpPrompt -o tmpPrompt.zst -f    # should successfully overwrite with -f
+zstd -q -d -f tmpPrompt.zst -o tmpPromptRegenerated
+$DIFF tmpPromptRegenerated tmpPrompt    # the first 'y' character should not be swallowed
+
+echo 'yes' | zstd tmpPrompt -o tmpPrompt.zst  # accept piped "y" input to force overwrite when using files
+echo 'yes' | zstd < tmpPrompt -o tmpPrompt.zst && die "should have aborted immediately and failed to overwrite"
+zstd tmpPrompt - < tmpPrompt -o tmpPromp.zst --rm && die "should have aborted immediately and failed to remove"
+
 println "Test completed"
 
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -309,7 +309,6 @@ test -f precompressedFilterTestDir/input.5.zst.zst
 test -f precompressedFilterTestDir/input.6.zst.zst
 println "Test completed"
 
-
 println "\n===>  recursive mode test "
 # combination of -r with empty list of input file
 zstd -c -r < tmp > tmp.zst


### PR DESCRIPTION
`getchar()`-dependent warning prompts may swallow characters from stdin. We don't want that if stdin is our input.
The following behavior is currently:
```
$ cat <<EOF >test
> y
> Hello, world!
> EOF
$ ./zstd test
test                 :181.25%   (    16 =>     29 bytes, test.zst)             
$ ./zstd -q -d test.zst -c           // compresses fine when directly processing file
y
Hello, world!
$ ./zstd < test -o test.zst.         // 'y' in the first line is consumed when input is fed thru stdin
/*stdin*\            :192.86%   (    14 =>     27 bytes, test.zst)             
$ ./zstd -q -d test.zst -c
Hello, world!
```

Unit tests included, and checked that they fail on current `dev` branch, but work with the patch.