### PR TITLE
parallel make build on linux

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -208,7 +208,7 @@ else
 endif
 
 SET_CACHE_DIRECTORY = \
-	$(MAKE) --no-print-directory $@ \
+   +$(MAKE) --no-print-directory $@ \
     BUILD_DIR=obj/$(HASH_DIR) \
     CPPFLAGS="$(CPPFLAGS)" \
     CFLAGS="$(CFLAGS)" \

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -194,7 +194,7 @@ endif
 endif
 
 SET_CACHE_DIRECTORY = \
-	$(MAKE) --no-print-directory $@ \
+   +$(MAKE) --no-print-directory $@ \
     BUILD_DIR=obj/$(HASH_DIR) \
     CPPFLAGS="$(CPPFLAGS)" \
     CFLAGS="$(CFLAGS)" \


### PR DESCRIPTION
fix #2474 : `make zstd -j8` was resulting in an effectively serial build on Linux.
Credit goes to @Have-a-question-about-this-project for detecting the issue.

Interestingly, the issue was not present on macOS.
