### PR TITLE
Add enum to define ZSTD_Sequence type and update sequence extraction API

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2550,7 +2550,7 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
 }
 
 size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
-    size_t outSeqsSize, const void* src, size_t srcSize)
+    size_t outSeqsSize, const void* src, size_t srcSize, ZSTD_sequenceFormat_e format)
 {
     const size_t dstCapacity = ZSTD_compressBound(srcSize);
     void* dst = ZSTD_customMalloc(dstCapacity, ZSTD_defaultCMem);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2562,6 +2562,7 @@ size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
     seqCollector.seqStart = outSeqs;
     seqCollector.seqIndex = 0;
     seqCollector.maxSequences = outSeqsSize;
+    seqCollector.format = format;
     zc->seqCollector = seqCollector;
 
     ZSTD_compress2(zc, dst, dstCapacity, src, srcSize);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2505,6 +2505,7 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
     for (i = 0; i < seqStoreSeqSize; ++i) {
         outSeqs[i].litLength = seqStoreSeqs[i].litLength;
         outSeqs[i].matchLength = seqStoreSeqs[i].matchLength + MINMATCH;
+        outSeqs[i].rep = 0;
 
         if (i == seqStore->longLengthPos) {
             if (seqStore->longLengthID == 1) {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2577,7 +2577,7 @@ size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
                 if (i != totalSeqs-1) {
                     /* Add last literals to next sequence, then "delete" this sequence */
                     seqCollector.seqStart[i+1].litLength += seqCollector.seqStart[i].litLength;
-                    memmove(seqCollector.seqStart+i, seqCollector.seqStart+i+1, (totalSeqs-i-1)*sizeof(ZSTD_Sequence));
+                    ZSTD_memmove(seqCollector.seqStart+i, seqCollector.seqStart+i+1, (totalSeqs-i-1)*sizeof(ZSTD_Sequence));
                 }
                 totalSeqs--;
             } else {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2570,7 +2570,7 @@ size_t ZSTD_generateSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
     return zc->seqCollector.seqIndex;
 }
 
-size_t ZSTD_mergeGeneratedSequences(ZSTD_Sequence* sequences, size_t seqsSize) {
+size_t ZSTD_mergeBlockDelimiters(ZSTD_Sequence* sequences, size_t seqsSize) {
     size_t in = 0;
     size_t out = 0;
     for (; in < seqsSize; ++in) {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2569,22 +2569,24 @@ size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
     ZSTD_customFree(dst, ZSTD_defaultCMem);
 
     if (format == ZSTD_sf_noBlockDelimiters) {
-        /* Merge the dummy block delimiters */
         size_t i = 0;
         size_t totalSeqs = zc->seqCollector.seqIndex;
-        for (; i < totalSeqs; ++i) {
+        while(i < totalSeqs) {
             if (seqCollector.seqStart[i].offset == 0 && seqCollector.seqStart[i].matchLength == 0) {
                 /* Merge the block boundary or last literals */
                 if (i != totalSeqs-1) {
                     /* Add last literals to next sequence, then "delete" this sequence */
                     seqCollector.seqStart[i+1].litLength += seqCollector.seqStart[i].litLength;
-                    memmove(seqCollector.seqStart+i, seqCollector.seqStart+i+1, (totalSeqs-i-1)*sizeof(ZSTD_sequence));
+                    memmove(seqCollector.seqStart+i, seqCollector.seqStart+i+1, (totalSeqs-i-1)*sizeof(ZSTD_Sequence));
                 }
                 totalSeqs--;
+            } else {
+                ++i;
             }
         }
         zc->seqCollector.seqIndex = totalSeqs;
     }
+    
     return zc->seqCollector.seqIndex;
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2562,7 +2562,6 @@ size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
     seqCollector.seqStart = outSeqs;
     seqCollector.seqIndex = 0;
     seqCollector.maxSequences = outSeqsSize;
-    seqCollector.format = format;
     zc->seqCollector = seqCollector;
 
     ZSTD_compress2(zc, dst, dstCapacity, src, srcSize);
@@ -2586,7 +2585,7 @@ size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
         }
         zc->seqCollector.seqIndex = totalSeqs;
     }
-    
+
     return zc->seqCollector.seqIndex;
 }
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2550,7 +2550,7 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
     zc->seqCollector.seqIndex += seqStoreSeqSize;
 }
 
-size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
+size_t ZSTD_generateSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
     size_t outSeqsSize, const void* src, size_t srcSize, ZSTD_sequenceFormat_e format)
 {
     const size_t dstCapacity = ZSTD_compressBound(srcSize);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2567,6 +2567,24 @@ size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
 
     ZSTD_compress2(zc, dst, dstCapacity, src, srcSize);
     ZSTD_customFree(dst, ZSTD_defaultCMem);
+
+    if (format == ZSTD_sf_noBlockDelimiters) {
+        /* Merge the dummy block delimiters */
+        size_t i = 0;
+        size_t totalSeqs = zc->seqCollector.seqIndex;
+        for (; i < totalSeqs; ++i) {
+            if (seqCollector.seqStart[i].offset == 0 && seqCollector.seqStart[i].matchLength == 0) {
+                /* Merge the block boundary or last literals */
+                if (i != totalSeqs-1) {
+                    /* Add last literals to next sequence, then "delete" this sequence */
+                    seqCollector.seqStart[i+1].litLength += seqCollector.seqStart[i].litLength;
+                    memmove(seqCollector.seqStart+i, seqCollector.seqStart+i+1, (totalSeqs-i-1)*sizeof(ZSTD_sequence));
+                }
+                totalSeqs--;
+            }
+        }
+        zc->seqCollector.seqIndex = totalSeqs;
+    }
     return zc->seqCollector.seqIndex;
 }
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -206,6 +206,7 @@ typedef struct {
     ZSTD_Sequence* seqStart;
     size_t seqIndex;
     size_t maxSequences;
+    ZSTD_sequenceFormat_e format;
 } SeqCollector;
 
 struct ZSTD_CCtx_params_s {

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -206,7 +206,6 @@ typedef struct {
     ZSTD_Sequence* seqStart;
     size_t seqIndex;
     size_t maxSequences;
-    ZSTD_sequenceFormat_e format;
 } SeqCollector;
 
 struct ZSTD_CCtx_params_s {

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1319,7 +1319,7 @@ typedef enum {
  */
 
 ZSTDLIB_API size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
-    size_t outSeqsSize, const void* src, size_t srcSize);
+    size_t outSeqsSize, const void* src, size_t srcSize, ZSTD_sequenceFormat_e format);
 
 
 /***************************************

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1304,23 +1304,29 @@ typedef enum {
 
 /*! ZSTD_getSequences() :
  * Extract sequences from the sequence store.
- * If invoked with ZSTD_sf_explicitBlockDelimiters, each block will end with a dummy sequence
- * with offset == 0, matchLength == 0, and litLength == length of last literals.
  * 
- * If invoked with ZSTD_sf_noBlockDelimiters, sequences will still be internally generated
- * on a per-block basis, but any last literals of a block will be merged into the
- * last literals of the first sequence in the next block.
- * As such, the final generated result has no explicit representation of block boundaries,
- * and the final last literals segment is not represented in the sequences.
+ * Each block will end with a dummy sequence
+ * with offset == 0, matchLength == 0, and litLength == length of last literals.
  * 
  * zc can be used to insert custom compression params.
  * This function invokes ZSTD_compress2
- * @return : number of sequences extracted
+ * @return : number of sequences generated
  */
 
 ZSTDLIB_API size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
-    size_t outSeqsSize, const void* src, size_t srcSize, ZSTD_sequenceFormat_e format);
+                       size_t outSeqsSize, const void* src, size_t srcSize);
 
+/*! ZSTD_mergeGeneratedSequences() :
+ * Convert an array of ZSTD_Sequence in the representation specified in ZSTD_getSequences()
+ * and merge all "dummy" sequences that represent last literals and block boundaries.
+ * 
+ * Any last literals in the block will be merged into the literals of the next sequence.
+ * 
+ * As such, the final generated result has no explicit representation of block boundaries,
+ * and the final last literals segment is not represented in the sequences.
+ * @return : number of sequences in final result
+ */
+ZSTDLIB_API size_t ZSTD_mergeGeneratedSequences(ZSTD_Sequence* sequences, size_t seqsSize);
 
 /***************************************
 *  Memory management

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1303,10 +1303,12 @@ typedef enum {
 } ZSTD_sequenceFormat_e;
 
 /*! ZSTD_generateSequences() :
- * Extract sequences from the sequence store.
+ * Generate sequences using ZSTD_compress2, given a source buffer.
  * 
  * Each block will end with a dummy sequence
  * with offset == 0, matchLength == 0, and litLength == length of last literals.
+ * litLength may be == 0, and if so, then the sequence of (of: 0 ml: 0 ll: 0)
+ * simply acts as a block delimiter.
  * 
  * zc can be used to insert custom compression params.
  * This function invokes ZSTD_compress2
@@ -1316,17 +1318,15 @@ typedef enum {
 ZSTDLIB_API size_t ZSTD_generateSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
                                           size_t outSeqsSize, const void* src, size_t srcSize);
 
-/*! ZSTD_mergeGeneratedSequences() :
- * Convert an array of ZSTD_Sequence in the representation specified in ZSTD_generateSequences()
- * and merge all "dummy" sequences that represent last literals and block boundaries.
- * 
- * Any last literals in the block will be merged into the literals of the next sequence.
+/*! ZSTD_mergeBlockDelimiters() :
+ * Given an array of ZSTD_Sequence, remove all sequences that represent block delimiters/last literals
+ * by merging them into into the literals of the next sequence.
  * 
  * As such, the final generated result has no explicit representation of block boundaries,
  * and the final last literals segment is not represented in the sequences.
- * @return : number of sequences in final result
+ * @return : number of sequences left after merging
  */
-ZSTDLIB_API size_t ZSTD_mergeGeneratedSequences(ZSTD_Sequence* sequences, size_t seqsSize);
+ZSTDLIB_API size_t ZSTD_mergeBlockDelimiters(ZSTD_Sequence* sequences, size_t seqsSize);
 
 /***************************************
 *  Memory management

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1298,16 +1298,16 @@ ZSTDLIB_API unsigned long long ZSTD_decompressBound(const void* src, size_t srcS
 ZSTDLIB_API size_t ZSTD_frameHeaderSize(const void* src, size_t srcSize);
 
 typedef enum {
-  ZSTD_sf_blockDelimiters = 0,
-  ZSTD_sf_noBlockDelimiters = 1,
+  ZSTD_sf_explicitBlockDelimiters = 0,  /* Representation of ZSTD_Sequence contains explicit block delimiters */
+  ZSTD_sf_noBlockDelimiters = 1,        /* Representation of ZSTD_Sequence has no block delimiters, sequences only */
 } ZSTD_sequenceFormat_e;
 
 /*! ZSTD_getSequences() :
  * Extract sequences from the sequence store.
- * If invoked with ZSTD_sf_blockDelimiters, block will end with a dummy sequence
+ * If invoked with ZSTD_sf_explicitBlockDelimiters, each block will end with a dummy sequence
  * with offset == 0, matchLength == 0, and litLength == length of last literals.
  * 
- * If invoked with ZSTD_sf_noBlockDelimiters, sequences will still be generated
+ * If invoked with ZSTD_sf_noBlockDelimiters, sequences will still be internally generated
  * on a per-block basis, but any last literals of a block will be merged into the
  * last literals of the first sequence in the next block.
  * As such, the final generated result has no explicit representation of block boundaries,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1298,8 +1298,8 @@ ZSTDLIB_API unsigned long long ZSTD_decompressBound(const void* src, size_t srcS
 ZSTDLIB_API size_t ZSTD_frameHeaderSize(const void* src, size_t srcSize);
 
 typedef enum {
-  ZSTD_sf_explicitBlockDelimiters = 0,  /* Representation of ZSTD_Sequence contains explicit block delimiters */
-  ZSTD_sf_noBlockDelimiters = 1,        /* Representation of ZSTD_Sequence has no block delimiters, sequences only */
+  ZSTD_sf_explicitBlockDelimiters,  /* Representation of ZSTD_Sequence contains explicit block delimiters */
+  ZSTD_sf_noBlockDelimiters         /* Representation of ZSTD_Sequence has no block delimiters, sequences only */
 } ZSTD_sequenceFormat_e;
 
 /*! ZSTD_getSequences() :

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1309,9 +1309,9 @@ typedef enum {
  * 
  * If invoked with ZSTD_sf_noBlockDelimiters, sequences will still be generated
  * on a per-block basis, but any last literals of a block will be merged into the
- * last literals of the first sequence in the next block with the exception of the
- * final segment of last literals. As such, the final generated result has no
- * explicit representation of block boundaries.
+ * last literals of the first sequence in the next block.
+ * As such, the final generated result has no explicit representation of block boundaries,
+ * and the final last literals segment is not represented in the sequences.
  * 
  * zc can be used to insert custom compression params.
  * This function invokes ZSTD_compress2

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1297,14 +1297,27 @@ ZSTDLIB_API unsigned long long ZSTD_decompressBound(const void* src, size_t srcS
  *           or an error code (if srcSize is too small) */
 ZSTDLIB_API size_t ZSTD_frameHeaderSize(const void* src, size_t srcSize);
 
+typedef enum {
+  ZSTD_sf_blockDelimiters = 0,
+  ZSTD_sf_noBlockDelimiters = 1,
+} ZSTD_sequenceFormat_e;
+
 /*! ZSTD_getSequences() :
  * Extract sequences from the sequence store.
- * Each block will end with a dummy sequence with offset == 0, matchLength == 0, and litLength == length of last literals.
+ * If invoked with ZSTD_sf_blockDelimiters, block will end with a dummy sequence
+ * with offset == 0, matchLength == 0, and litLength == length of last literals.
+ * 
+ * If invoked with ZSTD_sf_noBlockDelimiters, sequences will still be generated
+ * on a per-block basis, but any last literals of a block will be merged into the
+ * last literals of the first sequence in the next block with the exception of the
+ * final segment of last literals. As such, the final generated result has no
+ * explicit representation of block boundaries.
  * 
  * zc can be used to insert custom compression params.
  * This function invokes ZSTD_compress2
  * @return : number of sequences extracted
  */
+
 ZSTDLIB_API size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
     size_t outSeqsSize, const void* src, size_t srcSize);
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1149,7 +1149,7 @@ typedef struct {
                                *      rep == 2 --> offset == repeat_offset_3
                                *      rep == 3 --> offset == repeat_offset_1 - 1
                                * 
-                               * Note: This field is optional. ZSTD_getSequences() will calculate the value of
+                               * Note: This field is optional. ZSTD_generateSequences() will calculate the value of
                                * 'rep', but repeat offsets do not necessarily need to be calculated from an external
                                * sequence provider's perspective.
                                */
@@ -1302,7 +1302,7 @@ typedef enum {
   ZSTD_sf_noBlockDelimiters         /* Representation of ZSTD_Sequence has no block delimiters, sequences only */
 } ZSTD_sequenceFormat_e;
 
-/*! ZSTD_getSequences() :
+/*! ZSTD_generateSequences() :
  * Extract sequences from the sequence store.
  * 
  * Each block will end with a dummy sequence
@@ -1313,11 +1313,11 @@ typedef enum {
  * @return : number of sequences generated
  */
 
-ZSTDLIB_API size_t ZSTD_getSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
-                       size_t outSeqsSize, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_generateSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
+                                          size_t outSeqsSize, const void* src, size_t srcSize);
 
 /*! ZSTD_mergeGeneratedSequences() :
- * Convert an array of ZSTD_Sequence in the representation specified in ZSTD_getSequences()
+ * Convert an array of ZSTD_Sequence in the representation specified in ZSTD_generateSequences()
  * and merge all "dummy" sequences that represent last literals and block boundaries.
  * 
  * Any last literals in the block will be merged into the literals of the next sequence.

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2725,8 +2725,8 @@ static int basicUnitTests(U32 const seed, double compressibility)
         RDG_genBuffer(CNBuffer, srcSize, 0.03, 0., seed);
 
         /* Test with block delimiters roundtrip */
-        seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_blockDelimiters);
-        FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_blockDelimiters);
+        seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);
+        FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);
         assert(!memcmp(CNBuffer, compressedBuffer, srcSize));
 
         /* Test no block delimiters roundtrip */

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2722,7 +2722,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         assert(cctx != NULL);
 
         /* Populate src with random data */
-        RDG_genBuffer(CNBuffer, srcSize, 0.03, 0., seed);
+        RDG_genBuffer(CNBuffer, srcSize, compressibility, 0., seed);
 
         /* Test with block delimiters roundtrip */
         seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2718,7 +2718,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         RDG_genBuffer(CNBuffer, srcSize, compressibility, 0., seed);
 
         /* get the sequences */
-        seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize);
+        seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_blockDelimiters);
 
         /* "decode" and compare the sequences */
         FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2725,12 +2725,12 @@ static int basicUnitTests(U32 const seed, double compressibility)
         RDG_genBuffer(CNBuffer, srcSize, compressibility, 0., seed);
 
         /* Test with block delimiters roundtrip */
-        seqsSize = ZSTD_generateSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);
+        seqsSize = ZSTD_generateSequences(cctx, seqs, srcSize, src, srcSize);
         FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);
         assert(!memcmp(CNBuffer, compressedBuffer, srcSize));
 
         /* Test no block delimiters roundtrip */
-        seqsSize = ZSTD_generateSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_noBlockDelimiters);
+        seqsSize = ZSTD_mergeBlockDelimiters(seqs, seqsSize);
         FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_noBlockDelimiters);
         assert(!memcmp(CNBuffer, compressedBuffer, srcSize));
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -305,13 +305,17 @@ static int FUZ_mallocTests(unsigned seed, double compressibility, unsigned part)
 
 #endif
 
-static void FUZ_decodeSequences(BYTE* dst, ZSTD_Sequence* seqs, size_t seqsSize, BYTE* src, size_t size)
+static void FUZ_decodeSequences(BYTE* dst, ZSTD_Sequence* seqs, size_t seqsSize,
+                                BYTE* src, size_t size, ZSTD_sequenceFormat_e format)
 {
     size_t i;
     size_t j;
     for(i = 0; i < seqsSize; ++i) {
         assert(dst + seqs[i].litLength + seqs[i].matchLength <= dst + size);
         assert(src + seqs[i].litLength + seqs[i].matchLength <= src + size);
+        if (format == ZSTD_sf_noBlockDelimiters) {
+            assert(seqs[i].matchLength != 0 || seqs[i].offset != 0);
+        }
 
         memcpy(dst, src, seqs[i].litLength);
         dst += seqs[i].litLength;
@@ -325,6 +329,9 @@ static void FUZ_decodeSequences(BYTE* dst, ZSTD_Sequence* seqs, size_t seqsSize,
             src += seqs[i].matchLength;
             size -= seqs[i].matchLength;
         }
+    }
+    if (format == ZSTD_sf_noBlockDelimiters) {
+        memcpy(dst, src, size);
     }
 }
 
@@ -2703,7 +2710,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
     DISPLAYLEVEL(3, "test%3i : ZSTD_getSequences decode from sequences test : ", testNb++);
     {
-        size_t srcSize = 100 KB;
+        size_t srcSize = 150 KB;
         BYTE* src = (BYTE*)CNBuffer;
         BYTE* decoded = (BYTE*)compressedBuffer;
 
@@ -2715,13 +2722,16 @@ static int basicUnitTests(U32 const seed, double compressibility)
         assert(cctx != NULL);
 
         /* Populate src with random data */
-        RDG_genBuffer(CNBuffer, srcSize, compressibility, 0., seed);
+        RDG_genBuffer(CNBuffer, srcSize, 0.03, 0., seed);
 
-        /* get the sequences */
+        /* Test with block delimiters roundtrip */
         seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_blockDelimiters);
+        FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_blockDelimiters);
+        assert(!memcmp(CNBuffer, compressedBuffer, srcSize));
 
-        /* "decode" and compare the sequences */
-        FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize);
+        /* Test no block delimiters roundtrip */
+        seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_noBlockDelimiters);
+        FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_noBlockDelimiters);
         assert(!memcmp(CNBuffer, compressedBuffer, srcSize));
 
         ZSTD_freeCCtx(cctx);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2708,7 +2708,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         DISPLAYLEVEL(3, "OK \n");
     }
 
-    DISPLAYLEVEL(3, "test%3i : ZSTD_getSequences decode from sequences test : ", testNb++);
+    DISPLAYLEVEL(3, "test%3i : ZSTD_generateSequences decode from sequences test : ", testNb++);
     {
         size_t srcSize = 150 KB;
         BYTE* src = (BYTE*)CNBuffer;
@@ -2725,12 +2725,12 @@ static int basicUnitTests(U32 const seed, double compressibility)
         RDG_genBuffer(CNBuffer, srcSize, compressibility, 0., seed);
 
         /* Test with block delimiters roundtrip */
-        seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);
+        seqsSize = ZSTD_generateSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);
         FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_explicitBlockDelimiters);
         assert(!memcmp(CNBuffer, compressedBuffer, srcSize));
 
         /* Test no block delimiters roundtrip */
-        seqsSize = ZSTD_getSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_noBlockDelimiters);
+        seqsSize = ZSTD_generateSequences(cctx, seqs, srcSize, src, srcSize, ZSTD_sf_noBlockDelimiters);
         FUZ_decodeSequences(decoded, seqs, seqsSize, src, srcSize, ZSTD_sf_noBlockDelimiters);
         assert(!memcmp(CNBuffer, compressedBuffer, srcSize));
 


### PR DESCRIPTION
Currently, `ZSTD_getSequences()` emits an array of sequences with delimiters (in the form of sequences with `offset = 0, matchLength = 0` for block boundaries and last literals. We add the capability to emit sequences in a more "raw" form with no explicit block boundaries or last literals. 

This will be a "mode" of `ZSTD_Sequence` that the sequence compression API must be able to handle, so we should add the capability to extract sequences in this format via `ZSTD_getSequences()`.

This PR:
- Adds a new enum type to `zstd.h` that defines modes of sequence extracting/ingestion
- Extends the `ZSTD_getSequences()` function to support the new mode
- Updates the relevant docs

Test Plan:
- Include new mode in `fuzzer.c` unit test.
- Manual spot checking to ensure that output looks as expected.