### PR TITLE
[lib] Fix libzstd.pc for lib-mt builds

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -308,7 +308,7 @@ endif  # if windows
 libzstd : $(LIBZSTD)
 
 .PHONY: lib
-lib : libzstd.a libzstd
+lib : libzstd.a libzstd libzstd.pc
 
 
 # note : do not define lib-mt or lib-release as .PHONY
@@ -371,6 +371,18 @@ clean:
 	$(RM) -r obj/*
 	@echo Cleaning library completed
 
+libzstd.pc:
+libzstd.pc: libzstd.pc.in
+	@echo creating pkgconfig
+	@sed $(SED_ERE_OPT) \
+		-e 's|@PREFIX@|$(PREFIX)|' \
+		-e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
+		-e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \
+		-e 's|@LIBDIR@|$(PCLIBPREFIX)$(PCLIBDIR)|' \
+		-e 's|@VERSION@|$(VERSION)|' \
+		-e 's|@LIBS_PRIVATE@|$(LDFLAGS_DYNLIB)|' \
+		$< >$@
+
 #-----------------------------------------------------------------------------
 # make install is validated only for below listed environments
 #-----------------------------------------------------------------------------
@@ -420,17 +432,6 @@ endif
 INSTALL_PROGRAM ?= $(INSTALL)
 INSTALL_DATA    ?= $(INSTALL) -m 644
 
-
-libzstd.pc:
-libzstd.pc: libzstd.pc.in
-	@echo creating pkgconfig
-	@sed $(SED_ERE_OPT) \
-	        -e 's|@PREFIX@|$(PREFIX)|' \
-	        -e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
-          -e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \
-          -e 's|@LIBDIR@|$(PCLIBPREFIX)$(PCLIBDIR)|' \
-          -e 's|@VERSION@|$(VERSION)|' \
-          $< >$@
 
 .PHONY: install
 install: install-pc install-static install-shared install-includes

--- a/lib/libzstd.pc.in
+++ b/lib/libzstd.pc.in
@@ -12,4 +12,5 @@ Description: fast lossless compression algorithm library
 URL: http://www.zstd.net/
 Version: @VERSION@
 Libs: -L${libdir} -lzstd
+Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
Add the libzstd.pc target to the lib target in lib/Makefile, which makes
it inherit LDFLAGS_DYNLIB from the lib-mt target. This allows us to add
a Libs.private field to libzstd.pc which gets conditionally populated
with '-pthread'.

The 1.5.0 release notes mention that the static library isn't
multi-threaded by default, due to concern for people building static
binaries with libzstd:

   Now the dynamic library supports multi-threaded compression by
   default.  Note that this property is not extended to the static
   library because doing so would have impacted the build script of
   existing client applications (requiring them to add -pthread to their
   recipe), thus potentially breaking their build.

To get closer to being able to enable multi-threading for all library
builds by default, this commit makes it so that any libzstd consumer
using pkg-config gets the correct flags.