### PR TITLE
Make the number of physical CPU cores detection more robust

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -1212,11 +1212,13 @@ int UTIL_countPhysicalCores(void)
                 /* fall back on the sysconf value */
                 goto failed;
         }   }
-        if (siblings && cpu_cores) {
+        if (siblings && cpu_cores && siblings > cpu_cores) {
             ratio = siblings / cpu_cores;
         }
 
-        numPhysicalCores = numPhysicalCores / ratio;
+        if (ratio && numPhysicalCores > ratio) {
+            numPhysicalCores = numPhysicalCores / ratio;
+        }
 
 failed:
         fclose(cpuinfo);

--- a/programs/util.c
+++ b/programs/util.c
@@ -1215,9 +1215,12 @@ int UTIL_countPhysicalCores(void)
         if (siblings && cpu_cores) {
             ratio = siblings / cpu_cores;
         }
+
+        numPhysicalCores = numPhysicalCores / ratio;
+
 failed:
         fclose(cpuinfo);
-        return numPhysicalCores = numPhysicalCores / ratio;
+        return numPhysicalCores;
     }
 }
 


### PR DESCRIPTION
Bad data in `/proc/cpuinfo` can cause this calculation to divide by zero.  While there's clearly a bug in my kernel causing a weird `/proc/cpuinfo` it's a good idea to make zstd robust to bad/weird data like this.