### PR TITLE
[trace] remove zstd_trace.c reference from freestanding

### DIFF
--- a/contrib/freestanding_lib/freestanding.py
+++ b/contrib/freestanding_lib/freestanding.py
@@ -27,7 +27,6 @@ SKIPPED_FILES = [
     "common/pool.h",
     "common/threading.c",
     "common/threading.h",
-    "common/zstd_trace.c",
     "common/zstd_trace.h",
     "compress/zstdmt_compress.h",
     "compress/zstdmt_compress.c",


### PR DESCRIPTION
zstd_trace.c was removed as part of PR #2589