### PR TITLE
Enable SSE2 compression path to work on MSVC

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -222,7 +222,7 @@ static int ZSTD_rowMatchFinderUsed(const ZSTD_strategy strategy, const ZSTD_useR
 /* Returns row matchfinder usage enum given an initial mode and cParams */
 static ZSTD_useRowMatchFinderMode_e ZSTD_resolveRowMatchFinderMode(ZSTD_useRowMatchFinderMode_e mode,
                                                                    const ZSTD_compressionParameters* const cParams) {
-#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) || defined(__AVX__)  || defined(__ARM_NEON))
+#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) || defined(_M_AMD64)  || defined(__ARM_NEON))
     int const kHasSIMD128 = 1;
 #else
     int const kHasSIMD128 = 0;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -222,7 +222,7 @@ static int ZSTD_rowMatchFinderUsed(const ZSTD_strategy strategy, const ZSTD_useR
 /* Returns row matchfinder usage enum given an initial mode and cParams */
 static ZSTD_useRowMatchFinderMode_e ZSTD_resolveRowMatchFinderMode(ZSTD_useRowMatchFinderMode_e mode,
                                                                    const ZSTD_compressionParameters* const cParams) {
-#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) || defined(__ARM_NEON))
+#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) || defined(__AVX__)  || defined(__ARM_NEON))
     int const kHasSIMD128 = 1;
 #else
     int const kHasSIMD128 = 0;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -873,7 +873,7 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_extDict_selectMLS (
 
 typedef U32 ZSTD_VecMask;   /* Clarifies when we are interacting with a U32 representing a mask of matches */
 
-#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) ||defined(_M_AMD64)) /* SIMD SSE version*/
+#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) || defined(_M_AMD64)) /* SIMD SSE version*/
 
 #include <emmintrin.h>
 typedef __m128i ZSTD_Vec128;
@@ -894,7 +894,7 @@ static ZSTD_Vec128 ZSTD_Vec128_set8(BYTE val) {
 static ZSTD_VecMask ZSTD_Vec128_cmpMask8(ZSTD_Vec128 x, ZSTD_Vec128 y) {
   return (ZSTD_VecMask)_mm_movemask_epi8(_mm_cmpeq_epi8(x, y));
 }
-#if !defined(__AVX2__)
+
 typedef struct {
   __m128i fst;
   __m128i snd;
@@ -921,27 +921,6 @@ static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
   sndMask = ZSTD_Vec128_cmpMask8(x.snd, y.snd);
   return fstMask | (sndMask << 16);
 }
-#else/* AVX2 */
-typedef struct {
-  __m256i v;
-} ZSTD_Vec256;
-
-static ZSTD_Vec256 ZSTD_Vec256_read(const void* const ptr) {
-  ZSTD_Vec256 v;
-  v.v = _mm256_loadu_si256((const __m256i*)ptr);
-  return v;
-}
-
-static ZSTD_Vec256 ZSTD_Vec256_set8(BYTE val) {
-  ZSTD_Vec256 v;
-  v.v = _mm256_set1_epi8((char)val);
-  return v;
-}
-
-static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
-  return (ZSTD_VecMask)_mm256_movemask_epi8(_mm256_cmpeq_epi8(x.v, y.v));
-}
-#endif
 
 #elif !defined(ZSTD_NO_INTRINSICS) && defined(__ARM_NEON) /* SIMD ARM NEON Version */
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -873,7 +873,7 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_extDict_selectMLS (
 
 typedef U32 ZSTD_VecMask;   /* Clarifies when we are interacting with a U32 representing a mask of matches */
 
-#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) ||defined(_M_AMD64)) /* SIMD SSE version*/
+#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) || defined(_M_AMD64)) /* SIMD SSE version*/
 
 #include <emmintrin.h>
 typedef __m128i ZSTD_Vec128;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -934,7 +934,7 @@ static ZSTD_Vec256 ZSTD_Vec256_read(const void* const ptr) {
 
 static ZSTD_Vec256 ZSTD_Vec256_set8(BYTE val) {
 	ZSTD_Vec256 v;
-    v.v = _mm256_set1_epi8(val);
+    v.v = _mm256_set1_epi8((char)val);
 	return v;
 }
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -928,7 +928,7 @@ typedef struct {
 
 static ZSTD_Vec256 ZSTD_Vec256_read(const void* const ptr) {
 	ZSTD_Vec256 v;
-    v.v = _mm256_load_si256((const __m256i*)ptr);
+    v.v = _mm256_loadu_si256((const __m256i*)ptr);
 	return v;
 }
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -921,7 +921,7 @@ static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
   sndMask = ZSTD_Vec128_cmpMask8(x.snd, y.snd);
   return fstMask | (sndMask << 16);
 }
-#else//AVX2 
+#else/* AVX2 */
 typedef struct {
 	__m256i v;
 } ZSTD_Vec256;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -873,7 +873,7 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_extDict_selectMLS (
 
 typedef U32 ZSTD_VecMask;   /* Clarifies when we are interacting with a U32 representing a mask of matches */
 
-#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) || defined(_M_AMD64)) /* SIMD SSE version*/
+#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) ||defined(_M_AMD64)) /* SIMD SSE version*/
 
 #include <emmintrin.h>
 typedef __m128i ZSTD_Vec128;
@@ -894,7 +894,7 @@ static ZSTD_Vec128 ZSTD_Vec128_set8(BYTE val) {
 static ZSTD_VecMask ZSTD_Vec128_cmpMask8(ZSTD_Vec128 x, ZSTD_Vec128 y) {
   return (ZSTD_VecMask)_mm_movemask_epi8(_mm_cmpeq_epi8(x, y));
 }
-
+#if !defined(__AVX2__)
 typedef struct {
   __m128i fst;
   __m128i snd;
@@ -921,6 +921,27 @@ static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
   sndMask = ZSTD_Vec128_cmpMask8(x.snd, y.snd);
   return fstMask | (sndMask << 16);
 }
+#else/* AVX2 */
+typedef struct {
+  __m256i v;
+} ZSTD_Vec256;
+
+static ZSTD_Vec256 ZSTD_Vec256_read(const void* const ptr) {
+  ZSTD_Vec256 v;
+  v.v = _mm256_loadu_si256((const __m256i*)ptr);
+  return v;
+}
+
+static ZSTD_Vec256 ZSTD_Vec256_set8(BYTE val) {
+  ZSTD_Vec256 v;
+  v.v = _mm256_set1_epi8((char)val);
+  return v;
+}
+
+static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
+  return (ZSTD_VecMask)_mm256_movemask_epi8(_mm256_cmpeq_epi8(x.v, y.v));
+}
+#endif
 
 #elif !defined(ZSTD_NO_INTRINSICS) && defined(__ARM_NEON) /* SIMD ARM NEON Version */
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -873,7 +873,7 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_extDict_selectMLS (
 
 typedef U32 ZSTD_VecMask;   /* Clarifies when we are interacting with a U32 representing a mask of matches */
 
-#if !defined(ZSTD_NO_INTRINSICS) && defined(__SSE2__) /* SIMD SSE version */
+#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) ||defined(__AVX__)) /* SIMD SSE version*/
 
 #include <emmintrin.h>
 typedef __m128i ZSTD_Vec128;
@@ -894,7 +894,7 @@ static ZSTD_Vec128 ZSTD_Vec128_set8(BYTE val) {
 static ZSTD_VecMask ZSTD_Vec128_cmpMask8(ZSTD_Vec128 x, ZSTD_Vec128 y) {
   return (ZSTD_VecMask)_mm_movemask_epi8(_mm_cmpeq_epi8(x, y));
 }
-
+#if !defined(__AVX2__)
 typedef struct {
   __m128i fst;
   __m128i snd;
@@ -921,6 +921,28 @@ static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
   sndMask = ZSTD_Vec128_cmpMask8(x.snd, y.snd);
   return fstMask | (sndMask << 16);
 }
+#else//AVX2 
+typedef struct {
+	__m256i v;
+} ZSTD_Vec256;
+
+static ZSTD_Vec256 ZSTD_Vec256_read(const void* const ptr) {
+	ZSTD_Vec256 v;
+    v.v = _mm256_load_si256((const __m256i*)ptr);
+	return v;
+}
+
+static ZSTD_Vec256 ZSTD_Vec256_set8(BYTE val) {
+	ZSTD_Vec256 v;
+    v.v = _mm256_set1_epi32(val);
+	return v;
+}
+
+static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
+    return (ZSTD_VecMask)_mm256_movemask_epi8(_mm256_cmpeq_epi8(x.v, y.v));
+}
+
+#endif
 
 #elif !defined(ZSTD_NO_INTRINSICS) && defined(__ARM_NEON) /* SIMD ARM NEON Version */
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -873,7 +873,7 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_extDict_selectMLS (
 
 typedef U32 ZSTD_VecMask;   /* Clarifies when we are interacting with a U32 representing a mask of matches */
 
-#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) ||defined(__AVX__)) /* SIMD SSE version*/
+#if !defined(ZSTD_NO_INTRINSICS) && (defined(__SSE2__) ||defined(_M_AMD64)) /* SIMD SSE version*/
 
 #include <emmintrin.h>
 typedef __m128i ZSTD_Vec128;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -894,7 +894,7 @@ static ZSTD_Vec128 ZSTD_Vec128_set8(BYTE val) {
 static ZSTD_VecMask ZSTD_Vec128_cmpMask8(ZSTD_Vec128 x, ZSTD_Vec128 y) {
   return (ZSTD_VecMask)_mm_movemask_epi8(_mm_cmpeq_epi8(x, y));
 }
-#if !defined(__AVX2__)
+
 typedef struct {
   __m128i fst;
   __m128i snd;
@@ -921,28 +921,6 @@ static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
   sndMask = ZSTD_Vec128_cmpMask8(x.snd, y.snd);
   return fstMask | (sndMask << 16);
 }
-#else/* AVX2 */
-typedef struct {
-	__m256i v;
-} ZSTD_Vec256;
-
-static ZSTD_Vec256 ZSTD_Vec256_read(const void* const ptr) {
-	ZSTD_Vec256 v;
-    v.v = _mm256_loadu_si256((const __m256i*)ptr);
-	return v;
-}
-
-static ZSTD_Vec256 ZSTD_Vec256_set8(BYTE val) {
-	ZSTD_Vec256 v;
-    v.v = _mm256_set1_epi8((char)val);
-	return v;
-}
-
-static ZSTD_VecMask ZSTD_Vec256_cmpMask8(ZSTD_Vec256 x, ZSTD_Vec256 y) {
-    return (ZSTD_VecMask)_mm256_movemask_epi8(_mm256_cmpeq_epi8(x.v, y.v));
-}
-
-#endif
 
 #elif !defined(ZSTD_NO_INTRINSICS) && defined(__ARM_NEON) /* SIMD ARM NEON Version */
 

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -934,7 +934,7 @@ static ZSTD_Vec256 ZSTD_Vec256_read(const void* const ptr) {
 
 static ZSTD_Vec256 ZSTD_Vec256_set8(BYTE val) {
 	ZSTD_Vec256 v;
-    v.v = _mm256_set1_epi32(val);
+    v.v = _mm256_set1_epi8(val);
 	return v;
 }
 


### PR DESCRIPTION
The compile time detection uses the `__SSE2__ `predefined macro, but this does not exist on MSVC--resulting it that compiler always using scalar path.

On MSVC you can detect SSE support by checking for `_M_AMD64`, as when targeting x64 it requires SSE2 as a baseline, this patch adds this check.


