### PR TITLE
Optimize ZSTD_decodeSequence for clang

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -970,10 +970,8 @@ ZSTD_decodeSequence(seqState_t* seqState, const ZSTD_longOffset_e longOffsets)
         } else {
             U32 const ll0 = (llBase == 0);
             if (LIKELY((ofBits == 0))) {
-                if (LIKELY(!ll0))
-                    offset = seqState->prevOffset[0];
-                else {
-                    offset = seqState->prevOffset[1];
+                offset = seqState->prevOffset[ll0];
+                if (UNLIKELY(ll0)) {
                     seqState->prevOffset[1] = seqState->prevOffset[0];
                     seqState->prevOffset[0] = offset;
                 }


### PR DESCRIPTION
TL;DR; this patch optimizes number of cycles for clang by several percent in non bmi2 mode, e.g. simple compilation mode. I checked on clang-12, clang-11 and clang-9

Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz:

Before:

```
 Performance counter stats for './zstd -t /home/danilak/benchmark_zstd/data/silesia.tar.zst' (50 runs):

            227.71 msec task-clock                #    0.998 CPUs utilized            ( +-  0.29% )
                 1      context-switches          #    0.006 K/sec                    ( +- 14.18% )
                 0      cpu-migrations            #    0.001 K/sec                    ( +- 22.66% )
               656      page-faults               #    0.003 M/sec                    ( +-  3.85% )
       944,476,846      cycles                    #    4.148 GHz                      ( +-  0.07% )
     2,474,680,823      instructions              #    2.62  insn per cycle           ( +-  0.01% )
       261,676,884      branches                  # 1149.176 M/sec                    ( +-  0.03% )
         5,780,728      branch-misses             #    2.21% of all branches          ( +-  0.01% )

          0.228253 +- 0.000743 seconds time elapsed  ( +-  0.33% )
```

After:
```
 Performance counter stats for './zstd -t /home/danilak/benchmark_zstd/data/silesia.tar.zst' (50 runs):

            214.90 msec task-clock                #    0.997 CPUs utilized            ( +-  0.25% )
                 3      context-switches          #    0.013 K/sec                    ( +- 17.17% )
                 1      cpu-migrations            #    0.002 K/sec                    ( +- 19.99% )
               647      page-faults               #    0.003 M/sec                    ( +-  4.05% )
       892,299,745      cycles                    #    4.152 GHz                      ( +-  0.09% )
     2,503,422,821      instructions              #    2.81  insn per cycle           ( +-  0.00% )
       261,614,529      branches                  # 1217.365 M/sec                    ( +-  0.01% )
         5,782,972      branch-misses             #    2.21% of all branches          ( +-  0.01% )

          0.215486 +- 0.000562 seconds time elapsed  ( +-  0.26% )
```

Or, around 5%. GCC is stable and does not change. On server xeon I saw only around 1% performance win.

Why: Unfortunately, as all code is forced inlined, compilers have bad time in finding good opportunities

In current code prevOffset are reassigned in their order and clang generates 

```cpp
seqState->prevOffset[1] = seqState->prevOffset[0];
seqState->prevOffset[0] = offset;
```

3 times, see 3 pictures below.

![2021-05-21-021537_1533x216_scrot](https://user-images.githubusercontent.com/15173761/119068692-9b0a0180-b9dc-11eb-8377-6c80e37c40ec.png)

![2021-05-21-021550_1612x329_scrot](https://user-images.githubusercontent.com/15173761/119068698-9d6c5b80-b9dc-11eb-917b-d3e75548bff6.png)

![2021-05-21-021559_1575x605_scrot](https://user-images.githubusercontent.com/15173761/119068702-a0674c00-b9dc-11eb-86d8-7a114293d86c.png) 

After the change, clang manages to find common block 3, 4 and 5 for all 3 branches that end up in reassigning prevOffset[1] and prevOffset[0].

![2021-05-21-015511_1525x255_scrot](https://user-images.githubusercontent.com/15173761/119068669-90e80300-b9dc-11eb-8a2c-daf3686b7233.png)

![2021-05-21-015523_1505x732_scrot](https://user-images.githubusercontent.com/15173761/119068674-95142080-b9dc-11eb-9023-f4c21b2d78cb.png)

![2021-05-21-015532_1486x386_scrot](https://user-images.githubusercontent.com/15173761/119068682-980f1100-b9dc-11eb-9f29-1f1244dc995a.png)

In short, clang managed to do this

![qx6oGDvqGchzAw3](https://user-images.githubusercontent.com/15173761/119069223-a4479e00-b9dd-11eb-8c49-af7dc77e27e0.png)

I believe this is at least win for some platforms, I can check for other CPUs also but it will take time
