### PR TITLE
[cwksp] Align all allocated "tables" and "aligneds" to 64 bytes

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1322,8 +1322,8 @@ ZSTD_sizeof_matchState(const ZSTD_compressionParameters* const cParams,
                                 : 0;
     size_t const slackSpace = ZSTD_cwksp_slack_space_required();
 
-    /* tables are guaranteed to be sized in multiples of 64 */
-    ZSTD_STATIC_ASSERT(ZSTD_HASHLOG_MIN >= 6 && ZSTD_WINDOWLOG_MIN >= 6 && ZSTD_CHAINLOG_MIN >= 6);
+    /* tables are guaranteed to be sized in multiples of 64 bytes (or 16 uint32_t) */
+    ZSTD_STATIC_ASSERT(ZSTD_HASHLOG_MIN >= 4 && ZSTD_WINDOWLOG_MIN >= 4 && ZSTD_CHAINLOG_MIN >= 4);
 
     DEBUGLOG(4, "chainSize: %u - hSize: %u - h3Size: %u",
                 (U32)chainSize, (U32)hSize, (U32)h3Size);
@@ -1784,10 +1784,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
             ZSTD_resetTarget_CCtx), "");
 
         ZSTD_cwksp_finalize(ws);
-        /* Due to alignment, when reusing a workspace, we can actually consume
-         * up to 3 extra bytes for alignment. See the comments in zstd_cwksp.h
-         */
-        assert(ZSTD_cwksp_used(ws) >= neededSpace && ZSTD_cwksp_used(ws) <= neededSpace + 3);
+        assert(ZSTD_cwksp_used(ws) == neededSpace);
 
         zc->initialized = 1;
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1783,7 +1783,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
             needsIndexReset,
             ZSTD_resetTarget_CCtx), "");
 
-        ZSTD_cwksp_finalize(ws);
+        FORWARD_IF_ERROR(ZSTD_cwksp_finalize(ws), "failed ZSTD_cwksp_finalize() alloc!");
         assert(ZSTD_cwksp_used(ws) == neededSpace);
 
         zc->initialized = 1;


### PR DESCRIPTION
The general strategy is:
1. When we begin allocating aligneds or tables, move the start of that section so that it is 64-byte aligned, done through `ZSTD_cwksp_internal_advance_phase()`.
2. Guarantee that the size of every table allocated in the aligned or tables section are all 64-bytes, therefore all of them will be 64-byte aligned. This is done with `ZSTD_cwksp_aligned_alloc_size()` - however, the tables don't actually need this since they're already guaranteed to be in multiples of 64 (we additionally static assert this to be true).
3. Since we want our wksp estimation to still be accurate, we also will always reserve 64+64 bytes for the purposes of aligning the beginnings of the tables and aligned. The comments in `ZSTD_cwksp_slack_space_required()` explain this mechanism.

The two public functions added: `ZSTD_cwksp_slack_space_required()` and `ZSTD_cwksp_finalize()` are meant to be generic - the former returning all space required for internal purposes, and the latter handling any final things to take care of in the wksp after we're done allocating the buffers. In both cases we currently just deal with alignment.

Test Plan:
- Unit tests, manual spot checking of 64-byte alignment (and asserts that guarantee them)