### PR TITLE
Add msan fuzztest to github actions

### DIFF
--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -117,6 +117,16 @@ jobs:
         make gcc8install
         CC=gcc-8 FUZZER_FLAGS="--long-tests" make clean uasan-fuzztest
 
+  clang-msan-testzstd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: clang + MSan + Fuzz Test
+      run: |
+        sudo apt-get update
+        sudo apt-get install clang
+        CC=clang FUZZER_FLAGS="--long-tests" make clean msan-fuzztest
+
   gcc-asan-ubsan-fuzz32:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We need an msan fuzztest - block splitter PR actually failed this, but it went undetected since our CI no longer does an msan fuzztest.

Is there any way to force `generic-dev` to run on this PR? Or must there be changes to the actual code for that to happen.