### PR TITLE
Add ldm and block splitter auto-enable to old api

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -349,6 +349,17 @@ static void ZSTD_CCtxParams_init_internal(ZSTD_CCtx_params* cctxParams, ZSTD_par
     cctxParams->compressionLevel = compressionLevel;
     cctxParams->useRowMatchFinder = ZSTD_resolveRowMatchFinderMode(cctxParams->useRowMatchFinder, &params->cParams);
     DEBUGLOG(4, "ZSTD_CCtxParams_init_internal: useRowMatchFinder=%d", cctxParams->useRowMatchFinder);
+
+    if (ZSTD_CParams_shouldEnableLdm(&params->cParams)) {
+        /* Enable LDM by default for optimal parser and window size >= 128MB */
+        DEBUGLOG(4, "LDM enabled by default (window size >= 128MB, strategy >= btopt)");
+        cctxParams->ldmParams.enableLdm = 1;
+    }
+
+    if (ZSTD_CParams_useBlockSplitter(&params->cParams)) {
+        DEBUGLOG(4, "Block splitter enabled by default (window size >= 128K, strategy >= btopt)");
+        cctxParams->splitBlocks = 1;
+    }
 }
 
 size_t ZSTD_CCtxParams_init_advanced(ZSTD_CCtx_params* cctxParams, ZSTD_parameters params)

--- a/tests/regression/Makefile
+++ b/tests/regression/Makefile
@@ -15,7 +15,7 @@ CURL_LDFLAGS := $(shell curl-config --libs) -pthread
 
 PROGDIR := ../../programs
 LIBDIR := ../../lib
-ZSTD_CPPFLAGS := -I$(PROGDIR) -I$(LIBDIR) -I$(LIBDIR)/common
+ZSTD_CPPFLAGS := -I$(PROGDIR) -I$(LIBDIR) -I$(LIBDIR)/common -Wno-deprecated-declarations
 
 REGRESSION_CFLAGS = $(CFLAGS) $(CURL_CFLAGS)
 REGRESSION_CPPFLAGS = $(CPPFLAGS) $(ZSTD_CPPFLAGS)

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -11,10 +11,10 @@ silesia.tar,                        level 6,                            compress
 silesia.tar,                        level 7,                            compress simple,                    4613541
 silesia.tar,                        level 9,                            compress simple,                    4555426
 silesia.tar,                        level 13,                           compress simple,                    4491764
-silesia.tar,                        level 16,                           compress simple,                    4381350
-silesia.tar,                        level 19,                           compress simple,                    4281562
+silesia.tar,                        level 16,                           compress simple,                    4356834
+silesia.tar,                        level 19,                           compress simple,                    4264392
 silesia.tar,                        uncompressed literals,              compress simple,                    4861425
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4281562
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264392
 silesia.tar,                        huffman literals,                   compress simple,                    6186042
 github.tar,                         level -5,                           compress simple,                    46856
 github.tar,                         level -3,                           compress simple,                    43754
@@ -45,17 +45,17 @@ silesia,                            level 6,                            compress
 silesia,                            level 7,                            compress cctx,                      4603381
 silesia,                            level 9,                            compress cctx,                      4546001
 silesia,                            level 13,                           compress cctx,                      4482135
-silesia,                            level 16,                           compress cctx,                      4377465
-silesia,                            level 19,                           compress cctx,                      4293330
+silesia,                            level 16,                           compress cctx,                      4360251
+silesia,                            level 19,                           compress cctx,                      4283237
 silesia,                            long distance mode,                 compress cctx,                      4849552
 silesia,                            multithreaded,                      compress cctx,                      4849552
 silesia,                            multithreaded long distance mode,   compress cctx,                      4849552
 silesia,                            small window log,                   compress cctx,                      7084179
-silesia,                            small hash log,                     compress cctx,                      6555021
-silesia,                            small chain log,                    compress cctx,                      4931148
+silesia,                            small hash log,                     compress cctx,                      6526141
+silesia,                            small chain log,                    compress cctx,                      4912197
 silesia,                            explicit params,                    compress cctx,                      4794479
 silesia,                            uncompressed literals,              compress cctx,                      4849552
-silesia,                            uncompressed literals optimal,      compress cctx,                      4293330
+silesia,                            uncompressed literals optimal,      compress cctx,                      4283237
 silesia,                            huffman literals,                   compress cctx,                      6178460
 silesia,                            multithreaded with advanced params, compress cctx,                      4849552
 github,                             level -5,                           compress cctx,                      205285


### PR DESCRIPTION
This PR adds the auto-force-enabled ldm/block splitter to the old API, as well as the new one, and updates regressiontest.