### PR TITLE
Update cmake_minimum_required to 2.8.12

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -7,7 +7,7 @@
 # in the COPYING file in the root directory of this source tree).
 # ################################################################
 
-cmake_minimum_required(VERSION 2.8.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
   
 # As of 2018-12-26 ZSTD has been validated to build with cmake version 3.13.2 new policies. 
 # Set and use the newest cmake policies that are validated to work 


### PR DESCRIPTION
This has to do with a deprecated policy with the recent release of cmake 3.19.1. A policy about `INTERFACE_LINK_LIBRARIES` has been deprecated for versions `< 2.8.12`. The deprecation will produce warnings if an older version is used, or the policy is set to `OLD`. 

More info about the deprecated policy:
https://cmake.org/cmake/help/latest/policy/CMP0022.html

Signed-off-by: Stephen Brawner <brawner@gmail.com>