### PR TITLE
Fix CircleCI Config to Fully Remove `publish-github-release` Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,16 +99,6 @@ workflows:
             branches:
               only:
                 - regression
-      # Only run on release tags.
-      - publish-github-release:
-          requires:
-            - short-tests-0
-            - short-tests-1
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
Looks like I failed to completely remove this job in #2535.