### PR TITLE
Enable LDM by default if window size >= 128MB and strategy uses opt parser

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1542,6 +1542,12 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 
     zc->isFirstBlock = 1;
 
+    if (params.cParams.strategy >= ZSTD_btopt && params.cParams.windowLog >= 27) {
+        /* Enable LDM by default for optimal parser and window size >= 128MB */
+        DEBUGLOG(4, "LDM enabled by default (window size >= 128MB, strategy >= btopt)");
+        params.ldmParams.enableLdm = 1;
+    }
+
     if (params.ldmParams.enableLdm) {
         /* Adjust long distance matching parameters */
         ZSTD_ldm_adjustParameters(&params.ldmParams, &params.cParams);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1542,7 +1542,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 
     zc->isFirstBlock = 1;
 
-    if (params.cParams.strategy >= ZSTD_btopt && params.cParams.windowLog >= 27) {
+    if (params.cParams.strategy >= ZSTD_btopt && params.cParams.windowLog >= 27 && params.nbWorkers == 0) {
         /* Enable LDM by default for optimal parser and window size >= 128MB */
         DEBUGLOG(4, "LDM enabled by default (window size >= 128MB, strategy >= btopt)");
         params.ldmParams.enableLdm = 1;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1552,12 +1552,6 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 
     zc->isFirstBlock = 1;
 
-    if (params.cParams.strategy >= ZSTD_btopt && params.cParams.windowLog >= 27 && params.nbWorkers == 0) {
-        /* Enable LDM by default for optimal parser and window size >= 128MB */
-        DEBUGLOG(4, "LDM enabled by default (window size >= 128MB, strategy >= btopt)");
-        params.ldmParams.enableLdm = 1;
-    }
-
     if (params.ldmParams.enableLdm) {
         /* Adjust long distance matching parameters */
         ZSTD_ldm_adjustParameters(&params.ldmParams, &params.cParams);
@@ -4194,6 +4188,11 @@ size_t ZSTD_compressStream2( ZSTD_CCtx* cctx,
                     dictSize, mode);
         }
 
+        if (params.cParams.strategy >= ZSTD_btopt && params.cParams.windowLog >= 27) {
+            /* Enable LDM by default for optimal parser and window size >= 128MB */
+            DEBUGLOG(4, "LDM enabled by default (window size >= 128MB, strategy >= btopt)");
+            params.ldmParams.enableLdm = 1;
+        }
 
 #ifdef ZSTD_MULTITHREAD
         if ((cctx->pledgedSrcSizePlusOne-1) <= ZSTDMT_JOBSIZE_MIN) {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -209,6 +209,16 @@ static ZSTD_CCtx_params ZSTD_makeCCtxParamsFromCParams(
     /* should not matter, as all cParams are presumed properly defined */
     ZSTD_CCtxParams_init(&cctxParams, ZSTD_CLEVEL_DEFAULT);
     cctxParams.cParams = cParams;
+
+    if (cParams.strategy >= ZSTD_btopt && cParams.windowLog >= 27 && cctxParams.nbWorkers == 0) {
+        DEBUGLOG(4, "ZSTD_makeCCtxParamsFromCParams(): Including LDM into cctx params");
+        cctxParams.ldmParams.enableLdm = 1;
+        /* LDM is enabled by default for optimal parser and window size >= 128MB */
+        ZSTD_ldm_adjustParameters(&cctxParams.ldmParams, &cParams);
+        assert(cctxParams.ldmParams.hashLog >= cctxParams.ldmParams.bucketSizeLog);
+        assert(cctxParams.ldmParams.hashRateLog < 32);
+    }
+
     assert(!ZSTD_checkCParams(cParams));
     return cctxParams;
 }

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1459,6 +1459,13 @@ size_t ZSTDMT_initCStream_internal(
 
     mtctx->params = params;
     mtctx->frameContentSize = pledgedSrcSize;
+
+    if (params.cParams.strategy >= ZSTD_btopt && params.cParams.windowLog >= 27) {
+        /* Enable LDM by default for optimal parser and window size >= 128MB */
+        DEBUGLOG(4, "LDM enabled by default (window size >= 128MB, strategy >= btopt)");
+        params.ldmParams.enableLdm = 1;
+    }
+
     if (dict) {
         ZSTD_freeCDict(mtctx->cdictLocal);
         mtctx->cdictLocal = ZSTD_createCDict_advanced(dict, dictSize,

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -1459,13 +1459,6 @@ size_t ZSTDMT_initCStream_internal(
 
     mtctx->params = params;
     mtctx->frameContentSize = pledgedSrcSize;
-
-    if (params.cParams.strategy >= ZSTD_btopt && params.cParams.windowLog >= 27) {
-        /* Enable LDM by default for optimal parser and window size >= 128MB */
-        DEBUGLOG(4, "LDM enabled by default (window size >= 128MB, strategy >= btopt)");
-        params.ldmParams.enableLdm = 1;
-    }
-
     if (dict) {
         ZSTD_freeCDict(mtctx->cdictLocal);
         mtctx->cdictLocal = ZSTD_createCDict_advanced(dict, dictSize,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -339,7 +339,9 @@ typedef enum {
                                      * for large inputs, by finding large matches at long distance.
                                      * It increases memory usage and window size.
                                      * Note: enabling this parameter increases default ZSTD_c_windowLog to 128 MB
-                                     * except when expressly set to a different value. */
+                                     * except when expressly set to a different value. 
+                                     * Note: will be enabled by default if ZSTD_c_windowLog >= 128 MB and
+                                     * compression strategy >= ZSTD_btopt (== compression level 16+) */
     ZSTD_c_ldmHashLog=161,   /* Size of the table for long distance matching, as a power of 2.
                               * Larger values increase memory usage and compression ratio,
                               * but decrease compression speed.

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1196,6 +1196,26 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3d : ldm conditionally enabled by default doesn't change cctx params: ", testNb++);
+    {   ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+        ZSTD_outBuffer out = {NULL, 0, 0};
+        ZSTD_inBuffer in = {NULL, 0, 0};
+        int value;
+
+        /* Even if LDM will be enabled by default in the applied params (since wlog >= 27 and strategy >= btopt),
+         * we should not modify the actual parameter specified by the user within the CCtx
+         */
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog, 27));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_strategy, ZSTD_btopt));
+
+        CHECK_Z(ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_continue));
+        CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_enableLongDistanceMatching, &value));
+        CHECK_EQ(value, 0);
+
+        ZSTD_freeCCtx(cctx);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     /* this test is really too long, and should be made faster */
     DISPLAYLEVEL(3, "test%3d : overflow protection with large windowLog : ", testNb++);
     {   ZSTD_CCtx* const cctx = ZSTD_createCCtx();


### PR DESCRIPTION
Since the LDM can no longer cause compressed size regressions, and at worst, is only a tiny bit slower than without LDM at `btopt+` compression strategies (benchmarks in #2341), let's enable long mode by default when the window size is greater than 128 MB and we're using the `btopt+` strategies.

It seems this is about as far upstream in the compression codepath as it makes sense to do this change, and even then, MT and single-thread have to be dealt with separately, and `ZSTD_makeCCtxParamsFromCParams()` must get updated as well.

Tests:
- Unit test included in `fuzzer.c` to ensure this doesn't modify the user's requested params in the `cctx`
- Tested locally to make sure that LDM gets enabled with the specified conditions.