### PR TITLE
[cmake] Fix source directory with spaces

### DIFF
--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -90,10 +90,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: cmake build and test check
       run: |
-        make cmakebuild
+        FUZZERTEST=-T1mn ZSTREAM_TESTTIME=-T1mn make cmakebuild
         cp -r ./ "../zstd source"
         cd "../zstd source"
-        make cmakebuild
+        FUZZERTEST=-T1mn ZSTREAM_TESTTIME=-T1mn make cmakebuild
 
   gcc-8-asan-ubsan-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -89,7 +89,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: cmake build and test check
-      run: make cmakebuild
+      run: |
+        make cmakebuild
+        cp -r ./ "../zstd source"
+        cd "../zstd source"
+        make cmakebuild
 
   gcc-8-asan-ubsan-fuzz:
     runs-on: ubuntu-latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,6 +162,8 @@
   - if [%TEST%]==[cmake] (
       mkdir build\cmake\build &&
       cd build\cmake\build &&
+      SET FUZZERTEST=-T2mn &&
+      SET ZSTREAM_TESTTIME=-T2mn &&
       cmake -G "Visual Studio 14 2015 Win64" .. &&
       cd ..\..\.. &&
       make clean

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -157,14 +157,14 @@ if (UNIX OR MINGW)
 
     add_custom_target(libzstd.pc ALL
             ${CMAKE_COMMAND}
-            -DIN="${LIBRARY_DIR}/libzstd.pc.in"
+            -DIN=${LIBRARY_DIR}/libzstd.pc.in
             -DOUT="libzstd.pc"
             -DPREFIX="${PREFIX}"
             -DEXEC_PREFIX="${EXEC_PREFIX}"
             -DINCLUDEDIR="${INCLUDEDIR_PREFIX}${INCLUDEDIR_SUFFIX}"
             -DLIBDIR="${LIBDIR_PREFIX}${LIBDIR_SUFFIX}"
             -DVERSION="${VERSION}"
-            -P "${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig.cmake"
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig.cmake
             COMMENT "Creating pkg-config file")
 
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libzstd.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/build/cmake/tests/CMakeLists.txt
+++ b/build/cmake/tests/CMakeLists.txt
@@ -86,7 +86,7 @@ add_test(NAME zstreamtest COMMAND zstreamtest ${ZSTD_ZSTREAM_FLAGS})
 #
 AddTestFlagsOption(ZSTD_PLAYTESTS_FLAGS "--test-large-data"
     "Semicolon-separated list of flags to pass to the playTests.sh test")
-add_test(NAME playTests COMMAND sh -c "${TESTS_DIR}/playTests.sh" ${ZSTD_PLAYTESTS_FLAGS})
+add_test(NAME playTests COMMAND sh -c "\"${TESTS_DIR}/playTests.sh\" ${ZSTD_PLAYTESTS_FLAGS}")
 if (ZSTD_BUILD_PROGRAMS)
     set_property(TEST playTests APPEND PROPERTY ENVIRONMENT
         "ZSTD_BIN=$<TARGET_FILE:zstd>"

--- a/build/cmake/tests/CMakeLists.txt
+++ b/build/cmake/tests/CMakeLists.txt
@@ -84,7 +84,7 @@ add_test(NAME zstreamtest COMMAND zstreamtest ${ZSTD_ZSTREAM_FLAGS})
 #
 # playTests.sh
 #
-AddTestFlagsOption(ZSTD_PLAYTESTS_FLAGS "--test-large-data"
+AddTestFlagsOption(ZSTD_PLAYTESTS_FLAGS "$ENV{PLAYTESTS_FLAGS}"
     "Semicolon-separated list of flags to pass to the playTests.sh test")
 add_test(NAME playTests COMMAND sh -c "\"${TESTS_DIR}/playTests.sh\" ${ZSTD_PLAYTESTS_FLAGS}")
 if (ZSTD_BUILD_PROGRAMS)

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -273,10 +273,10 @@ ln -sf "$ZSTD_BIN" zstdcat
 rm -f tmp_grep
 echo "1234" > tmp_grep
 zstd -f tmp_grep
-lines=$(ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep tmp_grep.zst | wc -l)
+lines=$(ZCAT=./zstdcat "$ZSTDGREP" 2>&1 "1234" tmp_grep tmp_grep.zst | wc -l)
 test 2 -eq $lines
-ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep_bad.zst && die "Should have failed"
-ZCAT=./zstdcat $ZSTDGREP 2>&1 "1234" tmp_grep_bad.zst | grep "No such file or directory" || true
+ZCAT=./zstdcat "$ZSTDGREP" 2>&1 "1234" tmp_grep_bad.zst && die "Should have failed"
+ZCAT=./zstdcat "$ZSTDGREP" 2>&1 "1234" tmp_grep_bad.zst | grep "No such file or directory" || true
 rm -f tmp_grep*
 
 println "\n===>  --exclude-compressed flag"


### PR DESCRIPTION
* Fix quoting in the cmake files. Some places needed quotes, some places needed the quotes removed.
* Fix the `zstdgrep` tests in `playTests.sh`.
* Add a test case that tests the cmake build with spaces in the repo path.

Fixes #2255.