### PR TITLE
Integrate long distance matches into optimal parser

### DIFF
--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -1,10 +1,10 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>zstd 1.4.5 Manual</title>
+<title>zstd 1.4.6 Manual</title>
 </head>
 <body>
-<h1>zstd 1.4.5 Manual</h1>
+<h1>zstd 1.4.6 Manual</h1>
 <hr>
 <a name="Contents"></a><h2>Contents</h2>
 <ol>
@@ -24,19 +24,20 @@
 <li><a href="#Chapter14">experimental API (static linking only)</a></li>
 <li><a href="#Chapter15">Frame size functions</a></li>
 <li><a href="#Chapter16">Memory management</a></li>
-<li><a href="#Chapter17">Advanced compression functions</a></li>
-<li><a href="#Chapter18">Advanced decompression functions</a></li>
-<li><a href="#Chapter19">Advanced streaming functions</a></li>
-<li><a href="#Chapter20">! ZSTD_initCStream_usingDict() :</a></li>
-<li><a href="#Chapter21">! ZSTD_initCStream_advanced() :</a></li>
-<li><a href="#Chapter22">! ZSTD_initCStream_usingCDict() :</a></li>
-<li><a href="#Chapter23">! ZSTD_initCStream_usingCDict_advanced() :</a></li>
-<li><a href="#Chapter24">This function is deprecated, and is equivalent to:</a></li>
+<li><a href="#Chapter17">This API is temporary and is expected to change or disappear in the future!</a></li>
+<li><a href="#Chapter18">Advanced compression functions</a></li>
+<li><a href="#Chapter19">Advanced decompression functions</a></li>
+<li><a href="#Chapter20">Advanced streaming functions</a></li>
+<li><a href="#Chapter21">! ZSTD_initCStream_usingDict() :</a></li>
+<li><a href="#Chapter22">! ZSTD_initCStream_advanced() :</a></li>
+<li><a href="#Chapter23">! ZSTD_initCStream_usingCDict() :</a></li>
+<li><a href="#Chapter24">! ZSTD_initCStream_usingCDict_advanced() :</a></li>
 <li><a href="#Chapter25">This function is deprecated, and is equivalent to:</a></li>
-<li><a href="#Chapter26">Buffer-less and synchronous inner streaming functions</a></li>
-<li><a href="#Chapter27">Buffer-less streaming compression (synchronous mode)</a></li>
-<li><a href="#Chapter28">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter29">Block level API</a></li>
+<li><a href="#Chapter26">This function is deprecated, and is equivalent to:</a></li>
+<li><a href="#Chapter27">Buffer-less and synchronous inner streaming functions</a></li>
+<li><a href="#Chapter28">Buffer-less streaming compression (synchronous mode)</a></li>
+<li><a href="#Chapter29">Buffer-less streaming decompression (synchronous mode)</a></li>
+<li><a href="#Chapter30">Block level API</a></li>
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
@@ -72,8 +73,14 @@
 
 <a name="Chapter2"></a><h2>Version</h2><pre></pre>
 
-<pre><b>unsigned ZSTD_versionNumber(void);   </b>/**< to check runtime library version */<b>
-</b></pre><BR>
+<pre><b>unsigned ZSTD_versionNumber(void);
+</b><p>  Return runtime library version, the value is (MAJOR*100*100 + MINOR*100 + RELEASE). 
+</p></pre><BR>
+
+<pre><b>const char* ZSTD_versionString(void);
+</b><p>  Return runtime library version, like "1.4.5". Requires v1.3.0+. 
+</p></pre><BR>
+
 <a name="Chapter3"></a><h2>Simple API</h2><pre></pre>
 
 <pre><b>size_t ZSTD_compress( void* dst, size_t dstCapacity,
@@ -308,16 +315,20 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
     ZSTD_c_dictIDFlag=202,   </b>/* When applicable, dictionary's ID is written into frame header (default:1) */<b>
 
     </b>/* multi-threading parameters */<b>
-    </b>/* These parameters are only useful if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
-     * They return an error otherwise. */
+    </b>/* These parameters are only active if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
+     * Otherwise, trying to set any other value than default (0) will be a no-op and return an error.
+     * In a situation where it's unknown if the linked library supports multi-threading or not,
+     * setting ZSTD_c_nbWorkers to any value >= 1 and consulting the return value provides a quick way to check this property.
+     */
     ZSTD_c_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
-                              * When nbWorkers >= 1, triggers asynchronous mode when used with ZSTD_compressStream*() :
+                              * When nbWorkers >= 1, triggers asynchronous mode when invoking ZSTD_compressStream*() :
                               * ZSTD_compressStream*() consumes input and flush output if possible, but immediately gives back control to caller,
-                              * while compression work is performed in parallel, within worker threads.
+                              * while compression is performed in parallel, within worker thread(s).
                               * (note : a strong exception to this rule is when first invocation of ZSTD_compressStream2() sets ZSTD_e_end :
                               *  in which case, ZSTD_compressStream2() delegates to ZSTD_compress2(), which is always a blocking call).
                               * More workers improve speed, but also increase memory usage.
-                              * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
+                              * Default value is `0`, aka "single-threaded mode" : no worker is spawned,
+                              * compression is performed inside Caller's thread, and all invocations are blocking */
     ZSTD_c_jobSize=401,      </b>/* Size of a compression job. This value is enforced only when nbWorkers >= 1.<b>
                               * Each compression job is completed in parallel, so this value can indirectly impact the nb of active threads.
                               * 0 means default, which is dynamically determined based on compression parameters.
@@ -346,6 +357,7 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
      * ZSTD_c_literalCompressionMode
      * ZSTD_c_targetCBlockSize
      * ZSTD_c_srcSizeHint
+     * ZSTD_c_enableDedicatedDictSearch
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -356,7 +368,8 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
      ZSTD_c_experimentalParam4=1001,
      ZSTD_c_experimentalParam5=1002,
      ZSTD_c_experimentalParam6=1003,
-     ZSTD_c_experimentalParam7=1004
+     ZSTD_c_experimentalParam7=1004,
+     ZSTD_c_experimentalParam8=1005
 } ZSTD_cParameter;
 </b></pre><BR>
 <pre><b>typedef struct {
@@ -456,11 +469,13 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
      * At the time of this writing, they include :
      * ZSTD_d_format
      * ZSTD_d_stableOutBuffer
+     * ZSTD_d_forceIgnoreChecksum
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
      ZSTD_d_experimentalParam1=1000,
-     ZSTD_d_experimentalParam2=1001
+     ZSTD_d_experimentalParam2=1001,
+     ZSTD_d_experimentalParam3=1002
 
 } ZSTD_dParameter;
 </b></pre><BR>
@@ -591,8 +606,9 @@ size_t ZSTD_freeCStream(ZSTD_CStream* zcs);
   - Compression parameters cannot be changed once compression is started (save a list of exceptions in multi-threading mode)
   - output->pos must be <= dstCapacity, input->pos must be <= srcSize
   - output->pos and input->pos will be updated. They are guaranteed to remain below their respective limit.
+  - endOp must be a valid directive
   - When nbWorkers==0 (default), function is blocking : it completes its job before returning to caller.
-  - When nbWorkers>=1, function is non-blocking : it just acquires a copy of input, and distributes jobs to internal worker threads, flush whatever is available,
+  - When nbWorkers>=1, function is non-blocking : it copies a portion of input, distributes jobs to internal worker threads, flush to output whatever is available,
                                                   and then immediately returns, just indicating that there is some data remaining to be flushed.
                                                   The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
   - Exception : if the first call requests a ZSTD_e_end directive and provides enough dstCapacity, the function delegates to ZSTD_compress2() which is always blocking.
@@ -952,6 +968,12 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 } ZSTD_format_e;
 </b></pre><BR>
 <pre><b>typedef enum {
+    </b>/* Note: this enum controls ZSTD_d_forceIgnoreChecksum */<b>
+    ZSTD_d_validateChecksum = 0,
+    ZSTD_d_ignoreChecksum = 1
+} ZSTD_forceIgnoreChecksum_e;
+</b></pre><BR>
+<pre><b>typedef enum {
     </b>/* Note: this enum and the behavior it controls are effectively internal<b>
      * implementation details of the compressor. They are expected to continue
      * to evolve and should be considered only in the context of extremely
@@ -1148,7 +1170,10 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
  
 </p></pre><BR>
 
-<a name="Chapter17"></a><h2>Advanced compression functions</h2><pre></pre>
+<a name="Chapter17"></a><h2>This API is temporary and is expected to change or disappear in the future!</h2><pre> 
+<BR></pre>
+
+<a name="Chapter18"></a><h2>Advanced compression functions</h2><pre></pre>
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
@@ -1264,8 +1289,10 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
 <pre><b>size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, int value);
 </b><p>  Similar to ZSTD_CCtx_setParameter.
   Set one compression parameter, selected by enum ZSTD_cParameter.
-  Parameters must be applied to a ZSTD_CCtx using ZSTD_CCtx_setParametersUsingCCtxParams().
- @result : 0, or an error code (which can be tested with ZSTD_isError()).
+  Parameters must be applied to a ZSTD_CCtx using
+  ZSTD_CCtx_setParametersUsingCCtxParams().
+ @result : a code representing success or failure (which can be tested with
+           ZSTD_isError()).
  
 </p></pre><BR>
 
@@ -1298,7 +1325,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<a name="Chapter18"></a><h2>Advanced decompression functions</h2><pre></pre>
+<a name="Chapter19"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
 </b><p>  Tells if the content of `buffer` starts with a valid Frame Identifier.
@@ -1360,7 +1387,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<a name="Chapter19"></a><h2>Advanced streaming functions</h2><pre>  Warning : most of these functions are now redundant with the Advanced API.
+<a name="Chapter20"></a><h2>Advanced streaming functions</h2><pre>  Warning : most of these functions are now redundant with the Advanced API.
   Once Advanced API reaches "stable" status,
   redundant functions will be deprecated, and then at some point removed.
 <BR></pre>
@@ -1382,7 +1409,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
                          int compressionLevel,
                          unsigned long long pledgedSrcSize);
 </pre></b><BR>
-<a name="Chapter20"></a><h2>! ZSTD_initCStream_usingDict() :</h2><pre> This function is deprecated, and is equivalent to:
+<a name="Chapter21"></a><h2>! ZSTD_initCStream_usingDict() :</h2><pre> This function is deprecated, and is equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      ZSTD_CCtx_setParameter(zcs, ZSTD_c_compressionLevel, compressionLevel);
      ZSTD_CCtx_loadDictionary(zcs, dict, dictSize);
@@ -1395,7 +1422,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  
 <BR></pre>
 
-<a name="Chapter21"></a><h2>! ZSTD_initCStream_advanced() :</h2><pre> This function is deprecated, and is approximately equivalent to:
+<a name="Chapter22"></a><h2>! ZSTD_initCStream_advanced() :</h2><pre> This function is deprecated, and is approximately equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      // Pseudocode: Set each zstd parameter and leave the rest as-is.
      for ((param, value) : params) {
@@ -1411,7 +1438,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  
 <BR></pre>
 
-<a name="Chapter22"></a><h2>! ZSTD_initCStream_usingCDict() :</h2><pre> This function is deprecated, and equivalent to:
+<a name="Chapter23"></a><h2>! ZSTD_initCStream_usingCDict() :</h2><pre> This function is deprecated, and equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      ZSTD_CCtx_refCDict(zcs, cdict);
 
@@ -1420,7 +1447,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  
 <BR></pre>
 
-<a name="Chapter23"></a><h2>! ZSTD_initCStream_usingCDict_advanced() :</h2><pre>   This function is DEPRECATED, and is approximately equivalent to:
+<a name="Chapter24"></a><h2>! ZSTD_initCStream_usingCDict_advanced() :</h2><pre>   This function is DEPRECATED, and is approximately equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      // Pseudocode: Set each zstd frame parameter and leave the rest as-is.
      for ((fParam, value) : fParams) {
@@ -1488,7 +1515,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  */
 size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t dictSize);
 </pre></b><BR>
-<a name="Chapter24"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
+<a name="Chapter25"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
      ZSTD_DCtx_reset(zds, ZSTD_reset_session_only);
      ZSTD_DCtx_refDDict(zds, ddict);
 
@@ -1497,7 +1524,7 @@ size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t di
  
 <BR></pre>
 
-<a name="Chapter25"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
+<a name="Chapter26"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
      ZSTD_DCtx_reset(zds, ZSTD_reset_session_only);
 
  re-use decompression parameters from previous init; saves dictionary loading
@@ -1505,14 +1532,14 @@ size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t di
  
 <BR></pre>
 
-<a name="Chapter26"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
+<a name="Chapter27"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
   This is an advanced API, giving full control over buffer management, for users which need direct control over memory.
   But it's also a complex one, with several restrictions, documented below.
   Prefer normal streaming API for an easier experience.
  
 <BR></pre>
 
-<a name="Chapter27"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
+<a name="Chapter28"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
   A ZSTD_CCtx object is required to track streaming operations.
   Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.
   ZSTD_CCtx object can be re-used multiple times within successive compression operations.
@@ -1548,7 +1575,7 @@ size_t ZSTD_compressBegin_usingCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict); 
 size_t ZSTD_compressBegin_usingCDict_advanced(ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict, ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize);   </b>/* compression parameters are already set within cdict. pledgedSrcSize must be correct. If srcSize is not known, use macro ZSTD_CONTENTSIZE_UNKNOWN */<b>
 size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx, unsigned long long pledgedSrcSize); </b>/**<  note: if pledgedSrcSize is not known, use ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<a name="Chapter28"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
+<a name="Chapter29"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
   A ZSTD_DCtx object is required to track streaming operations.
   Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
   A ZSTD_DCtx object can be re-used multiple times.
@@ -1644,7 +1671,7 @@ size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long 
 
 <pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
 </b></pre><BR>
-<a name="Chapter29"></a><h2>Block level API</h2><pre></pre>
+<a name="Chapter30"></a><h2>Block level API</h2><pre></pre>
 
 <pre><b></b><p>    Frame metadata cost is typically ~12 bytes, which can be non-negligible for very small blocks (< 100 bytes).
     But users will have to take in charge needed metadata to regenerate data, such as compressed and content sizes.

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -1,10 +1,10 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>zstd 1.4.6 Manual</title>
+<title>zstd 1.4.5 Manual</title>
 </head>
 <body>
-<h1>zstd 1.4.6 Manual</h1>
+<h1>zstd 1.4.5 Manual</h1>
 <hr>
 <a name="Contents"></a><h2>Contents</h2>
 <ol>
@@ -24,20 +24,19 @@
 <li><a href="#Chapter14">experimental API (static linking only)</a></li>
 <li><a href="#Chapter15">Frame size functions</a></li>
 <li><a href="#Chapter16">Memory management</a></li>
-<li><a href="#Chapter17">This API is temporary and is expected to change or disappear in the future!</a></li>
-<li><a href="#Chapter18">Advanced compression functions</a></li>
-<li><a href="#Chapter19">Advanced decompression functions</a></li>
-<li><a href="#Chapter20">Advanced streaming functions</a></li>
-<li><a href="#Chapter21">! ZSTD_initCStream_usingDict() :</a></li>
-<li><a href="#Chapter22">! ZSTD_initCStream_advanced() :</a></li>
-<li><a href="#Chapter23">! ZSTD_initCStream_usingCDict() :</a></li>
-<li><a href="#Chapter24">! ZSTD_initCStream_usingCDict_advanced() :</a></li>
+<li><a href="#Chapter17">Advanced compression functions</a></li>
+<li><a href="#Chapter18">Advanced decompression functions</a></li>
+<li><a href="#Chapter19">Advanced streaming functions</a></li>
+<li><a href="#Chapter20">! ZSTD_initCStream_usingDict() :</a></li>
+<li><a href="#Chapter21">! ZSTD_initCStream_advanced() :</a></li>
+<li><a href="#Chapter22">! ZSTD_initCStream_usingCDict() :</a></li>
+<li><a href="#Chapter23">! ZSTD_initCStream_usingCDict_advanced() :</a></li>
+<li><a href="#Chapter24">This function is deprecated, and is equivalent to:</a></li>
 <li><a href="#Chapter25">This function is deprecated, and is equivalent to:</a></li>
-<li><a href="#Chapter26">This function is deprecated, and is equivalent to:</a></li>
-<li><a href="#Chapter27">Buffer-less and synchronous inner streaming functions</a></li>
-<li><a href="#Chapter28">Buffer-less streaming compression (synchronous mode)</a></li>
-<li><a href="#Chapter29">Buffer-less streaming decompression (synchronous mode)</a></li>
-<li><a href="#Chapter30">Block level API</a></li>
+<li><a href="#Chapter26">Buffer-less and synchronous inner streaming functions</a></li>
+<li><a href="#Chapter27">Buffer-less streaming compression (synchronous mode)</a></li>
+<li><a href="#Chapter28">Buffer-less streaming decompression (synchronous mode)</a></li>
+<li><a href="#Chapter29">Block level API</a></li>
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
@@ -73,14 +72,8 @@
 
 <a name="Chapter2"></a><h2>Version</h2><pre></pre>
 
-<pre><b>unsigned ZSTD_versionNumber(void);
-</b><p>  Return runtime library version, the value is (MAJOR*100*100 + MINOR*100 + RELEASE). 
-</p></pre><BR>
-
-<pre><b>const char* ZSTD_versionString(void);
-</b><p>  Return runtime library version, like "1.4.5". Requires v1.3.0+. 
-</p></pre><BR>
-
+<pre><b>unsigned ZSTD_versionNumber(void);   </b>/**< to check runtime library version */<b>
+</b></pre><BR>
 <a name="Chapter3"></a><h2>Simple API</h2><pre></pre>
 
 <pre><b>size_t ZSTD_compress( void* dst, size_t dstCapacity,
@@ -315,20 +308,16 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
     ZSTD_c_dictIDFlag=202,   </b>/* When applicable, dictionary's ID is written into frame header (default:1) */<b>
 
     </b>/* multi-threading parameters */<b>
-    </b>/* These parameters are only active if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
-     * Otherwise, trying to set any other value than default (0) will be a no-op and return an error.
-     * In a situation where it's unknown if the linked library supports multi-threading or not,
-     * setting ZSTD_c_nbWorkers to any value >= 1 and consulting the return value provides a quick way to check this property.
-     */
+    </b>/* These parameters are only useful if multi-threading is enabled (compiled with build macro ZSTD_MULTITHREAD).<b>
+     * They return an error otherwise. */
     ZSTD_c_nbWorkers=400,    </b>/* Select how many threads will be spawned to compress in parallel.<b>
-                              * When nbWorkers >= 1, triggers asynchronous mode when invoking ZSTD_compressStream*() :
+                              * When nbWorkers >= 1, triggers asynchronous mode when used with ZSTD_compressStream*() :
                               * ZSTD_compressStream*() consumes input and flush output if possible, but immediately gives back control to caller,
-                              * while compression is performed in parallel, within worker thread(s).
+                              * while compression work is performed in parallel, within worker threads.
                               * (note : a strong exception to this rule is when first invocation of ZSTD_compressStream2() sets ZSTD_e_end :
                               *  in which case, ZSTD_compressStream2() delegates to ZSTD_compress2(), which is always a blocking call).
                               * More workers improve speed, but also increase memory usage.
-                              * Default value is `0`, aka "single-threaded mode" : no worker is spawned,
-                              * compression is performed inside Caller's thread, and all invocations are blocking */
+                              * Default value is `0`, aka "single-threaded mode" : no worker is spawned, compression is performed inside Caller's thread, all invocations are blocking */
     ZSTD_c_jobSize=401,      </b>/* Size of a compression job. This value is enforced only when nbWorkers >= 1.<b>
                               * Each compression job is completed in parallel, so this value can indirectly impact the nb of active threads.
                               * 0 means default, which is dynamically determined based on compression parameters.
@@ -357,7 +346,6 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
      * ZSTD_c_literalCompressionMode
      * ZSTD_c_targetCBlockSize
      * ZSTD_c_srcSizeHint
-     * ZSTD_c_enableDedicatedDictSearch
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -368,8 +356,7 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
      ZSTD_c_experimentalParam4=1001,
      ZSTD_c_experimentalParam5=1002,
      ZSTD_c_experimentalParam6=1003,
-     ZSTD_c_experimentalParam7=1004,
-     ZSTD_c_experimentalParam8=1005
+     ZSTD_c_experimentalParam7=1004
 } ZSTD_cParameter;
 </b></pre><BR>
 <pre><b>typedef struct {
@@ -469,13 +456,11 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
      * At the time of this writing, they include :
      * ZSTD_d_format
      * ZSTD_d_stableOutBuffer
-     * ZSTD_d_forceIgnoreChecksum
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
      ZSTD_d_experimentalParam1=1000,
-     ZSTD_d_experimentalParam2=1001,
-     ZSTD_d_experimentalParam3=1002
+     ZSTD_d_experimentalParam2=1001
 
 } ZSTD_dParameter;
 </b></pre><BR>
@@ -606,9 +591,8 @@ size_t ZSTD_freeCStream(ZSTD_CStream* zcs);
   - Compression parameters cannot be changed once compression is started (save a list of exceptions in multi-threading mode)
   - output->pos must be <= dstCapacity, input->pos must be <= srcSize
   - output->pos and input->pos will be updated. They are guaranteed to remain below their respective limit.
-  - endOp must be a valid directive
   - When nbWorkers==0 (default), function is blocking : it completes its job before returning to caller.
-  - When nbWorkers>=1, function is non-blocking : it copies a portion of input, distributes jobs to internal worker threads, flush to output whatever is available,
+  - When nbWorkers>=1, function is non-blocking : it just acquires a copy of input, and distributes jobs to internal worker threads, flush whatever is available,
                                                   and then immediately returns, just indicating that there is some data remaining to be flushed.
                                                   The function nonetheless guarantees forward progress : it will return only after it reads or write at least 1+ byte.
   - Exception : if the first call requests a ZSTD_e_end directive and provides enough dstCapacity, the function delegates to ZSTD_compress2() which is always blocking.
@@ -968,12 +952,6 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 } ZSTD_format_e;
 </b></pre><BR>
 <pre><b>typedef enum {
-    </b>/* Note: this enum controls ZSTD_d_forceIgnoreChecksum */<b>
-    ZSTD_d_validateChecksum = 0,
-    ZSTD_d_ignoreChecksum = 1
-} ZSTD_forceIgnoreChecksum_e;
-</b></pre><BR>
-<pre><b>typedef enum {
     </b>/* Note: this enum and the behavior it controls are effectively internal<b>
      * implementation details of the compressor. They are expected to continue
      * to evolve and should be considered only in the context of extremely
@@ -1170,10 +1148,7 @@ static ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  </b>/**< t
  
 </p></pre><BR>
 
-<a name="Chapter17"></a><h2>This API is temporary and is expected to change or disappear in the future!</h2><pre> 
-<BR></pre>
-
-<a name="Chapter18"></a><h2>Advanced compression functions</h2><pre></pre>
+<a name="Chapter17"></a><h2>Advanced compression functions</h2><pre></pre>
 
 <pre><b>ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t dictSize, int compressionLevel);
 </b><p>  Create a digested dictionary for compression
@@ -1289,10 +1264,8 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
 <pre><b>size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* params, ZSTD_cParameter param, int value);
 </b><p>  Similar to ZSTD_CCtx_setParameter.
   Set one compression parameter, selected by enum ZSTD_cParameter.
-  Parameters must be applied to a ZSTD_CCtx using
-  ZSTD_CCtx_setParametersUsingCCtxParams().
- @result : a code representing success or failure (which can be tested with
-           ZSTD_isError()).
+  Parameters must be applied to a ZSTD_CCtx using ZSTD_CCtx_setParametersUsingCCtxParams().
+ @result : 0, or an error code (which can be tested with ZSTD_isError()).
  
 </p></pre><BR>
 
@@ -1325,7 +1298,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<a name="Chapter19"></a><h2>Advanced decompression functions</h2><pre></pre>
+<a name="Chapter18"></a><h2>Advanced decompression functions</h2><pre></pre>
 
 <pre><b>unsigned ZSTD_isFrame(const void* buffer, size_t size);
 </b><p>  Tells if the content of `buffer` starts with a valid Frame Identifier.
@@ -1387,7 +1360,7 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
  
 </p></pre><BR>
 
-<a name="Chapter20"></a><h2>Advanced streaming functions</h2><pre>  Warning : most of these functions are now redundant with the Advanced API.
+<a name="Chapter19"></a><h2>Advanced streaming functions</h2><pre>  Warning : most of these functions are now redundant with the Advanced API.
   Once Advanced API reaches "stable" status,
   redundant functions will be deprecated, and then at some point removed.
 <BR></pre>
@@ -1409,7 +1382,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
                          int compressionLevel,
                          unsigned long long pledgedSrcSize);
 </pre></b><BR>
-<a name="Chapter21"></a><h2>! ZSTD_initCStream_usingDict() :</h2><pre> This function is deprecated, and is equivalent to:
+<a name="Chapter20"></a><h2>! ZSTD_initCStream_usingDict() :</h2><pre> This function is deprecated, and is equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      ZSTD_CCtx_setParameter(zcs, ZSTD_c_compressionLevel, compressionLevel);
      ZSTD_CCtx_loadDictionary(zcs, dict, dictSize);
@@ -1422,7 +1395,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  
 <BR></pre>
 
-<a name="Chapter22"></a><h2>! ZSTD_initCStream_advanced() :</h2><pre> This function is deprecated, and is approximately equivalent to:
+<a name="Chapter21"></a><h2>! ZSTD_initCStream_advanced() :</h2><pre> This function is deprecated, and is approximately equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      // Pseudocode: Set each zstd parameter and leave the rest as-is.
      for ((param, value) : params) {
@@ -1438,7 +1411,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  
 <BR></pre>
 
-<a name="Chapter23"></a><h2>! ZSTD_initCStream_usingCDict() :</h2><pre> This function is deprecated, and equivalent to:
+<a name="Chapter22"></a><h2>! ZSTD_initCStream_usingCDict() :</h2><pre> This function is deprecated, and equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      ZSTD_CCtx_refCDict(zcs, cdict);
 
@@ -1447,7 +1420,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  
 <BR></pre>
 
-<a name="Chapter24"></a><h2>! ZSTD_initCStream_usingCDict_advanced() :</h2><pre>   This function is DEPRECATED, and is approximately equivalent to:
+<a name="Chapter23"></a><h2>! ZSTD_initCStream_usingCDict_advanced() :</h2><pre>   This function is DEPRECATED, and is approximately equivalent to:
      ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);
      // Pseudocode: Set each zstd frame parameter and leave the rest as-is.
      for ((fParam, value) : fParams) {
@@ -1515,7 +1488,7 @@ ZSTD_initCStream_srcSize(ZSTD_CStream* zcs,
  */
 size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t dictSize);
 </pre></b><BR>
-<a name="Chapter25"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
+<a name="Chapter24"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
      ZSTD_DCtx_reset(zds, ZSTD_reset_session_only);
      ZSTD_DCtx_refDDict(zds, ddict);
 
@@ -1524,7 +1497,7 @@ size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t di
  
 <BR></pre>
 
-<a name="Chapter26"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
+<a name="Chapter25"></a><h2>This function is deprecated, and is equivalent to:</h2><pre>
      ZSTD_DCtx_reset(zds, ZSTD_reset_session_only);
 
  re-use decompression parameters from previous init; saves dictionary loading
@@ -1532,14 +1505,14 @@ size_t ZSTD_initDStream_usingDict(ZSTD_DStream* zds, const void* dict, size_t di
  
 <BR></pre>
 
-<a name="Chapter27"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
+<a name="Chapter26"></a><h2>Buffer-less and synchronous inner streaming functions</h2><pre>
   This is an advanced API, giving full control over buffer management, for users which need direct control over memory.
   But it's also a complex one, with several restrictions, documented below.
   Prefer normal streaming API for an easier experience.
  
 <BR></pre>
 
-<a name="Chapter28"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
+<a name="Chapter27"></a><h2>Buffer-less streaming compression (synchronous mode)</h2><pre>
   A ZSTD_CCtx object is required to track streaming operations.
   Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.
   ZSTD_CCtx object can be re-used multiple times within successive compression operations.
@@ -1575,7 +1548,7 @@ size_t ZSTD_compressBegin_usingCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict); 
 size_t ZSTD_compressBegin_usingCDict_advanced(ZSTD_CCtx* const cctx, const ZSTD_CDict* const cdict, ZSTD_frameParameters const fParams, unsigned long long const pledgedSrcSize);   </b>/* compression parameters are already set within cdict. pledgedSrcSize must be correct. If srcSize is not known, use macro ZSTD_CONTENTSIZE_UNKNOWN */<b>
 size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx, unsigned long long pledgedSrcSize); </b>/**<  note: if pledgedSrcSize is not known, use ZSTD_CONTENTSIZE_UNKNOWN */<b>
 </pre></b><BR>
-<a name="Chapter29"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
+<a name="Chapter28"></a><h2>Buffer-less streaming decompression (synchronous mode)</h2><pre>
   A ZSTD_DCtx object is required to track streaming operations.
   Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
   A ZSTD_DCtx object can be re-used multiple times.
@@ -1671,7 +1644,7 @@ size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long 
 
 <pre><b>typedef enum { ZSTDnit_frameHeader, ZSTDnit_blockHeader, ZSTDnit_block, ZSTDnit_lastBlock, ZSTDnit_checksum, ZSTDnit_skippableFrame } ZSTD_nextInputType_e;
 </b></pre><BR>
-<a name="Chapter30"></a><h2>Block level API</h2><pre></pre>
+<a name="Chapter29"></a><h2>Block level API</h2><pre></pre>
 
 <pre><b></b><p>    Frame metadata cost is typically ~12 bytes, which can be non-negligible for very small blocks (< 100 bytes).
     But users will have to take in charge needed metadata to regenerate data, such as compressed and content sizes.

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2336,7 +2336,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-    //printf("--NEW BLOCK--\n");
+
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2336,7 +2336,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-    
+
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2336,7 +2336,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-
+    printf("--NEW BLOCK--\n");
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2354,7 +2354,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        src, srcSize);
             assert(zc->externSeqStore.pos <= zc->externSeqStore.size);
         } else if (zc->appliedParams.ldmParams.enableLdm) {
-            rawSeqStore_t ldmSeqStore = {NULL, 0, 0, 0, 0};
+            rawSeqStore_t ldmSeqStore = kNullRawSeqStore;
 
             ldmSeqStore.seq = zc->ldmSequences;
             ldmSeqStore.capacity = zc->maxNbLdmSequences;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2336,7 +2336,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-    printf("--NEW BLOCK--\n");
+    //printf("--NEW BLOCK--\n");
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;
@@ -2354,7 +2354,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        src, srcSize);
             assert(zc->externSeqStore.pos <= zc->externSeqStore.size);
         } else if (zc->appliedParams.ldmParams.enableLdm) {
-            rawSeqStore_t ldmSeqStore = {NULL, 0, 0, 0};
+            rawSeqStore_t ldmSeqStore = {NULL, NULL, 0, 0, 0};
 
             ldmSeqStore.seq = zc->ldmSequences;
             ldmSeqStore.capacity = zc->maxNbLdmSequences;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2371,6 +2371,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
             assert(ldmSeqStore.pos == ldmSeqStore.size);
         } else {   /* not long range mode */
             ZSTD_blockCompressor const blockCompressor = ZSTD_selectBlockCompressor(zc->appliedParams.cParams.strategy, dictMode);
+            ms->ldmSeqStore = NULL;
             lastLLSize = blockCompressor(ms, &zc->seqStore, zc->blockState.nextCBlock->rep, src, srcSize);
         }
         {   const BYTE* const lastLiterals = (const BYTE*)src + srcSize - lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2336,7 +2336,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-
+    
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2354,7 +2354,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        src, srcSize);
             assert(zc->externSeqStore.pos <= zc->externSeqStore.size);
         } else if (zc->appliedParams.ldmParams.enableLdm) {
-            rawSeqStore_t ldmSeqStore = {NULL, NULL, 0, 0, 0};
+            rawSeqStore_t ldmSeqStore = {NULL, 0, 0, 0, 0};
 
             ldmSeqStore.seq = zc->ldmSequences;
             ldmSeqStore.capacity = zc->maxNbLdmSequences;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -82,23 +82,23 @@ typedef struct {
 } ZSTD_entropyCTables_t;
 
 typedef struct {
-    U32 off;
-    U32 len;
+    U32 off;            /* Offset code for the match */
+    U32 len;            /* Raw length of match */
 } ZSTD_match_t;
 
 typedef struct {
-    U32 offset;
-    U32 litLength;
-    U32 matchLength;
+    U32 offset;         /* Offset of sequence */
+    U32 litLength;      /* Length of literals prior to match */
+    U32 matchLength;    /* Raw length of match */
 } rawSeq;
 
 typedef struct {
-  rawSeq* seq;     /* The start of the sequences */
-  size_t pos;      /* The index in this seqStore where reading stopped. <= size. */
-  size_t posInSequence; /* The position within the rawSeq at index 'pos' where reading
-                           stopped. */
-  size_t size;     /* The number of sequences. <= capacity. */
-  size_t capacity; /* The capacity starting from `seq` pointer */
+  rawSeq* seq;          /* The start of the sequences */
+  size_t pos;           /* The index in seq where reading stopped. pos <= size. */
+  size_t posInSequence; /* The position within the sequence at seq[pos] where reading
+                           stopped. posInSequence <= seq[pos].litLength + seq[pos].matchLength */
+  size_t size;          /* The number of sequences. <= capacity. */
+  size_t capacity;      /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;
 
 typedef struct {

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,8 +94,9 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
-  size_t pos;      /* The position where reading stopped. <= size. */
-  size_t posInSequence; /* The position to start at within the sequence when starting a new block */
+  size_t pos;      /* The index in this seqStore where reading stopped. <= size. */
+  size_t posInSequence; /* The position within the rawSeq at index 'pos' where reading
+                           stopped. */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,8 +94,8 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
-  BYTE const* base; /* The match state window base when LDMs were generated */
   size_t pos;      /* The position where reading stopped. <= size. */
+  size_t posInSequence; /* The position to start at within the sequence when starting a new block */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -82,7 +82,7 @@ typedef struct {
 } ZSTD_entropyCTables_t;
 
 typedef struct {
-    U32 off;            /* Offset code for the match */
+    U32 off;            /* Offset code (offset + ZSTD_REP_MOVE) for the match */
     U32 len;            /* Raw length of match */
 } ZSTD_match_t;
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -87,6 +87,19 @@ typedef struct {
 } ZSTD_match_t;
 
 typedef struct {
+    U32 offset;
+    U32 litLength;
+    U32 matchLength;
+} rawSeq;
+
+typedef struct {
+  rawSeq* seq;     /* The start of the sequences */
+  size_t pos;      /* The position where reading stopped. <= size. */
+  size_t size;     /* The number of sequences. <= capacity. */
+  size_t capacity; /* The capacity starting from `seq` pointer */
+} rawSeqStore_t;
+
+typedef struct {
     int price;
     U32 off;
     U32 mlen;
@@ -152,6 +165,7 @@ struct ZSTD_matchState_t {
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;
+    rawSeqStore_t ldmSeqStore;
 };
 
 typedef struct {
@@ -182,19 +196,6 @@ typedef struct {
     U32 hashRateLog;       /* Log number of entries to skip */
     U32 windowLog;          /* Window log for the LDM */
 } ldmParams_t;
-
-typedef struct {
-    U32 offset;
-    U32 litLength;
-    U32 matchLength;
-} rawSeq;
-
-typedef struct {
-  rawSeq* seq;     /* The start of the sequences */
-  size_t pos;      /* The position where reading stopped. <= size. */
-  size_t size;     /* The number of sequences. <= capacity. */
-  size_t capacity; /* The capacity starting from `seq` pointer */
-} rawSeqStore_t;
 
 typedef struct {
     int collectSequences;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -167,7 +167,7 @@ struct ZSTD_matchState_t {
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;
-    rawSeqStore_t ldmSeqStore;
+    const rawSeqStore_t* ldmSeqStore;
 };
 
 typedef struct {

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,7 +94,7 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
-  BYTE const* base;
+  BYTE const* base; /* The match state window base when LDMs were generated */
   size_t pos;      /* The position where reading stopped. <= size. */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -101,6 +101,8 @@ typedef struct {
   size_t capacity;      /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;
 
+UNUSED_ATTR static const rawSeqStore_t kNullRawSeqStore = {NULL, 0, 0, 0, 0};
+
 typedef struct {
     int price;
     U32 off;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,6 +94,7 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
+  BYTE const* base;
   size_t pos;      /* The position where reading stopped. <= size. */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -578,7 +578,6 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore;
-        ms->ldmSeqStore.base = ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
         /* ldm seqstore will have changed during blockCompressor() call, make sure we copy those changes */
         *rawSeqStore = ms->ldmSeqStore;

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -579,8 +579,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
-        /* ldm seqstore will have changed during blockCompressor() call, make sure we copy those changes */
-        *rawSeqStore = ms->ldmSeqStore;
+        *rawSeqStore = ms->ldmSeqStore;  /* Persist changes to ldmSeqStore during blockCompressor() */
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -562,13 +562,6 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
     return sequence;
 }
 
-static void printSeqStore(rawSeqStore_t* rawSeqStore) {
-    printf("rawSeqStore: pos: %zu\n", rawSeqStore->pos);
-    for (int i = 0; i < rawSeqStore->size; ++i) {
-        printf("pos %d (of:%u ml:%u ll: %u)\n", i, rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
-    }
-}
-
 size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
     void const* src, size_t srcSize)
@@ -582,19 +575,13 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     BYTE const* const iend = istart + srcSize;
     /* Input positions */
     BYTE const* ip = istart;
-    //printSeqStore(rawSeqStore);
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
-        //printSeqStore(rawSeqStore);
-        ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        ms->ldmSeqStore = *rawSeqStore;
         ms->ldmSeqStore.base = ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        /* ldm seqstore will have changed during blockCompressor() call, make sure we copy those changes */
         *rawSeqStore = ms->ldmSeqStore;
-        /*if (prevBase != ms->window.base) {
-            int baseDiff = (int)(prevBase - ms->window.base);
-            printf("Bases were different, adjusting, diff = %d\n", baseDiff);
-            rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
-        }*/
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -27,13 +27,6 @@ void ZSTD_ldm_adjustParameters(ldmParams_t* params,
     DEBUGLOG(4, "ZSTD_ldm_adjustParameters");
     if (!params->bucketSizeLog) params->bucketSizeLog = LDM_BUCKET_SIZE_LOG;
     if (!params->minMatchLength) params->minMatchLength = LDM_MIN_MATCH_LENGTH;
-    if (cParams->strategy >= ZSTD_btopt) {
-      /* Get out of the way of the optimal parser */
-      U32 const minMatch = MAX(cParams->targetLength, params->minMatchLength);
-      assert(minMatch >= ZSTD_LDM_MINMATCH_MIN);
-      assert(minMatch <= ZSTD_LDM_MINMATCH_MAX);
-      params->minMatchLength = minMatch;
-    }
     if (params->hashLog == 0) {
         params->hashLog = MAX(ZSTD_HASHLOG_MIN, params->windowLog - LDM_HASH_RLOG);
         assert(params->hashLog <= ZSTD_HASHLOG_MAX);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -576,6 +576,13 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     /* Input positions */
     BYTE const* ip = istart;
 
+    if (cParams->strategy >= ZSTD_btopt) {
+        size_t lastLLSize;
+        ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        return lastLLSize;
+    }
+
     DEBUGLOG(5, "ZSTD_ldm_blockCompress: srcSize=%zu", srcSize);
     assert(rawSeqStore->pos <= rawSeqStore->size);
     assert(rawSeqStore->size <= rawSeqStore->capacity);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -575,6 +575,8 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     BYTE const* const iend = istart + srcSize;
     /* Input positions */
     BYTE const* ip = istart;
+
+    /* If using opt parser, use LDMs only as candidates rather than always accepting them */
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore;

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -562,6 +562,13 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
     return sequence;
 }
 
+static void printSeqStore(rawSeqStore_t* rawSeqStore) {
+    printf("rawSeqStore: pos: %zu, bytesDiscarded: %zu\n", rawSeqStore->pos);
+    for (int i = 0; i < rawSeqStore->size; ++i) {
+        printf("(of:%u ml:%u ll: %u)\n", rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
+    }
+}
+
 size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
     void const* src, size_t srcSize)
@@ -578,6 +585,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
 
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
+        printSeqStore(rawSeqStore);
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
         const BYTE* const prevBase = (BYTE const*)ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -580,6 +580,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        rawSeqStore->pos = ms->ldmSeqStore.pos;
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -559,20 +559,22 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
  * Moves forward in rawSeqStore by nbBytes, updating fields 'pos' and 'posInSequence'.
  */
 static void ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore_t* rawSeqStore, size_t nbBytes) {
-    U32 currPos = rawSeqStore->posInSequence + nbBytes;
+    U32 currPos = (U32)(rawSeqStore->posInSequence + nbBytes);
     while (currPos && rawSeqStore->pos < rawSeqStore->size) {
         rawSeq currSeq = rawSeqStore->seq[rawSeqStore->pos];
         if (currPos >= currSeq.litLength + currSeq.matchLength) {
             currPos -= currSeq.litLength + currSeq.matchLength;
             rawSeqStore->pos++;
-            if (currPos == 0) {
-                rawSeqStore->posInSequence = 0;
-            }
         } else {
             rawSeqStore->posInSequence = currPos;
             break;
         }
     }
+    if (currPos == 0 || rawSeqStore->pos == rawSeqStore->size) {
+        rawSeqStore->posInSequence = 0;
+    }
+    assert(rawSeqStore->posInSequence <=
+           rawSeqStore->seq[rawSeqStore->pos].litLength + rawSeqStore->seq[rawSeqStore->pos].matchLength);
 }
 
 size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
@@ -597,7 +599,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore, srcSize);
         if (rawSeqStore->pos >= rawSeqStore->size) {
             /* If we're done with rawSeqStore, invalidate the one in matchState as well */
-            ms->ldmSeqStore.pos = rawSeqStore->size;
+            ms->ldmSeqStore.size = 0;
         }
         return lastLLSize;
     }

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -563,9 +563,9 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
 }
 
 static void printSeqStore(rawSeqStore_t* rawSeqStore) {
-    printf("rawSeqStore: pos: %zu, bytesDiscarded: %zu\n", rawSeqStore->pos);
+    printf("rawSeqStore: pos: %zu\n", rawSeqStore->pos);
     for (int i = 0; i < rawSeqStore->size; ++i) {
-        printf("(of:%u ml:%u ll: %u)\n", rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
+        printf("pos %d (of:%u ml:%u ll: %u)\n", i, rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
     }
 }
 
@@ -582,20 +582,19 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     BYTE const* const iend = istart + srcSize;
     /* Input positions */
     BYTE const* ip = istart;
-
+    //printSeqStore(rawSeqStore);
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
-        printSeqStore(rawSeqStore);
+        //printSeqStore(rawSeqStore);
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
-        const BYTE* const prevBase = (BYTE const*)ms->window.base;
+        ms->ldmSeqStore.base = ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
-        rawSeqStore->pos = ms->ldmSeqStore.pos;
-        ms->ldmSeqStore = *rawSeqStore;
-        if (prevBase != ms->window.base) {
+        *rawSeqStore = ms->ldmSeqStore;
+        /*if (prevBase != ms->window.base) {
             int baseDiff = (int)(prevBase - ms->window.base);
             printf("Bases were different, adjusting, diff = %d\n", baseDiff);
             rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
-        }
+        }*/
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -574,7 +574,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
-        *rawSeqStore = ms->ldmSeqStore;  /* Persist changes to ldmSeqStore during blockCompressor() */
+        *rawSeqStore = ms->ldmSeqStore;
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -579,8 +579,15 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        const BYTE* const prevBase = (BYTE const*)ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
         rawSeqStore->pos = ms->ldmSeqStore.pos;
+        ms->ldmSeqStore = *rawSeqStore;
+        if (prevBase != ms->window.base) {
+            int baseDiff = (int)(prevBase - ms->window.base);
+            printf("Bases were different, adjusting, diff = %d\n", baseDiff);
+            rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
+        }
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -1364,6 +1364,7 @@ ZSTD_initStats_ultra(ZSTD_matchState_t* ms,
                const void* src, size_t srcSize)
 {
     U32 tmpRep[ZSTD_REP_NUM];  /* updated rep codes will sink here */
+    rawSeqStore_t tmpSeqStore = ms->ldmSeqStore;
     ZSTD_memcpy(tmpRep, rep, sizeof(tmpRep));
 
     DEBUGLOG(4, "ZSTD_initStats_ultra (srcSize=%zu)", srcSize);
@@ -1380,6 +1381,7 @@ ZSTD_initStats_ultra(ZSTD_matchState_t* ms,
     ms->window.dictLimit += (U32)srcSize;
     ms->window.lowLimit = ms->window.dictLimit;
     ms->nextToUpdate = ms->window.dictLimit;
+    ms->ldmSeqStore = tmpSeqStore;
 
     /* re-inforce weight of collected statistics */
     ZSTD_upscaleStats(&ms->opt);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -849,6 +849,8 @@ static void ldm_getNextMatchAndUpdateSeqStore(rawSeqStore_t* ldmSeqStore,
         ldmSeqStore->posInSequence = 0;
         ldmSeqStore->pos++;
     }
+    DEBUGLOG(6, "ldm_getNextMatchAndUpdateSeqStore(): got an ldm that beginning at pos: %u, end at pos: %u, with offset: %u",
+             *matchStartPosInBlock, *matchEndPosInBlock, *matchOffset);
 }
 
 /* ldm_maybeAddLdm():
@@ -870,6 +872,8 @@ static void ldm_maybeAddLdm(ZSTD_match_t* matches, U32* nbMatches,
         candidateMatchLength < MINMATCH)
         return;
 
+    DEBUGLOG(6, "ldm_maybeAddLdm(): Adding ldm candidate match (offCode: %u matchLength %u) at block position=%u",
+             candidateOffCode, candidateMatchLength, currPosInBlock);
     if (*nbMatches == 0) {
         matches[*nbMatches].len = candidateMatchLength;
         matches[*nbMatches].off = candidateOffCode;
@@ -985,14 +989,14 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     U32 ldmStartPosInBlock = 0;
     U32 ldmEndPosInBlock = 0;
     U32 ldmOffset = 0;
-    
+
     /* Get first match from ldm seq store if long mode is enabled */
     if (ms->ldmSeqStore.size > 0 && ms->ldmSeqStore.pos < ms->ldmSeqStore.size) {
         ldm_getNextMatchAndUpdateSeqStore(&ms->ldmSeqStore, &ldmStartPosInBlock,
                                           &ldmEndPosInBlock, &ldmOffset,
                                           (U32)(ip-istart), (U32)(iend-ip));
     }
-
+    
     /* init */
     DEBUGLOG(5, "ZSTD_compressBlock_opt_generic: current=%u, prefix=%u, nextToUpdate=%u",
                 (U32)(ip - base), ms->window.dictLimit, ms->nextToUpdate);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -868,6 +868,10 @@ static void ldm_maybeAddLdm(ZSTD_match_t* matches, U32* nbMatches,
          * the ldm match down as necessary.
          */
         if (candidateMatchLength == matches[*nbMatches-1].len) {
+            if (candidateOffCode == matches[*nbMatches-1].off) {
+                /* No need to insert the match if it's the exact same */
+                return;
+            }
             U32 candidateMatchIdx = *nbMatches;
             matches[*nbMatches].len = candidateMatchLength;
             matches[*nbMatches].off = candidateOffCode;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -986,11 +986,11 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
      * since the base shifts back 131072 bytes (1 block) after the first block. The consequence is that
      * we should insert 35373 bytes into the 8th block, rather than 35373 bytes into the 7th block.
      */
-    if (ms->ldmSeqStore.size > 0) {
+    if (ms->ldmSeqStore.size > 0 && ms->ldmSeqStore.pos != ms->ldmSeqStore.size) {
         if (ms->ldmSeqStore.base != base) {
             int baseDiff = (int)(ms->ldmSeqStore.base - base);
             ms->ldmSeqStore.seq[ms->ldmSeqStore.pos].litLength += baseDiff;
-            ms->ldmSeqStore.base = ms->window.base;
+            ms->ldmSeqStore.base = base;
         }
         ldm_getNextMatch(&ms->ldmSeqStore, &ldmStartPosInBlock,
                          &ldmEndPosInBlock, &ldmOffset,

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -940,7 +940,10 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     U32 ldmEndPosInBlock = 0;
     U32 ldmOffset = 0;
     
-
+    if (ms->ldmSeqStore.size != 0) {
+        ldm_getNextMatch(&ms->ldmSeqStore, &ldmStartPosInBlock,
+                &ldmEndPosInBlock, &ldmOffset, (U32)(ip-istart), (U32)(iend-ip));
+    }
     /* init */
     DEBUGLOG(5, "ZSTD_compressBlock_opt_generic: current=%u, prefix=%u, nextToUpdate=%u",
                 (U32)(ip - base), ms->window.dictLimit, ms->nextToUpdate);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -871,7 +871,6 @@ static void ZSTD_opt_maybeAddLdm(ZSTD_match_t* matches, U32* nbMatches,
     /* Ensure that current block position is not outside of the match */
     if (currPosInBlock < matchStartPosInBlock
       || currPosInBlock >= matchEndPosInBlock
-      || posDiff > 0    /* As a next evolution we can enable adding LDMs in the middle of a match */
       || candidateMatchLength < MINMATCH) {
         return;
     }

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -867,20 +867,9 @@ static void ZSTD_optLdm_maybeAddMatch(ZSTD_match_t* matches, U32* nbMatches,
         return;
     }
 
-    DEBUGLOG(6, "ZSTD_optLdm_maybeAddMatch(): Adding ldm candidate match (offCode: %u matchLength %u) at block position=%u",
-             candidateOffCode, candidateMatchLength, currPosInBlock);
-    if (*nbMatches == 0) {
-        matches[*nbMatches].len = candidateMatchLength;
-        matches[*nbMatches].off = candidateOffCode;
-        (*nbMatches)++;
-    } else if ((candidateMatchLength >= matches[*nbMatches-1].len) && *nbMatches < ZSTD_OPT_NUM) {
-        if (candidateMatchLength == matches[*nbMatches-1].len) {
-            /* No need to insert match with same matchLength. At most, replace offCode if it is smaller. */
-            if (candidateOffCode < matches[*nbMatches-1].off) {
-                matches[*nbMatches-1].off = candidateOffCode;
-            }
-            return;
-        }
+    if (*nbMatches == 0 || ((candidateMatchLength > matches[*nbMatches-1].len) && *nbMatches < ZSTD_OPT_NUM)) {
+        DEBUGLOG(6, "ZSTD_optLdm_maybeAddMatch(): Adding ldm candidate match (offCode: %u matchLength %u) at block position=%u",
+                 candidateOffCode, candidateMatchLength, currPosInBlock);
         matches[*nbMatches].len = candidateMatchLength;
         matches[*nbMatches].off = candidateOffCode;
         (*nbMatches)++;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -774,7 +774,9 @@ FORCE_INLINE_TEMPLATE U32 ZSTD_BtGetAllMatches (
 static void ZSTD_opt_skipBytesInLdmSeqStore(rawSeqStore_t* ldmSeqStore, size_t nbBytes) {
     while (nbBytes && ldmSeqStore->pos < ldmSeqStore->size) {
         rawSeq currSeq = ldmSeqStore->seq[ldmSeqStore->pos];
+        /* posInSequence necessarily must never represent a value beyond the sequence */
         assert(ldmSeqStore->posInSequence <= currSeq.matchLength + currSeq.litLength);
+
         if (nbBytes <= currSeq.litLength) {
             ldmSeqStore->posInSequence += nbBytes;
             return;
@@ -782,6 +784,7 @@ static void ZSTD_opt_skipBytesInLdmSeqStore(rawSeqStore_t* ldmSeqStore, size_t n
             ldmSeqStore->posInSequence += currSeq.litLength;
             nbBytes -= currSeq.litLength;
         }
+        
         if (nbBytes < currSeq.matchLength) {
             ldmSeqStore->posInSequence += nbBytes;
             return;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -824,19 +824,19 @@ static void ldm_getNextMatch(rawSeqStore_t* ldmSeqStore,
     if (ldmSeqStore->pos >= ldmSeqStore->size) {
         *matchStartPosInBlock = UINT32_MAX;
         *matchEndPosInBlock = UINT32_MAX;
-        return 1;
+        return;
     }
     rawSeq seq = ldm_splitSequenceAndUpdateSeqStore(ldmSeqStore, remainingBytes);
     if (seq.offset == 0) {
         *matchStartPosInBlock = UINT32_MAX;
         *matchEndPosInBlock = UINT32_MAX;
-        return 1;
+        return;
     }
 
     *matchStartPosInBlock = currPosInBlock + seq.litLength;
     *matchEndPosInBlock = *matchStartPosInBlock + seq.matchLength;
     *matchOffset = seq.offset;
-    return 0;
+    return;
 }
 
 /* Adds an LDM if it's long enough */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -788,7 +788,7 @@ static void ldm_maybeUpdateSeqStoreReadPos() {
 }
 
 /* Wrapper function to call ldm functions as needed */
-static void ldm_handleLdm() {
+static void ldm_handleLdm(int* nbMatches) {
     int noMoreLdms = getNextMatch();
 }
 
@@ -861,6 +861,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
         {   U32 const litlen = (U32)(ip - anchor);
             U32 const ll0 = !litlen;
             U32 const nbMatches = ZSTD_BtGetAllMatches(matches, ms, &nextToUpdate3, ip, iend, dictMode, rep, ll0, minMatch);
+            ldm_handleLdm(&nbMatches);
             if (!nbMatches) { ip++; continue; }
 
             /* initialize opt[0] */
@@ -975,6 +976,8 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                 U32 const basePrice = previousPrice + ZSTD_litLengthPrice(0, optStatePtr, optLevel);
                 U32 const nbMatches = ZSTD_BtGetAllMatches(matches, ms, &nextToUpdate3, inr, iend, dictMode, opt[cur].rep, ll0, minMatch);
                 U32 matchNb;
+                
+                ldm_handleLdm(&nbMatches);
                 if (!nbMatches) {
                     DEBUGLOG(7, "rPos:%u : no match found", cur);
                     continue;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -784,7 +784,7 @@ static void ZSTD_opt_skipBytesInLdmSeqStore(rawSeqStore_t* ldmSeqStore, size_t n
             ldmSeqStore->posInSequence += currSeq.litLength;
             nbBytes -= currSeq.litLength;
         }
-        
+
         if (nbBytes < currSeq.matchLength) {
             ldmSeqStore->posInSequence += nbBytes;
             return;
@@ -823,10 +823,10 @@ static void ZSTD_opt_getNextLdmAndUpdateSeqStore(rawSeqStore_t* ldmSeqStore,
     assert(ldmSeqStore->posInSequence <= currSeq.litLength + currSeq.matchLength);
     currBlockEndPos = currPosInBlock + blockBytesRemaining;
     literalsBytesRemaining = (ldmSeqStore->posInSequence < currSeq.litLength) ?
-            currSeq.litLength - ldmSeqStore->posInSequence :
+            currSeq.litLength - (U32)ldmSeqStore->posInSequence :
             0;
     matchBytesRemaining = (literalsBytesRemaining == 0) ?
-            currSeq.matchLength - (ldmSeqStore->posInSequence - currSeq.litLength) :
+            currSeq.matchLength - ((U32)ldmSeqStore->posInSequence - currSeq.litLength) :
             currSeq.matchLength;
 
     /* If there are more literal bytes than bytes remaining in block, no ldm is possible */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -882,36 +882,13 @@ static void ZSTD_opt_maybeAddLdm(ZSTD_match_t* matches, U32* nbMatches,
         matches[*nbMatches].off = candidateOffCode;
         (*nbMatches)++;
     } else if ((candidateMatchLength >= matches[*nbMatches-1].len) && *nbMatches < ZSTD_OPT_NUM) {
-        /* Maintain order of matches, which is firstly - increasing in matchlength, 
-         * and secondly - decreasing in offCode. Since matches from the ldm seq store are likely
-         * to be the longest match found, we simply start at the end of the array and bubble
-         * the ldm match down as necessary.
-         */
-        if (candidateMatchLength == matches[*nbMatches-1].len) {
-            U32 candidateMatchIdx;
-            if (candidateOffCode == matches[*nbMatches-1].off) {
-                /* No need to insert the match if it's the exact same */
-                return;
-            }
-            candidateMatchIdx = *nbMatches;
-            matches[*nbMatches].len = candidateMatchLength;
-            matches[*nbMatches].off = candidateOffCode;
-            if (candidateOffCode != matches[*nbMatches-1].off) {
-                while (candidateMatchIdx > 0 &&
-                       matches[candidateMatchIdx].off > matches[candidateMatchIdx - 1].off &&
-                       matches[candidateMatchIdx].len == matches[candidateMatchIdx - 1].len) {
-                    ZSTD_match_t tmp = matches[candidateMatchIdx - 1];
-                    matches[candidateMatchIdx - 1] = matches[candidateMatchIdx];
-                    matches[candidateMatchIdx] = tmp;
-                    --candidateMatchIdx;
-                }
-            }
-            (*nbMatches)++;
-        } else {
-            matches[*nbMatches].len = candidateMatchLength;
-            matches[*nbMatches].off = candidateOffCode;
-            (*nbMatches)++;
+        /* No need to insert the match if it's the exact same, or offCode is larger with same matchLen */
+        if (candidateMatchLength == matches[*nbMatches-1].len && candidateOffCode >= matches[*nbMatches-1].off) {
+            return;
         }
+        matches[*nbMatches].len = candidateMatchLength;
+        matches[*nbMatches].off = candidateOffCode;
+        (*nbMatches)++;
     }
 }
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -964,14 +964,8 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     ZSTD_optimal_t lastSequence;
     ZSTD_optLdm_t optLdm;
 
-    if (ms->ldmSeqStore) {
-        optLdm.seqStore = *ms->ldmSeqStore;
-        optLdm.endPosInBlock = optLdm.startPosInBlock = optLdm.offset = 0;
-    } else {
-        optLdm.seqStore.size = optLdm.seqStore.pos = 0;
-    }
-
-    /* Get first match from ldm seq store if long mode is enabled */
+    optLdm.seqStore = ms->ldmSeqStore ? *ms->ldmSeqStore : kNullRawSeqStore;
+    optLdm.endPosInBlock = optLdm.startPosInBlock = optLdm.offset = 0;
     ZSTD_opt_getNextMatchAndUpdateSeqStore(&optLdm, (U32)(ip-istart), (U32)(iend-ip));
 
     /* init */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -874,8 +874,11 @@ static void ZSTD_optLdm_maybeAddMatch(ZSTD_match_t* matches, U32* nbMatches,
         matches[*nbMatches].off = candidateOffCode;
         (*nbMatches)++;
     } else if ((candidateMatchLength >= matches[*nbMatches-1].len) && *nbMatches < ZSTD_OPT_NUM) {
-        /* No need to insert the match if it's the exact same, or offCode is larger with same matchLen */
-        if (candidateMatchLength == matches[*nbMatches-1].len && candidateOffCode >= matches[*nbMatches-1].off) {
+        if (candidateMatchLength == matches[*nbMatches-1].len) {
+            /* No need to insert match with same matchLength. At most, replace offCode if it is smaller. */
+            if (candidateOffCode < matches[*nbMatches-1].off) {
+                matches[*nbMatches-1].off = candidateOffCode;
+            }
             return;
         }
         matches[*nbMatches].len = candidateMatchLength;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -838,8 +838,20 @@ static int ldm_getNextMatch(rawSeqStore_t* ldmSeqStore,
 }
 
 /* Adds an LDM if it's long enough */
-static void ldm_maybeAddLdm() {
+static void ldm_maybeAddLdm(ZSTD_match_t* matches, U32 nbMatches,
+                            U32 matchStartPosInBlock, U32 matchEndPosInBlock,
+                            U32 matchOffset, U32 currPosInBlock) {
+    /* Check that current block position is not outside of the match */
+    if (currPosInBlock < matchStartPosInBlock || currPosInBlock >= matchEndPosInBlock)
+        return;
+    U32 posDiff = currPosInBlock - matchStartPosInBlock;
+    assert(posDiff < matchEndPosInBlock - matchStartPosInBlock);
+    U32 matchLengthAdjusted = matchEndPosInBlock - matchStartPosInBlock - posDiff;
+    U32 matchOffsetAdjusted = matchOffset + posDiff;
 
+    if (matchLengthAdjusted >= matches[nbMatches-1]) {
+        
+    }
 }
 
 /* Updates the pos field in rawSeqStore */
@@ -849,12 +861,12 @@ static void ldm_maybeUpdateSeqStoreReadPos() {
 
 /* Wrapper function to call ldm functions as needed */
 static void ldm_handleLdm(ZSTD_match_t* matches, int* nbMatches,
-                          U32* matchStartPosInBlock, U32* matchEndPosInBlock,
+                          U32* matchStartPosInBlock, U32* matchEndPosInBlock, U32* matchOffset,
                           U32 currPosInBlock, U32 remainingBytes) {
     if (currPosInBlock >= matchEndPosInBlock) {
         int noMoreLdms = ldm_getNextMatch(matchStartPosInBlock, matchEndPosInBlock, remainingBytes);
     }
-    ldm_maybeAddLdm(matches, currPosInBlock, matchStartPosInBlock, matchEndPosInBlock);
+    ldm_maybeAddLdm(matches, *nbMatches, *matchStartPosInBlock, *matchEndPosInBlock, *matchOffset, currPosInBlock);
 }
 
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -764,6 +764,34 @@ FORCE_INLINE_TEMPLATE U32 ZSTD_BtGetAllMatches (
     }
 }
 
+/*-*******************************
+*  LDM util functions
+*********************************/
+
+static int ldm_splitSequence() {
+
+}
+
+/* Returns 1 if the rest of the block is just LDM literals */
+static int ldm_getNextMatch() {
+    int ret = ldm_splitSequence();
+}
+
+/* Adds an LDM if it's long enough */
+static void ldm_maybeAddLdm() {
+
+}
+
+/* Updates the pos field in rawSeqStore */
+static void ldm_maybeUpdateSeqStoreReadPos() {
+
+}
+
+/* Wrapper function to call ldm functions as needed */
+static void ldm_handleLdm() {
+    int noMoreLdms = getNextMatch();
+}
+
 
 /*-*******************************
 *  Optimal parser

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -789,6 +789,15 @@ static void ldm_skipOvershotBytes(rawSeqStore_t* rawSeqStore, U32 bytesOvershot)
     }
 }*/
 
+
+static void ldm_voidSequences(rawSeqStore_t* ldmSeqStore, U32 overshotBytes) {
+    U32 posAdjustment;
+    U32 bytesAdjustment;
+    while (overshotBytes > 0 && ldmSeqStore->pos < ldmSeqStore->size) {
+
+    }
+}
+
 static void ldm_skipSequences(rawSeqStore_t* rawSeqStore, size_t srcSize, U32 const minMatch) {
     while (srcSize > 0 && rawSeqStore->pos < rawSeqStore->size) {
         printf("ldm_skipSequences(): %u remaining\n", srcSize);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -866,7 +866,7 @@ static void ZSTD_opt_maybeAddLdm(ZSTD_match_t* matches, U32* nbMatches,
     U32 posDiff = currPosInBlock - matchStartPosInBlock;
     /* Note: ZSTD_match_t actually contains offCode and matchLength (before subtracting MINMATCH) */
     U32 candidateMatchLength = matchEndPosInBlock - matchStartPosInBlock - posDiff;
-    U32 candidateOffCode = matchOffset + posDiff + ZSTD_REP_MOVE;
+    U32 candidateOffCode = matchOffset + ZSTD_REP_MOVE;
 
     /* Ensure that current block position is not outside of the match */
     if (currPosInBlock < matchStartPosInBlock
@@ -1146,6 +1146,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                                         &ldmEndPosInBlock, &ldmOffset,
                                         (U32)(inr-istart), (U32)(iend-inr));
                 }
+
                 if (!nbMatches) {
                     DEBUGLOG(7, "rPos:%u : no match found", cur);
                     continue;

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -266,7 +266,7 @@ static void ZSTDMT_releaseBuffer(ZSTDMT_bufferPool* bufPool, buffer_t buf)
 
 /* =====   Seq Pool Wrapper   ====== */
 
-static rawSeqStore_t kNullRawSeqStore = {NULL, NULL, 0, 0, 0};
+static rawSeqStore_t kNullRawSeqStore = {NULL, 0, 0, 0, 0};
 
 typedef ZSTDMT_bufferPool ZSTDMT_seqPool;
 
@@ -277,7 +277,7 @@ static size_t ZSTDMT_sizeof_seqPool(ZSTDMT_seqPool* seqPool)
 
 static rawSeqStore_t bufferToSeq(buffer_t buffer)
 {
-    rawSeqStore_t seq = {NULL, NULL, 0, 0, 0};
+    rawSeqStore_t seq = {NULL, 0, 0, 0, 0};
     seq.seq = (rawSeq*)buffer.start;
     seq.capacity = buffer.capacity / sizeof(rawSeq);
     return seq;

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -266,7 +266,7 @@ static void ZSTDMT_releaseBuffer(ZSTDMT_bufferPool* bufPool, buffer_t buf)
 
 /* =====   Seq Pool Wrapper   ====== */
 
-static rawSeqStore_t kNullRawSeqStore = {NULL, 0, 0, 0};
+static rawSeqStore_t kNullRawSeqStore = {NULL, NULL, 0, 0, 0};
 
 typedef ZSTDMT_bufferPool ZSTDMT_seqPool;
 

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -277,7 +277,7 @@ static size_t ZSTDMT_sizeof_seqPool(ZSTDMT_seqPool* seqPool)
 
 static rawSeqStore_t bufferToSeq(buffer_t buffer)
 {
-    rawSeqStore_t seq = {NULL, 0, 0, 0, 0};
+    rawSeqStore_t seq = kNullRawSeqStore;
     seq.seq = (rawSeq*)buffer.start;
     seq.capacity = buffer.capacity / sizeof(rawSeq);
     return seq;

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -266,8 +266,6 @@ static void ZSTDMT_releaseBuffer(ZSTDMT_bufferPool* bufPool, buffer_t buf)
 
 /* =====   Seq Pool Wrapper   ====== */
 
-static rawSeqStore_t kNullRawSeqStore = {NULL, 0, 0, 0, 0};
-
 typedef ZSTDMT_bufferPool ZSTDMT_seqPool;
 
 static size_t ZSTDMT_sizeof_seqPool(ZSTDMT_seqPool* seqPool)

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -277,7 +277,7 @@ static size_t ZSTDMT_sizeof_seqPool(ZSTDMT_seqPool* seqPool)
 
 static rawSeqStore_t bufferToSeq(buffer_t buffer)
 {
-    rawSeqStore_t seq = {NULL, 0, 0, 0};
+    rawSeqStore_t seq = {NULL, NULL, 0, 0, 0};
     seq.seq = (rawSeq*)buffer.start;
     seq.capacity = buffer.capacity / sizeof(rawSeq);
     return seq;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -811,7 +811,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         if (cSizeLdm > cSizeNoLdm) {
             DISPLAY("Using long mode should not cause regressions for btopt+\n");
             testResult = 1;
-            goto _output_error;
+            goto _end;
         }
 
         ZSTD_freeCCtx(cctx);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -780,6 +780,44 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : testing ldm no regressions in size for opt parser : ", testNb++);
+    {
+        size_t cSizeLdm;
+        size_t cSizeNoLdm;
+        ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+
+        RDG_genBuffer(CNBuffer, CNBuffSize, 0.5, 0.5, seed);
+
+        /* Enable checksum to verify round trip. */
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 1));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 1));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 19));
+
+        /* Round trip once with ldm. */
+        cSizeLdm = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, CNBuffer, CNBuffSize);
+        CHECK_Z(cSizeLdm);
+        CHECK_Z(ZSTD_decompress(decodedBuffer, CNBuffSize, compressedBuffer, cSizeLdm));
+
+        ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters);
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 1));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching, 0));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 19));
+
+        /* Round trip once without ldm. */
+        cSizeNoLdm = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, CNBuffer, CNBuffSize);
+        CHECK_Z(cSizeNoLdm);
+        CHECK_Z(ZSTD_decompress(decodedBuffer, CNBuffSize, compressedBuffer, cSizeNoLdm));
+
+        if (cSizeLdm > cSizeNoLdm) {
+            DISPLAY("Using long mode should not cause regressions for btopt+\n");
+            testResult = 1;
+            goto _output_error;
+        }
+
+        ZSTD_freeCCtx(cctx);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     /* Note: this test takes 0.5 seconds to run */
     DISPLAYLEVEL(3, "test%3i : testing refPrefx vs refPrefx + ldm (size comparison) : ", testNb++);
     {

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1207,6 +1207,7 @@ roundTripTest -g1000K "1 --single-thread --long"
 roundTripTest -g517K "6 --single-thread --long"
 roundTripTest -g516K "16 --single-thread --long"
 roundTripTest -g518K "19 --single-thread --long"
+roundTripTest -g2M "22 --single-thread --ultra --long"
 fileRoundTripTest -g5M "3 --single-thread --long"
 
 
@@ -1216,6 +1217,7 @@ then
     println "\n===>  zstdmt round-trip tests "
     roundTripTest -g4M "1 -T0"
     roundTripTest -g8M "3 -T2"
+    roundTripTest -g8M "3 -T0 --long"
     roundTripTest -g8000K "2 --threads=2"
     fileRoundTripTest -g4M "19 -T2 -B1M"
 
@@ -1334,6 +1336,33 @@ roundTripTest -g1M -P50 "1 --single-thread --long=29" " --long=28 --memory=512MB
 roundTripTest -g1M -P50 "1 --single-thread --long=29" " --zstd=wlog=28 --memory=512MB"
 
 
+println "\n===>  zstd long distance matching with optimal parser compressed size tests "
+optCSize16=$(datagen -g511K | zstd -16 -c | wc -c)
+longCSize16=$(datagen -g511K | zstd -16 --long -c | wc -c)
+optCSize19=$(datagen -g2M | zstd -19 -c | wc -c)
+longCSize19=$(datagen -g2M | zstd -19 --long -c | wc -c)
+optCSize19wlog23=$(datagen -g2M | zstd -19 -c  --zstd=wlog=23 | wc -c)
+longCSize19wlog23=$(datagen -g2M | zstd -19 -c --long=23 | wc -c)
+optCSize19wlog27=$(datagen -g5M | zstd -19 -c  --zstd=wlog=27 | wc -c)
+longCSize19wlog27=$(datagen -g5M | zstd -19 -c --long=27 | wc -c)
+optCSize22=$(datagen -g900K | zstd -22 --ultra -c | wc -c)
+longCSize22=$(datagen -g900K | zstd -22 --ultra --long -c | wc -c)
+if [ "$longCSize16" -gt "$optCSize16" ]; then
+    echo using --long on compression level 16 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize19" -gt "$optCSize19" ]; then
+    echo using --long on compression level 19 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize19wlog23" -gt "$optCSize19wlog23" ]; then
+    echo using --long on compression level 19 with wLog=23 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize19wlog27" -gt "$optCSize19wlog27" ]; then
+    echo using --long on compression level 19 with wLog=27 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize22" -gt "$optCSize22" ]; then
+    echo using --long on compression level 22 should not cause compressed size regression
+    exit 1
+fi
 
 
 if [ "$1" != "--test-large-data" ]; then

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1343,8 +1343,6 @@ optCSize19=$(datagen -g2M | zstd -19 -c | wc -c)
 longCSize19=$(datagen -g2M | zstd -19 --long -c | wc -c)
 optCSize19wlog23=$(datagen -g2M | zstd -19 -c  --zstd=wlog=23 | wc -c)
 longCSize19wlog23=$(datagen -g2M | zstd -19 -c --long=23 | wc -c)
-optCSize19wlog27=$(datagen -g5M | zstd -19 -c  --zstd=wlog=27 | wc -c)
-longCSize19wlog27=$(datagen -g5M | zstd -19 -c --long=27 | wc -c)
 optCSize22=$(datagen -g900K | zstd -22 --ultra -c | wc -c)
 longCSize22=$(datagen -g900K | zstd -22 --ultra --long -c | wc -c)
 if [ "$longCSize16" -gt "$optCSize16" ]; then
@@ -1355,9 +1353,6 @@ elif [ "$longCSize19" -gt "$optCSize19" ]; then
     exit 1
 elif [ "$longCSize19wlog23" -gt "$optCSize19wlog23" ]; then
     echo using --long on compression level 19 with wLog=23 should not cause compressed size regression
-    exit 1
-elif [ "$longCSize19wlog27" -gt "$optCSize19wlog27" ]; then
-    echo using --long on compression level 19 with wLog=27 should not cause compressed size regression
     exit 1
 elif [ "$longCSize22" -gt "$optCSize22" ]; then
     echo using --long on compression level 22 should not cause compressed size regression

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1217,7 +1217,7 @@ then
     println "\n===>  zstdmt round-trip tests "
     roundTripTest -g4M "1 -T0"
     roundTripTest -g8M "3 -T2"
-    roundTripTest -g8M "3 -T0 --long"
+    roundTripTest -g8M "19 -T0 --long"
     roundTripTest -g8000K "2 --threads=2"
     fileRoundTripTest -g4M "19 -T2 -B1M"
 


### PR DESCRIPTION
## Context

Using the long range matchfinder (`--long`) with high compression levels (16 and above) currently can cause regressions compared to not using the long mode at all. This is because enabling long mode will cause the matches found by the long range matchfinder to be blindly accepted. This PR changes that behavior, and makes each LDM found a candidate for the optimal parser instead.
 
## --patch-from benchmarks
This PR improves `--long` mode compression the most when `--long` mode is actually useful. `--patch-from` is a great example of `--long` mode being useful, so there are some nice benefits here. With this PR, `--patch-from` becomes even more competitive with `bsdiff` for generating small patches. The following results are fastest of three runs. 

**linux kernels tarballs (5.8 -> 5.9-rc7) : ~1GB dst**
| Name               | Conf    | Patch Size   | % of new file | Peak Mem | CPU% | Total Time |
|--------------------|---------|--------|-------|----------|------|------------|
| `zstd-dev`           | -19 -T0 | 5.90MB | 0.58% | 3.24 GB  | 119% | 3m:36s     |
| `zstd-dev`           | -22 -T0 | 6.55MB | 0.65% | 4.09 GB  | 99%  | 5m:54s     |
| `bsdiff`             | default | 5.18MB | 0.51% | 15.58 GB | 99%  | 12m:08s    |
| `zstd-ldm_optimized` | -19 -T0 | 5.10MB | 0.51% | 3.24 GB  | 162% | 4m:30s     |
| `zstd-ldm_optimized` | -22 -T0 | 4.26MB | 0.42% | 4.09 GB  | 99%  | 9m:20s     |

**distant linux kernels tarballs (4.4.238 -> 5.9-rc7): ~1GB dst**
| Name               | Conf    | Patch Size | % of new file | Peak Mem | CPU% | Total Time |
|--------------------|---------|------------|---------------|----------|------|------------|
| `zstd-dev`           | -19 -T0 | 66.90MB    | 6.62%         | 2.68 GB  | 190% | 3m:38s     |
| `zstd-dev`           | -22 -T0 | 71.85MB    | 7.11%         | 3.53 GB  | 99%  | 9m:05s     |
| `bsdiff`             | default | 111.69MB   | 11.04%        | 10.3 GB  | 99%  | 10m:01s    |
| `zstd-ldm_optimized` | -19 -T0 | 58.84MB    | 5.82%         | 2.68 GB  | 220% | 3m:49s     |
| `zstd-ldm_optimized` | -22 -T0 | 56.54MB    | 5.59%         | 3.53 GB  | 99%  | 12m:34s    |

**wordpress.tar (5.5 -> 5.5.1): ~80MB dst**
| Name               | Conf    | Patch Size | % of new file | Peak Mem | CPU% | Total Time |
|--------------------|---------|------------|---------------|----------|------|------------|
| `zstd-dev`           | -19 -T0 | 21.31KB    | 0.04%         | 174 MB   | 99%  | 9.8s       |
| `bsdiff`             | default | 13.67KB    | 0.03%         | 800 MB   | 99%  | 23.8s      |
| `zstd-ldm_optimized` | -19 -T0 | 18.94KB    | 0.04%         | 174 MB   | 99%  | 9.8s       |

**zstd.tar (1.4.4 -> 1.4.5): ~7MB dst**
| Name               | Conf    | Patch Size | % of new file | Peak Mem | CPU% | Total Time |
|--------------------|---------|------------|---------------|----------|------|------------|
| `zstd-dev`           | -19 -T0 | 91.13KB    | 1.12%         | 95 MB    | 99%  | 1.6s       |
| `bsdiff`             | default | 124.23KB   | 1.60%         | 83 MB    | 99%  | 2.3s       |
| `zstd-ldm_optimized` | -19 -T0 | 86.74KB    | 1.12%         | 95 MB    | 99%  | 1.6s       |

Of note is that using `-22 --ultra -T0` with `--patch-from` on actually can cause compressed size regressions on `dev`, compared to `-19 -T0`. This issue is no longer present this PR's branch, however.

## General compression benchmarks

The original goal of this PR was to show that there are no compressed size regression with using `--long` with the opt parser. We demonstrate that fact with the following benchmarks, and show that we can actually get some nice improvements in compression ratio too, particularly in scenarios where `--long` mode is meant to work well. The following results are the fastest of 5 runs.

**five_linux_kernels.tar (4.19.148, 5.4.68, 5.8.12, 5.9-rc7, 5.8.12) ~5GB = 5259889920 bytes**
| Name         | Conf                   | Size      | % of original | CPU% | Time    |
|--------------|------------------------|-----------|-----------------|------|---------|
| `zstd-dev` | -22 --zstd=wlog=30 -T0 | 232896847 | 4.43% | 471% | 14m:30s |
| `zstd-ldm_opt` | -22 --zstd=wlog=30 -T0 | 232896847 | 4.43% | 470% | 14m:31s |
| `zstd-dev` | -22 --long=30 -T0   | 185109024 | 3.52% | 340% | 9m:50s |
| `zstd-ldm_opt` |-22 --long=30 -T0 | 154324523 | 2.93% | 411%  | 12m:30s |

**two_linux_kernels.tar (5.8, 5.9-rc7): ~2GB**
| Name         | Conf                   | Size      | % of original | CPU% | Time    |
|--------------|------------------------|-----------|-----------------|------|---------|
| `zstd-dev`     | -22 --zstd=wlog=30 -T0 | 131944438 | 6.61%           | 195% | 10m:46s |
| `zstd-ldm_opt` | -22 --zstd=wlog=30 -T0 | 131944438 | 6.61%           | 195% | 10m:40s |
| `zstd-dev`     | -22 --long=30 -T0      | 123668734 | 6.20%           | 124% | 9m:32s  |
| `zstd-ldm_opt` | -22 --long=30 -T0      | 120585499 | 6.06%           | 163% | 10m:13s |
| `xz`           | -9 --extreme -T0       | 113720040 | 11.24%          | 951% | 3m:08s  |

`xz` at highest compression settings included here just for fun - it also uses ~8 GB memory compared to 4 GB of `zstd -22 --long=30` too. But it parallelizes the workload incredibly well.

**silesia.tar: ~200MB**

| Name         | Conf                   | Size     | Pct of original | CPU% | Time   |
|--------------|------------------------|----------|-----------------|------|--------|
| `zstd-dev`     | -22 --zstd=wlog=27 -T0 | 52701591 | 24.87%         | 100% | 98.23s |
| `zstd-ldm_opt` | -22 --zstd=wlog=27 -T0 | 52701591 |24.87%          | 100% | 98.87s |
| `zstd-dev`     | -22 --long=27 -T0      | 52777588 | 24.90%          | 100% | 102.23s |
| `zstd-ldm_opt` | -22 --long=27 -T0      | 52695282 | 24.86%          | 100% | 97.98s |

| Name         | Conf                   | Size     | Pct of original | CPU% | Time   |
|--------------|------------------------|----------|-----------------|------|--------|
| `zstd-dev`     | -19 --zstd=wlog=27 -T0 | 53058292 | 25.03%          | 100% | 74.78s |
| `zstd-ldm_opt` | -19 --zstd=wlog=27 -T0 | 53058292 | 25.03%          | 100% | 75.44s |
| `zstd-dev`     | -19 --long=27 -T0      | 53307862 | 25.15%          | 100% | 76.87s |
| `zstd-ldm_opt` | -19 --long=27 -T0      | 53032764 | 25.02%          | 100% | 74.42s |

| Name         | Conf                   | Size     | Pct of original | CPU% | Time   |
|--------------|------------------------|----------|-----------------|------|--------|
| `zstd-dev`     | -16 --zstd=wlog=23 -T0 | 55497790 | 26.18%          | 520% | 11.95s |
| `zstd-ldm_opt` | -16 --zstd=wlog=23 -T0 | 55497790 | 26.18%          | 520% | 12.07s |
| `zstd-dev`     | -16 --long=23 -T0      | 55892935 | 26.37%          | 284% | 18.01s |
| `zstd-ldm_opt` | -16 --long=23 -T0      | 55454265 | 26.16%          | 293% | 17.32s |

Particularly at higher levels (18+), there is virtually no difference in speed on `silesia.tar` when using `--long`, and a speed _gain_ on the concatenated linux kernels file. Not to mention the compression ratio gain. As such, it makes a strong argument for enabling `--long` by default on the highest levels.

### Testing

I've added some more unit tests in `playTests.sh` and a unit test in `fuzzer.c` for regressions, although I'm not sure if there might be weird cases where adding a long match candidate to the optimal parser would legitimately cause a compression ratio regression (and as a result, we shouldn't have these regression tests). Either way, it seems like ldm is already tested decently in `fuzzer.c`, so I don't think adding too many additional tests to verify correctness of compression/roundtrip-ability with ldm here would be that helpful. Letting this patch sit in a fuzzer for a bit might be a good idea though.
