### PR TITLE
Detect Presence of `md5` on Darwin

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -176,7 +176,9 @@ UNAME := $(shell uname)
 
 ifndef BUILD_DIR
 ifeq ($(UNAME), Darwin)
-  HASH ?= md5
+  ifeq ($(shell md5 < /dev/null > /dev/null; echo $$?), 0)
+    HASH ?= md5
+  endif
 else ifeq ($(UNAME), FreeBSD)
   HASH ?= gmd5sum
 else ifeq ($(UNAME), NetBSD)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -103,7 +103,9 @@ UNAME := $(shell uname)
 
 ifndef BUILD_DIR
 ifeq ($(UNAME), Darwin)
-  HASH ?= md5
+  ifeq ($(shell md5 < /dev/null > /dev/null; echo $$?), 0)
+    HASH ?= md5
+  endif
 else ifeq ($(UNAME), FreeBSD)
   HASH ?= gmd5sum
 else ifeq ($(UNAME), NetBSD)


### PR DESCRIPTION
This fixes #2568.

If `md5` is not found, it falls back to the default `md5sum` below.