### PR TITLE
Increase the hero text's line height for better readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
         <!-- <h1><img src="images/zstd.png"/> Zstandard</h1> -->
         <h1><img src="images/zstd85.png"/> Zstandard</h1>
         <iframe src="https://ghbtns.com/github-btn.html?user=facebook&repo=zstd&type=star&count=true&size=large&v=2" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
-        <p>
+        <p style="line-height: 1.5; font-weight: 400">
         Zstandard is a fast compression algorithm, providing high compression ratios.
         It also offers a special mode for small data, called <a href="#small-data">dictionary compression</a>.
         The reference library offers a very wide range of speed / compression trade-off,


### PR DESCRIPTION
The font weight was also forced to 400 (Regular). This is because some browsers may display a font in a lower weight, which is difficult to read.

## Preview

### Before

![Screenshot_2020-12-17 Zstandard - Real-time data compression algorithm](https://user-images.githubusercontent.com/180032/102524540-73afb100-4099-11eb-8206-5930f7263315.png)

### After

![Screenshot_2020-12-17 Zstandard - Real-time data compression algorithm(1)](https://user-images.githubusercontent.com/180032/102524543-74484780-4099-11eb-911a-7f0bd01a73de.png)