### PR TITLE
[tests] Reduce memory usage of MT CLI tests

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1225,7 +1225,7 @@ then
     println "\n===>  zstdmt round-trip tests "
     roundTripTest -g4M "1 -T0"
     roundTripTest -g8M "3 -T2"
-    roundTripTest -g8M "19 -T0 --long"
+    roundTripTest -g8M "19 --long"
     roundTripTest -g8000K "2 --threads=2"
     fileRoundTripTest -g4M "19 -T2 -B1M"
 


### PR DESCRIPTION
Switch from `-T0` to the default `-T1` which significantly reduces
memory usage for level 19 when there are many cores. This should
fix the issue of 32-bit binaries of running out of address space.

Fixes #2528.