### PR TITLE
Fix dll path in case of cross-compilation

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -197,10 +197,10 @@ libzstd.a: $(ZSTD_OBJ)
 
 ifneq (,$(filter Windows%,$(TARGET_SYSTEM)))
 
-LIBZSTD = dll\libzstd.dll
+LIBZSTD = dll/libzstd.dll
 $(LIBZSTD): $(ZSTD_FILES)
 	@echo compiling dynamic library $(LIBVER)
-	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--out-implib,dll\libzstd.dll.a -shared $^ -o $@
+	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--out-implib,dll/libzstd.dll.a -shared $^ -o $@
 
 else
 


### PR DESCRIPTION
The result of building lib under Windows Subsystem for Linux is dlllibzstd.dll in lib folder, not libzstd.dll in lib/dll as expected.

```
zstd/lib$ make CC=x86_64-w64-mingw32-gcc TARGET_SYSTEM=Windows_NT all
compiling dynamic library 1.4.5
x86_64-w64-mingw32-gcc ... -Wl,--out-implib,dll\libzstd.dll.a -shared ... -o dll\libzstd.dll

zstd/lib$ ls *.dll
dlllibzstd.dll
```

Seems like a slash instead of a backslash should work everywhere.