### PR TITLE
Fix block splitter minor MSAN warning.

### DIFF
--- a/.github/workflows/generic-dev.yml
+++ b/.github/workflows/generic-dev.yml
@@ -126,6 +126,16 @@ jobs:
         make libc6install
         CFLAGS="-O2 -m32" FUZZER_FLAGS="--long-tests" make uasan-fuzztest
 
+  clang-msan-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: clang + MSan + Fuzz Test
+      run: |
+        sudo apt-get update
+        sudo apt-get install clang
+        CC=clang FUZZER_FLAGS="--long-tests" make clean msan-fuzztest
+
   asan-ubsan-msan-regression:
     runs-on: ubuntu-latest
     steps:

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -106,7 +106,7 @@ typedef struct {
     symbolEncodingType_e mlType;
     BYTE fseTablesBuffer[ZSTD_MAX_FSE_HEADERS_SIZE];
     size_t fseTablesSize;
-    size_t lastCountSize; /* This is to account for bug in 1.3.4. More detail in ZSTD_entropyCompressSequences_internal() */
+    size_t lastCountSize; /* This is to account for bug in 1.3.4. More detail in ZSTD_entropyCompressSeqStore_internal() */
 } ZSTD_fseCTablesMetadata_t;
 
 typedef struct {


### PR DESCRIPTION
`lastCountSize` wasn't always initialized when it was used in superblocks or block splitting, causing an msan warning. This only showed up later in fuzzing because `lastCountSize` exists purely to deal with a random edge case from `1.3.4`, so was unlikely to get checked.

test plan:
- Check that we fail `msan-fuzztest` prior to this PR, and succeed after this PR.
- Add msan fuzz test to the github CI