### PR TITLE
Apply flags to libzstd-nomt in libzstd style

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -334,7 +334,8 @@ include $(wildcard $(DEPFILES))
 # Special case : building library in single-thread mode _and_ without zstdmt_compress.c
 ZSTDMT_FILES = compress/zstdmt_compress.c
 ZSTD_NOMT_FILES = $(filter-out $(ZSTDMT_FILES),$(ZSTD_FILES))
-libzstd-nomt: LDFLAGS += -shared -fPIC -fvisibility=hidden
+libzstd-nomt: CFLAGS += -fPIC -fvisibility=hidden
+libzstd-nomt: LDFLAGS += -shared
 libzstd-nomt: $(ZSTD_NOMT_FILES)
 	@echo compiling single-thread dynamic library $(LIBVER)
 	@echo files : $(ZSTD_NOMT_FILES)


### PR DESCRIPTION
... for consistency (this doesn't actually change the build flags used
in practice, currently).

Signed-off-by: Stephen Kitt <steve@sk2.org>