### PR TITLE
Fuzzer test with no intrinsics on S390x (big endian)

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -27,6 +27,13 @@ jobs:
     - name: OS-X test
       run: make test # make -c lib all doesn't work because of the fact that it's not a tty
 
+  no-intrinsics-fuzztest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: no intrinsics fuzztest
+      run: MOREFLAGS="-DZSTD_NO_INTRINSICS" make -C tests fuzztest
+
   tsan-zstreamtest:
     runs-on: ubuntu-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,18 @@ env:
 matrix:
   fast_finish: true
   include:
+    - name: S390X (big endian) + Fuzz test
+      dist: trusty
+      arch: s390x
+      script:
+        - FUZZER_FLAGS=--no-big-tests make -C tests fuzztest
+
+    - name: S390X (big endian) + Fuzz test + no intrinsics
+      dist: trusty
+      arch: s390x
+      script:
+        - MOREFLAGS="-DZSTD_NO_INTRINSICS" FUZZER_FLAGS=--no-big-tests make -C tests fuzztest
+
     - name: arm64    # ~2.5 mn
       os: linux
       arch: arm64


### PR DESCRIPTION
Thanks to @aqrit , a bug on big-endian systems with the row-based matchfinder was discovered - the scalar fallback wouldn't work on those systems. We add a test for S390X architectures.

Adds:
- Fuzzer test case for `compress2` with forced row matchfinder for compression ratio regressions
- CI tests for:
  - S390X (big endian) fuzz test with and without intrinsics
  - Fuzz test without intrinsics on a normal LE system.
