### PR TITLE
Fix dictionary force reloading clevel selection

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -5164,11 +5164,11 @@ static size_t ZSTD_CCtx_init_compressStream2(ZSTD_CCtx* cctx,
                                              size_t inSize) {
     ZSTD_CCtx_params params = cctx->requestedParams;
     ZSTD_prefixDict const prefixDict = cctx->prefixDict;
+    if (cctx->cdict)
+        params.compressionLevel = cctx->cdict->compressionLevel; /* let cdict take priority in terms of compression level */
     FORWARD_IF_ERROR( ZSTD_initLocalDict(cctx) , ""); /* Init the local dict if present. */
     ZSTD_memset(&cctx->prefixDict, 0, sizeof(cctx->prefixDict));   /* single usage */
     assert(prefixDict.dict==NULL || cctx->cdict==NULL);    /* only one can be set */
-    if (cctx->cdict)
-        params.compressionLevel = cctx->cdict->compressionLevel; /* let cdict take priority in terms of compression level */
     DEBUGLOG(4, "ZSTD_compressStream2 : transparent init stage");
     if (endOp == ZSTD_e_end) cctx->pledgedSrcSizePlusOne = inSize + 1;  /* auto-fix pledgedSrcSize */
     {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -5164,7 +5164,7 @@ static size_t ZSTD_CCtx_init_compressStream2(ZSTD_CCtx* cctx,
                                              size_t inSize) {
     ZSTD_CCtx_params params = cctx->requestedParams;
     ZSTD_prefixDict const prefixDict = cctx->prefixDict;
-    if (cctx->cdict)
+    if (cctx->cdict && !cctx->localDict.cdict)
         params.compressionLevel = cctx->cdict->compressionLevel; /* let cdict take priority in terms of compression level */
     FORWARD_IF_ERROR( ZSTD_initLocalDict(cctx) , ""); /* Init the local dict if present. */
     ZSTD_memset(&cctx->prefixDict, 0, sizeof(cctx->prefixDict));   /* single usage */

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -188,15 +188,15 @@ github,                             uncompressed literals optimal,      zstdcli,
 github,                             huffman literals,                   zstdcli,                            144465
 github,                             multithreaded with advanced params, zstdcli,                            167915
 github.tar,                         level -5,                           zstdcli,                            46751
-github.tar,                         level -5 with dict,                 zstdcli,                            43975
+github.tar,                         level -5 with dict,                 zstdcli,                            44444
 github.tar,                         level -3,                           zstdcli,                            43541
-github.tar,                         level -3 with dict,                 zstdcli,                            40809
+github.tar,                         level -3 with dict,                 zstdcli,                            41116
 github.tar,                         level -1,                           zstdcli,                            42469
-github.tar,                         level -1 with dict,                 zstdcli,                            41126
+github.tar,                         level -1 with dict,                 zstdcli,                            41200
 github.tar,                         level 0,                            zstdcli,                            38445
 github.tar,                         level 0 with dict,                  zstdcli,                            37999
 github.tar,                         level 1,                            zstdcli,                            39346
-github.tar,                         level 1 with dict,                  zstdcli,                            38313
+github.tar,                         level 1 with dict,                  zstdcli,                            38297
 github.tar,                         level 3,                            zstdcli,                            38445
 github.tar,                         level 3 with dict,                  zstdcli,                            37999
 github.tar,                         level 4,                            zstdcli,                            38471
@@ -297,7 +297,7 @@ github,                             level 1 with dict,                  advanced
 github,                             level 1 with dict dms,              advanced one pass,                  41682
 github,                             level 1 with dict dds,              advanced one pass,                  41682
 github,                             level 1 with dict copy,             advanced one pass,                  41674
-github,                             level 1 with dict load,             advanced one pass,                  42252
+github,                             level 1 with dict load,             advanced one pass,                  43755
 github,                             level 3,                            advanced one pass,                  136335
 github,                             level 3 with dict,                  advanced one pass,                  41148
 github,                             level 3 with dict dms,              advanced one pass,                  41148
@@ -309,49 +309,49 @@ github,                             level 4 with dict,                  advanced
 github,                             level 4 with dict dms,              advanced one pass,                  41251
 github,                             level 4 with dict dds,              advanced one pass,                  41251
 github,                             level 4 with dict copy,             advanced one pass,                  41216
-github,                             level 4 with dict load,             advanced one pass,                  42252
+github,                             level 4 with dict load,             advanced one pass,                  41159
 github,                             level 5,                            advanced one pass,                  135121
 github,                             level 5 with dict,                  advanced one pass,                  38938
 github,                             level 5 with dict dms,              advanced one pass,                  38938
 github,                             level 5 with dict dds,              advanced one pass,                  38741
 github,                             level 5 with dict copy,             advanced one pass,                  38934
-github,                             level 5 with dict load,             advanced one pass,                  42252
+github,                             level 5 with dict load,             advanced one pass,                  40725
 github,                             level 6,                            advanced one pass,                  135122
 github,                             level 6 with dict,                  advanced one pass,                  38632
 github,                             level 6 with dict dms,              advanced one pass,                  38632
 github,                             level 6 with dict dds,              advanced one pass,                  38632
 github,                             level 6 with dict copy,             advanced one pass,                  38628
-github,                             level 6 with dict load,             advanced one pass,                  42252
+github,                             level 6 with dict load,             advanced one pass,                  40695
 github,                             level 7,                            advanced one pass,                  135122
 github,                             level 7 with dict,                  advanced one pass,                  38771
 github,                             level 7 with dict dms,              advanced one pass,                  38771
 github,                             level 7 with dict dds,              advanced one pass,                  38771
 github,                             level 7 with dict copy,             advanced one pass,                  38745
-github,                             level 7 with dict load,             advanced one pass,                  42252
+github,                             level 7 with dict load,             advanced one pass,                  40695
 github,                             level 9,                            advanced one pass,                  135122
 github,                             level 9 with dict,                  advanced one pass,                  39332
 github,                             level 9 with dict dms,              advanced one pass,                  39332
 github,                             level 9 with dict dds,              advanced one pass,                  39332
 github,                             level 9 with dict copy,             advanced one pass,                  39341
-github,                             level 9 with dict load,             advanced one pass,                  42252
+github,                             level 9 with dict load,             advanced one pass,                  41710
 github,                             level 13,                           advanced one pass,                  134064
 github,                             level 13 with dict,                 advanced one pass,                  39743
 github,                             level 13 with dict dms,             advanced one pass,                  39743
 github,                             level 13 with dict dds,             advanced one pass,                  39743
 github,                             level 13 with dict copy,            advanced one pass,                  39948
-github,                             level 13 with dict load,            advanced one pass,                  42252
+github,                             level 13 with dict load,            advanced one pass,                  42626
 github,                             level 16,                           advanced one pass,                  134064
 github,                             level 16 with dict,                 advanced one pass,                  37577
 github,                             level 16 with dict dms,             advanced one pass,                  37577
 github,                             level 16 with dict dds,             advanced one pass,                  37577
 github,                             level 16 with dict copy,            advanced one pass,                  37568
-github,                             level 16 with dict load,            advanced one pass,                  42252
+github,                             level 16 with dict load,            advanced one pass,                  42340
 github,                             level 19,                           advanced one pass,                  134064
 github,                             level 19 with dict,                 advanced one pass,                  37576
 github,                             level 19 with dict dms,             advanced one pass,                  37576
 github,                             level 19 with dict dds,             advanced one pass,                  37576
 github,                             level 19 with dict copy,            advanced one pass,                  37567
-github,                             level 19 with dict load,            advanced one pass,                  42252
+github,                             level 19 with dict load,            advanced one pass,                  39613
 github,                             no source size,                     advanced one pass,                  136335
 github,                             no source size with dict,           advanced one pass,                  41148
 github,                             long distance mode,                 advanced one pass,                  136335
@@ -366,11 +366,11 @@ github,                             uncompressed literals optimal,      advanced
 github,                             huffman literals,                   advanced one pass,                  142465
 github,                             multithreaded with advanced params, advanced one pass,                  165915
 github.tar,                         level -5,                           advanced one pass,                  46856
-github.tar,                         level -5 with dict,                 advanced one pass,                  43971
+github.tar,                         level -5 with dict,                 advanced one pass,                  44571
 github.tar,                         level -3,                           advanced one pass,                  43754
-github.tar,                         level -3 with dict,                 advanced one pass,                  40805
+github.tar,                         level -3 with dict,                 advanced one pass,                  41447
 github.tar,                         level -1,                           advanced one pass,                  42490
-github.tar,                         level -1 with dict,                 advanced one pass,                  41122
+github.tar,                         level -1 with dict,                 advanced one pass,                  41131
 github.tar,                         level 0,                            advanced one pass,                  38441
 github.tar,                         level 0 with dict,                  advanced one pass,                  37995
 github.tar,                         level 0 with dict dms,              advanced one pass,                  38003
@@ -378,11 +378,11 @@ github.tar,                         level 0 with dict dds,              advanced
 github.tar,                         level 0 with dict copy,             advanced one pass,                  37995
 github.tar,                         level 0 with dict load,             advanced one pass,                  37956
 github.tar,                         level 1,                            advanced one pass,                  39265
-github.tar,                         level 1 with dict,                  advanced one pass,                  38309
-github.tar,                         level 1 with dict dms,              advanced one pass,                  38319
-github.tar,                         level 1 with dict dds,              advanced one pass,                  38319
-github.tar,                         level 1 with dict copy,             advanced one pass,                  38309
-github.tar,                         level 1 with dict load,             advanced one pass,                  37956
+github.tar,                         level 1 with dict,                  advanced one pass,                  38280
+github.tar,                         level 1 with dict dms,              advanced one pass,                  38290
+github.tar,                         level 1 with dict dds,              advanced one pass,                  38290
+github.tar,                         level 1 with dict copy,             advanced one pass,                  38280
+github.tar,                         level 1 with dict load,             advanced one pass,                  38729
 github.tar,                         level 3,                            advanced one pass,                  38441
 github.tar,                         level 3 with dict,                  advanced one pass,                  37995
 github.tar,                         level 3 with dict dms,              advanced one pass,                  38003
@@ -394,49 +394,49 @@ github.tar,                         level 4 with dict,                  advanced
 github.tar,                         level 4 with dict dms,              advanced one pass,                  37954
 github.tar,                         level 4 with dict dds,              advanced one pass,                  37954
 github.tar,                         level 4 with dict copy,             advanced one pass,                  37948
-github.tar,                         level 4 with dict load,             advanced one pass,                  37956
+github.tar,                         level 4 with dict load,             advanced one pass,                  37927
 github.tar,                         level 5,                            advanced one pass,                  39788
 github.tar,                         level 5 with dict,                  advanced one pass,                  39715
 github.tar,                         level 5 with dict dms,              advanced one pass,                  39365
 github.tar,                         level 5 with dict dds,              advanced one pass,                  39227
 github.tar,                         level 5 with dict copy,             advanced one pass,                  39715
-github.tar,                         level 5 with dict load,             advanced one pass,                  37956
+github.tar,                         level 5 with dict load,             advanced one pass,                  39209
 github.tar,                         level 6,                            advanced one pass,                  39603
 github.tar,                         level 6 with dict,                  advanced one pass,                  38800
 github.tar,                         level 6 with dict dms,              advanced one pass,                  38665
 github.tar,                         level 6 with dict dds,              advanced one pass,                  38665
 github.tar,                         level 6 with dict copy,             advanced one pass,                  38800
-github.tar,                         level 6 with dict load,             advanced one pass,                  37956
+github.tar,                         level 6 with dict load,             advanced one pass,                  38983
 github.tar,                         level 7,                            advanced one pass,                  39206
 github.tar,                         level 7 with dict,                  advanced one pass,                  38071
 github.tar,                         level 7 with dict dms,              advanced one pass,                  37954
 github.tar,                         level 7 with dict dds,              advanced one pass,                  37954
 github.tar,                         level 7 with dict copy,             advanced one pass,                  38071
-github.tar,                         level 7 with dict load,             advanced one pass,                  37956
+github.tar,                         level 7 with dict load,             advanced one pass,                  38584
 github.tar,                         level 9,                            advanced one pass,                  36717
 github.tar,                         level 9 with dict,                  advanced one pass,                  36898
 github.tar,                         level 9 with dict dms,              advanced one pass,                  36882
 github.tar,                         level 9 with dict dds,              advanced one pass,                  36882
 github.tar,                         level 9 with dict copy,             advanced one pass,                  36898
-github.tar,                         level 9 with dict load,             advanced one pass,                  37956
+github.tar,                         level 9 with dict load,             advanced one pass,                  36363
 github.tar,                         level 13,                           advanced one pass,                  35621
 github.tar,                         level 13 with dict,                 advanced one pass,                  38726
 github.tar,                         level 13 with dict dms,             advanced one pass,                  38903
 github.tar,                         level 13 with dict dds,             advanced one pass,                  38903
 github.tar,                         level 13 with dict copy,            advanced one pass,                  38726
-github.tar,                         level 13 with dict load,            advanced one pass,                  37956
+github.tar,                         level 13 with dict load,            advanced one pass,                  36372
 github.tar,                         level 16,                           advanced one pass,                  40255
 github.tar,                         level 16 with dict,                 advanced one pass,                  33639
 github.tar,                         level 16 with dict dms,             advanced one pass,                  33544
 github.tar,                         level 16 with dict dds,             advanced one pass,                  33544
 github.tar,                         level 16 with dict copy,            advanced one pass,                  33639
-github.tar,                         level 16 with dict load,            advanced one pass,                  37956
+github.tar,                         level 16 with dict load,            advanced one pass,                  39353
 github.tar,                         level 19,                           advanced one pass,                  32837
 github.tar,                         level 19 with dict,                 advanced one pass,                  32895
 github.tar,                         level 19 with dict dms,             advanced one pass,                  32672
 github.tar,                         level 19 with dict dds,             advanced one pass,                  32672
 github.tar,                         level 19 with dict copy,            advanced one pass,                  32895
-github.tar,                         level 19 with dict load,            advanced one pass,                  37956
+github.tar,                         level 19 with dict load,            advanced one pass,                  32676
 github.tar,                         no source size,                     advanced one pass,                  38441
 github.tar,                         no source size with dict,           advanced one pass,                  37995
 github.tar,                         long distance mode,                 advanced one pass,                  39722
@@ -519,7 +519,7 @@ github,                             level 1 with dict,                  advanced
 github,                             level 1 with dict dms,              advanced one pass small out,        41682
 github,                             level 1 with dict dds,              advanced one pass small out,        41682
 github,                             level 1 with dict copy,             advanced one pass small out,        41674
-github,                             level 1 with dict load,             advanced one pass small out,        42252
+github,                             level 1 with dict load,             advanced one pass small out,        43755
 github,                             level 3,                            advanced one pass small out,        136335
 github,                             level 3 with dict,                  advanced one pass small out,        41148
 github,                             level 3 with dict dms,              advanced one pass small out,        41148
@@ -531,49 +531,49 @@ github,                             level 4 with dict,                  advanced
 github,                             level 4 with dict dms,              advanced one pass small out,        41251
 github,                             level 4 with dict dds,              advanced one pass small out,        41251
 github,                             level 4 with dict copy,             advanced one pass small out,        41216
-github,                             level 4 with dict load,             advanced one pass small out,        42252
+github,                             level 4 with dict load,             advanced one pass small out,        41159
 github,                             level 5,                            advanced one pass small out,        135121
 github,                             level 5 with dict,                  advanced one pass small out,        38938
 github,                             level 5 with dict dms,              advanced one pass small out,        38938
 github,                             level 5 with dict dds,              advanced one pass small out,        38741
 github,                             level 5 with dict copy,             advanced one pass small out,        38934
-github,                             level 5 with dict load,             advanced one pass small out,        42252
+github,                             level 5 with dict load,             advanced one pass small out,        40725
 github,                             level 6,                            advanced one pass small out,        135122
 github,                             level 6 with dict,                  advanced one pass small out,        38632
 github,                             level 6 with dict dms,              advanced one pass small out,        38632
 github,                             level 6 with dict dds,              advanced one pass small out,        38632
 github,                             level 6 with dict copy,             advanced one pass small out,        38628
-github,                             level 6 with dict load,             advanced one pass small out,        42252
+github,                             level 6 with dict load,             advanced one pass small out,        40695
 github,                             level 7,                            advanced one pass small out,        135122
 github,                             level 7 with dict,                  advanced one pass small out,        38771
 github,                             level 7 with dict dms,              advanced one pass small out,        38771
 github,                             level 7 with dict dds,              advanced one pass small out,        38771
 github,                             level 7 with dict copy,             advanced one pass small out,        38745
-github,                             level 7 with dict load,             advanced one pass small out,        42252
+github,                             level 7 with dict load,             advanced one pass small out,        40695
 github,                             level 9,                            advanced one pass small out,        135122
 github,                             level 9 with dict,                  advanced one pass small out,        39332
 github,                             level 9 with dict dms,              advanced one pass small out,        39332
 github,                             level 9 with dict dds,              advanced one pass small out,        39332
 github,                             level 9 with dict copy,             advanced one pass small out,        39341
-github,                             level 9 with dict load,             advanced one pass small out,        42252
+github,                             level 9 with dict load,             advanced one pass small out,        41710
 github,                             level 13,                           advanced one pass small out,        134064
 github,                             level 13 with dict,                 advanced one pass small out,        39743
 github,                             level 13 with dict dms,             advanced one pass small out,        39743
 github,                             level 13 with dict dds,             advanced one pass small out,        39743
 github,                             level 13 with dict copy,            advanced one pass small out,        39948
-github,                             level 13 with dict load,            advanced one pass small out,        42252
+github,                             level 13 with dict load,            advanced one pass small out,        42626
 github,                             level 16,                           advanced one pass small out,        134064
 github,                             level 16 with dict,                 advanced one pass small out,        37577
 github,                             level 16 with dict dms,             advanced one pass small out,        37577
 github,                             level 16 with dict dds,             advanced one pass small out,        37577
 github,                             level 16 with dict copy,            advanced one pass small out,        37568
-github,                             level 16 with dict load,            advanced one pass small out,        42252
+github,                             level 16 with dict load,            advanced one pass small out,        42340
 github,                             level 19,                           advanced one pass small out,        134064
 github,                             level 19 with dict,                 advanced one pass small out,        37576
 github,                             level 19 with dict dms,             advanced one pass small out,        37576
 github,                             level 19 with dict dds,             advanced one pass small out,        37576
 github,                             level 19 with dict copy,            advanced one pass small out,        37567
-github,                             level 19 with dict load,            advanced one pass small out,        42252
+github,                             level 19 with dict load,            advanced one pass small out,        39613
 github,                             no source size,                     advanced one pass small out,        136335
 github,                             no source size with dict,           advanced one pass small out,        41148
 github,                             long distance mode,                 advanced one pass small out,        136335
@@ -588,11 +588,11 @@ github,                             uncompressed literals optimal,      advanced
 github,                             huffman literals,                   advanced one pass small out,        142465
 github,                             multithreaded with advanced params, advanced one pass small out,        165915
 github.tar,                         level -5,                           advanced one pass small out,        46856
-github.tar,                         level -5 with dict,                 advanced one pass small out,        43971
+github.tar,                         level -5 with dict,                 advanced one pass small out,        44571
 github.tar,                         level -3,                           advanced one pass small out,        43754
-github.tar,                         level -3 with dict,                 advanced one pass small out,        40805
+github.tar,                         level -3 with dict,                 advanced one pass small out,        41447
 github.tar,                         level -1,                           advanced one pass small out,        42490
-github.tar,                         level -1 with dict,                 advanced one pass small out,        41122
+github.tar,                         level -1 with dict,                 advanced one pass small out,        41131
 github.tar,                         level 0,                            advanced one pass small out,        38441
 github.tar,                         level 0 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 0 with dict dms,              advanced one pass small out,        38003
@@ -600,11 +600,11 @@ github.tar,                         level 0 with dict dds,              advanced
 github.tar,                         level 0 with dict copy,             advanced one pass small out,        37995
 github.tar,                         level 0 with dict load,             advanced one pass small out,        37956
 github.tar,                         level 1,                            advanced one pass small out,        39265
-github.tar,                         level 1 with dict,                  advanced one pass small out,        38309
-github.tar,                         level 1 with dict dms,              advanced one pass small out,        38319
-github.tar,                         level 1 with dict dds,              advanced one pass small out,        38319
-github.tar,                         level 1 with dict copy,             advanced one pass small out,        38309
-github.tar,                         level 1 with dict load,             advanced one pass small out,        37956
+github.tar,                         level 1 with dict,                  advanced one pass small out,        38280
+github.tar,                         level 1 with dict dms,              advanced one pass small out,        38290
+github.tar,                         level 1 with dict dds,              advanced one pass small out,        38290
+github.tar,                         level 1 with dict copy,             advanced one pass small out,        38280
+github.tar,                         level 1 with dict load,             advanced one pass small out,        38729
 github.tar,                         level 3,                            advanced one pass small out,        38441
 github.tar,                         level 3 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 3 with dict dms,              advanced one pass small out,        38003
@@ -616,49 +616,49 @@ github.tar,                         level 4 with dict,                  advanced
 github.tar,                         level 4 with dict dms,              advanced one pass small out,        37954
 github.tar,                         level 4 with dict dds,              advanced one pass small out,        37954
 github.tar,                         level 4 with dict copy,             advanced one pass small out,        37948
-github.tar,                         level 4 with dict load,             advanced one pass small out,        37956
+github.tar,                         level 4 with dict load,             advanced one pass small out,        37927
 github.tar,                         level 5,                            advanced one pass small out,        39788
 github.tar,                         level 5 with dict,                  advanced one pass small out,        39715
 github.tar,                         level 5 with dict dms,              advanced one pass small out,        39365
 github.tar,                         level 5 with dict dds,              advanced one pass small out,        39227
 github.tar,                         level 5 with dict copy,             advanced one pass small out,        39715
-github.tar,                         level 5 with dict load,             advanced one pass small out,        37956
+github.tar,                         level 5 with dict load,             advanced one pass small out,        39209
 github.tar,                         level 6,                            advanced one pass small out,        39603
 github.tar,                         level 6 with dict,                  advanced one pass small out,        38800
 github.tar,                         level 6 with dict dms,              advanced one pass small out,        38665
 github.tar,                         level 6 with dict dds,              advanced one pass small out,        38665
 github.tar,                         level 6 with dict copy,             advanced one pass small out,        38800
-github.tar,                         level 6 with dict load,             advanced one pass small out,        37956
+github.tar,                         level 6 with dict load,             advanced one pass small out,        38983
 github.tar,                         level 7,                            advanced one pass small out,        39206
 github.tar,                         level 7 with dict,                  advanced one pass small out,        38071
 github.tar,                         level 7 with dict dms,              advanced one pass small out,        37954
 github.tar,                         level 7 with dict dds,              advanced one pass small out,        37954
 github.tar,                         level 7 with dict copy,             advanced one pass small out,        38071
-github.tar,                         level 7 with dict load,             advanced one pass small out,        37956
+github.tar,                         level 7 with dict load,             advanced one pass small out,        38584
 github.tar,                         level 9,                            advanced one pass small out,        36717
 github.tar,                         level 9 with dict,                  advanced one pass small out,        36898
 github.tar,                         level 9 with dict dms,              advanced one pass small out,        36882
 github.tar,                         level 9 with dict dds,              advanced one pass small out,        36882
 github.tar,                         level 9 with dict copy,             advanced one pass small out,        36898
-github.tar,                         level 9 with dict load,             advanced one pass small out,        37956
+github.tar,                         level 9 with dict load,             advanced one pass small out,        36363
 github.tar,                         level 13,                           advanced one pass small out,        35621
 github.tar,                         level 13 with dict,                 advanced one pass small out,        38726
 github.tar,                         level 13 with dict dms,             advanced one pass small out,        38903
 github.tar,                         level 13 with dict dds,             advanced one pass small out,        38903
 github.tar,                         level 13 with dict copy,            advanced one pass small out,        38726
-github.tar,                         level 13 with dict load,            advanced one pass small out,        37956
+github.tar,                         level 13 with dict load,            advanced one pass small out,        36372
 github.tar,                         level 16,                           advanced one pass small out,        40255
 github.tar,                         level 16 with dict,                 advanced one pass small out,        33639
 github.tar,                         level 16 with dict dms,             advanced one pass small out,        33544
 github.tar,                         level 16 with dict dds,             advanced one pass small out,        33544
 github.tar,                         level 16 with dict copy,            advanced one pass small out,        33639
-github.tar,                         level 16 with dict load,            advanced one pass small out,        37956
+github.tar,                         level 16 with dict load,            advanced one pass small out,        39353
 github.tar,                         level 19,                           advanced one pass small out,        32837
 github.tar,                         level 19 with dict,                 advanced one pass small out,        32895
 github.tar,                         level 19 with dict dms,             advanced one pass small out,        32672
 github.tar,                         level 19 with dict dds,             advanced one pass small out,        32672
 github.tar,                         level 19 with dict copy,            advanced one pass small out,        32895
-github.tar,                         level 19 with dict load,            advanced one pass small out,        37956
+github.tar,                         level 19 with dict load,            advanced one pass small out,        32676
 github.tar,                         no source size,                     advanced one pass small out,        38441
 github.tar,                         no source size with dict,           advanced one pass small out,        37995
 github.tar,                         long distance mode,                 advanced one pass small out,        39722
@@ -741,7 +741,7 @@ github,                             level 1 with dict,                  advanced
 github,                             level 1 with dict dms,              advanced streaming,                 41682
 github,                             level 1 with dict dds,              advanced streaming,                 41682
 github,                             level 1 with dict copy,             advanced streaming,                 41674
-github,                             level 1 with dict load,             advanced streaming,                 42252
+github,                             level 1 with dict load,             advanced streaming,                 43755
 github,                             level 3,                            advanced streaming,                 136335
 github,                             level 3 with dict,                  advanced streaming,                 41148
 github,                             level 3 with dict dms,              advanced streaming,                 41148
@@ -753,49 +753,49 @@ github,                             level 4 with dict,                  advanced
 github,                             level 4 with dict dms,              advanced streaming,                 41251
 github,                             level 4 with dict dds,              advanced streaming,                 41251
 github,                             level 4 with dict copy,             advanced streaming,                 41216
-github,                             level 4 with dict load,             advanced streaming,                 42252
+github,                             level 4 with dict load,             advanced streaming,                 41159
 github,                             level 5,                            advanced streaming,                 135121
 github,                             level 5 with dict,                  advanced streaming,                 38938
 github,                             level 5 with dict dms,              advanced streaming,                 38938
 github,                             level 5 with dict dds,              advanced streaming,                 38741
 github,                             level 5 with dict copy,             advanced streaming,                 38934
-github,                             level 5 with dict load,             advanced streaming,                 42252
+github,                             level 5 with dict load,             advanced streaming,                 40725
 github,                             level 6,                            advanced streaming,                 135122
 github,                             level 6 with dict,                  advanced streaming,                 38632
 github,                             level 6 with dict dms,              advanced streaming,                 38632
 github,                             level 6 with dict dds,              advanced streaming,                 38632
 github,                             level 6 with dict copy,             advanced streaming,                 38628
-github,                             level 6 with dict load,             advanced streaming,                 42252
+github,                             level 6 with dict load,             advanced streaming,                 40695
 github,                             level 7,                            advanced streaming,                 135122
 github,                             level 7 with dict,                  advanced streaming,                 38771
 github,                             level 7 with dict dms,              advanced streaming,                 38771
 github,                             level 7 with dict dds,              advanced streaming,                 38771
 github,                             level 7 with dict copy,             advanced streaming,                 38745
-github,                             level 7 with dict load,             advanced streaming,                 42252
+github,                             level 7 with dict load,             advanced streaming,                 40695
 github,                             level 9,                            advanced streaming,                 135122
 github,                             level 9 with dict,                  advanced streaming,                 39332
 github,                             level 9 with dict dms,              advanced streaming,                 39332
 github,                             level 9 with dict dds,              advanced streaming,                 39332
 github,                             level 9 with dict copy,             advanced streaming,                 39341
-github,                             level 9 with dict load,             advanced streaming,                 42252
+github,                             level 9 with dict load,             advanced streaming,                 41710
 github,                             level 13,                           advanced streaming,                 134064
 github,                             level 13 with dict,                 advanced streaming,                 39743
 github,                             level 13 with dict dms,             advanced streaming,                 39743
 github,                             level 13 with dict dds,             advanced streaming,                 39743
 github,                             level 13 with dict copy,            advanced streaming,                 39948
-github,                             level 13 with dict load,            advanced streaming,                 42252
+github,                             level 13 with dict load,            advanced streaming,                 42626
 github,                             level 16,                           advanced streaming,                 134064
 github,                             level 16 with dict,                 advanced streaming,                 37577
 github,                             level 16 with dict dms,             advanced streaming,                 37577
 github,                             level 16 with dict dds,             advanced streaming,                 37577
 github,                             level 16 with dict copy,            advanced streaming,                 37568
-github,                             level 16 with dict load,            advanced streaming,                 42252
+github,                             level 16 with dict load,            advanced streaming,                 42340
 github,                             level 19,                           advanced streaming,                 134064
 github,                             level 19 with dict,                 advanced streaming,                 37576
 github,                             level 19 with dict dms,             advanced streaming,                 37576
 github,                             level 19 with dict dds,             advanced streaming,                 37576
 github,                             level 19 with dict copy,            advanced streaming,                 37567
-github,                             level 19 with dict load,            advanced streaming,                 42252
+github,                             level 19 with dict load,            advanced streaming,                 39613
 github,                             no source size,                     advanced streaming,                 136335
 github,                             no source size with dict,           advanced streaming,                 41148
 github,                             long distance mode,                 advanced streaming,                 136335
@@ -810,11 +810,11 @@ github,                             uncompressed literals optimal,      advanced
 github,                             huffman literals,                   advanced streaming,                 142465
 github,                             multithreaded with advanced params, advanced streaming,                 165915
 github.tar,                         level -5,                           advanced streaming,                 46747
-github.tar,                         level -5 with dict,                 advanced streaming,                 43971
+github.tar,                         level -5 with dict,                 advanced streaming,                 44440
 github.tar,                         level -3,                           advanced streaming,                 43537
-github.tar,                         level -3 with dict,                 advanced streaming,                 40805
+github.tar,                         level -3 with dict,                 advanced streaming,                 41112
 github.tar,                         level -1,                           advanced streaming,                 42465
-github.tar,                         level -1 with dict,                 advanced streaming,                 41122
+github.tar,                         level -1 with dict,                 advanced streaming,                 41196
 github.tar,                         level 0,                            advanced streaming,                 38441
 github.tar,                         level 0 with dict,                  advanced streaming,                 37995
 github.tar,                         level 0 with dict dms,              advanced streaming,                 38003
@@ -822,11 +822,11 @@ github.tar,                         level 0 with dict dds,              advanced
 github.tar,                         level 0 with dict copy,             advanced streaming,                 37995
 github.tar,                         level 0 with dict load,             advanced streaming,                 37956
 github.tar,                         level 1,                            advanced streaming,                 39342
-github.tar,                         level 1 with dict,                  advanced streaming,                 38309
-github.tar,                         level 1 with dict dms,              advanced streaming,                 38319
-github.tar,                         level 1 with dict dds,              advanced streaming,                 38319
-github.tar,                         level 1 with dict copy,             advanced streaming,                 38309
-github.tar,                         level 1 with dict load,             advanced streaming,                 37956
+github.tar,                         level 1 with dict,                  advanced streaming,                 38293
+github.tar,                         level 1 with dict dms,              advanced streaming,                 38303
+github.tar,                         level 1 with dict dds,              advanced streaming,                 38303
+github.tar,                         level 1 with dict copy,             advanced streaming,                 38293
+github.tar,                         level 1 with dict load,             advanced streaming,                 38766
 github.tar,                         level 3,                            advanced streaming,                 38441
 github.tar,                         level 3 with dict,                  advanced streaming,                 37995
 github.tar,                         level 3 with dict dms,              advanced streaming,                 38003
@@ -838,49 +838,49 @@ github.tar,                         level 4 with dict,                  advanced
 github.tar,                         level 4 with dict dms,              advanced streaming,                 37954
 github.tar,                         level 4 with dict dds,              advanced streaming,                 37954
 github.tar,                         level 4 with dict copy,             advanced streaming,                 37948
-github.tar,                         level 4 with dict load,             advanced streaming,                 37956
+github.tar,                         level 4 with dict load,             advanced streaming,                 37927
 github.tar,                         level 5,                            advanced streaming,                 39788
 github.tar,                         level 5 with dict,                  advanced streaming,                 39715
 github.tar,                         level 5 with dict dms,              advanced streaming,                 39365
 github.tar,                         level 5 with dict dds,              advanced streaming,                 39227
 github.tar,                         level 5 with dict copy,             advanced streaming,                 39715
-github.tar,                         level 5 with dict load,             advanced streaming,                 37956
+github.tar,                         level 5 with dict load,             advanced streaming,                 39209
 github.tar,                         level 6,                            advanced streaming,                 39603
 github.tar,                         level 6 with dict,                  advanced streaming,                 38800
 github.tar,                         level 6 with dict dms,              advanced streaming,                 38665
 github.tar,                         level 6 with dict dds,              advanced streaming,                 38665
 github.tar,                         level 6 with dict copy,             advanced streaming,                 38800
-github.tar,                         level 6 with dict load,             advanced streaming,                 37956
+github.tar,                         level 6 with dict load,             advanced streaming,                 38983
 github.tar,                         level 7,                            advanced streaming,                 39206
 github.tar,                         level 7 with dict,                  advanced streaming,                 38071
 github.tar,                         level 7 with dict dms,              advanced streaming,                 37954
 github.tar,                         level 7 with dict dds,              advanced streaming,                 37954
 github.tar,                         level 7 with dict copy,             advanced streaming,                 38071
-github.tar,                         level 7 with dict load,             advanced streaming,                 37956
+github.tar,                         level 7 with dict load,             advanced streaming,                 38584
 github.tar,                         level 9,                            advanced streaming,                 36717
 github.tar,                         level 9 with dict,                  advanced streaming,                 36898
 github.tar,                         level 9 with dict dms,              advanced streaming,                 36882
 github.tar,                         level 9 with dict dds,              advanced streaming,                 36882
 github.tar,                         level 9 with dict copy,             advanced streaming,                 36898
-github.tar,                         level 9 with dict load,             advanced streaming,                 37956
+github.tar,                         level 9 with dict load,             advanced streaming,                 36363
 github.tar,                         level 13,                           advanced streaming,                 35621
 github.tar,                         level 13 with dict,                 advanced streaming,                 38726
 github.tar,                         level 13 with dict dms,             advanced streaming,                 38903
 github.tar,                         level 13 with dict dds,             advanced streaming,                 38903
 github.tar,                         level 13 with dict copy,            advanced streaming,                 38726
-github.tar,                         level 13 with dict load,            advanced streaming,                 37956
+github.tar,                         level 13 with dict load,            advanced streaming,                 36372
 github.tar,                         level 16,                           advanced streaming,                 40255
 github.tar,                         level 16 with dict,                 advanced streaming,                 33639
 github.tar,                         level 16 with dict dms,             advanced streaming,                 33544
 github.tar,                         level 16 with dict dds,             advanced streaming,                 33544
 github.tar,                         level 16 with dict copy,            advanced streaming,                 33639
-github.tar,                         level 16 with dict load,            advanced streaming,                 37956
+github.tar,                         level 16 with dict load,            advanced streaming,                 39353
 github.tar,                         level 19,                           advanced streaming,                 32837
 github.tar,                         level 19 with dict,                 advanced streaming,                 32895
 github.tar,                         level 19 with dict dms,             advanced streaming,                 32672
 github.tar,                         level 19 with dict dds,             advanced streaming,                 32672
 github.tar,                         level 19 with dict copy,            advanced streaming,                 32895
-github.tar,                         level 19 with dict load,            advanced streaming,                 37956
+github.tar,                         level 19 with dict load,            advanced streaming,                 32676
 github.tar,                         no source size,                     advanced streaming,                 38438
 github.tar,                         no source size with dict,           advanced streaming,                 38000
 github.tar,                         long distance mode,                 advanced streaming,                 39722
@@ -964,15 +964,15 @@ github,                             uncompressed literals,              old stre
 github,                             uncompressed literals optimal,      old streaming,                      134064
 github,                             huffman literals,                   old streaming,                      175568
 github.tar,                         level -5,                           old streaming,                      46747
-github.tar,                         level -5 with dict,                 old streaming,                      43971
+github.tar,                         level -5 with dict,                 old streaming,                      44440
 github.tar,                         level -3,                           old streaming,                      43537
-github.tar,                         level -3 with dict,                 old streaming,                      40805
+github.tar,                         level -3 with dict,                 old streaming,                      41112
 github.tar,                         level -1,                           old streaming,                      42465
-github.tar,                         level -1 with dict,                 old streaming,                      41122
+github.tar,                         level -1 with dict,                 old streaming,                      41196
 github.tar,                         level 0,                            old streaming,                      38441
 github.tar,                         level 0 with dict,                  old streaming,                      37995
 github.tar,                         level 1,                            old streaming,                      39342
-github.tar,                         level 1 with dict,                  old streaming,                      38309
+github.tar,                         level 1 with dict,                  old streaming,                      38293
 github.tar,                         level 3,                            old streaming,                      38441
 github.tar,                         level 3 with dict,                  old streaming,                      37995
 github.tar,                         level 4,                            old streaming,                      38467


### PR DESCRIPTION
As title - reloading the dictionary with `ZSTD_dictForceLoad` was basically broken because we would always choose the default compression level since `initLocalDict()` always sets a cdict. Now, we only override cctx clevel with cdict's clevel if the cctx had the cdict to begin with.

`results.csv` updated accordingly.