### PR TITLE
Seekable hang fix

### DIFF
--- a/contrib/seekable_format/tests/seekable_tests.c
+++ b/contrib/seekable_format/tests/seekable_tests.c
@@ -53,6 +53,60 @@ int main(int argc, const char** argv)
     }
     printf("Success!\n");
 
+    printf("Test %u - check that seekable decompress does not hang: ", testNb++);
+    {   /* Github issue #FIXME */
+        const size_t compressed_size = 27;
+        const uint8_t compressed_data[27] = {
+	    '\x28',
+	    '\xb5',
+	    '\x2f',
+	    '\xfd',
+	    '\x00',
+	    '\x32',
+	    '\x91',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x5e',
+	    '\x2a',
+	    '\x4d',
+	    '\x18',
+	    '\x09',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\x00',
+	    '\xb1',
+	    '\xea',
+	    '\x92',
+	    '\x8f',
+	};
+        const size_t uncompressed_size = 8936;
+        uint8_t uncompressed_data[8936];
+
+        ZSTD_seekable* stream = ZSTD_seekable_create();
+        size_t status = ZSTD_seekable_initBuff(stream, compressed_data, compressed_size);
+        if (ZSTD_isError(status)) {
+            ZSTD_seekable_free(stream);
+            goto _test_error;
+        }
+
+        const size_t offset = 2;
+        /* Should return an error, but not hang */
+        status = ZSTD_seekable_decompress(stream, uncompressed_data, uncompressed_size, offset);
+        if (!ZSTD_isError(status)) {
+            ZSTD_seekable_free(stream);
+            goto _test_error;
+        }
+
+        ZSTD_seekable_free(stream);
+    }
+    printf("Success!\n");
+
     /* TODO: Add more tests */
     printf("Finished tests\n");
     return 0;

--- a/contrib/seekable_format/tests/seekable_tests.c
+++ b/contrib/seekable_format/tests/seekable_tests.c
@@ -53,7 +53,7 @@ int main(int argc, const char** argv)
     }
     printf("Success!\n");
 
-    printf("Test %u - check that seekable decompress does not hang: ", testNb++);
+    printf("Test %u - check #2 that seekable decompress does not hang: ", testNb++);
     {   /* Github issue #FIXME */
         const size_t compressed_size = 27;
         const uint8_t compressed_data[27] = {
@@ -85,8 +85,8 @@ int main(int argc, const char** argv)
 	    '\x92',
 	    '\x8f',
 	};
-        const size_t uncompressed_size = 8936;
-        uint8_t uncompressed_data[8936];
+        const size_t uncompressed_size = 400;
+        uint8_t uncompressed_data[400];
 
         ZSTD_seekable* stream = ZSTD_seekable_create();
         size_t status = ZSTD_seekable_initBuff(stream, compressed_data, compressed_size);


### PR DESCRIPTION
This PR prevents the issue described in #2506 of seekable decompression hanging.

`ZSTD_seekable_decompress()` may get stuck re-decompressing the input in an infinite loop (see line 451: `targetFrame = ZSTD_seekable_offsetToFrameIndex(zs, zs->decompressedOffset);`). I'm not aware of any valid reason to decompress more input than actually exists for seekable decompression in a single `ZSTD_seekable_decompress()` call, so we should check that we aren't reading too much input.

Thanks @mlindsay for discovering issue!

Test Plan:
- New test passes with PR (and fails without)
- Manual roundtrip testing with examples in `seekable_format/examples` 
  - We'll want to add a fuzzer and maybe some more unit tests in the future so that we can test changes better.