### PR TITLE
[build] Fix icc build. Using updated ubuntu packages

### DIFF
--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -196,9 +196,9 @@ jobs:
         sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
         sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
-        sudo apt-get install -y intel-oneapi-icc
+        sudo apt-get install -y intel-basekit intel-hpckit
     - uses: actions/checkout@v2
     - name: make check
       run: |


### PR DESCRIPTION
Intel-oneapi doesn't exist anymore. Instead, it looks like it's been split into specific packages. Just needed to install the new ones:)
