### PR TITLE
10x speedup for ZSTD_isRLE()

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2590,7 +2590,7 @@ size_t ZSTD_mergeBlockDelimiters(ZSTD_Sequence* sequences, size_t seqsSize) {
 static int ZSTD_isRLE(const BYTE* src, size_t length) {
     const BYTE* ip = src;
     const BYTE value = ip[0];
-    const size_t valueST = value * 0x0101010101010101ULL;
+    const size_t valueST = (size_t)((U64)value * 0x0101010101010101ULL);
     const size_t unrollSize = sizeof(size_t) * 4;
     const size_t unrollMask = unrollSize - 1;
     const size_t prefixLength = length & unrollMask;


### PR DESCRIPTION
Clickbait title, but I noticed that `ZSTD_isRLE()` is unoptimized. @terrelln suggested unrolling the loop and showed me an unrolled version of `ZSTD_isRLE()` that's much faster (most of the code here he wrote!), and I've made some minor tweaks.

Using `fullbench.c` to do a microbenchmark on just the function with a buffer of all 0:
Raw input: 1000 bytes 
Old version: ~3700MB/s
New version: ~35000MB/s

Raw input: 100000 bytes
Old version: ~4500MB/s
New version: ~45000MB/s

And actual compression:
When compressing a file of all 'a', 150K, compression level 1:
Old version: ~10000MB/s
New version: ~14000MB/s

When compressing a file of all 'a', 7MB, compression level 1:
Old version: ~3000MB/s
New version: ~11000MB/s

These not really realistic files, but as expected, compression speed is a bit better on files that are just 1 character. This PR will mostly be useful because it should speed up ASAN a lot on cases that would time out in the sequence compression fuzzer.