### PR TITLE
replace links by actual copies

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -243,7 +243,7 @@ $(ZSTD_STATLIB): $(ZSTD_STATLIB_OBJ)
 	$(AR) $(ARFLAGS) $@ $^
 
 libzstd.a: $(ZSTD_STATLIB)
-	ln -sf $< $@
+	cp -f $< $@
 
 endif
 
@@ -283,7 +283,7 @@ $(ZSTD_DYNLIB): $(ZSTD_DYNLIB_OBJ)
 	ln -sf $@ libzstd.$(SHARED_EXT)
 
 $(LIBZSTD): $(ZSTD_DYNLIB)
-	ln -sf $< $@
+	cp -f $< $@
 
 endif  # ifndef BUILD_DIR
 endif  # if windows

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -233,7 +233,7 @@ $(BUILD_DIR)/zstd : $(ZSTD_OBJ)
 	$(CC) $(FLAGS) $^ -o $@$(EXT) $(LDFLAGS)
 
 zstd : $(BUILD_DIR)/zstd
-	ln -sf $< $@
+	cp -f $< $@
 	@echo zstd build completed
 
 endif  # BUILD_DIR

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -98,8 +98,6 @@ ZSTD_ALL_SRC := $(ZSTDLIB_LOCAL_SRC) $(ZSTD_CLI_SRC)
 ZSTD_ALL_OBJ := $(ZSTD_ALL_SRC:.c=.o)
 
 UNAME := $(shell uname)
-
-ifndef BUILD_DIR
 ifeq ($(UNAME), Darwin)
   HASH ?= md5
 else ifeq ($(UNAME), FreeBSD)
@@ -108,9 +106,10 @@ else ifeq ($(UNAME), OpenBSD)
   HASH ?= md5
 endif
 HASH ?= md5sum
-
-HASH_DIR = conf_$(shell echo $(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(ZSTD_FILES) | $(HASH) | cut -f 1 -d " ")
 HAVE_HASH :=$(shell echo 1 | $(HASH) > /dev/null && echo 1 || echo 0)
+
+ifndef BUILD_DIR
+HASH_DIR = conf_$(shell echo $(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(ZSTD_FILES) | $(HASH) | cut -f 1 -d " ")
 ifeq ($(HAVE_HASH),0)
   $(info warning : could not find HASH ($(HASH)), needed to differentiate builds using different flags)
   BUILD_DIR := obj/generic_noconf
@@ -232,9 +231,21 @@ $(BUILD_DIR)/zstd : $(ZSTD_OBJ)
 	@echo LINK $@
 	$(CC) $(FLAGS) $^ -o $@$(EXT) $(LDFLAGS)
 
+ifeq ($(HAVE_HASH),1)
+SRCBIN_HASH = $(shell cat $(BUILD_DIR)/zstd 2> $(VOID) | $(HASH) | cut -f 1 -d " ")
+DSTBIN_HASH = $(shell cat zstd 2> $(VOID) | $(HASH) | cut -f 1 -d " ")
+BIN_ISDIFFERENT = $(if $(filter $(SRCBIN_HASH),$(DSTBIN_HASH)),0,1)
+else
+BIN_ISDIFFERENT = 1
+endif
+
 zstd : $(BUILD_DIR)/zstd
-	cp -f $< $@
-	@echo zstd build completed
+	if [ $(BIN_ISDIFFERENT) -eq 1 ]; then \
+		cp -f $< $@; \
+		echo zstd build completed; \
+	else \
+		echo zstd already built; \
+	fi
 
 endif  # BUILD_DIR
 


### PR DESCRIPTION
In some circumstances, links can have a slightly different behavior from real binaries,
which can potentially break a few scripts relying on "real binary" assumption.

remove this risk by copying the actual binary to final destination.
