### PR TITLE
Fix nondeterministic LDM behavior in multithreading

### DIFF
--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -154,6 +154,26 @@ static size_t ZSTD_ldm_countBackwardsMatch(
     return matchLength;
 }
 
+/** ZSTD_ldm_countBackwardsMatch_2segments() :
+ *  Returns the number of bytes that match backwards from pMatch,
+ *  even with the backwards match spanning 2 different segments.
+ *
+ *  On reaching `pMatchBase`, start counting from mEnd */
+static size_t ZSTD_ldm_countBackwardsMatch_2segments(
+            const BYTE* pIn, const BYTE* pAnchor,
+            const BYTE* pMatch, const BYTE* pMatchBase, const BYTE* mEnd)
+{
+    const BYTE* const vBegin = MAX(pIn - (pMatch - pMatchBase), pAnchor);
+    size_t const matchLength = ZSTD_ldm_countBackwardsMatch(pIn, vBegin, pMatch, pMatchBase);
+    if (pMatch - matchLength != pMatchBase) {
+        return matchLength;
+    }
+    DEBUGLOG(7, "ZSTD_ldm_countBackwardsMatch_2segments: found a 2-parts backwards match (current length==%zu)", matchLength);
+    DEBUGLOG(7, "distance from pMatch to start = %zi", pMatch - pMatchBase);
+    DEBUGLOG(7, "final backwards match length = %zu", matchLength + ZSTD_ldm_countBackwardsMatch(pIn - matchLength, pAnchor, mEnd, pMatchBase));
+    return matchLength + ZSTD_ldm_countBackwardsMatch(pIn - matchLength, pAnchor, mEnd, pMatchBase);
+}
+
 /** ZSTD_ldm_fillFastTables() :
  *
  *  Fills the relevant tables for the ZSTD_fast and ZSTD_dfast strategies.
@@ -329,8 +349,8 @@ static size_t ZSTD_ldm_generateSequences_internal(
                         continue;
                     }
                     curBackwardMatchLength =
-                        ZSTD_ldm_countBackwardsMatch(ip, anchor, pMatch,
-                                                     lowMatchPtr);
+                        ZSTD_ldm_countBackwardsMatch_2segments(ip, anchor, pMatch,
+                                                               lowMatchPtr, dictEnd);
                     curTotalMatchLength = curForwardMatchLength +
                                           curBackwardMatchLength;
                 } else { /* !extDict */


### PR DESCRIPTION
@terrelln is currently working on more robust nondeterminism tests. One of the failures that showed up was in the LDM. 

The investigation revelaed that the LDM backwards match counting causes the nondeterminism. Essentially, the backwards match counting function will stop if it reaches the beginning of the circular buffer. However, we shouldn't stop if we reach the beginning - we should keep counting from the very end of the circular buffer once we reach the beginning since the backwards match might continue from the back. Note that the forward match counter already has this functionality.

The tests are yet to be merged, but if you want to check it out you can observe that if you run:
```
git remote add terrelln https://github.com/terrelln/zstd
git fetch terrelln
git checkout T77290931
cd tests
make -j zstreamtest
./zstreamtest --newapi -s5992
```
it will fail.

If you apply this patch then run the tests, it will succeed.