### PR TITLE
Fixed meson test on travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ matrix:
     # meson dedicated test
     - name: Xenial (Meson + clang)    # ~15mn
       if: branch = release
-      dist: xenial
+      dist: bionic
       language: cpp
       compiler: clang
       install:


### PR DESCRIPTION
simply by updating distribution to a more recent version featuring a more recent `python`
required to install `meson`.

Note that the `meson` test is only triggered automatically on `release` branch.

Also note that it currently results in a build error and many warnings : 
https://travis-ci.org/github/facebook/zstd/jobs/771041148