### PR TITLE
ZSTD_VecMask_next: fix incorrect variable name in fallback code path

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1081,7 +1081,7 @@ static U32 ZSTD_VecMask_next(ZSTD_VecMask val) {
         0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
 		31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
     };
-	return multiplyDeBruijnBitPosition[((U32)((v & -(int)v) * 0x077CB531U)) >> 27];
+	return multiplyDeBruijnBitPosition[((U32)((val & -(int)val) * 0x077CB531U)) >> 27];
 #   endif
 }
 


### PR DESCRIPTION
This is a trivial typo fix found when building zstd with the tinycc compiler (which doesn't claim gcc compatibility and doesn't provide a __builtin_ctz).  The resulting binary passes "gmake check", so even though this codepath has never been used it seems to work :)
