### PR TITLE
Fix long distance matcher OSS-fuzz issue

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2374,7 +2374,11 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
     /* Assert that we have correctly flushed the ctx params into the ms's copy */
     ZSTD_assertEqualCParams(zc->appliedParams.cParams, ms->cParams);
     if (srcSize < MIN_CBLOCK_SIZE+ZSTD_blockHeaderSize+1) {
-        ZSTD_ldm_skipSequences(&zc->externSeqStore, srcSize, zc->appliedParams.cParams.minMatch);
+        if (zc->appliedParams.cParams.strategy >= ZSTD_btopt) {
+            ZSTD_ldm_skipRawSeqStoreBytes(&zc->externSeqStore, srcSize);
+        } else {
+            ZSTD_ldm_skipSequences(&zc->externSeqStore, srcSize, zc->appliedParams.cParams.minMatch);
+        }
         return ZSTDbss_noCompress; /* don't even attempt compression below a certain srcSize */
     }
     ZSTD_resetSeqStore(&(zc->seqStore));

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2853,6 +2853,7 @@ size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSe
     cctx->externSeqStore.size = nbSeq;
     cctx->externSeqStore.capacity = nbSeq;
     cctx->externSeqStore.pos = 0;
+    cctx->externSeqStore.posInSequence = 0;
     return 0;
 }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -555,10 +555,7 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
     return sequence;
 }
 
-/* ZSTD_ldm_skipRawSeqStoreBytes():
- * Moves forward in rawSeqStore by nbBytes, updating fields 'pos' and 'posInSequence'.
- */
-static void ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore_t* rawSeqStore, size_t nbBytes) {
+void ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore_t* rawSeqStore, size_t nbBytes) {
     U32 currPos = (U32)(rawSeqStore->posInSequence + nbBytes);
     while (currPos && rawSeqStore->pos < rawSeqStore->size) {
         rawSeq currSeq = rawSeqStore->seq[rawSeqStore->pos];

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -78,6 +78,12 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
 void ZSTD_ldm_skipSequences(rawSeqStore_t* rawSeqStore, size_t srcSize,
     U32 const minMatch);
 
+/* ZSTD_ldm_skipRawSeqStoreBytes():
+ * Moves forward in rawSeqStore by nbBytes, updating fields 'pos' and 'posInSequence'.
+ * Not to be used in conjunction with ZSTD_ldm_skipSequences().
+ * Must be called for data with is not passed to ZSTD_ldm_blockCompress().
+ */
+void ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore_t* rawSeqStore, size_t nbBytes);
 
 /** ZSTD_ldm_getTableSize() :
  *  Estimate the space needed for long distance matching tables or 0 if LDM is


### PR DESCRIPTION
#2341 introduced some issues in OSS-Fuzz. This PR fixes those issues.

The root cause was that sometimes we could begin an LDM compression job without having a "clean" `rawSeqStore` to begin with - i.e., the `posInSequence` value was not set to 0 during `ZSTD_referenceExternalSequences()`, which could cause the opt parser to integrate some LDMs that weren't in the right position.

Luckily, the blame PR already included an assert made debugging this much easier: `assert(optLdm->seqStore.posInSequence <= currSeq.litLength + currSeq.matchLength)`

Now, it's not entirely clear to me what the best way is to test/catch this specific case earlier - would appreciate any suggestions

1) I don't think `assert(pos == 0 && posInSequence == 0)` in the code that follows the call to `ZSTD_referenceExternalSequences()` is useful, since `ZSTD_referenceExternalSequences()` is a simple function that sets some values. For example, similar-ish functions like `ZSTD_CCtx_setParameter(zc, ZSTD_c_compressionLevel, cLevel)` doesn't expect a check/assert like `assert(zc->compressionLevel == cLevel)` after calling them, so that type of `assert()` doesn't seem so useful. 

Perhaps if there's some point/function in the compression codepath where we do a one-time validation of all parameters in the `cctx` prior to compressing, an assert like this could belong there? I couldn't find a particular place for that though.

2) It doesn't seem like a good idea to add a unit test that tests specifically for the input that caused this issue, cause then we'd have to apply that principle in general, and have unit tests for really specific inputs that might cause other issues, which would go on into infinity.

3) The MT-specific tests in `fuzzer.c` mostly deal with higher-level parameters, and `rawSeqStore.posInSequence` seems too low-level of a parameter to directly test (it is in `compress_internal.h` after all)