### PR TITLE
[seekable_format][reproducible] ZSTD_seekable_decompress() example that hangs

### DIFF
--- a/contrib/seekable_format/examples/.gitignore
+++ b/contrib/seekable_format/examples/.gitignore
@@ -3,3 +3,4 @@ seekable_decompression
 seekable_decompression_mem
 parallel_processing
 parallel_compression
+hang

--- a/contrib/seekable_format/examples/Makefile
+++ b/contrib/seekable_format/examples/Makefile
@@ -25,7 +25,7 @@ SEEKABLE_OBJS = ../zstdseek_compress.c ../zstdseek_decompress.c $(ZSTDLIB)
 default: all
 
 all: seekable_compression seekable_decompression seekable_decompression_mem \
-	parallel_processing
+	parallel_processing hang
 
 $(ZSTDLIB):
 	make -C $(ZSTDLIB_PATH) $(ZSTDLIB_NAME)
@@ -45,9 +45,12 @@ parallel_processing : parallel_processing.c $(SEEKABLE_OBJS)
 parallel_compression : parallel_compression.c $(SEEKABLE_OBJS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $^ $(LDFLAGS) -o $@ -pthread
 
+hang : hang.c $(SEEKABLE_OBJS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ $(LDFLAGS) -o $@
+
 clean:
 	@rm -f core *.o tmp* result* *.zst \
 		seekable_compression seekable_decompression \
 		seekable_decompression_mem \
-		parallel_processing parallel_compression
+		parallel_processing parallel_compression hang
 	@echo Cleaning completed

--- a/contrib/seekable_format/examples/hang.c
+++ b/contrib/seekable_format/examples/hang.c
@@ -1,0 +1,81 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "zstd_seekable.h"
+
+static const size_t compressed_size = 17;
+static const uint8_t compressed_data[17] = {
+    '^',
+    '*',
+    'M',
+    '\x18',
+    '\t',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    ';',
+    (uint8_t)('\xb1'),
+    (uint8_t)('\xea'),
+    (uint8_t)('\x92'),
+    (uint8_t)('\x8f'),
+};
+
+static const size_t uncompressed_size = 32;
+static uint8_t uncompressed_data[32] = {
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+    '\x00',
+};
+
+int main(int argc, const char** argv)
+{
+    ZSTD_seekable* stream = ZSTD_seekable_create();
+    size_t status = ZSTD_seekable_initBuff(stream, compressed_data, compressed_size);
+    if (ZSTD_isError(status)) {
+        ZSTD_seekable_free(stream);
+        return status;
+    }
+
+    const size_t offset = 2;
+    status = ZSTD_seekable_decompress(stream, uncompressed_data, uncompressed_size, offset);
+    if (ZSTD_isError(status)) {
+        ZSTD_seekable_free(stream);
+        return status;
+    }
+
+    ZSTD_seekable_free(stream);
+    return 0;
+}


### PR DESCRIPTION
This change illustrates a bug in which using the seekable format library as intended hangs. Granted, the input is contrived (not a valid ZSTD archive) but the expected behaviour is an error, not a hang.