### PR TITLE
Generate skippable frame API

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2954,6 +2954,26 @@ static size_t ZSTD_writeFrameHeader(void* dst, size_t dstCapacity,
     return pos;
 }
 
+/* ZSTD_generateSkippableFrame_advanced() :
+ * Writes out a skippable frame with the specified magic number variant (16 are supported), 
+ * from ZSTD_MAGIC_SKIPPABLE_START to ZSTD_MAGIC_SKIPPABLE_START+15, and the desired source data.
+ * 
+ * Returns the total number of bytes written, or a ZSTD error code.
+ */
+size_t ZSTD_generateSkippableFrame_advanced(void* dst, size_t dstCapacity,
+                                            const void* src, size_t srcSize, U32 magicVariant) {
+    BYTE* op = dst;
+    RETURN_ERROR_IF(dstCapacity < srcSize + 8 /* Skippable frame overhead */,
+                    dstSize_tooSmall, "Not enough room for skippable frame");
+    RETURN_ERROR_IF(srcSize > (unsigned)0xFFFFFFFF, srcSize_wrong, "Src size too large for skippable frame");
+    RETURN_ERROR_IF(magicVariant > 15, parameter_outOfBound, "Skippable frame magic number variant not supported");
+
+    MEM_writeLE32(op, (U32)(ZSTD_MAGIC_SKIPPABLE_START + magicVariant));
+    MEM_writeLE32(op+4, (U32)srcSize);
+    ZSTD_memcpy(op+8, src, srcSize);
+    return srcSize + 8;
+}
+
 /* ZSTD_writeLastEmptyBlock() :
  * output an empty Block with end-of-frame mark to complete a frame
  * @return : size of data written into `dst` (== ZSTD_blockHeaderSize (defined in zstd_internal.h))

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2954,16 +2954,16 @@ static size_t ZSTD_writeFrameHeader(void* dst, size_t dstCapacity,
     return pos;
 }
 
-/* ZSTD_generateSkippableFrame_advanced() :
+/* ZSTD_writeSkippableFrame_advanced() :
  * Writes out a skippable frame with the specified magic number variant (16 are supported), 
  * from ZSTD_MAGIC_SKIPPABLE_START to ZSTD_MAGIC_SKIPPABLE_START+15, and the desired source data.
  * 
  * Returns the total number of bytes written, or a ZSTD error code.
  */
-size_t ZSTD_generateSkippableFrame_advanced(void* dst, size_t dstCapacity,
-                                            const void* src, size_t srcSize, U32 magicVariant) {
-    BYTE* op = dst;
-    RETURN_ERROR_IF(dstCapacity < srcSize + 8 /* Skippable frame overhead */,
+size_t ZSTD_writeSkippableFrame(void* dst, size_t dstCapacity,
+                                const void* src, size_t srcSize, unsigned magicVariant) {
+    BYTE* op = (BYTE*)dst;
+    RETURN_ERROR_IF(dstCapacity < srcSize + ZSTD_SKIPPABLEHEADERSIZE /* Skippable frame overhead */,
                     dstSize_tooSmall, "Not enough room for skippable frame");
     RETURN_ERROR_IF(srcSize > (unsigned)0xFFFFFFFF, srcSize_wrong, "Src size too large for skippable frame");
     RETURN_ERROR_IF(magicVariant > 15, parameter_outOfBound, "Skippable frame magic number variant not supported");
@@ -2971,7 +2971,7 @@ size_t ZSTD_generateSkippableFrame_advanced(void* dst, size_t dstCapacity,
     MEM_writeLE32(op, (U32)(ZSTD_MAGIC_SKIPPABLE_START + magicVariant));
     MEM_writeLE32(op+4, (U32)srcSize);
     ZSTD_memcpy(op+8, src, srcSize);
-    return srcSize + 8;
+    return srcSize + ZSTD_SKIPPABLEHEADERSIZE;
 }
 
 /* ZSTD_writeLastEmptyBlock() :

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1372,6 +1372,22 @@ ZSTDLIB_API size_t ZSTD_compressSequences(ZSTD_CCtx* const cctx, void* dst, size
                                   const void* src, size_t srcSize);
 
 
+/*! ZSTD_generateSkippableFrame() :
+ * Generates a zstd skippable frame containing data given by src, and writes it to dst buffer.
+ * 
+ * Skippable frames have a 4-byte magic number, which can range from ZSTD_MAGIC_SKIPPABLE_START to ZSTD_MAGIC_SKIPPABLE_START+15.
+ * As such, the parameter magicVariant controls the exact skippable frame magic number variant used, so
+ * the final magic number will be ZSTD_MAGIC_SKIPPABLE_START + magicVariant.
+ * 
+ * Returns an error if destination buffer is not large enough, if the source size is not representable
+ * with a 4-byte unsigned int, or if the magicVariant is greater than 15.
+ * 
+ * @return : number of bytes written or a ZSTD error.
+ */
+ZSTDLIB_API size_t ZSTD_generateSkippableFrame(void* dst, size_t dstCapacity,
+                                               const void* src, size_t srcSize, unsigned magicVariant);
+
+
 /***************************************
 *  Memory management
 ***************************************/

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1372,20 +1372,21 @@ ZSTDLIB_API size_t ZSTD_compressSequences(ZSTD_CCtx* const cctx, void* dst, size
                                   const void* src, size_t srcSize);
 
 
-/*! ZSTD_generateSkippableFrame() :
+/*! ZSTD_writeSkippableFrame() :
  * Generates a zstd skippable frame containing data given by src, and writes it to dst buffer.
  * 
- * Skippable frames have a 4-byte magic number, which can range from ZSTD_MAGIC_SKIPPABLE_START to ZSTD_MAGIC_SKIPPABLE_START+15.
+ * Skippable frames begin with a a 4-byte magic number. There are 16 possible choices of magic number,
+ * ranging from ZSTD_MAGIC_SKIPPABLE_START to ZSTD_MAGIC_SKIPPABLE_START+15.
  * As such, the parameter magicVariant controls the exact skippable frame magic number variant used, so
- * the final magic number will be ZSTD_MAGIC_SKIPPABLE_START + magicVariant.
+ * the magic number used will be ZSTD_MAGIC_SKIPPABLE_START + magicVariant.
  * 
  * Returns an error if destination buffer is not large enough, if the source size is not representable
- * with a 4-byte unsigned int, or if the magicVariant is greater than 15.
+ * with a 4-byte unsigned int, or if the parameter magicVariant is greater than 15 (and therefore invalid).
  * 
  * @return : number of bytes written or a ZSTD error.
  */
-ZSTDLIB_API size_t ZSTD_generateSkippableFrame(void* dst, size_t dstCapacity,
-                                               const void* src, size_t srcSize, unsigned magicVariant);
+ZSTDLIB_API size_t ZSTD_writeSkippableFrame(void* dst, size_t dstCapacity,
+                                            const void* src, size_t srcSize, unsigned magicVariant);
 
 
 /***************************************

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1583,7 +1583,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
             off += r;
             if (i == segs/2) {
                 /* insert skippable frame */
-                skippableSize = ZSTD_generateSkippableFrame(compressedBuffer + off, compressedBufferSize, skipBuff, skipLen, seed % 15);
+                skippableSize = ZSTD_writeSkippableFrame(compressedBuffer + off, compressedBufferSize, skipBuff, skipLen, seed % 15);
                 CHECK_Z(skippableSize);
                 off += skippableSize;
             }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1570,6 +1570,11 @@ static int basicUnitTests(U32 const seed, double compressibility)
         int const segs = 4;
         /* only use the first half so we don't push against size limit of compressedBuffer */
         size_t const segSize = (CNBuffSize / 2) / segs;
+
+        U32 skippableSize;
+        const U32 skipLen = 129 KB;
+        char* skipBuff = (char*)malloc(skipLen);
+        memset(skipBuff, 0, skipLen);
         for (i = 0; i < segs; i++) {
             CHECK_NEWV(r, ZSTD_compress(
                             (BYTE*)compressedBuffer + off, CNBuffSize - off,
@@ -1578,13 +1583,13 @@ static int basicUnitTests(U32 const seed, double compressibility)
             off += r;
             if (i == segs/2) {
                 /* insert skippable frame */
-                const U32 skipLen = 129 KB;
-                MEM_writeLE32((BYTE*)compressedBuffer + off, ZSTD_MAGIC_SKIPPABLE_START);
-                MEM_writeLE32((BYTE*)compressedBuffer + off + 4, skipLen);
-                off += skipLen + ZSTD_SKIPPABLEHEADERSIZE;
+                skippableSize = ZSTD_generateSkippableFrame(compressedBuffer + off, compressedBufferSize, skipBuff, skipLen, seed % 15);
+                CHECK_Z(skippableSize);
+                off += skippableSize;
             }
         }
         cSize = off;
+        free(skipBuff);
     }
     DISPLAYLEVEL(3, "OK \n");
 


### PR DESCRIPTION
`ZSTD_writeSkippableFrame(void* dst, size_t dstCapacity, const void* src, size_t srcSize, U32 magicVariant)`

Writes a skippable frame into `dst` buffer, using `src` content, and using one of the 16 available skippable frame magic numbers, controllable with `magicVariant`. More detailed documentation in `zstd.h`.

Test Plan:
- Modify existing unit test to ensure roundtrip-ability