### PR TITLE
[minor] Fix some /tests/fuzz Makefile annoyances

### DIFF
--- a/tests/fuzz/.gitignore
+++ b/tests/fuzz/.gitignore
@@ -13,7 +13,11 @@ simple_round_trip
 stream_decompress
 stream_round_trip
 zstd_frame_info
+decompress_dstSize_tooSmall
+fse_read_ncount
 fuzz-*.log
+rt_lib_*
+d_lib_*
 
 # misc
 trace

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -99,7 +99,7 @@ FUZZ_TARGETS :=       \
 	decompress_dstSize_tooSmall \
 	fse_read_ncount
 
-all: $(FUZZ_TARGETS)
+all: libregression.a $(FUZZ_TARGETS)
 
 rt_lib_common_%.o: $(ZSTDDIR)/common/%.c
 	$(CC) $(FUZZ_CPPFLAGS) $(FUZZ_CFLAGS) $(FUZZ_ROUND_TRIP_FLAGS) $< -c -o $@
@@ -209,12 +209,10 @@ regressiontest: corpora
 	$(PYTHON) ./fuzz.py regression all
 
 clean:
-	@$(RM) *.a *.o
-	@$(RM) simple_round_trip stream_round_trip simple_decompress \
-           stream_decompress block_decompress block_round_trip \
-           simple_compress dictionary_round_trip dictionary_decompress \
-           zstd_frame_info
+	@$(RM) *.a *.o $(FUZZ_TARGETS)
+	@echo Cleaning completed
 
 cleanall:
 	@$(RM) -r Fuzzer
 	@$(RM) -r corpora
+	@echo Cleaning completed


### PR DESCRIPTION
Using a clean checkout of zstd, running `make` in tests/fuzz/ will currently fail, apparently unless you also run `make regressiontest` beforehand. I'm no Makefile expert, but I usually expect `make` to just work. So, this PR does three things:

- Adds `libregression.a` to the build targets in `fuzz/Makefile`
- Make clean now properly removes all the fuzz build targets and prints the usual message
- .gitignore is updated to include all the appropriate build artifacts, as well as transient ones that might stick around if you abort in the middle of `make`.