### PR TITLE
[CI] Fix zlib-wrapper test

### DIFF
--- a/.github/workflows/generic-release.yml
+++ b/.github/workflows/generic-release.yml
@@ -17,7 +17,7 @@ jobs:
   # meson test
 
   osx:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: OS-X
@@ -35,7 +35,7 @@ jobs:
         CC=clang make tsan-fuzztest
 
   zlib-wrapper:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: zlib wrapper test
@@ -45,7 +45,7 @@ jobs:
         make -C zlibWrapper valgrindTest
 
   lz4-threadpool-partial-libs:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: LZ4, thread pool, and partial libs testslib wrapper test


### PR DESCRIPTION
GH Action tests should typically use `*-latest` platforms, otherwise when a version gets deprecated things might break. This should fix `zlib-wrapper` test.