### PR TITLE
seekable decompression fixes

### DIFF
--- a/contrib/seekable_format/examples/seekable_decompression.c
+++ b/contrib/seekable_format/examples/seekable_decompression.c
@@ -99,6 +99,9 @@ static void decompressFile_orDie(const char* fname, off_t startOffset, off_t end
 
     while (startOffset < endOffset) {
         size_t const result = ZSTD_seekable_decompress(seekable, buffOut, MIN(endOffset - startOffset, buffOutSize), startOffset);
+        if (!result) {
+            break;
+        }
 
         if (ZSTD_isError(result)) {
             fprintf(stderr, "ZSTD_seekable_decompress() error : %s \n",

--- a/contrib/seekable_format/examples/seekable_decompression_mem.c
+++ b/contrib/seekable_format/examples/seekable_decompression_mem.c
@@ -104,6 +104,9 @@ static void decompressFile_orDie(const char* fname, off_t startOffset, off_t end
 
     while (startOffset < endOffset) {
         size_t const result = ZSTD_seekable_decompress(seekable, buffOut, MIN(endOffset - startOffset, buffOutSize), startOffset);
+        if (!result) {
+            break;
+        }
 
         if (ZSTD_isError(result)) {
             fprintf(stderr, "ZSTD_seekable_decompress() error : %s \n",

--- a/contrib/seekable_format/zstdseek_decompress.c
+++ b/contrib/seekable_format/zstdseek_decompress.c
@@ -449,7 +449,7 @@ size_t ZSTD_seekable_decompress(ZSTD_seekable* zs, void* dst, size_t len, unsign
             zs->in = (ZSTD_inBuffer){zs->inBuff, 0, 0};
             XXH64_reset(&zs->xxhState, 0);
             ZSTD_DCtx_reset(zs->dstream, ZSTD_reset_session_only);
-            if (srcBytesRead > zs->buffWrapper.size) {
+            if (zs->buffWrapper.size && srcBytesRead > zs->buffWrapper.size) {
                 return ERROR(seekableIO);
             }
         }


### PR DESCRIPTION
### Changelog:

- **seekable_format: cap the offset+len up to the last dOffset**
  This will allow to read the whole file w/o gotting corruption error if
  the offset is more then the data left in file, i.e.:

      $ ./seekable_compression seekable_compression.c 8192 | head
      $ zstd -cdq seekable_compression.c.zst | wc -c
      4737

  Before this patch:

      $ ./seekable_decompression seekable_compression.c.zst 0 10000000 | wc -c
      ZSTD_seekable_decompress() error : Corrupted block detected
      0

  After:

      $ ./seekable_decompression seekable_compression.c.zst 0 10000000 | wc -c
      4737

- **seekable_decompression: break when ZSTD_seekable_decompress() returns zero**
- **seekable_decompression_mem: break when ZSTD_seekable_decompress() returns zero**
- **seekable_format: fix from-file reading (not in-memory)**
