### PR TITLE
Reduce --long mode MT jobsize at higher levels

### DIFF
--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1193,7 +1193,7 @@ static unsigned ZSTDMT_computeTargetJobLog(const ZSTD_CCtx_params* params)
         /* In Long Range Mode, the windowLog is typically oversized.
          * In which case, it's preferable to determine the jobSize
          * based on cycleLog instead. */
-        jobLog = MAX(21, ZSTD_cycleLog(params->cParams.chainLog, params->cParams.strategy) + 4);
+        jobLog = MAX(21, ZSTD_cycleLog(params->cParams.chainLog, params->cParams.strategy) + 3);
     } else {
         jobLog = MAX(20, params->cParams.windowLog + 2);
     }

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1184,8 +1184,8 @@ static unsigned ZSTDMT_computeTargetJobLog(const ZSTD_CCtx_params* params)
     if (params->ldmParams.enableLdm) {
         /* In Long Range Mode, the windowLog is typically oversized.
          * In which case, it's preferable to determine the jobSize
-         * based on chainLog instead. */
-        jobLog = MAX(21, params->cParams.chainLog + 4);
+         * based on cycleLog instead. */
+        jobLog = MAX(21, ZSTD_cycleLog(params->cParams.chainLog, params->cParams.strategy) + 4);
     } else {
         jobLog = MAX(20, params->cParams.windowLog + 2);
     }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -897,7 +897,7 @@ static void FIO_adjustParamsForPatchFromMode(FIO_prefs_t* const prefs,
     if (fileWindowLog > ZSTD_WINDOWLOG_MAX)
         DISPLAYLEVEL(1, "Max window log exceeded by file (compression ratio will suffer)\n");
     comprParams->windowLog = MIN(ZSTD_WINDOWLOG_MAX, fileWindowLog);
-    if (fileWindowLog > ZSTD_cycleLog(cParams.hashLog, cParams.strategy)) {
+    if (fileWindowLog > ZSTD_cycleLog(cParams.chainLog, cParams.strategy)) {
         if (!prefs->ldmFlag)
             DISPLAYLEVEL(1, "long mode automatically triggered\n");
         FIO_setLdmFlag(prefs, 1);


### PR DESCRIPTION
Brought up in #2352. Since `cycleLog(chainLog)` is just `chainLog-1` if the compression strategy is `btlazy2` or higher. The effect of this change is that we use smaller jobsizes at higher compression levels with `--long`, allowing greater use of multithreading on files a few hundred megabytes large.

This PR also corrects an error in `FIO_adjustParamsForPatchFromMode()` related to `cycleLog()`.

| Conf        | dev, no `--long` | dev, `--long`: `MAX(21, chainLog+4)` | change_ldm_config, `--long`: `MAX(21, ZSTD_cycleLog(chainLog, strategy)+4` |
|-------------|------------------|--------------------------------------|----------------------------------------------------------------------|
| -22 wlog=27 | 29               | 30                                   | 30                                                                   |
| -19 wlog=27 | 29               | 28                                   | 27                                                                   |
| -19 wlog=23 | 25               | 28                                   | 27                                                                   |
| -16 wlog=23 | 25               | 26                                   | 25                                                                   |
| -13 wlog=22 | 24               | 25                                   | 24                                                                   |
| -11 wlog=22 | 24               | 25                                   | 25                                                                   |
| -11 wlog=27 | 29               | 25                                   | 25                                                                   |
| -9 wlog=21  | 23               | 23                                   | 23                                                                   |
| -7 wlog=21  | 23               | 23                                   | 23                                                                   |
| -3 wlog=21  | 23               | 21                                   | 21                                                                   |
| -3 wlog=27  | 29               | 21                                   | 21                                                                   |
| -1 wlog=19  | 21               | 21                                   | 21                                                                   |
| -1 wlog=22  | 25               | 21                                   | 21                                                                   |
| -1 wlog=27  | 29               | 21                                   | 21                                                                   |