### PR TITLE
Fix chaintable check to include rowhash in ZSTD_reduceIndex()

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2303,7 +2303,7 @@ static void ZSTD_reduceIndex (ZSTD_matchState_t* ms, ZSTD_CCtx_params const* par
         ZSTD_reduceTable(ms->hashTable, hSize, reducerValue);
     }
 
-    if (params->cParams.strategy != ZSTD_fast) {
+    if (ZSTD_allocateChainTable(params->cParams.strategy, params->useRowMatchFinder, (U32)ms->dedicatedDictSearch)) {
         U32 const chainSize = (U32)1 << params->cParams.chainLog;
         if (params->cParams.strategy == ZSTD_btlazy2)
             ZSTD_reduceTable_btlazy2(ms->chainTable, chainSize, reducerValue);


### PR DESCRIPTION
The row hash strategy doesn't use a chainTable, similarly to `ZSTD_fast`. Therefore, existing checks that `strategy != ZSTD_fast` whose _actual intent_ it was to check for a chaintable, are no longer accurate, and all existing sites must be migrated to `ZSTD_allocateChainTable()`. I didn't see any more instances of this in the codebase.

In this case, `ZSTD_reduceIndex()` with row hash could actually end up trying to access memory outside the `cctx` in cases where the `chainLog` was large enough (even though that's not a param row hash actually uses).

`ZSTD_reduceIndex()` actually has just the right params for us to use, so the fix is fairly straightforward. The `params` passed are `appliedParams`, so the matchfinder mode won't be `ZSTD_urm_auto` (and we assert that in `ZSTD_allocateChainTable()`).

Repro of the bug:
```
yes | ./zstd -5 --single-thread -v -c --zstd=clog=30 -o /dev/null                                                                                                                                               ✔  19:44:30

*** zstd command line interface 64-bits v1.4.10, by Yann Collet ***
(L5) Buffered :   0 MB - Consumed :3583 MB - Compressed :   0 MB => 0.01% Caught SIGSEGV signal, printing stack:
4   zstd                                0x000000010a4bdbaf ZSTD_compressContinue_internal + 1103
5   zstd                                0x000000010a4c34a0 ZSTD_compressStream2 + 1424
6   zstd                                0x000000010a5eb4c2 FIO_compressFilename_srcFile + 3586
7   zstd                                0x000000010a5e8e88 FIO_compressFilename + 136
8   zstd                                0x000000010a5f948d main + 21805
9   libdyld.dylib                       0x00007fff204ae621 start + 1
[1]    38461 broken pipe         yes | 
       38462 segmentation fault  ./zstd -5 --single-thread -v -c --zstd=clog=30 -o /dev/null
```