### PR TITLE
Refine external ZSTD_Sequence API

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -341,23 +341,28 @@ MEM_STATIC size_t ZSTD_limitCopy(void* dst, size_t dstCapacity, const void* src,
 *  Private declarations
 *********************************************/
 typedef struct seqDef_s {
-    U32 offset;
+    U32 offset;         /* Offset code of the sequence */
     U16 litLength;
     U16 matchLength;
 } seqDef;
 
 typedef struct {
     seqDef* sequencesStart;
-    seqDef* sequences;
+    seqDef* sequences;      /* ptr to end of sequences */
     BYTE* litStart;
-    BYTE* lit;
+    BYTE* lit;              /* ptr to end of literals */
     BYTE* llCode;
     BYTE* mlCode;
     BYTE* ofCode;
     size_t maxNbSeq;
     size_t maxNbLit;
-    U32   longLengthID;   /* 0 == no longLength; 1 == Lit.longLength; 2 == Match.longLength; */
-    U32   longLengthPos;
+
+    /* longLengthPos and longLengthID to allow us to represent either a single litLength or matchLength
+     * in the seqStore that has a value larger than U16 (if it exists). To do so, we increment
+     * the existing value of the literal or match by 0x10000. 
+     */
+    U32   longLengthID;   /* 0 == no longLength; 1 == Represent the long literal; 2 == Represent the long match; */
+    U32   longLengthPos;  /* Index of the sequence to apply long length modification to */
 } seqStore_t;
 
 typedef struct {

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -359,7 +359,7 @@ typedef struct {
 
     /* longLengthPos and longLengthID to allow us to represent either a single litLength or matchLength
      * in the seqStore that has a value larger than U16 (if it exists). To do so, we increment
-     * the existing value of the literal or match by 0x10000. 
+     * the existing value of the litLength or matchLength by 0x10000. 
      */
     U32   longLengthID;   /* 0 == no longLength; 1 == Represent the long literal; 2 == Represent the long match; */
     U32   longLengthPos;  /* Index of the sequence to apply long length modification to */

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2506,11 +2506,11 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
 
     /* Insert last literals (if any exist) in the block as a sequence with ml == off == 0 */
     lastLLSize = seqStoreLiteralsSize - literalsRead;
-    if (lastLLSize) {
+    if (lastLLSize > 0) {
         outSeqs[i].litLength = lastLLSize;
         outSeqs[i].matchLength = outSeqs[i].offset = outSeqs[i].rep = 0;
+        seqStoreSeqSize++;
     }
-    
     zc->seqCollector.seqIndex += seqStoreSeqSize;
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2480,9 +2480,6 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
                 }
             }
             assert(repIdx >= -3);
-            /* Use default repcodes if repcode references an offset that doesn't exist yet 
-             * This can only occur within the first two sequences.
-             */
             outSeqs[i].offset = repIdx >= 0 ? outSeqs[repIdx].offset : repStartValue[-repIdx - 1];
             if (outSeqs[i].rep == 3 && outSeqs[i].litLength == 0) {
                 --outSeqs[i].offset;
@@ -2493,6 +2490,7 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
     }
 
     /* Insert last literals (if any exist) in the block as a sequence with ml == off == 0 */
+    assert(seqStoreLiteralsSize >= literalsRead);
     lastLLSize = seqStoreLiteralsSize - literalsRead;
     if (lastLLSize > 0) {
         outSeqs[i].litLength = lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2489,14 +2489,16 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
         literalsRead += outSeqs[i].litLength;
     }
 
-    /* Insert last literals (if any exist) in the block as a sequence with ml == off == 0 */
+    /* Insert last literals (if any exist) in the block as a sequence with ml == off == 0.
+     * If there are no last literals, then we'll emit (of: 0, ml: 0, ll: 0), which is a marker
+     * for the block boundary, according to the API.
+     */
     assert(seqStoreLiteralsSize >= literalsRead);
     lastLLSize = seqStoreLiteralsSize - literalsRead;
-    if (lastLLSize > 0) {
-        outSeqs[i].litLength = (U32)lastLLSize;
-        outSeqs[i].matchLength = outSeqs[i].offset = outSeqs[i].rep = 0;
-        seqStoreSeqSize++;
-    }
+    outSeqs[i].litLength = (U32)lastLLSize;
+    outSeqs[i].matchLength = outSeqs[i].offset = outSeqs[i].rep = 0;
+    seqStoreSeqSize++;
+
     zc->seqCollector.seqIndex += seqStoreSeqSize;
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2450,7 +2450,6 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
 
     ZSTD_Sequence* outSeqs = &zc->seqCollector.seqStart[zc->seqCollector.seqIndex];
     size_t i;
-    size_t position;
     int repIdx;
 
     assert(zc->seqCollector.seqIndex + 1 < zc->seqCollector.maxSequences);
@@ -2469,17 +2468,6 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
             }
         }
 
-       /* Repcode handling:
-        * See docs/format.md for more detail about repeat offset codes
-        * If litLength != 0:
-        *      rep == 1 --> offset == repeat_offset_1
-        *      rep == 2 --> offset == repeat_offset_2
-        *      rep == 3 --> offset == repeat_offset_3
-        * If litLength == 0:
-        *      rep == 1 --> offset == repeat_offset_2
-        *      rep == 2 --> offset == repeat_offset_3
-        *      rep == 3 --> offset == repeat_offset_1 - 1
-        */
         if (seqStoreSeqs[i].offset <= ZSTD_REP_NUM) {
             outSeqs[i].rep = seqStoreSeqs[i].offset;
             repIdx = (unsigned int)i - seqStoreSeqs[i].offset;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2574,6 +2574,7 @@ static size_t ZSTD_compressBlock_internal(ZSTD_CCtx* zc,
 
     if (zc->seqCollector.collectSequences) {
         ZSTD_copyBlockSequences(zc);
+        ZSTD_confirmRepcodesAndEntropyTables(zc);
         return 0;
     }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2493,7 +2493,7 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
     assert(seqStoreLiteralsSize >= literalsRead);
     lastLLSize = seqStoreLiteralsSize - literalsRead;
     if (lastLLSize > 0) {
-        outSeqs[i].litLength = lastLLSize;
+        outSeqs[i].litLength = (U32)lastLLSize;
         outSeqs[i].matchLength = outSeqs[i].offset = outSeqs[i].rep = 0;
         seqStoreSeqSize++;
     }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2456,7 +2456,6 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
     /* Ensure we have enough space for last literals "sequence" */
     assert(zc->seqCollector.maxSequences >= seqStoreSeqSize + 1);
     for (i = 0; i < seqStoreSeqSize; ++i) {
-        literalsRead += seqStoreSeqs[i].litLength;
         outSeqs[i].litLength = seqStoreSeqs[i].litLength;
         outSeqs[i].matchLength = seqStoreSeqs[i].matchLength + MINMATCH;
 
@@ -2487,6 +2486,7 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
         } else {
             outSeqs[i].offset = seqStoreSeqs[i].offset - ZSTD_REP_NUM;
         }
+        literalsRead += outSeqs[i].litLength;
     }
 
     /* Insert last literals (if any exist) in the block as a sequence with ml == off == 0 */

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2455,10 +2455,6 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
         outSeqs[i].litLength = seqStoreSeqs[i].litLength;
         outSeqs[i].matchLength = seqStoreSeqs[i].matchLength + MINMATCH;
 
-        /* matchLength and litLength are stored with U16. longLengthPos
-         * and longLengthID to allow us to represent a single litLength or matchLength
-         * in the seqStore that has a value larger than U16 (if it exists).
-         */
         if (i == seqStore->longLengthPos) {
             if (seqStore->longLengthID == 1) {
                 outSeqs[i].litLength += 0x10000;

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1115,7 +1115,7 @@ typedef struct ZSTD_CCtx_params_s ZSTD_CCtx_params;
 
 typedef struct {
     unsigned int offset;      /* The offset of the match.
-                               * If == 0, then represents a block of literals, determined by litLength
+                               * If == 0, then represents a section of literals of litLength size
                                */
 
     unsigned int litLength;   /* Literal length */
@@ -1278,7 +1278,8 @@ ZSTDLIB_API unsigned long long ZSTD_decompressBound(const void* src, size_t srcS
 ZSTDLIB_API size_t ZSTD_frameHeaderSize(const void* src, size_t srcSize);
 
 /*! ZSTD_getSequences() :
- * Extract sequences from the sequence store
+ * Extract sequences from the sequence store. Any last literals in the block will be represented as a sequence
+ * with offset == 0, matchLength == 0, litLength == last literals size.
  * zc can be used to insert custom compression params.
  * This function invokes ZSTD_compress2
  * @return : number of sequences extracted

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1143,7 +1143,7 @@ typedef struct {
                                *      rep == 2 --> offset == repeat_offset_3
                                *      rep == 3 --> offset == repeat_offset_1 - 1
                                * 
-                               * Note: This field is optional. ZSTD_getSequence() will calculate the value of
+                               * Note: This field is optional. ZSTD_getSequences() will calculate the value of
                                * 'rep', but repeat offsets do not necessarily need to be calculated from an external
                                * sequence provider's perspective.
                                */
@@ -1292,8 +1292,9 @@ ZSTDLIB_API unsigned long long ZSTD_decompressBound(const void* src, size_t srcS
 ZSTDLIB_API size_t ZSTD_frameHeaderSize(const void* src, size_t srcSize);
 
 /*! ZSTD_getSequences() :
- * Extract sequences from the sequence store. Any last literals in the block will be represented as a sequence
- * with offset == 0, matchLength == 0, litLength == last literals size.
+ * Extract sequences from the sequence store.
+ * Each block will end with a dummy sequence with offset == 0, matchLength == 0, and litLength == length of last literals.
+ * 
  * zc can be used to insert custom compression params.
  * This function invokes ZSTD_compress2
  * @return : number of sequences extracted

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1114,24 +1114,25 @@ ZSTDLIB_API size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 typedef struct ZSTD_CCtx_params_s ZSTD_CCtx_params;
 
 typedef struct {
-    unsigned int offset;  /* The offset of the match.
-                           * If == 0, then represents a block of literals, determined by litLength
-                           */
+    unsigned int offset;      /* The offset of the match.
+                              * If == 0, then represents a block of literals, determined by litLength
+                              */
 
     unsigned int litLength;   /* Literal length */
     unsigned int matchLength; /* Match length. */
-    unsigned int rep;     /* Represents which repeat offset is used. Ranges from [0, 3].
-                           * If rep == 0, then this sequence does not contain a repeat offset.
-                           * Otherwise:
-                           *  If litLength != 0:
-                           *      rep == 1 --> offset == repeat offset 1
-                           *      rep == 2 --> offset == repeat offset 2
-                           *      rep == 3 --> offset == repeat offset 3
-                           *  If litLength == 0:
-                           *      rep == 1 --> offset == repeat offset 2
-                           *      rep == 2 --> offset == repeat offset 3
-                           *      rep == 3 --> offset == repeat offset 1 - 1
-                           */
+    
+    unsigned int rep;         /* Represents which repeat offset is used. Ranges from [0, 3].
+                              * If rep == 0, then this sequence does not contain a repeat offset.
+                              * Otherwise:
+                              *  If litLength != 0:
+                              *      rep == 1 --> offset == repeat offset 1
+                              *      rep == 2 --> offset == repeat offset 2
+                              *      rep == 3 --> offset == repeat offset 3
+                              *  If litLength == 0:
+                              *      rep == 1 --> offset == repeat offset 2
+                              *      rep == 2 --> offset == repeat offset 3
+                              *      rep == 3 --> offset == repeat offset 1 - 1
+                              */
 } ZSTD_Sequence;
 
 typedef struct {

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1115,23 +1115,28 @@ typedef struct ZSTD_CCtx_params_s ZSTD_CCtx_params;
 
 typedef struct {
     unsigned int offset;      /* The offset of the match.
-                               * If == 0, then represents a section of literals of litLength size
+                               * If offset == 0 and matchLength == 0,
+                               * then this sequence represents last literals in the block of litLength size.
                                */
 
-    unsigned int litLength;   /* Literal length */
-    unsigned int matchLength; /* Match length. */
+    unsigned int litLength;   /* Literal length of the sequence. */
+    unsigned int matchLength; /* Match length of the sequence. */
+
+                              /* Note: Users of this API may provide a sequence with matchLength == litLength == offset == 0.
+                               * In this case, we will treat the "sequence" as a marker for a block boundary.
+                               */
     
     unsigned int rep;         /* Represents which repeat offset is used. Ranges from [0, 3].
                                * If rep == 0, then this sequence does not contain a repeat offset.
-                               * Otherwise:
+                               * If rep > 0:
                                *  If litLength != 0:
-                               *      rep == 1 --> offset == repeat offset 1
-                               *      rep == 2 --> offset == repeat offset 2
-                               *      rep == 3 --> offset == repeat offset 3
+                               *      rep == 1 --> offset == repeat_offset_1
+                               *      rep == 2 --> offset == repeat_offset_2
+                               *      rep == 3 --> offset == repeat_offset_3
                                *  If litLength == 0:
-                               *      rep == 1 --> offset == repeat offset 2
-                               *      rep == 2 --> offset == repeat offset 3
-                               *      rep == 3 --> offset == repeat offset 1 - 1
+                               *      rep == 1 --> offset == repeat_offset_2
+                               *      rep == 2 --> offset == repeat_offset_3
+                               *      rep == 3 --> offset == repeat_offset_1 - 1
                                */
 } ZSTD_Sequence;
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1114,21 +1114,24 @@ ZSTDLIB_API size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 typedef struct ZSTD_CCtx_params_s ZSTD_CCtx_params;
 
 typedef struct {
-    unsigned int matchPos; /* Match pos in dst */
-    /* If seqDef.offset > 3, then this is seqDef.offset - 3
-     * If seqDef.offset < 3, then this is the corresponding repeat offset
-     * But if seqDef.offset < 3 and litLength == 0, this is the
-     *   repeat offset before the corresponding repeat offset
-     * And if seqDef.offset == 3 and litLength == 0, this is the
-     *   most recent repeat offset - 1
-     */
-    unsigned int offset;
-    unsigned int litLength; /* Literal length */
-    unsigned int matchLength; /* Match length */
-    /* 0 when seq not rep and seqDef.offset otherwise
-     * when litLength == 0 this will be <= 4, otherwise <= 3 like normal
-     */
-    unsigned int rep;
+    unsigned int offset;  /* The offset of the match.
+                           * If == 0, then represents a block of literals, determined by litLength
+                           */
+
+    unsigned int litLength;   /* Literal length */
+    unsigned int matchLength; /* Match length. */
+    unsigned int rep;     /* Represents which repeat offset is used. Ranges from [0, 3].
+                           * If rep == 0, then this sequence does not contain a repeat offset.
+                           * Otherwise:
+                           *  If litLength != 0:
+                           *      rep == 1 --> offset == repeat offset 1
+                           *      rep == 2 --> offset == repeat offset 2
+                           *      rep == 3 --> offset == repeat offset 3
+                           *  If litLength == 0:
+                           *      rep == 1 --> offset == repeat offset 2
+                           *      rep == 2 --> offset == repeat offset 3
+                           *      rep == 3 --> offset == repeat offset 1 - 1
+                           */
 } ZSTD_Sequence;
 
 typedef struct {

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1115,24 +1115,24 @@ typedef struct ZSTD_CCtx_params_s ZSTD_CCtx_params;
 
 typedef struct {
     unsigned int offset;      /* The offset of the match.
-                              * If == 0, then represents a block of literals, determined by litLength
-                              */
+                               * If == 0, then represents a block of literals, determined by litLength
+                               */
 
     unsigned int litLength;   /* Literal length */
     unsigned int matchLength; /* Match length. */
     
     unsigned int rep;         /* Represents which repeat offset is used. Ranges from [0, 3].
-                              * If rep == 0, then this sequence does not contain a repeat offset.
-                              * Otherwise:
-                              *  If litLength != 0:
-                              *      rep == 1 --> offset == repeat offset 1
-                              *      rep == 2 --> offset == repeat offset 2
-                              *      rep == 3 --> offset == repeat offset 3
-                              *  If litLength == 0:
-                              *      rep == 1 --> offset == repeat offset 2
-                              *      rep == 2 --> offset == repeat offset 3
-                              *      rep == 3 --> offset == repeat offset 1 - 1
-                              */
+                               * If rep == 0, then this sequence does not contain a repeat offset.
+                               * Otherwise:
+                               *  If litLength != 0:
+                               *      rep == 1 --> offset == repeat offset 1
+                               *      rep == 2 --> offset == repeat offset 2
+                               *      rep == 3 --> offset == repeat offset 3
+                               *  If litLength == 0:
+                               *      rep == 1 --> offset == repeat offset 2
+                               *      rep == 2 --> offset == repeat offset 3
+                               *      rep == 3 --> offset == repeat offset 1 - 1
+                               */
 } ZSTD_Sequence;
 
 typedef struct {

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1114,20 +1114,25 @@ ZSTDLIB_API size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 typedef struct ZSTD_CCtx_params_s ZSTD_CCtx_params;
 
 typedef struct {
-    unsigned int offset;      /* The offset of the match.
-                               * If offset == 0 and matchLength == 0,
-                               * then this sequence represents last literals in the block of litLength size.
+    unsigned int offset;      /* The offset of the match. (NOT the same as the offset code)
+                               * If offset == 0 and matchLength == 0, this sequence represents the last
+                               * literals in the block of litLength size.
                                */
 
     unsigned int litLength;   /* Literal length of the sequence. */
     unsigned int matchLength; /* Match length of the sequence. */
 
                               /* Note: Users of this API may provide a sequence with matchLength == litLength == offset == 0.
-                               * In this case, we will treat the "sequence" as a marker for a block boundary.
+                               * In this case, we will treat the sequence as a marker for a block boundary.
                                */
     
-    unsigned int rep;         /* Represents which repeat offset is used. Ranges from [0, 3].
-                               * If rep == 0, then this sequence does not contain a repeat offset.
+    unsigned int rep;         /* Represents which repeat offset is represented by the field 'offset'.
+                               * Ranges from [0, 3].
+                               * 
+                               * Repeat offsets are essentially previous offsets from previous sequences sorted in
+                               * recency order. For more detail, see doc/zstd_compression_format.md
+                               * 
+                               * If rep == 0, then 'offset' does not contain a repeat offset.
                                * If rep > 0:
                                *  If litLength != 0:
                                *      rep == 1 --> offset == repeat_offset_1
@@ -1137,6 +1142,10 @@ typedef struct {
                                *      rep == 1 --> offset == repeat_offset_2
                                *      rep == 2 --> offset == repeat_offset_3
                                *      rep == 3 --> offset == repeat_offset_1 - 1
+                               * 
+                               * Note: This field is optional. ZSTD_getSequence() will calculate the value of
+                               * 'rep', but repeat offsets do not necessarily need to be calculated from an external
+                               * sequence provider's perspective.
                                */
 } ZSTD_Sequence;
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -310,22 +310,23 @@ static void FUZ_decodeSequences(BYTE* dst, ZSTD_Sequence* seqs, size_t seqsSize,
 {
     size_t i;
     size_t j;
-    for(i = 0; i < seqsSize - 1; ++i) {
-        assert(dst + seqs[i].litLength + seqs[i].matchLength < dst + size);
-        assert(src + seqs[i].litLength + seqs[i].matchLength < src + size);
+    for(i = 0; i < seqsSize; ++i) {
+        assert(dst + seqs[i].litLength + seqs[i].matchLength <= dst + size);
+        assert(src + seqs[i].litLength + seqs[i].matchLength <= src + size);
 
         memcpy(dst, src, seqs[i].litLength);
         dst += seqs[i].litLength;
         src += seqs[i].litLength;
         size -= seqs[i].litLength;
 
-        for (j = 0; j < seqs[i].matchLength; ++j)
-            dst[j] = dst[j - seqs[i].offset];
-        dst += seqs[i].matchLength;
-        src += seqs[i].matchLength;
-        size -= seqs[i].matchLength;
+        if (seqs[i].offset != 0) {
+            for (j = 0; j < seqs[i].matchLength; ++j)
+                dst[j] = dst[j - seqs[i].offset];
+            dst += seqs[i].matchLength;
+            src += seqs[i].matchLength;
+            size -= seqs[i].matchLength;
+        }
     }
-    memcpy(dst, src, size);
 }
 
 /*=============================================
@@ -2666,6 +2667,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         ZSTD_freeCCtx(cctx);
         free(seqs);
     }
+    DISPLAYLEVEL(3, "OK \n");
 
     /* Multiple blocks of zeros test */
     #define LONGZEROSLENGTH 1000000 /* 1MB of zeros */


### PR DESCRIPTION
This PR modifies the public-facing `ZSTD_Sequence` API. This will make it easier to integrate with the upcoming sequence compression API.

- Removes unnecessary field `matchPos` from `ZSTD_Sequence` and adjusts member `rep` to make more sense.
- Changes `ZSTD_getSequences()` to provide last literals (rather than ignoring them).
- Improves documentation regarding the `ZSTD_Sequence` as well as some internal definitions.
- Adjusts/fixes existing related unit tests.

Test Plan:
- Unit test for sequence extraction modified to suit new definitions
- Spot checking on multiple files that even with modifications, `ZSTD_getSequences()` outputs the exact same output, with the only difference being the value of 'rep' (we no longer allow `rep == 4`).