### PR TITLE
Add memory monotonicity test over srcSize

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -3181,7 +3181,23 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
-    DISPLAYLEVEL(3, "test%3i : check compression mem usage monotonicity over srcSize : ", testNb++);
+    DISPLAYLEVEL(3, "test%3i : check compression mem usage monotonicity over levels for estimateCCtxSize() : ", testNb++);
+    {
+        int level = 1;
+        size_t prevSize = 0;
+        for (; level < ZSTD_maxCLevel(); ++level) {
+            size_t const currSize = ZSTD_estimateCCtxSize(level);
+            if (prevSize > currSize) {
+                DISPLAYLEVEL(3, "Error! previous cctx size: %zu at level: %d is larger than current cctx size: %zu at level: %d",
+                             prevSize, level-1, currSize, level);
+                goto _output_error;
+            }
+            prevSize = currSize;
+        }
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
+    DISPLAYLEVEL(3, "test%3i : check estimateCCtxSize() always larger or equal to ZSTD_estimateCCtxSize_usingCParams() : ", testNb++);
     {
         size_t const kSizeIncrement = 2 KB;
         int level = -3;
@@ -3190,16 +3206,17 @@ static int basicUnitTests(U32 const seed, double compressibility)
             size_t dictSize = 0;
             for (; dictSize <= 256 KB; dictSize += 8 * kSizeIncrement) {
                 size_t srcSize = 2 KB;
-                size_t prevCCtxSize = 0;
                 for (; srcSize < 300 KB; srcSize += kSizeIncrement) {
                     ZSTD_compressionParameters const cParams = ZSTD_getCParams(level, srcSize, dictSize);
-                    size_t const cctxSize = ZSTD_estimateCCtxSize_usingCParams(cParams);
-                    if (cctxSize < prevCCtxSize || ZSTD_isError(cctxSize)) {
-                        DISPLAYLEVEL(3, "error! level: %d dictSize: %zu srcSize: %zu cctx size: %zu, prevsize: %zu\n",
-                                     level, dictSize, srcSize, cctxSize, prevCCtxSize);
+                    size_t const cctxSizeUsingCParams = ZSTD_estimateCCtxSize_usingCParams(cParams);
+                    size_t const cctxSizeUsingLevel = ZSTD_estimateCCtxSize(level);
+                    if (cctxSizeUsingLevel < cctxSizeUsingCParams
+                     || ZSTD_isError(cctxSizeUsingCParams)
+                     || ZSTD_isError(cctxSizeUsingLevel)) {
+                        DISPLAYLEVEL(3, "error! l: %d dict: %zu srcSize: %zu cctx size cpar: %zu, cctx size level: %zu\n",
+                                     level, dictSize, srcSize, cctxSizeUsingCParams, cctxSizeUsingLevel);
                         goto _output_error;
                     }
-                    prevCCtxSize = cctxSize;
                 }
             }
         }


### PR DESCRIPTION
@terrelln and I were discussing about monotonicity of memory usage as source size increases, as well as compression level increases. This PR adds a test for the former case: mem usage monotonically increases w/ `srcSize`.

It actually appears that we don't currently do this. Between the 16 KB and 128 KB parameters for level 1, if the source file is > 16 KB and <= 128 KB, we actually use less memory compared to source files <= 16 KB. The parameters in [`zstd_compress.c`](https://github.com/facebook/zstd/blob/dev/lib/compress/zstd_compress.c#L5114) confirm this `wLog: 14 cLog: 14 hLog: 15` -> `wLog: 17 cLog: 12 hLog:13` is a decrease in memory usage.

Is this something we would want to fix? Do we also want to maintain memory usage monotonicity as compression level increases?

