### PR TITLE
Fix visibility of symbols in .so

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -252,14 +252,14 @@ ifneq (,$(filter Windows%,$(TARGET_SYSTEM)))
 LIBZSTD = dll/libzstd.dll
 $(LIBZSTD): $(ZSTD_FILES)
 	@echo compiling dynamic library $(LIBVER)
-	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--out-implib,dll/libzstd.dll.a -shared $^ -o $@
+	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--defsym=ZSTD_getSequences=ZSTD_generateSequences -Wl,--out-implib,dll/libzstd.dll.a -shared $^ -o $@
 
 else  # not Windows
 
 LIBZSTD = libzstd.$(SHARED_EXT_VER)
 .PHONY: $(LIBZSTD)  # must be run every time
-$(LIBZSTD): CFLAGS += -fPIC
-$(LIBZSTD): LDFLAGS += -shared -fvisibility=hidden
+$(LIBZSTD): CFLAGS += -fPIC -fvisibility=hidden
+$(LIBZSTD): LDFLAGS += -shared -Wl,--defsym=ZSTD_getSequences=ZSTD_generateSequences
 
 ifndef BUILD_DIR
 # determine BUILD_DIR from compilation flags

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -252,14 +252,14 @@ ifneq (,$(filter Windows%,$(TARGET_SYSTEM)))
 LIBZSTD = dll/libzstd.dll
 $(LIBZSTD): $(ZSTD_FILES)
 	@echo compiling dynamic library $(LIBVER)
-	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--defsym=ZSTD_getSequences=ZSTD_generateSequences -Wl,--out-implib,dll/libzstd.dll.a -shared $^ -o $@
+	$(CC) $(FLAGS) -DZSTD_DLL_EXPORT=1 -Wl,--out-implib,dll/libzstd.dll.a -shared $^ -o $@
 
 else  # not Windows
 
 LIBZSTD = libzstd.$(SHARED_EXT_VER)
 .PHONY: $(LIBZSTD)  # must be run every time
 $(LIBZSTD): CFLAGS += -fPIC -fvisibility=hidden
-$(LIBZSTD): LDFLAGS += -shared -Wl,--defsym=ZSTD_getSequences=ZSTD_generateSequences
+$(LIBZSTD): LDFLAGS += -shared
 
 ifndef BUILD_DIR
 # determine BUILD_DIR from compilation flags


### PR DESCRIPTION
There was a change of the makefile that converted compiling static/shared lib _once with multiple source files_ to _compiling each to object file and linking_. But the `-fvisibility=hidden` flag is not moved onto compiling stage by mistake. So this fixes the default visibility by moving it there.

~~Furthermore, I discovered there is an API renaming. so I also added an alias for this API for the sake of backward-compatibility.~~ 
~~Only makefile under *nix/mingw is fixed. cmake/Visual Studio project files in `build/` directory may also want this alias in the .so/.dll symbol table, but the change is not contained in this PR.~~ 
~~On MSVC this can be done via linker flag: `"/EXPORT:ZSTD_getSequences=ZSTD_generateSequences"`(mangling with prefix `_` is required on x86_32)~~