### PR TITLE
ZSTD_seekable_decompress() example that hangs.

### DIFF
--- a/contrib/seekable_format/tests/seekable_tests.c
+++ b/contrib/seekable_format/tests/seekable_tests.c
@@ -53,6 +53,60 @@ int main(int argc, const char** argv)
     }
     printf("Success!\n");
 
+    printf("Test %u - check that seekable decompress does not hang: ", testNb++);
+    {   /* Github issue #FIXME */
+        const size_t compressed_size = 27;
+        const uint8_t compressed_data[27] = {
+	    '\x28',
+	    '\xb5',
+	    '\x2f',
+	    '\xfd',
+	    '\x00',
+	    '\x32',
+	    '\x91',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x5e',
+	    '\x2a',
+	    '\x4d',
+	    '\x18',
+	    '\x09',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\xb1',
+	    '\xea',
+	    '\x92',
+	    '\x8f',
+	};
+        const size_t uncompressed_size = 8936;
+        uint8_t uncompressed_data[8936];
+
+        ZSTD_seekable* stream = ZSTD_seekable_create();
+        size_t status = ZSTD_seekable_initBuff(stream, compressed_data, compressed_size);
+        if (ZSTD_isError(status)) {
+            ZSTD_seekable_free(stream);
+            goto _test_error;
+        }
+
+        const size_t offset = 2;
+        /* Should return an error, but not hang */
+        status = ZSTD_seekable_decompress(stream, uncompressed_data, uncompressed_size, offset);
+        if (!ZSTD_isError(status)) {
+            ZSTD_seekable_free(stream);
+            goto _test_error;
+        }
+
+        ZSTD_seekable_free(stream);
+    }
+    printf("Success!\n");
+
     /* TODO: Add more tests */
     printf("Finished tests\n");
     return 0;


### PR DESCRIPTION
This generates a hang using the zstd_seekable format. It is contrived as it was generated using the fuzzer at https://fuchsia.googlesource.com/fuchsia/+/6c0911153a4b36d5a6ab86f74cc9d1a313d8e8ca/src/storage/blobfs/test/zstd-seekable-fuzzer.cc  but it should return an error for an invalid archive instead of hanging.

This change is just a reference for issue #2506