### PR TITLE
Improve repcode handling in sequence extraction API

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2497,7 +2497,6 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
 
     ZSTD_Sequence* outSeqs = &zc->seqCollector.seqStart[zc->seqCollector.seqIndex];
     size_t i;
-    int repIdx;
     U32 rep[ZSTD_REP_NUM];
     U32 shouldUpdateRep;
 
@@ -2561,8 +2560,9 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
         }
         outSeqs[i].offset = rawOffset;
         if (shouldUpdateRep) {
-            for (int i = ZSTD_REP_NUM - 1; i > 0; i--) {
-                rep[i] = rep[i - 1];
+            int j;
+            for (j = ZSTD_REP_NUM - 1; j > 0; j--) {
+                rep[j] = rep[j - 1];
             }
             rep[0] = outSeqs[i].offset;
         }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2503,7 +2503,8 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
     assert(zc->seqCollector.seqIndex + 1 < zc->seqCollector.maxSequences);
     /* Ensure we have enough space for last literals "sequence" */
     assert(zc->seqCollector.maxSequences >= seqStoreSeqSize + 1);
-    ZSTD_memcpy(rep, repStartValue, ZSTD_REP_NUM * sizeof(U32));
+    ZSTD_memcpy(rep, zc->blockState.prevCBlock->rep, ZSTD_REP_NUM * sizeof(U32));
+    DEBUGLOG(2, "%u %u %u", rep[0], rep[1], rep[2]);
 
     for (i = 0; i < seqStoreSeqSize; ++i) {
         U32 rawOffset = seqStoreSeqs[i].offset - ZSTD_REP_NUM;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2522,6 +2522,7 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
 
         /* Derive the correct offset from the repcode in seqStore_t */
         if (seqStoreSeqs[i].offset <= ZSTD_REP_NUM) {
+            outSeqs[i].rep = seqStoreSeqs[i].offset;
             if (seqStoreSeqs[i].litLength != 0) {
                 if (seqStoreSeqs[i].offset == 1) {
                     shouldUpdateRep = 0;
@@ -2537,12 +2538,10 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
                 } else if (seqStoreSeqs[i].offset == 3) {
                     rawOffset = rep[2];
                 }
-                outSeqs[i].rep = seqStoreSeqs[i].offset;
             } else {
                 /* Litlength == 0 is a special case for repcode handling */
                 if (seqStoreSeqs[i].offset == 1) {
                     U32 tmp;
-                    outSeqs[i].rep = 1;
                     rawOffset = rep[1];
                     /* Swap ranks of rep[0] and rep[1] */
                     tmp = rep[0];
@@ -2550,10 +2549,8 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
                     rep[1] = tmp;
                     shouldUpdateRep = 0;
                 } else if (seqStoreSeqs[i].offset == 2) {
-                    outSeqs[i].rep = 2;
                     rawOffset = rep[2];
                 } else if (seqStoreSeqs[i].offset == 3) {
-                    outSeqs[i].rep = 1;
                     rawOffset = rep[0] - 1;
                 }
             }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2721,7 +2721,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
         if (seqs == NULL) goto _output_error;
         assert(cctx != NULL);
-
+        ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 19);
         /* Populate src with random data */
         RDG_genBuffer(CNBuffer, srcSize, compressibility, 0.5, seed);
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2723,7 +2723,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         assert(cctx != NULL);
 
         /* Populate src with random data */
-        RDG_genBuffer(CNBuffer, srcSize, compressibility, 0., seed);
+        RDG_genBuffer(CNBuffer, srcSize, compressibility, 0.5, seed);
 
         /* Test with block delimiters roundtrip */
         seqsSize = ZSTD_generateSequences(cctx, seqs, srcSize, src, srcSize);


### PR DESCRIPTION
The repcode handling logic was slightly off in the original version of this API - this PR aims to fix it by: 1) Keeping track of a dedicated repcode array, and 2) Persist the repcodes array through each block. I've aimed to make the handling logic as clear to read as possible since we will need a similar process in the sequence compression API.

Test Plan:
- Manual spot checking (roundtrips silesia.tar with compression api)
- Modify the unit test. Previously, it turns out that setting the `litProbability` field to something like 0.5 in the `RDG_genBuffer()` function would almost always cause the unit test to fail. With this PR, it no longer does.