### PR TITLE
[lib] Ensure that multithreaded compression always makes some progress

### DIFF
--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -2299,6 +2299,7 @@ static int fuzzerTests_newAPI(U32 seed, int nbTests, int startTest,
                             /* Ensure maximal forward progress for determinism */
                             forwardProgress = (inBuff.pos != ipos) || (outBuff.pos != opos);
                         } while (forwardProgress);
+                        assert(inBuff.pos == inBuff.size);
 
                         XXH64_update(&xxhState, srcBuffer+srcStart, inBuff.pos);
                         memcpy(copyBuffer+totalTestSize, srcBuffer+srcStart, inBuff.pos);


### PR DESCRIPTION
`ZSTDMT_compressStream()` doesn't **guarantee** that it makes progress every iteration. It guarantees it won't enter a busy waiting loop, but it may loop for a few iterations before it blocks, under the right circumstances.

There are two solutions:
1. Add a loop inside of `ZSTDMT_compressStream()` that loops until progress is made.
2. Modify the loop already in `ZSTD_compressStream()` to wait for progress with `ZSTD_e_continue`.

I've chosen the second approach, because we already had to call `ZSTDMT_compressStream()` in a loop for `ZSTD_e_flush` and `ZSTD_e_end`. Now, we will also call it in a loop for `ZSTD_e_continue`, and wait for some progress.

The determinism test caught this bug because of its odd loop condition. It loops until no forward progress is made, and it assumes that the input has been entirely consumed. This assumption was broken when `ZSTD_compressStream2()` failed to make forward progress while there was still input remaining.

I was able to reproduce this bug by running the test case for ~10 minutes. After this fix I ran it overnight without failures.