### PR TITLE
Fix appveyor warnings in fuzzer.c 

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -340,11 +340,11 @@ static void FUZ_decodeSequences(BYTE* dst, ZSTD_Sequence* seqs, size_t seqsSize,
 typedef struct {
     ZSTD_CCtx* cctx;
     ZSTD_threadPool* pool;
-    void* const CNBuffer;
+    void* CNBuffer;
     size_t CNBuffSize;
-    void* const compressedBuffer;
+    void* compressedBuffer;
     size_t compressedBufferSize;
-    void* const decodedBuffer;
+    void* decodedBuffer;
     int err;
 } threadPoolTests_compressionJob_payload;
 


### PR DESCRIPTION
Appveyor complains that 'default constructor could not be generated'.

Apparently, according to the docs, [error C4510](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4510?view=msvc-160) can happen because of `const` data members (but also because of data members that are a reference).

I'm surprised that the appveyor tests on `dev -> release` are different than the ones on `PRs -> dev`, since this error has not shown up before.