### PR TITLE
Initialize "potentially uninitialized" pointers.

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1296,8 +1296,8 @@ size_t ZSTD_RowFindBestMatch_generic (
     size_t ddsIdx;
     U32 ddsExtraAttempts; /* cctx hash tables are limited in searches, but allow extra searches into DDS */
     U32 dmsTag;
-    U32* dmsRow;
-    BYTE* dmsTagRow;
+    U32* dmsRow = NULL;
+    BYTE* dmsTagRow = NULL;
 
     if (dictMode == ZSTD_dedicatedDictSearch) {
         const U32 ddsHashLog = dms->cParams.hashLog - ZSTD_LAZY_DDSS_BUCKET_LOG;


### PR DESCRIPTION
In certain configurations MSVC may enable some sort of a static analyser during compilation, which marks "unsafe" code constructs. In this case the error messages are:

```
1>...\zstd\compress\zstd_lazy.c(1399): error C4703: potentially uninitialized local pointer variable 'dmsTagRow' used
1>...\zstd\compress\zstd_lazy.c(1407): error C4703: potentially uninitialized local pointer variable 'dmsRow' used
```

Initialization and usage of both `dmsRow` and `dmsTagRow` is contained within two separate `if (dictMode == ZSTD_dictMatchState)` sections. It is not possible to enter the second (usage) section without entering the first (initialization), but the analyser fails to see this.

This change silences the "error".