### PR TITLE
Add GitHub Action to Automatically Publish Release Tarballs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,33 +36,6 @@ jobs:
             make armbuild   V=1; make clean
             make -C tests test-legacy test-longmatch; make clean
             make -C lib libzstd-nomt; make clean
-  # This step is only run on release tags.
-  # It publishes the source tarball as artifacts and if the GITHUB_TOKEN
-  # environment variable is set it will publish the source tarball to the
-  # tagged release.
-  publish-github-release:
-    docker:
-      - image: fbopensource/zstd-circleci-primary:0.0.1
-    environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-    steps:
-      - checkout
-      - run:
-          name: Publish
-          command: |
-            export VERSION=$(echo $CIRCLE_TAG | tail -c +2)
-            export ZSTD_VERSION=zstd-$VERSION
-            git archive $CIRCLE_TAG --prefix $ZSTD_VERSION/ --format tar \
-                        -o $ZSTD_VERSION.tar
-            sha256sum $ZSTD_VERSION.tar > $ZSTD_VERSION.tar.sha256
-            zstd -19 $ZSTD_VERSION.tar
-            sha256sum $ZSTD_VERSION.tar.zst > $ZSTD_VERSION.tar.zst.sha256
-            gzip -k -9 $ZSTD_VERSION.tar
-            sha256sum $ZSTD_VERSION.tar.gz > $ZSTD_VERSION.tar.gz.sha256
-            mkdir -p $CIRCLE_ARTIFACTS
-            cp $ZSTD_VERSION.tar* $CIRCLE_ARTIFACTS
-      - store_artifacts:
-          path: /tmp/circleci-artifacts
   # This step should only be run in a cron job
   regression-test:
     docker:

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -1,0 +1,62 @@
+name: publish-release-artifacts
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  publish-release-artifacts:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Archive
+        env:
+          RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+        run: |
+          # compute file name
+          export TAG=$(echo $GITHUB_REF | sed -n 's_^refs/tags/__p')
+          if [ -z "$TAG" ]; then
+            echo "action must be run on a tag. GITHUB_REF is not a tag: $GITHUB_REF"
+            exit 1
+          fi
+          export ZSTD_VERSION=zstd-$TAG
+
+          # archive
+          git archive $TAG \
+              --prefix $ZSTD_VERSION/ \
+              --format tar \
+              -o $ZSTD_VERSION.tar
+
+          # Do the rest of the work in a sub-dir so we can glob everything we want to publish.
+          mkdir artifacts/
+          mv $ZSTD_VERSION.tar artifacts/
+          cd artifacts/
+
+          # compress
+          zstd -k -19 $ZSTD_VERSION.tar
+          gzip -k  -9 $ZSTD_VERSION.tar
+
+          rm $ZSTD_VERSION.tar
+
+          # hash
+          sha256sum $ZSTD_VERSION.tar.zst > $ZSTD_VERSION.tar.zst.sha256
+          sha256sum $ZSTD_VERSION.tar.gz  > $ZSTD_VERSION.tar.gz.sha256
+
+          # sign
+          if [ -n "$RELEASE_SIGNING_KEY" ]; then
+            echo "$RELEASE_SIGNING_KEY" | gpg --import
+            gpg --armor --sign --sign-with signing@zstd.net --detach-sig --output $ZSTD_VERSION.tar.zst.sig $ZSTD_VERSION.tar.zst
+            gpg --armor --sign --sign-with signing@zstd.net --detach-sig --output $ZSTD_VERSION.tar.gz.sig  $ZSTD_VERSION.tar.gz
+          fi
+
+      - name: Publish
+        uses: skx/github-action-publish-binaries@release-1.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: artifacts/*

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Archive
         env:
           RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+          RELEASE_SIGNING_KEY_PASSPHRASE: ${{ secrets.RELEASE_SIGNING_KEY_PASSPHRASE }}
         run: |
           # compute file name
           export TAG="$(echo "$GITHUB_REF" | sed -n 's_^refs/tags/__p')"
@@ -53,9 +54,10 @@ jobs:
 
           # sign
           if [ -n "$RELEASE_SIGNING_KEY" ]; then
-            echo "$RELEASE_SIGNING_KEY" | gpg --import
-            gpg --armor --sign --sign-with signing@zstd.net --detach-sig --output $ZSTD_VERSION.tar.zst.sig $ZSTD_VERSION.tar.zst
-            gpg --armor --sign --sign-with signing@zstd.net --detach-sig --output $ZSTD_VERSION.tar.gz.sig  $ZSTD_VERSION.tar.gz
+            export GPG_BATCH_OPTS="--batch --no-use-agent --pinentry-mode loopback --no-tty --yes"
+            echo "$RELEASE_SIGNING_KEY" | gpg $GPG_BATCH_OPTS --import
+            gpg $GPG_BATCH_OPTS --armor --sign --sign-with signing@zstd.net --detach-sig --passphrase "$RELEASE_SIGNING_KEY_PASSPHRASE" --output $ZSTD_VERSION.tar.zst.sig $ZSTD_VERSION.tar.zst
+            gpg $GPG_BATCH_OPTS --armor --sign --sign-with signing@zstd.net --detach-sig --passphrase "$RELEASE_SIGNING_KEY_PASSPHRASE" --output $ZSTD_VERSION.tar.gz.sig  $ZSTD_VERSION.tar.gz
           fi
 
       - name: Publish

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -19,12 +19,15 @@ jobs:
           RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
         run: |
           # compute file name
-          export TAG=$(echo $GITHUB_REF | sed -n 's_^refs/tags/__p')
+          export TAG="$(echo "$GITHUB_REF" | sed -n 's_^refs/tags/__p')"
           if [ -z "$TAG" ]; then
             echo "action must be run on a tag. GITHUB_REF is not a tag: $GITHUB_REF"
             exit 1
           fi
-          export ZSTD_VERSION=zstd-$TAG
+          # Attempt to extract "1.2.3" from "v1.2.3" to maintain artifact name backwards compat.
+          # Otherwise, degrade to using full tag.
+          export VERSION="$(echo "$TAG" | sed 's_^v\([0-9]\+\.[0-9]\+\.[0-9]\+\)$_\1_')"
+          export ZSTD_VERSION="zstd-$VERSION"
 
           # archive
           git archive $TAG \
@@ -41,6 +44,7 @@ jobs:
           zstd -k -19 $ZSTD_VERSION.tar
           gzip -k  -9 $ZSTD_VERSION.tar
 
+          # we only publish the compressed tarballs
           rm $ZSTD_VERSION.tar
 
           # hash


### PR DESCRIPTION
This PR introduces a GitHub action that is triggered on release creation, which creates the release tarball, compresses it, hashes it, signs it, and attaches all of those files to the release.

Here's an example invocation on my repo:

![Screenshot from 2021-03-12 17-33-48](https://user-images.githubusercontent.com/1154694/111005657-35a0f100-8359-11eb-9469-e72d4c26250c.png)

I wanted to also generate the windows artifacts but windows is hard and I gave up.

Because this PR signs the artifacts when a key is provided, this is one step towards addressing #2520.