### PR TITLE
[trace] Keep track of a uint64_t tracing context

### DIFF
--- a/lib/common/zstd_trace.c
+++ b/lib/common/zstd_trace.c
@@ -15,27 +15,27 @@
 
 #if ZSTD_TRACE && ZSTD_HAVE_WEAK_SYMBOLS
 
-ZSTD_WEAK_ATTR int ZSTD_trace_compress_begin(ZSTD_CCtx const* cctx)
+ZSTD_WEAK_ATTR ZSTD_TraceCtx ZSTD_trace_compress_begin(ZSTD_CCtx const* cctx)
 {
     (void)cctx;
     return 0;
 }
 
-ZSTD_WEAK_ATTR void ZSTD_trace_compress_end(ZSTD_CCtx const* cctx, ZSTD_trace const* trace)
+ZSTD_WEAK_ATTR void ZSTD_trace_compress_end(ZSTD_TraceCtx ctx, ZSTD_Trace const* trace)
 {
-    (void)cctx;
+    (void)ctx;
     (void)trace;
 }
 
-ZSTD_WEAK_ATTR int ZSTD_trace_decompress_begin(ZSTD_DCtx const* dctx)
+ZSTD_WEAK_ATTR ZSTD_TraceCtx ZSTD_trace_decompress_begin(ZSTD_DCtx const* dctx)
 {
     (void)dctx;
     return 0;
 }
 
-ZSTD_WEAK_ATTR void ZSTD_trace_decompress_end(ZSTD_DCtx const* dctx, ZSTD_trace const* trace)
+ZSTD_WEAK_ATTR void ZSTD_trace_decompress_end(ZSTD_TraceCtx ctx, ZSTD_Trace const* trace)
 {
-    (void)dctx;
+    (void)ctx;
     (void)trace;
 }
 

--- a/lib/common/zstd_trace.h
+++ b/lib/common/zstd_trace.h
@@ -77,41 +77,67 @@ typedef struct {
      * The fully resolved CCtx parameters (NULL on decompression).
      */
     struct ZSTD_CCtx_params_s const* params;
-} ZSTD_trace;
+    /**
+     * The ZSTD_CCtx pointer (NULL on decompression).
+     */
+    struct ZSTD_CCtx_s const* cctx;
+    /**
+     * The ZSTD_DCtx pointer (NULL on compression).
+     */
+    struct ZSTD_DCtx_s const* dctx;
+} ZSTD_Trace;
+
+/**
+ * A tracing context. It must be 0 when tracing is disabled.
+ * Otherwise, any non-zero value returned by a tracing begin()
+ * function is presented to any subsequent calls to end().
+ *
+ * Any non-zero value is treated as tracing is enabled and not
+ * interpreted by the library.
+ *
+ * Two possible uses are:
+ * * A timestamp for when the begin() function was called.
+ * * A unique key identifying the (de)compression, like the
+ *   address of the [dc]ctx pointer if you need to track
+ *   more information than just a timestamp.
+ */
+typedef unsigned long long ZSTD_TraceCtx;
 
 /**
  * Trace the beginning of a compression call.
  * @param cctx The dctx pointer for the compression.
  *             It can be used as a key to map begin() to end().
- * @returns Non-zero if tracing is enabled.
+ * @returns Non-zero if tracing is enabled. The return value is
+ *          passed to ZSTD_trace_compress_end().
  */
-int ZSTD_trace_compress_begin(struct ZSTD_CCtx_s const* cctx);
+ZSTD_TraceCtx ZSTD_trace_compress_begin(struct ZSTD_CCtx_s const* cctx);
 
 /**
  * Trace the end of a compression call.
- * @param cctx The dctx pointer for the decompression.
+ * @param ctx The return value of ZSTD_trace_compress_begin().
  * @param trace The zstd tracing info.
  */
 void ZSTD_trace_compress_end(
-    struct ZSTD_CCtx_s const* cctx,
-    ZSTD_trace const* trace);
+    ZSTD_TraceCtx ctx,
+    ZSTD_Trace const* trace);
 
 /**
  * Trace the beginning of a decompression call.
  * @param dctx The dctx pointer for the decompression.
  *             It can be used as a key to map begin() to end().
- * @returns Non-zero if tracing is enabled.
+ * @returns Non-zero if tracing is enabled. The return value is
+ *          passed to ZSTD_trace_compress_end().
  */
-int ZSTD_trace_decompress_begin(struct ZSTD_DCtx_s const* dctx);
+ZSTD_TraceCtx ZSTD_trace_decompress_begin(struct ZSTD_DCtx_s const* dctx);
 
 /**
  * Trace the end of a decompression call.
- * @param dctx The dctx pointer for the decompression.
+ * @param ctx The return value of ZSTD_trace_decompress_begin().
  * @param trace The zstd tracing info.
  */
 void ZSTD_trace_decompress_end(
-    struct ZSTD_DCtx_s const* dctx,
-    ZSTD_trace const* trace);
+    ZSTD_TraceCtx ctx,
+    ZSTD_Trace const* trace);
 
 #endif /* ZSTD_TRACE */
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3386,7 +3386,7 @@ static size_t ZSTD_compressBegin_internal(ZSTD_CCtx* cctx,
                                     ZSTD_buffered_policy_e zbuff)
 {
 #if ZSTD_TRACE
-    cctx->tracingEnabled = ZSTD_trace_compress_begin(cctx);
+    cctx->traceCtx = ZSTD_trace_compress_begin(cctx);
 #endif
     DEBUGLOG(4, "ZSTD_compressBegin_internal: wlog=%u", params->cParams.windowLog);
     /* params are supposed to be fully validated at this point */
@@ -3512,12 +3512,12 @@ static size_t ZSTD_writeEpilogue(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity)
     return op-ostart;
 }
 
-static void ZSTD_CCtx_trace(ZSTD_CCtx const* cctx, size_t extraCSize)
+void ZSTD_CCtx_trace(ZSTD_CCtx* cctx, size_t extraCSize)
 {
 #if ZSTD_TRACE
-    if (cctx->tracingEnabled) {
+    if (cctx->traceCtx) {
         int const streaming = cctx->inBuffSize > 0 || cctx->outBuffSize > 0 || cctx->appliedParams.nbWorkers > 0;
-        ZSTD_trace trace;
+        ZSTD_Trace trace;
         ZSTD_memset(&trace, 0, sizeof(trace));
         trace.version = ZSTD_VERSION_NUMBER;
         trace.streaming = streaming;
@@ -3526,8 +3526,10 @@ static void ZSTD_CCtx_trace(ZSTD_CCtx const* cctx, size_t extraCSize)
         trace.uncompressedSize = cctx->consumedSrcSize;
         trace.compressedSize = cctx->producedCSize + extraCSize;
         trace.params = &cctx->appliedParams;
-        ZSTD_trace_compress_end(cctx, &trace);
+        trace.cctx = cctx;
+        ZSTD_trace_compress_end(cctx->traceCtx, &trace);
     }
+    cctx->traceCtx = 0;
 #else
     (void)cctx;
     (void)extraCSize;
@@ -4441,7 +4443,7 @@ static size_t ZSTD_CCtx_init_compressStream2(ZSTD_CCtx* cctx,
     }
     if (params.nbWorkers > 0) {
 #if ZSTD_TRACE
-        cctx->tracingEnabled = ZSTD_trace_compress_begin(cctx);
+        cctx->traceCtx = ZSTD_trace_compress_begin(cctx);
 #endif
         /* mt context creation */
         if (cctx->mtctx == NULL) {

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -19,6 +19,7 @@
 *  Dependencies
 ***************************************/
 #include "../common/zstd_internal.h"
+#include "../common/zstd_trace.h"  /* ZSTD_TraceCtx */
 #include "zstd_cwksp.h"
 #ifdef ZSTD_MULTITHREAD
 #  include "zstdmt_compress.h"
@@ -324,7 +325,9 @@ struct ZSTD_CCtx_s {
 #endif
 
     /* Tracing */
-    int tracingEnabled;
+#if ZSTD_TRACE
+    ZSTD_TraceCtx traceCtx;
+#endif
 };
 
 typedef enum { ZSTD_dtlm_fast, ZSTD_dtlm_full } ZSTD_dictTableLoadMethod_e;
@@ -1203,5 +1206,10 @@ size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSe
 /** ZSTD_cycleLog() :
  *  condition for correct operation : hashLog > 1 */
 U32 ZSTD_cycleLog(U32 hashLog, ZSTD_strategy strat);
+
+/** ZSTD_CCtx_trace() :
+ *  Trace the end of a compression call.
+ */
+void ZSTD_CCtx_trace(ZSTD_CCtx* cctx, size_t extraCSize);
 
 #endif /* ZSTD_COMPRESS_H */

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -683,6 +683,8 @@ static void ZSTDMT_compressionJob(void* jobDescription)
     if (job->jobID != 0) jobParams.fParams.checksumFlag = 0;
     /* Don't run LDM for the chunks, since we handle it externally */
     jobParams.ldmParams.enableLdm = 0;
+    /* Correct nbWorkers to 0. */
+    jobParams.nbWorkers = 0;
 
 
     /* init */
@@ -750,6 +752,7 @@ static void ZSTDMT_compressionJob(void* jobDescription)
             if (ZSTD_isError(cSize)) JOB_ERROR(cSize);
             lastCBlockSize = cSize;
     }   }
+    ZSTD_CCtx_trace(cctx, 0);
 
 _endJob:
     ZSTDMT_serialState_ensureFinished(job->serial, job->jobID, job->cSize);

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -789,8 +789,8 @@ static size_t ZSTD_setRleBlock(void* dst, size_t dstCapacity,
 static void ZSTD_DCtx_trace_end(ZSTD_DCtx const* dctx, U64 uncompressedSize, U64 compressedSize, unsigned streaming)
 {
 #if ZSTD_TRACE
-    if (dctx->tracingEnabled) {
-        ZSTD_trace trace;
+    if (dctx->traceCtx) {
+        ZSTD_Trace trace;
         ZSTD_memset(&trace, 0, sizeof(trace));
         trace.version = ZSTD_VERSION_NUMBER;
         trace.streaming = streaming;
@@ -801,7 +801,8 @@ static void ZSTD_DCtx_trace_end(ZSTD_DCtx const* dctx, U64 uncompressedSize, U64
         }
         trace.uncompressedSize = (size_t)uncompressedSize;
         trace.compressedSize = (size_t)compressedSize;
-        ZSTD_trace_decompress_end(dctx, &trace);
+        trace.dctx = dctx;
+        ZSTD_trace_decompress_end(dctx->traceCtx, &trace);
     }
 #else
     (void)dctx;
@@ -1383,7 +1384,7 @@ size_t ZSTD_decompressBegin(ZSTD_DCtx* dctx)
 {
     assert(dctx != NULL);
 #if ZSTD_TRACE
-    dctx->tracingEnabled = ZSTD_trace_decompress_begin(dctx);
+    dctx->traceCtx = ZSTD_trace_decompress_begin(dctx);
 #endif
     dctx->expected = ZSTD_startingInputLength(dctx->format);  /* dctx->format must be properly set */
     dctx->stage = ZSTDds_getFrameHeaderSize;

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -21,6 +21,7 @@
  *********************************************************/
 #include "../common/mem.h"             /* BYTE, U16, U32 */
 #include "../common/zstd_internal.h"   /* ZSTD_seqSymbol */
+#include "../common/zstd_trace.h"      /* ZSTD_TraceCtx */
 
 
 
@@ -178,7 +179,9 @@ struct ZSTD_DCtx_s
 #endif
 
     /* Tracing */
-    int tracingEnabled;
+#if ZSTD_TRACE
+    ZSTD_TraceCtx traceCtx;
+#endif
 };  /* typedef'd to ZSTD_DCtx within "zstd.h" */
 
 


### PR DESCRIPTION
The most common information that you want to track between begin() and
end() is the timestamp of the begin function, so you can measure the
duration of the (de)compression call. Allow the tracing library to put
this information inside the `ZSTD_TraceCtx` (`U64`), so it doesn't need to keep
a global map in this case. If a single `U64` is not enough, the
tracing library can return a unique identifier (like the context
pointer) instead, and use it as a key in a map.

This keeps the simple case simple, and still allows more complex use cases.

Also transition the `zstdcli_trace.c` library to pass the begin timestamp as the context,
which allows it to trace all the intermediate zstdmt jobs, as well as the overall compression:
```
> ./zstd -T0 --trace trace.txt ~/datasets/silesia.tar -f
> ./zstd -t --trace trace.txt ~/datasets/silesia.tar.zst
> cat trace.txt
Algorithm, Version, Method, Mode, Level, Workers, Dictionary Size, Uncompressed Size, Compressed Size, Duration Nanos, Compression Ratio, Speed MB/s
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 737911, 34673914, 11.37, 241.93
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 696799, 32253855, 12.04, 260.08
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 656658, 29858343, 12.77, 280.95
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 4800712, 96412564, 1.75, 87.01
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2240561, 93051675, 3.74, 90.15
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2876294, 94600978, 2.92, 88.67
zstd, 10408, compress, single-pass, 3, 0, 0, 8388608, 3024680, 113934439, 2.77, 73.63
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2710851, 107134061, 3.09, 78.30
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 1972080, 89393313, 4.25, 93.84
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2727969, 101423086, 3.08, 82.71
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 3002655, 102899024, 2.79, 81.52
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2762947, 105617233, 3.04, 79.42
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 1646767, 67882416, 5.09, 123.58
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2658613, 98329326, 3.16, 85.31
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2662751, 106443784, 3.15, 78.81
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2645866, 131990218, 3.17, 63.55
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 3109838, 135087214, 2.70, 62.10
zstd, 10408, compress, single-pass, 3, 0, 262144, 2242560, 1604979, 57998867, 1.40, 38.67
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2506474, 82716629, 3.35, 101.41
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 1931538, 80175485, 4.34, 104.63
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2467706, 89191743, 3.40, 94.05
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2471512, 98938190, 3.39, 84.79
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2441141, 92939975, 3.44, 90.26
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 2452253, 98063221, 3.42, 85.54
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 5144824, 110925521, 1.63, 75.62
zstd, 10408, compress, single-pass, 3, 0, 262144, 8388608, 4759224, 117426792, 1.76, 71.44
zstd, 10408, compress, streaming, 3, 14, 0, 211957760, 66713607, 264877047, 3.18, 800.21
zstd, 10408, decompress, streaming, 0, 0, 0, 211957760, 66713607, 229716896, 3.18, 922.69

```