### PR TITLE
meson: Deny shared build on MSVC compiler

### DIFF
--- a/build/meson/contrib/pzstd/meson.build
+++ b/build/meson/contrib/pzstd/meson.build
@@ -19,9 +19,11 @@ pzstd_sources = [
   join_paths(zstd_rootdir, 'programs/util.c'),
 ]
 
+pzstd_cpp_args = cxx.get_supported_arguments([ '-DNDEBUG', '-Wno-shadow', '-pedantic' ])
+
 pzstd = executable('pzstd',
   pzstd_sources,
-  cpp_args: [ '-DNDEBUG', '-Wno-shadow', '-pedantic' ],
+  cpp_args: pzstd_cpp_args,
   include_directories: pzstd_includes,
   dependencies: [ libzstd_dep, thread_dep ],
   install: true)

--- a/build/meson/contrib/pzstd/meson.build
+++ b/build/meson/contrib/pzstd/meson.build
@@ -11,11 +11,14 @@ zstd_rootdir = '../../../..'
 
 pzstd_includes = include_directories(join_paths(zstd_rootdir, 'programs'),
   join_paths(zstd_rootdir, 'contrib/pzstd'))
-pzstd_sources = [join_paths(zstd_rootdir, 'programs/util.c'),
+pzstd_sources = [
   join_paths(zstd_rootdir, 'contrib/pzstd/main.cpp'),
   join_paths(zstd_rootdir, 'contrib/pzstd/Options.cpp'),
   join_paths(zstd_rootdir, 'contrib/pzstd/Pzstd.cpp'),
-  join_paths(zstd_rootdir, 'contrib/pzstd/SkippableFrame.cpp')]
+  join_paths(zstd_rootdir, 'contrib/pzstd/SkippableFrame.cpp'),
+  join_paths(zstd_rootdir, 'programs/util.c'),
+]
+
 pzstd = executable('pzstd',
   pzstd_sources,
   cpp_args: [ '-DNDEBUG', '-Wno-shadow', '-pedantic' ],

--- a/build/meson/lib/meson.build
+++ b/build/meson/lib/meson.build
@@ -77,8 +77,12 @@ endif
 libzstd_c_args = []
 if cc_id == compiler_msvc
   if default_library_type != 'static'
-    libzstd_sources += [windows_mod.compile_resources(
-      join_paths(zstd_rootdir, 'build/VS2010/libzstd-dll/libzstd-dll.rc'))]
+    libzstd_sources += [
+      windows_mod.compile_resources(
+        join_paths(zstd_rootdir, 'build/VS2010/libzstd-dll/libzstd-dll.rc'),
+        include_directories: include_directories(join_paths(zstd_rootdir, 'lib')),
+      )
+    ]
     libzstd_c_args += ['-DZSTD_DLL_EXPORT=1',
       '-DZSTD_HEAPMODE=0',
       '-D_CONSOLE',

--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -36,6 +36,10 @@ compiler_gcc = 'gcc'
 compiler_clang = 'clang'
 compiler_msvc = 'msvc'
 
+if cc_id == compiler_msvc
+  error('MSVC 2019 compiler is not supported and not tested in Zstd')
+endif
+
 zstd_version = meson.project_version()
 
 zstd_h_file = join_paths(meson.current_source_dir(), '../../lib/zstd.h')

--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -36,10 +36,6 @@ compiler_gcc = 'gcc'
 compiler_clang = 'clang'
 compiler_msvc = 'msvc'
 
-if cc_id == compiler_msvc
-  error('MSVC 2019 compiler is not supported and not tested in Zstd')
-endif
-
 zstd_version = meson.project_version()
 
 zstd_h_file = join_paths(meson.current_source_dir(), '../../lib/zstd.h')
@@ -88,6 +84,10 @@ feature_zlib = get_option('zlib')
 feature_lzma = get_option('lzma')
 feature_lz4 = get_option('lz4')
 
+if cc_id == compiler_msvc and default_library_type == 'shared'
+  error('Shared build for MSVC 2019 compiler is not tested by Zstd')
+endif
+
 # =============================================================================
 # Dependencies
 # =============================================================================
@@ -121,7 +121,7 @@ if [compiler_gcc, compiler_clang].contains(cc_id)
   add_project_arguments(cc_compile_flags, language : 'c')
   add_project_arguments(cxx_compile_flags, language : 'cpp')
 elif cc_id == compiler_msvc
-  msvc_compile_flags = [ '/D_UNICODE', '/DUNICODE' ]
+  msvc_compile_flags = [ '/D_UNICODE', '/DUNICODE', '/DNOMINMAX' ]
   if use_multi_thread
     msvc_compile_flags += '/MP'
   endif

--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -84,10 +84,6 @@ feature_zlib = get_option('zlib')
 feature_lzma = get_option('lzma')
 feature_lz4 = get_option('lz4')
 
-if cc_id == compiler_msvc and default_library_type == 'shared'
-  error('Shared build for MSVC 2019 compiler is not tested by Zstd')
-endif
-
 # =============================================================================
 # Dependencies
 # =============================================================================

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -51,8 +51,12 @@ endif
 
 if cc_id == compiler_msvc
   if default_library_type != 'static'
-    zstd_programs_sources += [windows_mod.compile_resources(
-      join_paths(zstd_rootdir, 'build/VS2010/zstd/zstd.rc'))]
+    zstd_programs_sources += [
+      windows_mod.compile_resources(
+        join_paths(zstd_rootdir, 'build/VS2010/zstd/zstd.rc'),
+        include_directories: include_directories(join_paths(zstd_rootdir, 'lib')),
+      )
+    ]
   endif
 endif
 

--- a/lib/common/xxhash.c
+++ b/lib/common/xxhash.c
@@ -459,7 +459,7 @@ FORCE_INLINE_TEMPLATE U64 XXH64_endian_align(const void* input, size_t len, U64 
 }
 
 
-XXH_PUBLIC_API unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
+XXHASH_DLL_PUBLIC XXH_PUBLIC_API unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
 {
 #if 0
     /* Simple version, good for code maintenance, but unfortunately slow for small inputs */

--- a/lib/common/xxhash.h
+++ b/lib/common/xxhash.h
@@ -88,6 +88,20 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 #  define XXH_PUBLIC_API   /* do nothing */
 #endif /* XXH_PRIVATE_API */
 
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define XXHASH_DLL_PUBLIC __attribute__ ((dllexport))
+  #else
+    #define XXHASH_DLL_PUBLIC __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+  #endif
+#else
+  #if __GNUC__ >= 4
+    #define XXHASH_DLL_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+    #define XXHASH_DLL_PUBLIC
+  #endif
+#endif
+
 /*!XXH_NAMESPACE, aka Namespace Emulation :
 
 If you want to include _and expose_ xxHash functions from within your own library,
@@ -141,7 +155,7 @@ typedef unsigned int       XXH32_hash_t;
 typedef unsigned long long XXH64_hash_t;
 
 XXH_PUBLIC_API XXH32_hash_t XXH32 (const void* input, size_t length, unsigned int seed);
-XXH_PUBLIC_API XXH64_hash_t XXH64 (const void* input, size_t length, unsigned long long seed);
+XXHASH_DLL_PUBLIC XXH_PUBLIC_API XXH64_hash_t XXH64 (const void* input, size_t length, unsigned long long seed);
 
 /*!
 XXH32() :

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1057,7 +1057,7 @@ ZSTD_clampCParams(ZSTD_compressionParameters cParams)
 
 /** ZSTD_cycleLog() :
  *  condition for correct operation : hashLog > 1 */
-U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat)
+ZSTD_COMPRESS_DLL_PUBLIC U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat)
 {
     U32 const btScale = ((U32)strat >= (U32)ZSTD_btlazy2);
     return hashLog - btScale;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -24,6 +24,20 @@
 #  include "zstdmt_compress.h"
 #endif
 
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ZSTD_COMPRESS_DLL_PUBLIC __attribute__ ((dllexport))
+  #else
+    #define ZSTD_COMPRESS_DLL_PUBLIC __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+  #endif
+#else
+  #if __GNUC__ >= 4
+    #define ZSTD_COMPRESS_DLL_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+    #define ZSTD_COMPRESS_DLL_PUBLIC
+  #endif
+#endif
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -1173,6 +1187,6 @@ size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSe
 
 /** ZSTD_cycleLog() :
  *  condition for correct operation : hashLog > 1 */
-U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat);
+ZSTD_COMPRESS_DLL_PUBLIC U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat);
 
 #endif /* ZSTD_COMPRESS_H */

--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -968,6 +968,12 @@ static size_t ZDICT_addEntropyTablesFromBuffer_advanced(
     return MIN(dictBufferCapacity, hSize+dictContentSize);
 }
 
+/* Hidden declaration for dbio.c */
+ZDICTLIB_API size_t ZDICT_trainFromBuffer_unsafe_legacy(
+                            void* dictBuffer, size_t maxDictSize,
+                            const void* samplesBuffer, const size_t* samplesSizes, unsigned nbSamples,
+                            ZDICT_legacy_params_t params);
+
 /*! ZDICT_trainFromBuffer_unsafe_legacy() :
 *   Warning : `samplesBuffer` must be followed by noisy guard band.
 *   @return : size of dictionary, or an error code which can be tested with ZDICT_isError()

--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -968,16 +968,11 @@ static size_t ZDICT_addEntropyTablesFromBuffer_advanced(
     return MIN(dictBufferCapacity, hSize+dictContentSize);
 }
 
-/* Hidden declaration for dbio.c */
-size_t ZDICT_trainFromBuffer_unsafe_legacy(
-                            void* dictBuffer, size_t maxDictSize,
-                            const void* samplesBuffer, const size_t* samplesSizes, unsigned nbSamples,
-                            ZDICT_legacy_params_t params);
 /*! ZDICT_trainFromBuffer_unsafe_legacy() :
 *   Warning : `samplesBuffer` must be followed by noisy guard band.
 *   @return : size of dictionary, or an error code which can be tested with ZDICT_isError()
 */
-size_t ZDICT_trainFromBuffer_unsafe_legacy(
+ZDICTLIB_API size_t ZDICT_trainFromBuffer_unsafe_legacy(
                             void* dictBuffer, size_t maxDictSize,
                             const void* samplesBuffer, const size_t* samplesSizes, unsigned nbSamples,
                             ZDICT_legacy_params_t params)


### PR DESCRIPTION
Apparently, zstd has never tested on MSVC 2019 and currently fall to build on that compiler.
It would make sense to gate Meson until there is proper support for that compiler.
cc #2358

This PR also fixes some minor correctness issues.