### PR TITLE
[OSS-Fuzz] Make sequence compression fuzzer's generated minmatch to be same as CCtx's minmatch

### DIFF
--- a/tests/fuzz/sequence_compression_api.c
+++ b/tests/fuzz/sequence_compression_api.c
@@ -198,6 +198,7 @@ static size_t roundTripTest(void *result, size_t resultCapacity,
     ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, 0);
     ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, cLevel);
     ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog, wLog);
+    ZSTD_CCtx_setParameter(cctx, ZSTD_c_minMatch, ZSTD_MINMATCH_MIN);
     /* TODO: Add block delim mode fuzzing */
     ZSTD_CCtx_setParameter(cctx, ZSTD_c_blockDelimiters, ZSTD_sf_noBlockDelimiters);
     if (hasDict) {


### PR DESCRIPTION
OSS Fuzz found an issue with the sequence compression API. Root cause is in the fuzzer's sequence generator itself.

The sequence generator can generate match lengths between `ZSTD_MINMATCH_MIN` and some maximum allowable matchlength. However, at compression time, the value of `cParams.minMatch` will change depending on the `cctx` generated. 

So, prior to this change, it could have been the case that the fuzzer's sequence generator could generate matches of length `ZSTD_MINMATCH_MIN`, while than the actual value of `cParams.minMatch` in the cctx could be higher, which could cause issues further down the line (since the `seqStore::maxNbSeq` is sized partially based on the size of `minMatch).

By always setting the value of `minMatch` in the `cctx` to the same as what the sequence generator is generating, we ensure that the `cctx` doesn't have some invalid derived settings. 

I believe this is also a better approach than changing the minimum match values that the sequence generator can generate, since 1) the `minMatch` is set at compression time when the cctx is transparently initialized, and 2) we want the sequence generator to generate the full range of matchlengths, even when the compression level is low enough that we typically wouldn't generate such small matches, modelling the case where someone has a low compression level, but manually reduces `ZSTD_c_minMatch`.

Validated that this change fixes the OSS-Fuzz issue.