### PR TITLE
[linux] Add the linux wrapper API

### DIFF
--- a/contrib/linux-kernel/Makefile
+++ b/contrib/linux-kernel/Makefile
@@ -63,15 +63,8 @@ import: libzstd
 	cp -r linux/lib/zstd $(LINUX)/lib
 
 import-upstream:
-	rm -f $(LINUX)/include/linux/zstd.h
-	rm -f $(LINUX)/include/linux/zstd_errors.h
 	rm -rf $(LINUX)/lib/zstd
 	mkdir $(LINUX)/lib/zstd
-	cp linux_zstd.h $(LINUX)/include/linux/zstd.h
-	cp zstd_compress_module.c $(LINUX)/lib/zstd
-	cp zstd_decompress_module.c $(LINUX)/lib/zstd
-	cp decompress_sources.h $(LINUX)/lib/zstd
-	cp linux.mk $(LINUX)/lib/zstd/Makefile
 	cp ../../lib/zstd.h $(LINUX)/lib/zstd
 	cp -r ../../lib/common $(LINUX)/lib/zstd
 	cp -r ../../lib/compress $(LINUX)/lib/zstd

--- a/contrib/linux-kernel/Makefile
+++ b/contrib/linux-kernel/Makefile
@@ -62,6 +62,25 @@ import: libzstd
 	cp linux/include/linux/zstd.h $(LINUX)/include/linux
 	cp -r linux/lib/zstd $(LINUX)/lib
 
+import-upstream:
+	rm -f $(LINUX)/include/linux/zstd.h
+	rm -f $(LINUX)/include/linux/zstd_errors.h
+	rm -rf $(LINUX)/lib/zstd
+	mkdir $(LINUX)/lib/zstd
+	cp linux_zstd.h $(LINUX)/include/linux/zstd.h
+	cp zstd_compress_module.c $(LINUX)/lib/zstd
+	cp zstd_decompress_module.c $(LINUX)/lib/zstd
+	cp decompress_sources.h $(LINUX)/lib/zstd
+	cp linux.mk $(LINUX)/lib/zstd/Makefile
+	cp ../../lib/zstd.h $(LINUX)/lib/zstd
+	cp -r ../../lib/common $(LINUX)/lib/zstd
+	cp -r ../../lib/compress $(LINUX)/lib/zstd
+	cp -r ../../lib/decompress $(LINUX)/lib/zstd
+	rm $(LINUX)/lib/zstd/common/threading.*
+	rm $(LINUX)/lib/zstd/common/pool.*
+	rm $(LINUX)/lib/zstd/common/xxhash.*
+	rm $(LINUX)/lib/zstd/compress/zstdmt_*
+
 .PHONY: test
 test: libzstd
 	$(MAKE) -C test run-test CFLAGS="-O3 $(CFLAGS)" -j

--- a/contrib/linux-kernel/Makefile
+++ b/contrib/linux-kernel/Makefile
@@ -22,8 +22,6 @@ libzstd:
 		--xxh64-prefix 'xxh64' \
 		--rewrite-include '<limits\.h>=<linux/limits.h>' \
 		--rewrite-include '<stddef\.h>=<linux/types.h>' \
-		--rewrite-include '"\.\./zstd.h"=<linux/zstd.h>' \
-		--rewrite-include '"(\.\./common/)?zstd_errors.h"=<linux/zstd_errors.h>' \
 		-DZSTD_NO_INTRINSICS \
 		-DZSTD_NO_UNUSED_FUNCTIONS \
 		-DZSTD_LEGACY_SUPPORT=0 \
@@ -48,8 +46,7 @@ libzstd:
 		-U_WIN32 \
 		-RZSTDLIB_VISIBILITY= \
 		-RZSTDERRORLIB_VISIBILITY=
-	mv linux/lib/zstd/zstd.h linux/include/linux
-	mv linux/lib/zstd/common/zstd_errors.h linux/include/linux
+	cp linux_zstd.h linux/include/linux/zstd.h
 	cp zstd_compress_module.c linux/lib/zstd
 	cp zstd_decompress_module.c linux/lib/zstd
 	cp decompress_sources.h linux/lib/zstd
@@ -62,9 +59,8 @@ import: libzstd
 	rm -f $(LINUX)/include/linux/zstd.h
 	rm -f $(LINUX)/include/linux/zstd_errors.h
 	rm -rf $(LINUX)/lib/zstd
-	mv linux/include/linux/zstd.h $(LINUX)/include/linux
-	mv linux/include/linux/zstd_errors.h $(LINUX)/include/linux
-	mv linux/lib/zstd $(LINUX)/lib
+	cp linux/include/linux/zstd.h $(LINUX)/include/linux
+	cp -r linux/lib/zstd $(LINUX)/lib
 
 .PHONY: test
 test: libzstd

--- a/contrib/linux-kernel/decompress_sources.h
+++ b/contrib/linux-kernel/decompress_sources.h
@@ -16,3 +16,4 @@
 #include "decompress/zstd_ddict.c"
 #include "decompress/zstd_decompress.c"
 #include "decompress/zstd_decompress_block.c"
+#include "zstd_decompress_module.c"

--- a/contrib/linux-kernel/decompress_sources.h
+++ b/contrib/linux-kernel/decompress_sources.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+/* SPDX-License-Identifier: GPL-2.0-only */
 
 /*
  * This file includes every .c file needed for decompression.

--- a/contrib/linux-kernel/linux_zstd.h
+++ b/contrib/linux-kernel/linux_zstd.h
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of https://github.com/facebook/zstd.
+ * An additional grant of patent rights can be found in the PATENTS file in the
+ * same directory.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation. This program is dual-licensed; you may select
+ * either version 2 of the GNU General Public License ("GPL") or BSD license
+ * ("BSD").
+ */
+
+#ifndef LINUX_ZSTD_H
+#define LINUX_ZSTD_H
+
+/**
+ * This is a kernel-style API that wraps the upstream zstd API, which cannot be
+ * used directly because the symbols aren't exported. It exposes the minimal
+ * functionality which is currently required by users of zstd in the kernel.
+ * Expose extra functions from lib/zstd/zstd.h as needed.
+ */
+
+/* ======   Dependency   ====== */
+#include <linux/types.h>
+
+/* ======   Helper Functions   ====== */
+/**
+ * zstd_compress_bound() - maximum compressed size in worst case scenario
+ * @src_size: The size of the data to compress.
+ *
+ * Return:    The maximum compressed size in the worst case scenario.
+ */
+size_t zstd_compress_bound(size_t src_size);
+
+/**
+ * zstd_is_error() - tells if a size_t function result is an error code
+ * @code:  The function result to check for error.
+ *
+ * Return: Non-zero iff the code is an error.
+ */
+unsigned int zstd_is_error(size_t code);
+
+/**
+ * zstd_get_error_code() - translates an error function result to an error code
+ * @code:  The function result for which zstd_is_error(code) is true.
+ *
+ * Return: A unique error code for this error.
+ */
+int zstd_get_error_code(size_t code);
+
+/**
+ * zstd_get_error_name() - translates an error function result to a string
+ * @code:  The function result for which zstd_is_error(code) is true.
+ *
+ * Return: An error string corresponding to the error code.
+ */
+const char* zstd_get_error_name(size_t code);
+
+/* ======   Parameter Selection   ====== */
+
+/**
+ * enum zstd_strategy - zstd compression search strategy
+ *
+ * From faster to stronger.
+ */
+enum zstd_strategy {
+	zstd_fast = 1,
+	zstd_dfast = 2,
+	zstd_greedy = 3,
+	zstd_lazy = 4,
+	zstd_lazy2 = 5,
+	zstd_btlazy2 = 6,
+	zstd_btopt = 7,
+	zstd_btultra = 8,
+	zstd_btultra2 = 9
+};
+
+/**
+ * struct zstd_compression_parameters - zstd compression parameters
+ * @window_log:    Log of the largest match distance. Larger means more
+ *                 compression, and more memory needed during decompression.
+ * @chain_log:     Fully searched segment. Larger means more compression,
+ *                 slower, and more memory (useless for fast).
+ * @hash_log:      Dispatch table. Larger means more compression,
+ *                 slower, and more memory.
+ * @search_log:    Number of searches. Larger means more compression and slower.
+ * @search_length: Match length searched. Larger means faster decompression,
+ *                 sometimes less compression.
+ * @target_length: Acceptable match size for optimal parser (only). Larger means
+ *                 more compression, and slower.
+ * @strategy:      The zstd compression strategy.
+ */
+struct zstd_compression_parameters {
+	unsigned int window_log;
+	unsigned int chain_log;
+	unsigned int hash_log;
+	unsigned int search_log;
+	unsigned int search_length;
+	unsigned int target_length;
+	enum zstd_strategy strategy;
+};
+
+/**
+ * struct zstd_frame_parameters - zstd frame parameters
+ * @content_size_flag: Controls whether content size will be present in the
+ *                     frame header (when known).
+ * @checksum_flag:     Controls whether a 32-bit checksum is generated at the
+ *                     end of the frame for error detection.
+ * @no_dict_id_flag:   Controls whether dictID will be saved into the frame
+ *                     header when using dictionary compression.
+ *
+ * The default value is all fields set to 0.
+ */
+struct zstd_frame_parameters {
+	unsigned int content_size_flag;
+	unsigned int checksum_flag;
+	unsigned int no_dict_id_flag;
+};
+
+/**
+ * struct zstd_parameters - zstd parameters
+ * @cparams: The compression parameters.
+ * @fparams: The frame parameters.
+ */
+struct zstd_parameters {
+	struct zstd_compression_parameters cparams;
+	struct zstd_frame_parameters fparams;
+};
+
+/**
+ * zstd_get_params() - returns zstd_parameters for selected level
+ * @level:              The compression level
+ * @estimated_src_size: The estimated source size to compress or 0
+ *                      if unknown.
+ * 
+ * Return:              The selected zstd_parameters.
+ */
+struct zstd_parameters zstd_get_params(int level,
+	unsigned long long estimated_src_size);
+
+/* ======   Single-pass Compression   ====== */
+
+typedef struct ZSTD_CCtx_s zstd_cctx;
+
+/**
+ * zstd_cctx_workspace_bound() - max memory needed to initialize a zstd_cctx
+ * @parameters: The compression parameters to be used.
+ *
+ * If multiple compression parameters might be used, the caller must call
+ * zstd_cctx_workspace_bound() for each set of parameters and use the maximum
+ * size.
+ *
+ * Return:      A lower bound on the size of the workspace that is passed to
+ *              zstd_init_cctx().
+ */
+size_t zstd_cctx_workspace_bound(
+	const struct zstd_compression_parameters *parameters);
+
+/**
+ * zstd_init_cctx() - initialize a zstd compression context
+ * @workspace:      The workspace to emplace the context into. It must outlive
+ *                  the returned context.
+ * @workspace_size: The size of workspace. Use zstd_cctx_workspace_bound() to
+ *                  determine how large the workspace must be.
+ *
+ * Return:          A zstd compression context or NULL on error.
+ */
+zstd_cctx *zstd_init_cctx(void *workspace, size_t workspace_size);
+
+/**
+ * zstd_compress_cctx() - compress src into dst with the initialized parameters
+ * @cctx:         The context. Must have been initialized with zstd_init_cctx().
+ * @dst:          The buffer to compress src into.
+ * @dst_capacity: The size of the destination buffer. May be any size, but
+ *                ZSTD_compressBound(srcSize) is guaranteed to be large enough.
+ * @src:          The data to compress.
+ * @src_size:     The size of the data to compress.
+ * @parameters:   The compression parameters to be used.
+ *
+ * Return:        The compressed size or an error, which can be checked using
+ *                zstd_is_error().
+ */
+size_t zstd_compress_cctx(zstd_cctx *cctx, void *dst, size_t dst_capacity,
+	const void *src, size_t src_size, const struct zstd_parameters* parameters);
+
+/* ======   Single-pass Decompression   ====== */
+
+typedef struct ZSTD_DCtx_s zstd_dctx;
+
+/**
+ * zstd_dctx_workspace_bound() - max memory needed to initialize a zstd_dctx
+ *
+ * Return: A lower bound on the size of the workspace that is passed to
+ *         zstd_init_dctx().
+ */
+size_t zstd_dctx_workspace_bound(void);
+
+/**
+ * zstd_init_dctx() - initialize a zstd decompression context
+ * @workspace:      The workspace to emplace the context into. It must outlive
+ *                  the returned context.
+ * @workspace_size: The size of workspace. Use zstd_dctx_workspace_bound() to
+ *                  determine how large the workspace must be.
+ *
+ * Return:          A zstd decompression context or NULL on error.
+ */
+zstd_dctx *zstd_init_dctx(void *workspace, size_t workspace_size);
+
+/**
+ * zstd_decompress_dctx() - decompress zstd compressed src into dst
+ * @dctx:         The decompression context.
+ * @dst:          The buffer to decompress src into.
+ * @dst_capacity: The size of the destination buffer. Must be at least as large
+ *                as the decompressed size. If the caller cannot upper bound the
+ *                decompressed size, then it's better to use the streaming API.
+ * @src:          The zstd compressed data to decompress. Multiple concatenated
+ *                frames and skippable frames are allowed.
+ * @src_size:     The exact size of the data to decompress.
+ *
+ * Return:        The decompressed size or an error, which can be checked using
+ *                zstd_is_error().
+ */
+size_t zstd_decompress_dctx(zstd_dctx *dctx, void *dst, size_t dst_capacity,
+	const void *src, size_t src_size);
+
+/* ======   Streaming Buffers   ====== */
+
+/**
+ * struct zstd_in_buffer - input buffer for streaming
+ * @src:  Start of the input buffer.
+ * @size: Size of the input buffer.
+ * @pos:  Position where reading stopped. Will be updated.
+ *        Necessarily 0 <= pos <= size.
+ */
+struct zstd_in_buffer {
+	const void *src;
+	size_t size;
+	size_t pos;
+};
+
+/**
+ * struct zstd_out_buffer - output buffer for streaming
+ * @dst:  Start of the output buffer.
+ * @size: Size of the output buffer.
+ * @pos:  Position where writing stopped. Will be updated.
+ *        Necessarily 0 <= pos <= size.
+ */
+struct zstd_out_buffer {
+	void *dst;
+	size_t size;
+	size_t pos;
+};
+
+/* ======   Streaming Compression   ====== */
+
+typedef struct ZSTD_CCtx_s zstd_cstream;
+
+/**
+ * zstd_cstream_workspace_bound() - memory needed to initialize a zstd_cstream
+ * @cparams: The compression parameters to be used for compression.
+ *
+ * Return:   A lower bound on the size of the workspace that is passed to
+ *           zstd_init_cstream().
+ */
+size_t zstd_cstream_workspace_bound(
+	const struct zstd_compression_parameters *cparams);
+
+/**
+ * zstd_init_cstream() - initialize a zstd streaming compression context
+ * @parameters        The zstd parameters to use for compression.
+ * @pledged_src_size: If params.fParams.contentSizeFlag == 1 then the caller
+ *                    must pass the source size (zero means empty source).
+ *                    Otherwise, the caller may optionally pass the source
+ *                    size, or zero if unknown.
+ * @workspace:        The workspace to emplace the context into. It must outlive
+ *                    the returned context.
+ * @workspace_size:   The size of workspace.
+ *                    Use zstd_cstream_workspace_bound(params->cparams) to
+ *                    determine how large the workspace must be.
+ *
+ * Return:            The zstd streaming compression context or NULL on error.
+ */
+zstd_cstream *zstd_init_cstream(const struct zstd_parameters *parameters,
+	unsigned long long pledged_src_size, void *workspace, size_t workspace_size);
+
+/**
+ * zstd_reset_cstream() - reset the context using parameters from creation
+ * @cstream:          The zstd streaming compression context to reset.
+ * @pledged_src_size: Optionally the source size, or zero if unknown.
+ *
+ * Resets the context using the parameters from creation. Skips dictionary
+ * loading, since it can be reused. If `pledged_src_size` is non-zero the frame
+ * content size is always written into the frame header.
+ *
+ * Return:            Zero or an error, which can be checked using
+ *                    zstd_is_error().
+ */
+size_t zstd_reset_cstream(zstd_cstream *cstream,
+	unsigned long long pledged_src_size);
+
+/**
+ * zstd_compress_stream() - streaming compress some of input into output
+ * @cstream: The zstd streaming compression context.
+ * @output:  Destination buffer. `output->pos` is updated to indicate how much
+ *           compressed data was written.
+ * @input:   Source buffer. `input->pos` is updated to indicate how much data
+ *           was read. Note that it may not consume the entire input, in which
+ *           case `input->pos < input->size`, and it's up to the caller to
+ *           present remaining data again.
+ *
+ * The `input` and `output` buffers may be any size. Guaranteed to make some
+ * forward progress if `input` and `output` are not empty.
+ *
+ * Return:   A hint for the number of bytes to use as the input for the next
+ *           function call or an error, which can be checked using
+ *           zstd_is_error().
+ */
+size_t zstd_compress_stream(zstd_cstream *cstream,
+	struct zstd_out_buffer *output, struct zstd_in_buffer *input);
+
+/**
+ * zstd_flush_stream() - flush internal buffers into output
+ * @cstream: The zstd streaming compression context.
+ * @output:  Destination buffer. `output->pos` is updated to indicate how much
+ *           compressed data was written.
+ *
+ * zstd_flush_stream() must be called until it returns 0, meaning all the data
+ * has been flushed. Since zstd_flush_stream() causes a block to be ended,
+ * calling it too often will degrade the compression ratio.
+ *
+ * Return:   The number of bytes still present within internal buffers or an
+ *           error, which can be checked using zstd_is_error().
+ */
+size_t zstd_flush_stream(zstd_cstream *cstream, struct zstd_out_buffer *output);
+
+/**
+ * zstd_end_stream() - flush internal buffers into output and end the frame
+ * @cstream: The zstd streaming compression context.
+ * @output:  Destination buffer. `output->pos` is updated to indicate how much
+ *           compressed data was written.
+ *
+ * zstd_end_stream() must be called until it returns 0, meaning all the data has
+ * been flushed and the frame epilogue has been written.
+ *
+ * Return:   The number of bytes still present within internal buffers or an
+ *           error, which can be checked using zstd_is_error().
+ */
+size_t zstd_end_stream(zstd_cstream *cstream, struct zstd_out_buffer *output);
+
+/* ======   Streaming Decompression   ====== */
+
+typedef struct ZSTD_DCtx_s zstd_dstream;
+
+/**
+ * zstd_dstream_workspace_bound() - memory needed to initialize a zstd_dstream
+ * @max_window_size: The maximum window size allowed for compressed frames.
+ *
+ * Return:           A lower bound on the size of the workspace that is passed
+ *                   to zstd_init_dstream().
+ */
+size_t zstd_dstream_workspace_bound(size_t max_window_size);
+
+/**
+ * zstd_init_dstream() - initialize a zstd streaming decompression context
+ * @max_window_size: The maximum window size allowed for compressed frames.
+ * @workspace:       The workspace to emplace the context into. It must outlive
+ *                   the returned context.
+ * @workspaceSize:   The size of workspace.
+ *                   Use zstd_dstream_workspace_bound(max_window_size) to
+ *                   determine how large the workspace must be.
+ *
+ * Return:           The zstd streaming decompression context.
+ */
+zstd_dstream *zstd_init_dstream(size_t max_window_size, void* workspace,
+	size_t workspace_size);
+
+/**
+ * zstd_reset_dstream() - reset the context using parameters from creation
+ * @dstream: The zstd streaming decompression context to reset.
+ *
+ * Resets the context using the parameters from creation. Skips dictionary
+ * loading, since it can be reused.
+ *
+ * Return:   Zero or an error, which can be checked using zstd_is_error().
+ */
+size_t zstd_reset_dstream(zstd_dstream *dstream);
+
+/**
+ * zstd_decompress_stream() - streaming decompress some of input into output
+ * @dstream: The zstd streaming decompression context.
+ * @output:  Destination buffer. `output.pos` is updated to indicate how much
+ *           decompressed data was written.
+ * @input:   Source buffer. `input.pos` is updated to indicate how much data was
+ *           read. Note that it may not consume the entire input, in which case
+ *           `input.pos < input.size`, and it's up to the caller to present
+ *           remaining data again.
+ *
+ * The `input` and `output` buffers may be any size. Guaranteed to make some
+ * forward progress if `input` and `output` are not empty.
+ * zstd_decompress_stream() will not consume the last byte of the frame until
+ * the entire frame is flushed.
+ *
+ * Return:   Returns 0 iff a frame is completely decoded and fully flushed.
+ *           Otherwise returns a hint for the number of bytes to use as the
+ *           input for the next function call or an error, which can be checked
+ *           using zstd_is_error(). The size hint will never load more than the
+ *           frame.
+ */
+size_t zstd_decompress_stream(zstd_dstream *dstream,
+	struct zstd_out_buffer *output, struct zstd_in_buffer *input);
+
+/* ======   Frame Inspection Functions ====== */
+
+/**
+ * zstd_find_frame_compressed_size() - returns the size of a compressed frame
+ * @src:      Source buffer. It should point to the start of a zstd encoded
+ *            frame or a skippable frame.
+ * @src_size: The size of the source buffer. It must be at least as large as the
+ *            size of the frame.
+ *
+ * Return:    The compressed size of the frame pointed to by `src` or an error,
+ *            which can be check with zstd_is_error().
+ *            Suitable to pass to ZSTD_decompress() or similar functions.
+ */
+size_t zstd_find_frame_compressed_size(const void *src, size_t src_size);
+
+/**
+ * struct zstd_frame_params - zstd frame parameters stored in the frame header
+ * @frame_content_size: The frame content size, or 0 if not present.
+ * @window_size:        The window size, or 0 if the frame is a skippable frame.
+ * @dict_id:            The dictionary id, or 0 if not present.
+ * @checksum_flag:      Whether a checksum was used.
+ */
+struct zstd_frame_params {
+	unsigned long long frame_content_size;
+	unsigned int window_size;
+	unsigned int dict_id;
+	unsigned int checksum_flag;
+};
+
+/**
+ * zstd_get_frame_params() - extracts parameters from a zstd or skippable frame
+ * @params:   On success the frame parameters are written here.
+ * @src:      The source buffer. It must point to a zstd or skippable frame.
+ * @src_size: The size of the source buffer.
+ *
+ * Return:    0 on success. If more data is required it returns how many bytes
+ *            must be provided to make forward progress. Otherwise it returns
+ *            an error, which can be checked using zstd_is_error().
+ */
+size_t zstd_get_frame_params(struct zstd_frame_params *params, const void *src,
+	size_t src_size);
+
+#endif  /* LINUX_ZSTD_H */

--- a/contrib/linux-kernel/linux_zstd.h
+++ b/contrib/linux-kernel/linux_zstd.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
 /*
  * Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
  * All rights reserved.

--- a/contrib/linux-kernel/linux_zstd.h
+++ b/contrib/linux-kernel/linux_zstd.h
@@ -58,7 +58,7 @@ int zstd_get_error_code(size_t code);
  *
  * Return: An error string corresponding to the error code.
  */
-const char* zstd_get_error_name(size_t code);
+const char *zstd_get_error_name(size_t code);
 
 /* ======   Parameter Selection   ====== */
 
@@ -136,7 +136,7 @@ struct zstd_parameters {
  * @level:              The compression level
  * @estimated_src_size: The estimated source size to compress or 0
  *                      if unknown.
- * 
+ *
  * Return:              The selected zstd_parameters.
  */
 struct zstd_parameters zstd_get_params(int level,
@@ -185,7 +185,7 @@ zstd_cctx *zstd_init_cctx(void *workspace, size_t workspace_size);
  *                zstd_is_error().
  */
 size_t zstd_compress_cctx(zstd_cctx *cctx, void *dst, size_t dst_capacity,
-	const void *src, size_t src_size, const struct zstd_parameters* parameters);
+	const void *src, size_t src_size, const struct zstd_parameters *parameters);
 
 /* ======   Single-pass Decompression   ====== */
 
@@ -375,7 +375,7 @@ size_t zstd_dstream_workspace_bound(size_t max_window_size);
  *
  * Return:           The zstd streaming decompression context.
  */
-zstd_dstream *zstd_init_dstream(size_t max_window_size, void* workspace,
+zstd_dstream *zstd_init_dstream(size_t max_window_size, void *workspace,
 	size_t workspace_size);
 
 /**

--- a/contrib/linux-kernel/test/Makefile
+++ b/contrib/linux-kernel/test/Makefile
@@ -6,10 +6,11 @@ CPPFLAGS += -I$(LINUX)/include -I$(LINUX_ZSTDLIB) -Iinclude -DNDEBUG
 # Don't poison the workspace, it currently doesn't work with static allocation and workspace reuse
 CPPFLAGS += -DZSTD_ASAN_DONT_POISON_WORKSPACE
 
+LINUX_ZSTD_MODULE     := $(wildcard $(LINUX_ZSTDLIB)/*.c)
 LINUX_ZSTD_COMMON     := $(wildcard $(LINUX_ZSTDLIB)/common/*.c) 
 LINUX_ZSTD_COMPRESS   := $(wildcard $(LINUX_ZSTDLIB)/compress/*.c) 
 LINUX_ZSTD_DECOMPRESS := $(wildcard $(LINUX_ZSTDLIB)/decompress/*.c) 
-LINUX_ZSTD_FILES      := $(LINUX_ZSTD_COMMON) $(LINUX_ZSTD_COMPRESS) $(LINUX_ZSTD_DECOMPRESS)
+LINUX_ZSTD_FILES      := $(LINUX_ZSTD_MODULE) $(LINUX_ZSTD_COMMON) $(LINUX_ZSTD_COMPRESS) $(LINUX_ZSTD_DECOMPRESS)
 LINUX_ZSTD_OBJECTS    := $(LINUX_ZSTD_FILES:.c=.o)
 
 liblinuxzstd.a: $(LINUX_ZSTD_OBJECTS)

--- a/contrib/linux-kernel/test/include/linux/module.h
+++ b/contrib/linux-kernel/test/include/linux/module.h
@@ -12,8 +12,7 @@
 
 #define EXPORT_SYMBOL(symbol)                                                  \
   void* __##symbol = symbol
-#define MODULE_LICENSE(license) static char const *const LICENSE = license
-#define MODULE_DESCRIPTION(description)                                        \
-  static char const *const DESCRIPTION = description
+#define MODULE_LICENSE(license)
+#define MODULE_DESCRIPTION(description)
 
 #endif

--- a/contrib/linux-kernel/test/static_test.c
+++ b/contrib/linux-kernel/test/static_test.c
@@ -31,13 +31,13 @@ static const char kEmptyZstdFrame[] = {
 static void test_decompress_unzstd() {
     fprintf(stderr, "Testing decompress unzstd... ");
     {
-        size_t const wkspSize = ZSTD_estimateDCtxSize();
+        size_t const wkspSize = zstd_dctx_workspace_bound();
         void* wksp = malloc(wkspSize);
         CONTROL(wksp != NULL);
-        ZSTD_DCtx* dctx = ZSTD_initStaticDCtx(wksp, wkspSize);
+        ZSTD_DCtx* dctx = zstd_init_dctx(wksp, wkspSize);
         CONTROL(dctx != NULL);
-        size_t const dSize = ZSTD_decompressDCtx(dctx, NULL, 0, kEmptyZstdFrame, sizeof(kEmptyZstdFrame));
-        CONTROL(!ZSTD_isError(dSize));
+        size_t const dSize = zstd_decompress_dctx(dctx, NULL, 0, kEmptyZstdFrame, sizeof(kEmptyZstdFrame));
+        CONTROL(!zstd_is_error(dSize));
         CONTROL(dSize == 0);
         free(wksp);
     }

--- a/contrib/linux-kernel/zstd_compress_module.c
+++ b/contrib/linux-kernel/zstd_compress_module.c
@@ -11,22 +11,37 @@
 
 static void zstd_check_structs(void) {
 	/* Check that the structs have the same size. */
-	ZSTD_STATIC_ASSERT(sizeof(ZSTD_parameters) == sizeof(struct zstd_parameters));
-	ZSTD_STATIC_ASSERT(sizeof(ZSTD_compressionParameters) == sizeof(struct zstd_compression_parameters));
-	ZSTD_STATIC_ASSERT(sizeof(ZSTD_frameParameters) == sizeof(struct zstd_frame_parameters));
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_parameters) ==
+		sizeof(struct zstd_parameters));
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_compressionParameters) ==
+		sizeof(struct zstd_compression_parameters));
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_frameParameters) ==
+		sizeof(struct zstd_frame_parameters));
 	/* Zstd guarantees that the layout of the structs never change. Verify it. */
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_parameters, cParams) == offsetof(struct zstd_parameters, cparams));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_parameters, fParams) == offsetof(struct zstd_parameters, fparams));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, windowLog) == offsetof(struct zstd_compression_parameters, window_log));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, chainLog) == offsetof(struct zstd_compression_parameters, chain_log));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, hashLog) == offsetof(struct zstd_compression_parameters, hash_log));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, searchLog) == offsetof(struct zstd_compression_parameters, search_log));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, minMatch) == offsetof(struct zstd_compression_parameters, search_length));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, targetLength) == offsetof(struct zstd_compression_parameters, target_length));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, strategy) == offsetof(struct zstd_compression_parameters, strategy));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, contentSizeFlag) == offsetof(struct zstd_frame_parameters, content_size_flag));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, checksumFlag) == offsetof(struct zstd_frame_parameters, checksum_flag));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, noDictIDFlag) == offsetof(struct zstd_frame_parameters, no_dict_id_flag));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_parameters, cParams) ==
+		offsetof(struct zstd_parameters, cparams));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_parameters, fParams) ==
+		offsetof(struct zstd_parameters, fparams));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, windowLog) ==
+		offsetof(struct zstd_compression_parameters, window_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, chainLog) ==
+		offsetof(struct zstd_compression_parameters, chain_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, hashLog) ==
+		offsetof(struct zstd_compression_parameters, hash_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, searchLog) ==
+		offsetof(struct zstd_compression_parameters, search_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, minMatch) ==
+		offsetof(struct zstd_compression_parameters, search_length));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, targetLength) ==
+		offsetof(struct zstd_compression_parameters, target_length));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, strategy) ==
+		offsetof(struct zstd_compression_parameters, strategy));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, contentSizeFlag) ==
+		offsetof(struct zstd_frame_parameters, content_size_flag));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, checksumFlag) ==
+		offsetof(struct zstd_frame_parameters, checksum_flag));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, noDictIDFlag) ==
+		offsetof(struct zstd_frame_parameters, no_dict_id_flag));
 	/* Check that the strategies are the same. This can change. */
 	ZSTD_STATIC_ASSERT((int)ZSTD_fast == (int)zstd_fast);
 	ZSTD_STATIC_ASSERT((int)ZSTD_dfast == (int)zstd_dfast);
@@ -39,14 +54,21 @@ static void zstd_check_structs(void) {
 	ZSTD_STATIC_ASSERT((int)ZSTD_btultra2 == (int)zstd_btultra2);
 	/* Check input buffer */
 	ZSTD_STATIC_ASSERT(sizeof(ZSTD_inBuffer) == sizeof(struct zstd_in_buffer));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, src) == offsetof(struct zstd_in_buffer, src));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, size) == offsetof(struct zstd_in_buffer, size));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, pos) == offsetof(struct zstd_in_buffer, pos));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, src) ==
+		offsetof(struct zstd_in_buffer, src));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, size) ==
+		offsetof(struct zstd_in_buffer, size));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, pos) ==
+		offsetof(struct zstd_in_buffer, pos));
 	/* Check output buffer */
-	ZSTD_STATIC_ASSERT(sizeof(ZSTD_outBuffer) == sizeof(struct zstd_out_buffer));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, dst) == offsetof(struct zstd_out_buffer, dst));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, size) == offsetof(struct zstd_out_buffer, size));
-	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, pos) == offsetof(struct zstd_out_buffer, pos));
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_outBuffer) ==
+		sizeof(struct zstd_out_buffer));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, dst) ==
+		offsetof(struct zstd_out_buffer, dst));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, size) ==
+		offsetof(struct zstd_out_buffer, size));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, pos) ==
+		offsetof(struct zstd_out_buffer, pos));
 }
 
 size_t zstd_compress_bound(size_t src_size)
@@ -55,7 +77,8 @@ size_t zstd_compress_bound(size_t src_size)
 }
 EXPORT_SYMBOL(zstd_compress_bound);
 
-struct zstd_parameters zstd_get_params(int level, unsigned long long estimated_src_size)
+struct zstd_parameters zstd_get_params(int level,
+	unsigned long long estimated_src_size)
 {
 	const ZSTD_parameters params = ZSTD_getParams(level, estimated_src_size, 0);
 	struct zstd_parameters out;
@@ -67,7 +90,8 @@ struct zstd_parameters zstd_get_params(int level, unsigned long long estimated_s
 }
 EXPORT_SYMBOL(zstd_get_params);
 
-size_t zstd_cctx_workspace_bound(const struct zstd_compression_parameters *cparams)
+size_t zstd_cctx_workspace_bound(
+	const struct zstd_compression_parameters *cparams)
 {
 	ZSTD_compressionParameters p;
 
@@ -84,7 +108,8 @@ zstd_cctx *zstd_init_cctx(void *workspace, size_t workspace_size)
 }
 EXPORT_SYMBOL(zstd_init_cctx);
 
-size_t zstd_compress_cctx(zstd_cctx *cctx, void *dst, size_t dst_capacity, const void *src, size_t src_size, const struct zstd_parameters* parameters)
+size_t zstd_compress_cctx(zstd_cctx *cctx, void *dst, size_t dst_capacity,
+	const void *src, size_t src_size, const struct zstd_parameters *parameters)
 {
 	ZSTD_parameters p;
 
@@ -93,7 +118,8 @@ size_t zstd_compress_cctx(zstd_cctx *cctx, void *dst, size_t dst_capacity, const
 }
 EXPORT_SYMBOL(zstd_compress_cctx);
 
-size_t zstd_cstream_workspace_bound(const struct zstd_compression_parameters *cparams)
+size_t zstd_cstream_workspace_bound(
+	const struct zstd_compression_parameters *cparams)
 {
 	ZSTD_compressionParameters p;
 
@@ -102,7 +128,8 @@ size_t zstd_cstream_workspace_bound(const struct zstd_compression_parameters *cp
 }
 EXPORT_SYMBOL(zstd_cstream_workspace_bound);
 
-zstd_cstream *zstd_init_cstream(const struct zstd_parameters *parameters, unsigned long long pledged_src_size, void *workspace, size_t workspace_size)
+zstd_cstream *zstd_init_cstream(const struct zstd_parameters *parameters,
+	unsigned long long pledged_src_size, void *workspace, size_t workspace_size)
 {
 	ZSTD_parameters p;
 	zstd_cstream *cstream;
@@ -128,13 +155,15 @@ zstd_cstream *zstd_init_cstream(const struct zstd_parameters *parameters, unsign
 }
 EXPORT_SYMBOL(zstd_init_cstream);
 
-size_t zstd_reset_cstream(zstd_cstream *cstream, unsigned long long pledged_src_size)
+size_t zstd_reset_cstream(zstd_cstream *cstream,
+	unsigned long long pledged_src_size)
 {
 	return ZSTD_resetCStream(cstream, pledged_src_size);
 }
 EXPORT_SYMBOL(zstd_reset_cstream);
 
-size_t zstd_compress_stream(zstd_cstream *cstream, struct zstd_out_buffer *output, struct zstd_in_buffer *input)
+size_t zstd_compress_stream(zstd_cstream *cstream,
+	struct zstd_out_buffer *output, struct zstd_in_buffer *input)
 {
 	ZSTD_outBuffer o;
 	ZSTD_inBuffer i;

--- a/contrib/linux-kernel/zstd_compress_module.c
+++ b/contrib/linux-kernel/zstd_compress_module.c
@@ -2,78 +2,176 @@
 
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/string.h>
 #include <linux/zstd.h>
 
-EXPORT_SYMBOL(ZSTD_compressBound);
-EXPORT_SYMBOL(ZSTD_minCLevel);
-EXPORT_SYMBOL(ZSTD_maxCLevel);
-EXPORT_SYMBOL(ZSTD_freeCCtx);
-EXPORT_SYMBOL(ZSTD_compressCCtx);
-EXPORT_SYMBOL(ZSTD_cParam_getBounds);
-EXPORT_SYMBOL(ZSTD_CCtx_setParameter);
-EXPORT_SYMBOL(ZSTD_CCtx_setPledgedSrcSize);
-EXPORT_SYMBOL(ZSTD_CCtx_reset);
-EXPORT_SYMBOL(ZSTD_compress2);
-EXPORT_SYMBOL(ZSTD_freeCStream);
-EXPORT_SYMBOL(ZSTD_compressStream2);
-EXPORT_SYMBOL(ZSTD_CStreamInSize);
-EXPORT_SYMBOL(ZSTD_CStreamOutSize);
-EXPORT_SYMBOL(ZSTD_initCStream);
-EXPORT_SYMBOL(ZSTD_compressStream);
-EXPORT_SYMBOL(ZSTD_flushStream);
-EXPORT_SYMBOL(ZSTD_endStream);
-EXPORT_SYMBOL(ZSTD_compress_usingDict);
-EXPORT_SYMBOL(ZSTD_freeCDict);
-EXPORT_SYMBOL(ZSTD_compress_usingCDict);
-EXPORT_SYMBOL(ZSTD_CCtx_refCDict);
-EXPORT_SYMBOL(ZSTD_CCtx_refPrefix);
-EXPORT_SYMBOL(ZSTD_sizeof_CCtx);
-EXPORT_SYMBOL(ZSTD_sizeof_CStream);
-EXPORT_SYMBOL(ZSTD_sizeof_CDict);
-EXPORT_SYMBOL(ZSTD_getSequences);
-EXPORT_SYMBOL(ZSTD_estimateCCtxSize);
-EXPORT_SYMBOL(ZSTD_estimateCCtxSize_usingCParams);
-EXPORT_SYMBOL(ZSTD_estimateCCtxSize_usingCCtxParams);
-EXPORT_SYMBOL(ZSTD_estimateCStreamSize);
-EXPORT_SYMBOL(ZSTD_estimateCStreamSize_usingCParams);
-EXPORT_SYMBOL(ZSTD_estimateCDictSize);
-EXPORT_SYMBOL(ZSTD_estimateCDictSize_advanced);
-EXPORT_SYMBOL(ZSTD_initStaticCCtx);
-EXPORT_SYMBOL(ZSTD_initStaticCStream);
-EXPORT_SYMBOL(ZSTD_initStaticCDict);
-EXPORT_SYMBOL(ZSTD_createCCtx_advanced);
-EXPORT_SYMBOL(ZSTD_createCStream_advanced);
-EXPORT_SYMBOL(ZSTD_createCDict_advanced);
-EXPORT_SYMBOL(ZSTD_createCDict_byReference);
-EXPORT_SYMBOL(ZSTD_getCParams);
-EXPORT_SYMBOL(ZSTD_getParams);
-EXPORT_SYMBOL(ZSTD_checkCParams);
-EXPORT_SYMBOL(ZSTD_adjustCParams);
-EXPORT_SYMBOL(ZSTD_compress_advanced);
-EXPORT_SYMBOL(ZSTD_compress_usingCDict_advanced);
-EXPORT_SYMBOL(ZSTD_CCtx_loadDictionary_byReference);
-EXPORT_SYMBOL(ZSTD_CCtx_loadDictionary_advanced);
-EXPORT_SYMBOL(ZSTD_CCtx_refPrefix_advanced);
-EXPORT_SYMBOL(ZSTD_CCtx_getParameter);
-EXPORT_SYMBOL(ZSTD_compressStream2_simpleArgs);
-EXPORT_SYMBOL(ZSTD_initCStream_srcSize);
-EXPORT_SYMBOL(ZSTD_initCStream_usingDict);
-EXPORT_SYMBOL(ZSTD_initCStream_advanced);
-EXPORT_SYMBOL(ZSTD_initCStream_usingCDict);
-EXPORT_SYMBOL(ZSTD_initCStream_usingCDict_advanced);
-EXPORT_SYMBOL(ZSTD_resetCStream);
-EXPORT_SYMBOL(ZSTD_getFrameProgression);
-EXPORT_SYMBOL(ZSTD_toFlushNow);
-EXPORT_SYMBOL(ZSTD_compressBegin);
-EXPORT_SYMBOL(ZSTD_compressBegin_usingDict);
-EXPORT_SYMBOL(ZSTD_compressBegin_advanced);
-EXPORT_SYMBOL(ZSTD_compressBegin_usingCDict);
-EXPORT_SYMBOL(ZSTD_compressBegin_usingCDict_advanced);
-EXPORT_SYMBOL(ZSTD_copyCCtx);
-EXPORT_SYMBOL(ZSTD_compressContinue);
-EXPORT_SYMBOL(ZSTD_compressEnd);
-EXPORT_SYMBOL(ZSTD_getBlockSize);
-EXPORT_SYMBOL(ZSTD_compressBlock);
+#include "zstd.h"
+#include "common/zstd_deps.h"
+#include "common/zstd_internal.h"
+
+static void zstd_check_structs(void) {
+	/* Check that the structs have the same size. */
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_parameters) == sizeof(struct zstd_parameters));
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_compressionParameters) == sizeof(struct zstd_compression_parameters));
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_frameParameters) == sizeof(struct zstd_frame_parameters));
+	/* Zstd guarantees that the layout of the structs never change. Verify it. */
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_parameters, cParams) == offsetof(struct zstd_parameters, cparams));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_parameters, fParams) == offsetof(struct zstd_parameters, fparams));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, windowLog) == offsetof(struct zstd_compression_parameters, window_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, chainLog) == offsetof(struct zstd_compression_parameters, chain_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, hashLog) == offsetof(struct zstd_compression_parameters, hash_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, searchLog) == offsetof(struct zstd_compression_parameters, search_log));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, minMatch) == offsetof(struct zstd_compression_parameters, search_length));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, targetLength) == offsetof(struct zstd_compression_parameters, target_length));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_compressionParameters, strategy) == offsetof(struct zstd_compression_parameters, strategy));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, contentSizeFlag) == offsetof(struct zstd_frame_parameters, content_size_flag));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, checksumFlag) == offsetof(struct zstd_frame_parameters, checksum_flag));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_frameParameters, noDictIDFlag) == offsetof(struct zstd_frame_parameters, no_dict_id_flag));
+	/* Check that the strategies are the same. This can change. */
+	ZSTD_STATIC_ASSERT((int)ZSTD_fast == (int)zstd_fast);
+	ZSTD_STATIC_ASSERT((int)ZSTD_dfast == (int)zstd_dfast);
+	ZSTD_STATIC_ASSERT((int)ZSTD_greedy == (int)zstd_greedy);
+	ZSTD_STATIC_ASSERT((int)ZSTD_lazy == (int)zstd_lazy);
+	ZSTD_STATIC_ASSERT((int)ZSTD_lazy2 == (int)zstd_lazy2);
+	ZSTD_STATIC_ASSERT((int)ZSTD_btlazy2 == (int)zstd_btlazy2);
+	ZSTD_STATIC_ASSERT((int)ZSTD_btopt == (int)zstd_btopt);
+	ZSTD_STATIC_ASSERT((int)ZSTD_btultra == (int)zstd_btultra);
+	ZSTD_STATIC_ASSERT((int)ZSTD_btultra2 == (int)zstd_btultra2);
+	/* Check input buffer */
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_inBuffer) == sizeof(struct zstd_in_buffer));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, src) == offsetof(struct zstd_in_buffer, src));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, size) == offsetof(struct zstd_in_buffer, size));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_inBuffer, pos) == offsetof(struct zstd_in_buffer, pos));
+	/* Check output buffer */
+	ZSTD_STATIC_ASSERT(sizeof(ZSTD_outBuffer) == sizeof(struct zstd_out_buffer));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, dst) == offsetof(struct zstd_out_buffer, dst));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, size) == offsetof(struct zstd_out_buffer, size));
+	ZSTD_STATIC_ASSERT(offsetof(ZSTD_outBuffer, pos) == offsetof(struct zstd_out_buffer, pos));
+}
+
+size_t zstd_compress_bound(size_t src_size)
+{
+	return ZSTD_compressBound(src_size);
+}
+EXPORT_SYMBOL(zstd_compress_bound);
+
+struct zstd_parameters zstd_get_params(int level, unsigned long long estimated_src_size)
+{
+	const ZSTD_parameters params = ZSTD_getParams(level, estimated_src_size, 0);
+	struct zstd_parameters out;
+
+	/* no-op */
+	zstd_check_structs();
+	ZSTD_memcpy(&out, &params, sizeof(out));
+	return out;
+}
+EXPORT_SYMBOL(zstd_get_params);
+
+size_t zstd_cctx_workspace_bound(const struct zstd_compression_parameters *cparams)
+{
+	ZSTD_compressionParameters p;
+
+	ZSTD_memcpy(&p, cparams, sizeof(p));
+	return ZSTD_estimateCCtxSize_usingCParams(p);
+}
+EXPORT_SYMBOL(zstd_cctx_workspace_bound);
+
+zstd_cctx *zstd_init_cctx(void *workspace, size_t workspace_size)
+{
+	if (workspace == NULL)
+		return NULL;
+	return ZSTD_initStaticCCtx(workspace, workspace_size);
+}
+EXPORT_SYMBOL(zstd_init_cctx);
+
+size_t zstd_compress_cctx(zstd_cctx *cctx, void *dst, size_t dst_capacity, const void *src, size_t src_size, const struct zstd_parameters* parameters)
+{
+	ZSTD_parameters p;
+
+	ZSTD_memcpy(&p, parameters, sizeof(p));
+	return ZSTD_compress_advanced(cctx, dst, dst_capacity, src, src_size, NULL, 0, p);
+}
+EXPORT_SYMBOL(zstd_compress_cctx);
+
+size_t zstd_cstream_workspace_bound(const struct zstd_compression_parameters *cparams)
+{
+	ZSTD_compressionParameters p;
+
+	ZSTD_memcpy(&p, cparams, sizeof(p));
+	return ZSTD_estimateCStreamSize_usingCParams(p);
+}
+EXPORT_SYMBOL(zstd_cstream_workspace_bound);
+
+zstd_cstream *zstd_init_cstream(const struct zstd_parameters *parameters, unsigned long long pledged_src_size, void *workspace, size_t workspace_size)
+{
+	ZSTD_parameters p;
+	zstd_cstream *cstream;
+	size_t ret;
+
+	if (workspace == NULL)
+		return NULL;
+
+	cstream = ZSTD_initStaticCStream(workspace, workspace_size);
+	if (cstream == NULL)
+		return NULL;
+
+	/* 0 means unknown in linux zstd API but means 0 in new zstd API */
+	if (pledged_src_size == 0)
+		pledged_src_size = ZSTD_CONTENTSIZE_UNKNOWN;
+
+	ZSTD_memcpy(&p, parameters, sizeof(p));
+	ret = ZSTD_initCStream_advanced(cstream, NULL, 0, p, pledged_src_size);
+	if (ZSTD_isError(ret))
+		return NULL;
+
+	return cstream;
+}
+EXPORT_SYMBOL(zstd_init_cstream);
+
+size_t zstd_reset_cstream(zstd_cstream *cstream, unsigned long long pledged_src_size)
+{
+	return ZSTD_resetCStream(cstream, pledged_src_size);
+}
+EXPORT_SYMBOL(zstd_reset_cstream);
+
+size_t zstd_compress_stream(zstd_cstream *cstream, struct zstd_out_buffer *output, struct zstd_in_buffer *input)
+{
+	ZSTD_outBuffer o;
+	ZSTD_inBuffer i;
+	size_t ret;
+
+	ZSTD_memcpy(&o, output, sizeof(o));
+	ZSTD_memcpy(&i, input, sizeof(i));
+	ret = ZSTD_compressStream(cstream, &o, &i);
+	ZSTD_memcpy(output, &o, sizeof(o));
+	ZSTD_memcpy(input, &i, sizeof(i));
+	return ret;
+}
+EXPORT_SYMBOL(zstd_compress_stream);
+
+size_t zstd_flush_stream(zstd_cstream *cstream, struct zstd_out_buffer *output)
+{
+	ZSTD_outBuffer o;
+	size_t ret;
+
+	ZSTD_memcpy(&o, output, sizeof(o));
+	ret = ZSTD_flushStream(cstream, &o);
+	ZSTD_memcpy(output, &o, sizeof(o));
+	return ret;
+}
+EXPORT_SYMBOL(zstd_flush_stream);
+
+size_t zstd_end_stream(zstd_cstream *cstream, struct zstd_out_buffer *output)
+{
+	ZSTD_outBuffer o;
+	size_t ret;
+
+	ZSTD_memcpy(&o, output, sizeof(o));
+	ret = ZSTD_endStream(cstream, &o);
+	ZSTD_memcpy(output, &o, sizeof(o));
+	return ret;
+}
+EXPORT_SYMBOL(zstd_end_stream);
 
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Zstd Compressor");

--- a/contrib/linux-kernel/zstd_decompress_module.c
+++ b/contrib/linux-kernel/zstd_decompress_module.c
@@ -37,7 +37,7 @@ size_t zstd_dctx_workspace_bound(void)
 }
 EXPORT_SYMBOL(zstd_dctx_workspace_bound);
 
-zstd_dctx* zstd_init_dctx(void *workspace, size_t workspace_size)
+zstd_dctx *zstd_init_dctx(void *workspace, size_t workspace_size)
 {
 	if (workspace == NULL)
 		return NULL;
@@ -45,7 +45,8 @@ zstd_dctx* zstd_init_dctx(void *workspace, size_t workspace_size)
 }
 EXPORT_SYMBOL(zstd_init_dctx);
 
-size_t zstd_decompress_dctx(zstd_dctx *dctx, void *dst, size_t dst_capacity, const void *src, size_t src_size)
+size_t zstd_decompress_dctx(zstd_dctx *dctx, void *dst, size_t dst_capacity,
+	const void *src, size_t src_size)
 {
 	return ZSTD_decompressDCtx(dctx, dst, dst_capacity, src, src_size);
 }
@@ -57,7 +58,8 @@ size_t zstd_dstream_workspace_bound(size_t max_window_size)
 }
 EXPORT_SYMBOL(zstd_dstream_workspace_bound);
 
-zstd_dstream *zstd_init_dstream(size_t max_window_size, void *workspace, size_t workspace_size)
+zstd_dstream *zstd_init_dstream(size_t max_window_size, void *workspace,
+	size_t workspace_size)
 {
 	if (workspace == NULL)
 		return NULL;
@@ -72,7 +74,8 @@ size_t zstd_reset_dstream(zstd_dstream *dstream)
 }
 EXPORT_SYMBOL(zstd_reset_dstream);
 
-size_t zstd_decompress_stream(zstd_dstream *dstream, struct zstd_out_buffer *output, struct zstd_in_buffer *input)
+size_t zstd_decompress_stream(zstd_dstream *dstream,
+	struct zstd_out_buffer *output, struct zstd_in_buffer *input)
 {
 	ZSTD_outBuffer o;
 	ZSTD_inBuffer i;
@@ -93,7 +96,8 @@ size_t zstd_find_frame_compressed_size(const void *src, size_t src_size)
 }
 EXPORT_SYMBOL(zstd_find_frame_compressed_size);
 
-size_t zstd_get_frame_params(struct zstd_frame_params *params, const void *src, size_t src_size)
+size_t zstd_get_frame_params(struct zstd_frame_params *params, const void *src,
+	size_t src_size)
 {
 	ZSTD_frameHeader h;
 	const size_t ret = ZSTD_getFrameHeader(&h, src, src_size);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3574,7 +3574,7 @@ size_t ZSTD_compress(void* dst, size_t dstCapacity,
     ZSTD_CCtx* cctx = ZSTD_createCCtx();
     RETURN_ERROR_IF(!cctx, memory_allocation, "ZSTD_createCCtx failed");
     result = ZSTD_compressCCtx(cctx, dst, dstCapacity, src, srcSize, compressionLevel);
-    ZSTD_freeCCtx(cctx);;
+    ZSTD_freeCCtx(cctx);
 #else
     ZSTD_CCtx ctxBody;
     ZSTD_initCCtx(&ctxBody, ZSTD_defaultCMem);


### PR DESCRIPTION
Adds the linux wrapper API. It is a functionally equivalent subset of the current API in the linux kernel. The only difference is name changes and taking parameter structs by const pointer instead of value. It preserves exactly the same semantics.