### PR TITLE
[easy][cli] Add newline to boundary of --help message of --trace and --[no-]check

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -191,6 +191,7 @@ static void usage_advanced(const char* programName)
 #endif /* ZSTD_NOCOMPRESS */
 
 #ifndef ZSTD_NOTRACE
+    DISPLAYOUT( "\n");
     DISPLAYOUT( "--trace FILE : log tracing information to FILE.");
 #endif
     DISPLAYOUT( "\n");


### PR DESCRIPTION
Noticed that it was displaying like:
```
--[no-]check : during compression, add XXH64 integrity checksum to frame (default: enabled). If specified with -d, decompressor will ignore/validate checksums in compressed frame (default: validate).--trace FILE : log tracing information to FILE.
```

Now displays like:
```
--[no-]check : during compression, add XXH64 integrity checksum to frame (default: enabled). If specified with -d, decompressor will ignore/validate checksums in compressed frame (default: validate).
--trace FILE : log tracing information to FILE.
```