### PR TITLE
Add ZSTD_defaultCLevel() function to public API

### DIFF
--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -1441,6 +1441,11 @@ size_t ZSTD_freeCCtxParams(ZSTD_CCtx_params* params);
   which have troubles handling structures containing memory pointers.
  
 </p></pre><BR>
+  
+<pre><b>int ZSTD_defaultCLevel();
+</b><p> Returns the default compression level, specified by ZSTD_CLEVEL_DEFAULT
+
+</p></pre><BR>
 
 <a name="Chapter18"></a><h2>Advanced decompression functions</h2><pre></pre>
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -5054,6 +5054,7 @@ size_t ZSTD_endStream(ZSTD_CStream* zcs, ZSTD_outBuffer* output)
 #define ZSTD_MAX_CLEVEL     22
 int ZSTD_maxCLevel(void) { return ZSTD_MAX_CLEVEL; }
 int ZSTD_minCLevel(void) { return (int)-ZSTD_TARGETLENGTH_MAX; }
+int ZSTD_defaultCLevel(void) { return ZSTD_CLEVEL_DEFAULT; }
 
 static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEVEL+1] = {
 {   /* "default" - for any srcSize > 256 KB */

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1918,6 +1918,10 @@ ZSTDLIB_API size_t ZSTD_compressStream2_simpleArgs (
                       const void* src, size_t srcSize, size_t* srcPos,
                             ZSTD_EndDirective endOp);
 
+/*! ZSTD_defaultCLevel() :
+ * Returns the default compression level, specified by ZSTD_CLEVEL_DEFAULT
+ */
+ZSTDLIB_API int ZSTD_defaultCLevel(void);
 
 /***************************************
 *  Advanced decompression functions

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -374,6 +374,12 @@ static int basicUnitTests(U32 const seed, double compressibility)
         DISPLAYLEVEL(3, "%i (OK) \n", mcl);
     }
 
+    DISPLAYLEVEL(3, "test%3u : default compression level : ", testNb++);
+    {   int const defaultCLevel = ZSTD_defaultCLevel();
+        if (defaultCLevel != ZSTD_CLEVEL_DEFAULT) goto _output_error;
+        DISPLAYLEVEL(3, "%i (OK) \n", defaultCLevel);
+    }
+
     DISPLAYLEVEL(3, "test%3u : ZSTD_versionNumber : ", testNb++);
     {   unsigned const vn = ZSTD_versionNumber();
         DISPLAYLEVEL(3, "%u (OK) \n", vn);


### PR DESCRIPTION
Requested in #2531

Simple unit test included. I didn't see much value in changing existing `ZSTD_CLEVEL_DEFAULT` invocations to `ZSTD_defaultCLevel()`, so existing code is basically left as-is.