### PR TITLE
Correct the block splitter mismatched repcodes detection.

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -352,7 +352,7 @@ typedef enum {
 *  Private declarations
 *********************************************/
 typedef struct seqDef_s {
-    U32 offset;         /* Offset code of the sequence */
+    U32 offset;         /* offset == rawOffset + ZSTD_REP_NUM, or equivalently, offCode + 1 */
     U16 litLength;
     U16 matchLength;
 } seqDef;


### PR DESCRIPTION
The block splitter maintains separate repcode histories for both compression and decompression. Previously, only the repcode updating process factored in `litLength==0`, but not the check for mismatch itself. 

This PR fixes that logic and should make the `ZSTD_seqStore_resolveOffCodes()` easier to read and make sense of, and corrects an incorrect (or easy to misinterpret) comment regarding what `seqDef::offset` actually means.

No performance impact.
```
this_branch: 1#silesia.tar       : 211957760 ->  72914525 (2.907), 161.8 MB/s ,1137.9 MB/s 
dev: 1#silesia.tar       : 211957760 ->  72914525 (2.907), 161.4 MB/s ,1140.0 MB/s
```

Test Plan: verifies that this fixes the OSS-fuzz error, and all previous failures remain fixed.