### PR TITLE
Un-promote literalCompressionMode back to experimental

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,7 @@
 v1.5.0  (May 11, 2021)
-api: Various functions and parameters promoted from experimental to stable API: (#2579-2581, @senhuang42)
+api: Various functions promoted from experimental to stable API: (#2579-2581, @senhuang42)
   `ZSTD_defaultCLevel()`
   `ZSTD_getDictID_fromCDict()`
- `ZSTD_c_literalCompressionMode`
 api: Several experimental functions have been deprecated and will emit a compiler warning (#2582, @senhuang42)
   `ZSTD_compress_advanced()`
   `ZSTD_compress_usingCDict_advanced()`

--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -207,15 +207,6 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);  </b>/* accept NULL pointer */<b>
 } ZSTD_strategy;
 </b></pre><BR>
 <pre><b>typedef enum {
-  ZSTD_lcm_auto = 0,          </b>/**< Automatically determine the compression mode based on the compression level.<b>
-                               *   Negative compression levels will be uncompressed, and positive compression
-                               *   levels will be compressed. */
-  ZSTD_lcm_huffman = 1,       </b>/**< Always attempt Huffman compression. Uncompressed literals will still be<b>
-                               *   emitted if Huffman compression is not profitable. */
-  ZSTD_lcm_uncompressed = 2   </b>/**< Always emit uncompressed literals. */<b>
-} ZSTD_literalCompressionMode_e;  </b>/* Requires v1.5.0+ */<b>
-</b></pre><BR>
-<pre><b>typedef enum {
 
     </b>/* compression parameters<b>
      * Note: When compressing with a ZSTD_CDict these parameters are superseded
@@ -280,12 +271,6 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);  </b>/* accept NULL pointer */<b>
                               * The higher the value of selected strategy, the more complex it is,
                               * resulting in stronger and slower compression.
                               * Special: value 0 means "use default strategy". */
-    ZSTD_c_literalCompressionMode=108,  </b>/* Note : requires v1.5.0+<b>
-                                         * Controls how the literals are compressed (default is auto).
-                                         * The value must be of type ZSTD_literalCompressionMode_e.
-                                         * See ZSTD_literalCompressionMode_e enum definition for details.
-                                         */
-
     </b>/* LDM mode parameters */<b>
     ZSTD_c_enableLongDistanceMatching=160, </b>/* Enable long distance matching.<b>
                                      * This parameter is designed to improve compression ratio
@@ -364,6 +349,7 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);  </b>/* accept NULL pointer */<b>
      * ZSTD_c_format
      * ZSTD_c_forceMaxWindow
      * ZSTD_c_forceAttachDict
+     * ZSTD_c_literalCompressionMode
      * ZSTD_c_targetCBlockSize
      * ZSTD_c_srcSizeHint
      * ZSTD_c_enableDedicatedDictSearch
@@ -381,6 +367,7 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);  </b>/* accept NULL pointer */<b>
      ZSTD_c_experimentalParam2=10,
      ZSTD_c_experimentalParam3=1000,
      ZSTD_c_experimentalParam4=1001,
+     ZSTD_c_experimentalParam5=1002,
      ZSTD_c_experimentalParam6=1003,
      ZSTD_c_experimentalParam7=1004,
      ZSTD_c_experimentalParam8=1005,
@@ -1074,6 +1061,15 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
     ZSTD_dictForceCopy     = 2, </b>/* Always copy the dictionary. */<b>
     ZSTD_dictForceLoad     = 3  </b>/* Always reload the dictionary */<b>
 } ZSTD_dictAttachPref_e;
+</b></pre><BR>
+<pre><b>typedef enum {
+  ZSTD_lcm_auto = 0,          </b>/**< Automatically determine the compression mode based on the compression level.<b>
+                               *   Negative compression levels will be uncompressed, and positive compression
+                               *   levels will be compressed. */
+  ZSTD_lcm_huffman = 1,       </b>/**< Always attempt Huffman compression. Uncompressed literals will still be<b>
+                               *   emitted if Huffman compression is not profitable. */
+  ZSTD_lcm_uncompressed = 2   </b>/**< Always emit uncompressed literals. */<b>
+} ZSTD_literalCompressionMode_e;
 </b></pre><BR>
 <pre><b>typedef enum {
   ZSTD_urm_auto = 0,                   </b>/* Automatically determine whether or not we use row matchfinder */<b>

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -267,15 +267,6 @@ typedef enum { ZSTD_fast=1,
 } ZSTD_strategy;
 
 typedef enum {
-  ZSTD_lcm_auto = 0,          /**< Automatically determine the compression mode based on the compression level.
-                               *   Negative compression levels will be uncompressed, and positive compression
-                               *   levels will be compressed. */
-  ZSTD_lcm_huffman = 1,       /**< Always attempt Huffman compression. Uncompressed literals will still be
-                               *   emitted if Huffman compression is not profitable. */
-  ZSTD_lcm_uncompressed = 2   /**< Always emit uncompressed literals. */
-} ZSTD_literalCompressionMode_e;  /* Requires v1.5.0+ */
-
-typedef enum {
 
     /* compression parameters
      * Note: When compressing with a ZSTD_CDict these parameters are superseded
@@ -340,12 +331,6 @@ typedef enum {
                               * The higher the value of selected strategy, the more complex it is,
                               * resulting in stronger and slower compression.
                               * Special: value 0 means "use default strategy". */
-    ZSTD_c_literalCompressionMode=108,  /* Note : requires v1.5.0+
-                                         * Controls how the literals are compressed (default is auto).
-                                         * The value must be of type ZSTD_literalCompressionMode_e.
-                                         * See ZSTD_literalCompressionMode_e enum definition for details.
-                                         */
-
     /* LDM mode parameters */
     ZSTD_c_enableLongDistanceMatching=160, /* Enable long distance matching.
                                      * This parameter is designed to improve compression ratio
@@ -424,6 +409,7 @@ typedef enum {
      * ZSTD_c_format
      * ZSTD_c_forceMaxWindow
      * ZSTD_c_forceAttachDict
+     * ZSTD_c_literalCompressionMode
      * ZSTD_c_targetCBlockSize
      * ZSTD_c_srcSizeHint
      * ZSTD_c_enableDedicatedDictSearch
@@ -441,6 +427,7 @@ typedef enum {
      ZSTD_c_experimentalParam2=10,
      ZSTD_c_experimentalParam3=1000,
      ZSTD_c_experimentalParam4=1001,
+     ZSTD_c_experimentalParam5=1002,
      ZSTD_c_experimentalParam6=1003,
      ZSTD_c_experimentalParam7=1004,
      ZSTD_c_experimentalParam8=1005,
@@ -1306,6 +1293,15 @@ typedef enum {
 } ZSTD_dictAttachPref_e;
 
 typedef enum {
+  ZSTD_lcm_auto = 0,          /**< Automatically determine the compression mode based on the compression level.
+                               *   Negative compression levels will be uncompressed, and positive compression
+                               *   levels will be compressed. */
+  ZSTD_lcm_huffman = 1,       /**< Always attempt Huffman compression. Uncompressed literals will still be
+                               *   emitted if Huffman compression is not profitable. */
+  ZSTD_lcm_uncompressed = 2   /**< Always emit uncompressed literals. */
+} ZSTD_literalCompressionMode_e;
+
+typedef enum {
   ZSTD_urm_auto = 0,                   /* Automatically determine whether or not we use row matchfinder */
   ZSTD_urm_disableRowMatchFinder = 1,  /* Never use row matchfinder */
   ZSTD_urm_enableRowMatchFinder = 2    /* Always use row matchfinder when applicable */
@@ -1715,6 +1711,12 @@ ZSTDLIB_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const void* pre
  * Accepts values from the ZSTD_dictAttachPref_e enum.
  * See the comments on that enum for an explanation of the feature. */
 #define ZSTD_c_forceAttachDict ZSTD_c_experimentalParam4
+
+/* Controls how the literals are compressed (default is auto).
+ * The value must be of type ZSTD_literalCompressionMode_e.
+ * See ZSTD_literalCompressionMode_e enum definition for details.
+ */
+#define ZSTD_c_literalCompressionMode ZSTD_c_experimentalParam5
 
 /* Tries to fit compressed block size to be around targetCBlockSize.
  * No target when targetCBlockSize == 0.


### PR DESCRIPTION
Unpromotes this param back to experimental. Not ready for stable yet.