### PR TITLE
Simple performance improvements for ldm

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1723,11 +1723,11 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
         /* ldm bucketOffsets table */
         if (params.ldmParams.enableLdm) {
             /* TODO: avoid memset? */
-            size_t const ldmBucketSize =
+            size_t const numBuckets =
                   ((size_t)1) << (params.ldmParams.hashLog -
                                   params.ldmParams.bucketSizeLog);
-            zc->ldmState.bucketOffsets = ZSTD_cwksp_reserve_buffer(ws, ldmBucketSize);
-            ZSTD_memset(zc->ldmState.bucketOffsets, 0, ldmBucketSize);
+            zc->ldmState.bucketOffsets = ZSTD_cwksp_reserve_buffer(ws, numBuckets);
+            ZSTD_memset(zc->ldmState.bucketOffsets, 0, numBuckets);
         }
 
         /* sequences storage */

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -77,7 +77,7 @@ static U32 ZSTD_ldm_getChecksum(U64 hash, U32 numBitsToDiscard)
  *  checked. */
 static U64 ZSTD_ldm_getTagMask(U32 hbits, U32 hashRateLog)
 {
-    assert(numTagBits < 32 && hbits <= 32);
+    assert(hashRateLog < 32 && hbits <= 32);
     if (32 - hbits < hashRateLog) {
         return (((U64)1 << hashRateLog) - 1);
     } else {

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -295,7 +295,7 @@ static size_t ZSTD_ldm_generateSequences_internal(
     U64 rollingHash = 0;
 
     while (ip <= ilimit) {
-        U32 const currentOffset = (U32)(ip - base);
+        U32 const currentIndex = (U32)(ip - base);
         U32 hash, checksum;
         size_t mLength;
         size_t forwardMatchLength = 0, backwardMatchLength = 0;
@@ -320,7 +320,7 @@ static size_t ZSTD_ldm_generateSequences_internal(
         hash = ZSTD_ldm_getSmallHash(rollingHash, hBits);
         checksum = ZSTD_ldm_getChecksum(rollingHash, hBits);
 
-        newEntry.offset = currentOffset;
+        newEntry.offset = currentIndex;
         newEntry.checksum = checksum;
 
         /* Get the best entry and compute the match lengths */
@@ -391,11 +391,11 @@ static size_t ZSTD_ldm_generateSequences_internal(
 
         {
             /* Store the sequence:
-             * ip = currentOffset - backwardMatchLength
+             * ip = currentIndex - backwardMatchLength
              * The match is at (bestEntry->offset - backwardMatchLength)
              */
             U32 const matchIndex = bestEntry->offset;
-            U32 const offset = currentOffset - matchIndex;
+            U32 const offset = currentIndex - matchIndex;
             rawSeq* const seq = rawSeqStore->seq + rawSeqStore->size;
 
             /* Out of sequence storage */

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -73,7 +73,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
  *
  * Skip past `srcSize` bytes worth of sequences in `rawSeqStore`.
  * Avoids emitting matches less than `minMatch` bytes.
- * Must be called for data with is not passed to ZSTD_ldm_blockCompress().
+ * Must be called for data that is not passed to ZSTD_ldm_blockCompress().
  */
 void ZSTD_ldm_skipSequences(rawSeqStore_t* rawSeqStore, size_t srcSize,
     U32 const minMatch);

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -486,10 +486,10 @@ ZSTDMT_serialState_reset(serialState_t* serialState,
         size_t const hashSize = ((size_t)1 << hashLog) * sizeof(ldmEntry_t);
         unsigned const bucketLog =
             params.ldmParams.hashLog - params.ldmParams.bucketSizeLog;
-        size_t const bucketSize = (size_t)1 << bucketLog;
         unsigned const prevBucketLog =
             serialState->params.ldmParams.hashLog -
             serialState->params.ldmParams.bucketSizeLog;
+        size_t const numBuckets = (size_t)1 << bucketLog;
         /* Size the seq pool tables */
         ZSTDMT_setNbSeq(seqPool, ZSTD_ldm_getMaxNbSeq(params.ldmParams, jobSize));
         /* Reset the window */
@@ -501,13 +501,13 @@ ZSTDMT_serialState_reset(serialState_t* serialState,
         }
         if (serialState->ldmState.bucketOffsets == NULL || prevBucketLog < bucketLog) {
             ZSTD_customFree(serialState->ldmState.bucketOffsets, cMem);
-            serialState->ldmState.bucketOffsets = (BYTE*)ZSTD_customMalloc(bucketSize, cMem);
+            serialState->ldmState.bucketOffsets = (BYTE*)ZSTD_customMalloc(numBuckets, cMem);
         }
         if (!serialState->ldmState.hashTable || !serialState->ldmState.bucketOffsets)
             return 1;
         /* Zero the tables */
         ZSTD_memset(serialState->ldmState.hashTable, 0, hashSize);
-        ZSTD_memset(serialState->ldmState.bucketOffsets, 0, bucketSize);
+        ZSTD_memset(serialState->ldmState.bucketOffsets, 0, numBuckets);
 
         /* Update window state and fill hash table with dict */
         serialState->ldmState.loadedDictEnd = 0;


### PR DESCRIPTION
# Description

This PR contains some simple performance improvements to the ldm matcher, together with some other cosmetic changes that I made "en passant" (variable renames, typo fixes, ...).

The changes to the ldm matcher only affect performance and the new code should produce precisely the same output as the baseline. Two changes helped improve the performance relatively uniformly:
- Instead of computing the tag with a branch and a fair amount of arithmetic operations in the hot loop of `ZSTD_ldm_generateSequences` we now compute a tag mask once before entering the loop and use it to check if the rolling hash satisfies the "tag condition". The tag mask is computed in such a way that the new tag condition is equivalent to the original one.
- When the tag condition is met but we did not find a match in the ldm hash table (it is the common case), we insert a new entry in the hash table using `ZSTD_ldm_insertEntry` instead of `ZSTD_ldm_makeEntryAndInsertByTag` which performs some redundant checks.

# Benchmarks

The following files were used to assess the impact of the change:
- `hhvm-rt.tar` (5.9G) - an image of production version of HHVM
- `l1m.tar` (2.0G) - two snapshots of the linux kernel source code taken a month apart
- `l1y.tar` (1.9G) - two snapshots of the linux kernel source code taken a year apart
- `l5.tar` (544M) - the first 544M of an archive containing the linux kernel source code

The results are compiled in the table below. All times are computed as the best over a set of 5 runs.

| FILE                 | CONFIG               | DEFLATE Δ | TIME Δ    |
|------------|-------------------|------------------|-----------------|
| data/hhvm-rt.tar     |  `--long=27 -1`      | =         | - 07.69%  |
| data/l1m.tar         |  `--long=27 -1`      | =         | - 07.15%  |
| data/l1y.tar         |  `--long=27 -1`      | =         | - 05.76%  |
| data/l5.tar          |  `--long=27 -1`      | =         | - 01.63%  |
| data/hhvm-rt.tar     |  `--long=30 -1`      | =         | - 05.23%  |
| data/l1m.tar         |  `--long=30 -1`      | =         | - 05.97%  |
| data/l1y.tar         |  `--long=30 -1`      | =         | - 07.31%  |
| data/l5.tar          |  `--long=30 -1`      | =         | - 04.13%  |
| data/hhvm-rt.tar     |  `--long=27 -8`      | =         | - 07.26%  |
| data/l1m.tar         |  `--long=27 -8`      | =         | - 10.21%  |
| data/l1y.tar         |  `--long=27 -8`      | =         | - 05.42%  |
| data/l5.tar          |  `--long=27 -8`      | =         | - 06.97%  |
| data/hhvm-rt.tar     |  `--long=30 -8`      | =         | - 04.97%  |
| data/l1m.tar         |  `--long=30 -8`      | =         | - 06.05%  |
| data/l1y.tar         |  `--long=30 -8`      | =         | - 09.55%  |
| data/l5.tar          |  `--long=30 -8`      | =         | - 01.70%  |
| data/hhvm-rt.tar     |  `--long=27 -16`     | =         | + 01.20%  |
| data/l1m.tar         |  `--long=27 -16`     | =         | - 00.55%  |
| data/l1y.tar         |  `--long=27 -16`     | =         | + 06.68%  |
| data/l5.tar          |  `--long=27 -16`     | =         | + 01.80%  |
| data/hhvm-rt.tar     |  `--long=30 -16`     | =         | + 02.35%  |
| data/l1m.tar         |  `--long=30 -16`     | =         | + 02.68%  |
| data/l1y.tar         |  `--long=30 -16`     | =         | + 01.26%  |
| data/l5.tar          |  `--long=30 -16`     | =         | + 00.35%  |
| data/hhvm-rt.tar     |  `--long=27 -19`     | =         | - 00.09%  |
| data/l1m.tar         |  `--long=27 -19`     | =         | + 01.43%  |
| data/l1y.tar         |  `--long=27 -19`     | =         | - 00.52%  |
| data/l5.tar          |  `--long=27 -19`     | =         | + 02.94%  |
| data/hhvm-rt.tar     |  `--long=30 -19`     | =         | + 02.88%  |
| data/l1m.tar         |  `--long=30 -19`     | =         | - 00.51%  |
| data/l1y.tar         |  `--long=30 -19`     | =         | + 01.14%  |
| data/l5.tar          |  `--long=30 -19`     | =         | - 02.13%  |