### PR TITLE
Fix dedicated dict search isSupported() requirements.

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -5186,7 +5186,10 @@ static ZSTD_compressionParameters ZSTD_dedicatedDictSearch_getCParams(int const 
 static int ZSTD_dedicatedDictSearch_isSupported(
         ZSTD_compressionParameters const* cParams)
 {
-    return (cParams->strategy >= ZSTD_greedy) && (cParams->strategy <= ZSTD_lazy2);
+    return (cParams->strategy >= ZSTD_greedy)
+        && (cParams->strategy <= ZSTD_lazy2)
+        && (cParams->hashLog >= cParams->chainLog)
+        && (cParams->chainLog <= 24);
 }
 
 /**

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -805,6 +805,8 @@ println "- Dictionary compression roundtrip"
 zstd -f tmp -D tmpDict
 zstd -d tmp.zst -D tmpDict -fo result
 $DIFF "$TESTFILE" result
+println "- Dictionary compression with hlog < clog"
+zstd -6f tmp -D tmpDict --zstd=clog=25,hlog=23
 println "- Dictionary compression with btlazy2 strategy"
 zstd -f tmp -D tmpDict --zstd=strategy=6
 zstd -d tmp.zst -D tmpDict -fo result


### PR DESCRIPTION
Currently, asserts in `zstd_lazy.c` will fail if you try to compress with `chainLog > 24` or `hLog < cLog` with dedicated dict search.

The following command fails on `dev`:
`make -j zstd DEBUGLEVEL=1 && ./zstd [file] -D [dictFile] --zstd=clog=25,hlog=23 -7f`

This PR adds the same checks that are `assert()`ed to be true in `zstd_lazy.c` when using dedicated dict search, and includes a unit test that fails without this fix.

Though, I will note that dedicated dict search at least seems to work fine when `clog > 24` or `hLog < cLog`, so an alternative could just be to remove the asserts.
