### PR TITLE
[RFC] Rebalance compression levels

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -6187,14 +6187,14 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 20, 15, 16,  1,  6,  0, ZSTD_fast    },  /* level  2 */
     { 21, 16, 17,  1,  5,  0, ZSTD_dfast   },  /* level  3 */
     { 21, 18, 18,  1,  5,  0, ZSTD_dfast   },  /* level  4 */
-    { 21, 18, 19,  2,  5,  2, ZSTD_greedy  },  /* level  5 */
-    { 21, 19, 19,  3,  5,  4, ZSTD_greedy  },  /* level  6 */
-    { 21, 19, 19,  3,  5,  8, ZSTD_lazy    },  /* level  7 */
-    { 21, 19, 19,  3,  5, 16, ZSTD_lazy2   },  /* level  8 */
-    { 21, 19, 20,  4,  5, 16, ZSTD_lazy2   },  /* level  9 */
-    { 22, 20, 21,  4,  5, 16, ZSTD_lazy2   },  /* level 10 */
-    { 22, 21, 22,  4,  5, 16, ZSTD_lazy2   },  /* level 11 */
-    { 22, 21, 22,  5,  5, 16, ZSTD_lazy2   },  /* level 12 */
+    { 21, 18, 19,  4,  5,  2, ZSTD_greedy  },  /* level  5 */
+    { 21, 19, 20,  5,  5,  4, ZSTD_greedy  },  /* level  6 */
+    { 21, 19, 20,  4,  5,  8, ZSTD_lazy    },  /* level  7 */
+    { 21, 19, 20,  5,  5, 16, ZSTD_lazy    },  /* level  8 */
+    { 21, 20, 21,  4,  5, 16, ZSTD_lazy2   },  /* level  9 */
+    { 22, 21, 22,  4,  5, 16, ZSTD_lazy2   },  /* level 10 */
+    { 22, 21, 22,  5,  5, 16, ZSTD_lazy2   },  /* level 11 */
+    { 22, 21, 22,  6,  5, 32, ZSTD_lazy2   },  /* level 12 */
     { 22, 21, 22,  5,  5, 32, ZSTD_btlazy2 },  /* level 13 */
     { 22, 22, 23,  5,  5, 32, ZSTD_btlazy2 },  /* level 14 */
     { 22, 23, 23,  6,  5, 32, ZSTD_btlazy2 },  /* level 15 */
@@ -6212,13 +6212,13 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 18, 13, 14,  1,  6,  0, ZSTD_fast    },  /* level  1 */
     { 18, 14, 14,  1,  5,  0, ZSTD_dfast   },  /* level  2 */
     { 18, 16, 16,  1,  4,  0, ZSTD_dfast   },  /* level  3 */
-    { 18, 16, 17,  2,  5,  2, ZSTD_greedy  },  /* level  4.*/
-    { 18, 18, 18,  3,  5,  2, ZSTD_greedy  },  /* level  5.*/
-    { 18, 18, 19,  3,  5,  4, ZSTD_lazy    },  /* level  6.*/
-    { 18, 18, 19,  4,  4,  4, ZSTD_lazy    },  /* level  7 */
-    { 18, 18, 19,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
-    { 18, 18, 19,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 18, 18, 19,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 18, 16, 17,  3,  5,  2, ZSTD_greedy  },  /* level  4.*/
+    { 18, 18, 18,  4,  5,  2, ZSTD_greedy  },  /* level  5.*/
+    { 18, 18, 19,  5,  5,  4, ZSTD_greedy  },  /* level  6.*/
+    { 18, 18, 19,  3,  4,  4, ZSTD_lazy    },  /* level  7 */
+    { 18, 18, 19,  4,  4,  8, ZSTD_lazy    },  /* level  8 */
+    { 18, 18, 19,  4,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 18, 18, 19,  5,  4,  8, ZSTD_lazy2   },  /* level 10 */
     { 18, 18, 19,  5,  4, 12, ZSTD_btlazy2 },  /* level 11.*/
     { 18, 19, 19,  7,  4, 12, ZSTD_btlazy2 },  /* level 12.*/
     { 18, 18, 19,  4,  4, 16, ZSTD_btopt   },  /* level 13 */
@@ -6239,12 +6239,12 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 17, 13, 15,  1,  5,  0, ZSTD_fast    },  /* level  2 */
     { 17, 15, 16,  2,  5,  0, ZSTD_dfast   },  /* level  3 */
     { 17, 17, 17,  2,  4,  0, ZSTD_dfast   },  /* level  4 */
-    { 17, 16, 17,  3,  4,  2, ZSTD_greedy  },  /* level  5 */
-    { 17, 17, 17,  3,  4,  4, ZSTD_lazy    },  /* level  6 */
-    { 17, 17, 17,  3,  4,  8, ZSTD_lazy2   },  /* level  7 */
-    { 17, 17, 17,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
-    { 17, 17, 17,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 17, 17, 17,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 17, 16, 17,  4,  4,  2, ZSTD_greedy  },  /* level  5 */
+    { 17, 16, 17,  5,  4,  4, ZSTD_greedy  },  /* level  6 */
+    { 17, 16, 17,  4,  4,  8, ZSTD_lazy    },  /* level  7 */
+    { 17, 16, 17,  5,  4,  8, ZSTD_lazy    },  /* level  8 */
+    { 17, 16, 17,  4,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 17, 16, 17,  5,  4,  8, ZSTD_lazy2   },  /* level 10 */
     { 17, 17, 17,  5,  4,  8, ZSTD_btlazy2 },  /* level 11 */
     { 17, 18, 17,  7,  4, 12, ZSTD_btlazy2 },  /* level 12 */
     { 17, 18, 17,  3,  4, 12, ZSTD_btopt   },  /* level 13.*/

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1785,8 +1785,8 @@ ZSTD_reset_matchState(ZSTD_matchState_t* ms,
             if (ms->tagTable) ZSTD_memset(ms->tagTable, 0, tagTableSize);
         }
         {   /* Switch to 32-entry rows if searchLog is 5 (or more) */
-            U32 const rowLog = cParams->searchLog < 5 ? 4 : 5;
-            assert(cParams->hashLog > rowLog);
+            U32 const rowLog = MAX(MIN(cParams->searchLog, 6), 4);
+            assert(cParams->hashLog >= rowLog);
             ms->rowHashLog = cParams->hashLog - rowLog;
         }
     }
@@ -6213,12 +6213,12 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 18, 14, 14,  1,  5,  0, ZSTD_dfast   },  /* level  2 */
     { 18, 16, 16,  1,  4,  0, ZSTD_dfast   },  /* level  3 */
     { 18, 16, 17,  3,  5,  2, ZSTD_greedy  },  /* level  4.*/
-    { 18, 18, 18,  4,  5,  2, ZSTD_greedy  },  /* level  5.*/
-    { 18, 18, 19,  5,  5,  4, ZSTD_greedy  },  /* level  6.*/
-    { 18, 18, 19,  3,  4,  4, ZSTD_lazy    },  /* level  7 */
-    { 18, 18, 19,  4,  4,  8, ZSTD_lazy    },  /* level  8 */
-    { 18, 18, 19,  4,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 18, 18, 19,  5,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 18, 17, 18,  5,  5,  2, ZSTD_greedy  },  /* level  5.*/
+    { 18, 18, 19,  3,  5,  4, ZSTD_lazy    },  /* level  6.*/
+    { 18, 18, 19,  4,  4,  4, ZSTD_lazy    },  /* level  7 */
+    { 18, 18, 19,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 18, 18, 19,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 18, 18, 19,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
     { 18, 18, 19,  5,  4, 12, ZSTD_btlazy2 },  /* level 11.*/
     { 18, 19, 19,  7,  4, 12, ZSTD_btlazy2 },  /* level 12.*/
     { 18, 18, 19,  4,  4, 16, ZSTD_btopt   },  /* level 13 */
@@ -6239,12 +6239,12 @@ static const ZSTD_compressionParameters ZSTD_defaultCParameters[4][ZSTD_MAX_CLEV
     { 17, 13, 15,  1,  5,  0, ZSTD_fast    },  /* level  2 */
     { 17, 15, 16,  2,  5,  0, ZSTD_dfast   },  /* level  3 */
     { 17, 17, 17,  2,  4,  0, ZSTD_dfast   },  /* level  4 */
-    { 17, 16, 17,  4,  4,  2, ZSTD_greedy  },  /* level  5 */
-    { 17, 16, 17,  5,  4,  4, ZSTD_greedy  },  /* level  6 */
-    { 17, 16, 17,  4,  4,  8, ZSTD_lazy    },  /* level  7 */
-    { 17, 16, 17,  5,  4,  8, ZSTD_lazy    },  /* level  8 */
-    { 17, 16, 17,  4,  4,  8, ZSTD_lazy2   },  /* level  9 */
-    { 17, 16, 17,  5,  4,  8, ZSTD_lazy2   },  /* level 10 */
+    { 17, 16, 17,  3,  4,  2, ZSTD_greedy  },  /* level  5 */
+    { 17, 16, 17,  3,  4,  4, ZSTD_lazy    },  /* level  6 */
+    { 17, 16, 17,  3,  4,  8, ZSTD_lazy2   },  /* level  7 */
+    { 17, 16, 17,  4,  4,  8, ZSTD_lazy2   },  /* level  8 */
+    { 17, 16, 17,  5,  4,  8, ZSTD_lazy2   },  /* level  9 */
+    { 17, 16, 17,  6,  4,  8, ZSTD_lazy2   },  /* level 10 */
     { 17, 17, 17,  5,  4,  8, ZSTD_btlazy2 },  /* level 11 */
     { 17, 18, 17,  7,  4, 12, ZSTD_btlazy2 },  /* level 12 */
     { 17, 18, 17,  3,  4, 12, ZSTD_btopt   },  /* level 13.*/

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -865,39 +865,48 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_HcFindBestMatch_extDict_selectMLS (
 * (SIMD) Row-based matchfinder
 ***********************************/
 /* Constants for row-based hash */
-#define ZSTD_ROW_HASH_TAG_OFFSET 16                              /* byte offset of hashes in the match state's tagTable from the beginning of a row */
-#define ZSTD_ROW_HASH_TAG_BITS 8                                 /* nb bits to use for the tag */
+#define ZSTD_ROW_HASH_TAG_OFFSET 16     /* byte offset of hashes in the match state's tagTable from the beginning of a row */
+#define ZSTD_ROW_HASH_TAG_BITS 8        /* nb bits to use for the tag */
 #define ZSTD_ROW_HASH_TAG_MASK ((1u << ZSTD_ROW_HASH_TAG_BITS) - 1)
+#define ZSTD_ROW_HASH_MAX_ENTRIES 64    /* absolute maximum number of entries per row, for all configurations */               
 
 #define ZSTD_ROW_HASH_CACHE_MASK (ZSTD_ROW_HASH_CACHE_SIZE - 1)
 
-typedef U32 ZSTD_VecMask;   /* Clarifies when we are interacting with a U32 representing a mask of matches */
+typedef U64 ZSTD_VecMask;   /* Clarifies when we are interacting with a U64 representing a mask of matches */
 
 /* ZSTD_VecMask_next():
  * Starting from the LSB, returns the idx of the next non-zero bit.
  * Basically counting the nb of trailing zeroes.
  */
 static U32 ZSTD_VecMask_next(ZSTD_VecMask val) {
-#   if defined(_MSC_VER)   /* Visual */
+    assert(val != 0);
+#   if defined(_MSC_VER) && defined(_WIN64)
     unsigned long r=0;
-    return _BitScanForward(&r, val) ? (U32)r : 0;
-#   elif defined(__GNUC__) && (__GNUC__ >= 3)
-    return (U32)__builtin_ctz(val);
+    return _BitScanForward64(&r, val) ? (U64)r : 0; /* _BitScanForward64 not defined outside of x86/64 */
+#   elif (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))
+    return (U32)__builtin_ctzll(val);
 #   else
-    /* Software ctz version: http://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup */
-    static const U32 multiplyDeBruijnBitPosition[32] =
-    {
-        0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
-		31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
-    };
-	return multiplyDeBruijnBitPosition[((U32)((val & -(int)val) * 0x077CB531U)) >> 27];
+    /* Software ctz version: http://aggregate.org/MAGIC/#Trailing%20Zero%20Count
+     * and: https://stackoverflow.com/questions/2709430/count-number-of-bits-in-a-64-bit-long-big-integer
+     */
+    val = ~val & (val - 1ULL); /* Lowest set bit mask */
+    val = val - ((val >> 1) & 0x5555555555555555);
+    val = (val & 0x3333333333333333ULL) + ((val >> 2) & 0x3333333333333333ULL);
+    return (U32)((((val + (val >> 4)) & 0xF0F0F0F0F0F0F0FULL) * 0x101010101010101ULL) >> 56);
 #   endif
 }
 
-/* ZSTD_rotateRight_U32():
+/* ZSTD_rotateRight_*():
  * Rotates a bitfield to the right by "count" bits.
  * https://en.wikipedia.org/w/index.php?title=Circular_shift&oldid=991635599#Implementing_circular_shifts
  */
+FORCE_INLINE_TEMPLATE
+U64 ZSTD_rotateRight_U64(U64 const value, U32 count) {
+    assert(count < 64);
+    count &= 0x3F; /* for fickle pattern recognition */
+    return (value >> count) | (U64)(value << ((0U - count) & 0x3F));
+}
+
 FORCE_INLINE_TEMPLATE
 U32 ZSTD_rotateRight_U32(U32 const value, U32 count) {
     assert(count < 32);
@@ -935,13 +944,17 @@ MEM_STATIC int ZSTD_isAligned(void const* ptr, size_t align) {
  */
 FORCE_INLINE_TEMPLATE void ZSTD_row_prefetch(U32 const* hashTable, U16 const* tagTable, U32 const relRow, U32 const rowLog) {
     PREFETCH_L1(hashTable + relRow);
-    if (rowLog == 5) {
+    if (rowLog >= 5) {
         PREFETCH_L1(hashTable + relRow + 16);
+        /* Note: prefetching more of the hash table does not appear to be beneficial for 128-entry rows */
     }
     PREFETCH_L1(tagTable + relRow);
-    assert(rowLog == 4 || rowLog == 5);
+    if (rowLog == 6) {
+        PREFETCH_L1(tagTable + relRow + 32);
+    }
+    assert(rowLog == 4 || rowLog == 5 || rowLog == 6);
     assert(ZSTD_isAligned(hashTable + relRow, 64));                 /* prefetched hash row always 64-byte aligned */
-    assert(ZSTD_isAligned(tagTable + relRow, (size_t)1 << rowLog)); /* prefetched tagRow sits on a multiple of 32 or 64 bytes */
+    assert(ZSTD_isAligned(tagTable + relRow, (size_t)1 << rowLog)); /* prefetched tagRow sits on correct multiple of bytes (32,64,128) */
 }
 
 /* ZSTD_row_fillHashCache():
@@ -1025,7 +1038,7 @@ FORCE_INLINE_TEMPLATE void ZSTD_row_update_internal(ZSTD_matchState_t* ms, const
  * processing.
  */
 void ZSTD_row_update(ZSTD_matchState_t* const ms, const BYTE* ip) {
-    const U32 rowLog = ms->cParams.searchLog < 5 ? 4 : 5;
+    const U32 rowLog = MAX(MIN(ms->cParams.searchLog, 6), 4);
     const U32 rowMask = (1u << rowLog) - 1;
     const U32 mls = MIN(ms->cParams.minMatch, 6 /* mls caps out at 6 */);
 
@@ -1040,14 +1053,15 @@ void ZSTD_row_update(ZSTD_matchState_t* const ms, const BYTE* ip) {
 FORCE_INLINE_TEMPLATE
 ZSTD_VecMask ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, const U32 head, const U32 rowEntries) {
     const BYTE* const src = tagRow + ZSTD_ROW_HASH_TAG_OFFSET;
-    assert((rowEntries == 16) || (rowEntries == 32));
+    assert((rowEntries == 16) || (rowEntries == 32) || rowEntries == 64);
+    assert(rowEntries <= ZSTD_ROW_HASH_MAX_ENTRIES);
 #if defined(ZSTD_ARCH_X86_SSE2)
     if (rowEntries == 16) {
         const __m128i chunk = _mm_loadu_si128((const __m128i*)(const void*)src);
         const __m128i equalMask = _mm_cmpeq_epi8(chunk, _mm_set1_epi8(tag));
         const U16 matches = (U16)_mm_movemask_epi8(equalMask);
         return ZSTD_rotateRight_U16(matches, head);
-    } else { /* rowEntries == 32 */
+    } else if (rowEntries == 32) {
         const __m128i chunk0 = _mm_loadu_si128((const __m128i*)(const void*)&src[0]);
         const __m128i chunk1 = _mm_loadu_si128((const __m128i*)(const void*)&src[16]);
         const __m128i equalMask0 = _mm_cmpeq_epi8(chunk0, _mm_set1_epi8(tag));
@@ -1055,6 +1069,21 @@ ZSTD_VecMask ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, con
         const U32 lo = (U32)_mm_movemask_epi8(equalMask0);
         const U32 hi = (U32)_mm_movemask_epi8(equalMask1);
         return ZSTD_rotateRight_U32((hi << 16) | lo, head);
+    } else {  /* rowEntries == 64 */
+        const __m128i chunk0 = _mm_loadu_si128((const __m128i*)(const void*)&src[0]);
+        const __m128i chunk1 = _mm_loadu_si128((const __m128i*)(const void*)&src[16]);
+        const __m128i chunk2 = _mm_loadu_si128((const __m128i*)(const void*)&src[32]);
+        const __m128i chunk3 = _mm_loadu_si128((const __m128i*)(const void*)&src[48]);
+        const __m128i comparisonMask = _mm_set1_epi8(tag);
+        const __m128i equalMask0 = _mm_cmpeq_epi8(chunk0, comparisonMask);
+        const __m128i equalMask1 = _mm_cmpeq_epi8(chunk1, comparisonMask);
+        const __m128i equalMask2 = _mm_cmpeq_epi8(chunk2, comparisonMask);
+        const __m128i equalMask3 = _mm_cmpeq_epi8(chunk3, comparisonMask);
+        const U64 mask0 = (U64)_mm_movemask_epi8(equalMask0);
+        const U64 mask1 = (U64)_mm_movemask_epi8(equalMask1);
+        const U64 mask2 = (U64)_mm_movemask_epi8(equalMask2);
+        const U64 mask3 = (U64)_mm_movemask_epi8(equalMask3);
+        return ZSTD_rotateRight_U64((mask3 << 48) | (mask2 << 32) | (mask1 << 16) | mask0, head);
     }
 #else
 #  if defined(ZSTD_ARCH_ARM_NEON)
@@ -1069,7 +1098,7 @@ ZSTD_VecMask ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, con
             const U16 hi = (U16)vgetq_lane_u8(t3, 8);
             const U16 lo = (U16)vgetq_lane_u8(t3, 0);
             return ZSTD_rotateRight_U16((hi << 8) | lo, head);
-        } else { /* rowEntries == 32 */
+        } else if (rowEntries == 32) {
             const uint16x8x2_t chunk = vld2q_u16((const U16*)(const void*)src);
             const uint8x16_t chunk0 = vreinterpretq_u8_u16(chunk.val[0]);
             const uint8x16_t chunk1 = vreinterpretq_u8_u16(chunk.val[1]);
@@ -1084,6 +1113,21 @@ ZSTD_VecMask ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, con
             const uint8x8_t t4 = vsri_n_u8(t3.val[1], t3.val[0], 4);
             const U32 matches = vget_lane_u32(vreinterpret_u32_u8(t4), 0);
             return ZSTD_rotateRight_U32(matches, head);
+        } else { /* rowEntries == 64 */
+            const uint8x16x4_t chunk = vld4q_u8(src);
+            const uint8x16_t dup = vdupq_n_u8(tag);
+            const uint8x16_t cmp0 = vceqq_u8(chunk.val[0], dup);
+            const uint8x16_t cmp1 = vceqq_u8(chunk.val[1], dup);
+            const uint8x16_t cmp2 = vceqq_u8(chunk.val[2], dup);
+            const uint8x16_t cmp3 = vceqq_u8(chunk.val[3], dup);
+
+            const uint8x16_t t0 = vsriq_n_u8(cmp1, cmp0, 1);
+            const uint8x16_t t1 = vsriq_n_u8(cmp3, cmp2, 1);
+            const uint8x16_t t2 = vsriq_n_u8(t1, t0, 2);
+            const uint8x16_t t3 = vsriq_n_u8(t2, t2, 4);
+            const uint8x8_t t4 = vshrn_n_u16(vreinterpretq_u16_u8(t3), 4);
+            const U64 matches = vget_lane_u64(vreinterpret_u64_u8(t4), 0);
+            return ZSTD_rotateRight_U64(matches, head);
         }
     }
 #  endif
@@ -1094,7 +1138,7 @@ ZSTD_VecMask ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, con
         const size_t x01 = xFF / 0xFF;
         const size_t x80 = x01 << 7;
         const size_t splatChar = tag * x01;
-        size_t matches = 0;
+        ZSTD_VecMask matches = 0;
         int i = rowEntries - chunkSize;
         assert((sizeof(size_t) == 4) || (sizeof(size_t) == 8));
         if (MEM_isLittleEndian()) { /* runtime check so have two loops */
@@ -1122,8 +1166,10 @@ ZSTD_VecMask ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, con
         matches = ~matches;
         if (rowEntries == 16) {
             return ZSTD_rotateRight_U16((U16)matches, head);
-        } else { /* rowEntries == 32 */
+        } else if (rowEntries == 32) {
             return ZSTD_rotateRight_U32((U32)matches, head);
+        } else {
+            return ZSTD_rotateRight_U64((U64)matches, head);
         }
     }
 #endif
@@ -1176,6 +1222,7 @@ size_t ZSTD_RowFindBestMatch_generic (
 
     /* DMS/DDS variables that may be referenced laster */
     const ZSTD_matchState_t* const dms = ms->dictMatchState;
+
     /* Initialize the following variables to satisfy static analyzer */
     size_t ddsIdx = 0;
     U32 ddsExtraAttempts = 0; /* cctx hash tables are limited in searches, but allow extra searches into DDS */
@@ -1213,7 +1260,7 @@ size_t ZSTD_RowFindBestMatch_generic (
         U32* const row = hashTable + relRow;
         BYTE* tagRow = (BYTE*)(tagTable + relRow);
         U32 const head = *tagRow & rowMask;
-        U32 matchBuffer[32 /* maximum nb entries per row */];
+        U32 matchBuffer[ZSTD_ROW_HASH_MAX_ENTRIES];
         size_t numMatches = 0;
         size_t currMatch = 0;
         ZSTD_VecMask matches = ZSTD_row_getMatchMask(tagRow, (BYTE)tag, head, rowEntries);
@@ -1281,7 +1328,7 @@ size_t ZSTD_RowFindBestMatch_generic (
         const U32 dmsIndexDelta        = dictLimit - dmsSize;
 
         {   U32 const head = *dmsTagRow & rowMask;
-            U32 matchBuffer[32 /* maximum nb row entries */];
+            U32 matchBuffer[ZSTD_ROW_HASH_MAX_ENTRIES];
             size_t numMatches = 0;
             size_t currMatch = 0;
             ZSTD_VecMask matches = ZSTD_row_getMatchMask(dmsTagRow, (BYTE)dmsTag, head, rowEntries);
@@ -1340,12 +1387,13 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_RowFindBestMatch_selectRowLog (
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 5);
+    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 6);
     switch(cappedSearchLog)
     {
     default :
     case 4 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_noDict, offsetPtr, 4);
     case 5 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_noDict, offsetPtr, 5);
+    case 6 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_noDict, offsetPtr, 6);
     }
 }
 
@@ -1354,12 +1402,13 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_RowFindBestMatch_dictMatchState_selectRowLog(
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 5);
+    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 6);
     switch(cappedSearchLog)
     {
     default :
     case 4 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_dictMatchState, offsetPtr, 4);
     case 5 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_dictMatchState, offsetPtr, 5);
+    case 6 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_dictMatchState, offsetPtr, 6);
     }
 }
 
@@ -1368,12 +1417,13 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_RowFindBestMatch_dedicatedDictSearch_selectRow
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 5);
+    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 6);
     switch(cappedSearchLog)
     {
     default :
     case 4 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_dedicatedDictSearch, offsetPtr, 4);
     case 5 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_dedicatedDictSearch, offsetPtr, 5);
+    case 6 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_dedicatedDictSearch, offsetPtr, 6);
     }
 }
 
@@ -1382,12 +1432,13 @@ FORCE_INLINE_TEMPLATE size_t ZSTD_RowFindBestMatch_extDict_selectRowLog (
                         const BYTE* ip, const BYTE* const iLimit,
                         size_t* offsetPtr)
 {
-    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 5);
+    const U32 cappedSearchLog = MIN(ms->cParams.searchLog, 6);
     switch(cappedSearchLog)
     {
     default :
     case 4 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_extDict, offsetPtr, 4);
     case 5 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_extDict, offsetPtr, 5);
+    case 6 : return ZSTD_RowFindBestMatch_selectMLS(ms, ip, iLimit, ZSTD_extDict, offsetPtr, 6);
     }
 }
 

--- a/tests/regression/levels.h
+++ b/tests/regression/levels.h
@@ -35,21 +35,23 @@ LEVEL(1)
 LEVEL(3)
 LEVEL(4)
 /* ROW_LEVEL triggers the row hash (force enabled and disabled) with different
- * dictionary strategies, and 16/32 row entries based on the level/searchLog.
+ * dictionary strategies, and 16/32/64 row entries based on the level/searchLog.
  * 1 == disabled, 2 == enabled.
  */
 ROW_LEVEL(5, 1)
-ROW_LEVEL(5, 2)
+ROW_LEVEL(5, 2) /* 16-entry rows */
 LEVEL(5)
 LEVEL(6)
 ROW_LEVEL(7, 1)
-ROW_LEVEL(7, 2)
+ROW_LEVEL(7, 2) /* 16-entry rows */
 LEVEL(7)
 
 LEVEL(9)
 
+ROW_LEVEL(11, 1)
+ROW_LEVEL(11, 2) /* 32-entry rows */
 ROW_LEVEL(12, 1)
-ROW_LEVEL(12, 2)
+ROW_LEVEL(12, 2) /* 64-entry rows */
 LEVEL(13)
 
 LEVEL(16)

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -4,23 +4,13 @@ silesia.tar,                        level -3,                           compress
 silesia.tar,                        level -1,                           compress simple,                    6186042
 silesia.tar,                        level 0,                            compress simple,                    4861423
 silesia.tar,                        level 1,                            compress simple,                    5334885
-<<<<<<< HEAD
 silesia.tar,                        level 3,                            compress simple,                    4861423
 silesia.tar,                        level 4,                            compress simple,                    4799632
-silesia.tar,                        level 5,                            compress simple,                    4719256
-silesia.tar,                        level 6,                            compress simple,                    4677724
-silesia.tar,                        level 7,                            compress simple,                    4613545
-silesia.tar,                        level 9,                            compress simple,                    4555426
-silesia.tar,                        level 13,                           compress simple,                    4491768
-=======
-silesia.tar,                        level 3,                            compress simple,                    4861425
-silesia.tar,                        level 4,                            compress simple,                    4799630
-silesia.tar,                        level 5,                            compress simple,                    4650203
+silesia.tar,                        level 5,                            compress simple,                    4650202
 silesia.tar,                        level 6,                            compress simple,                    4616811
-silesia.tar,                        level 7,                            compress simple,                    4576830
-silesia.tar,                        level 9,                            compress simple,                    4552585
-silesia.tar,                        level 13,                           compress simple,                    4491764
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia.tar,                        level 7,                            compress simple,                    4576828
+silesia.tar,                        level 9,                            compress simple,                    4552584
+silesia.tar,                        level 13,                           compress simple,                    4491768
 silesia.tar,                        level 16,                           compress simple,                    4356834
 silesia.tar,                        level 19,                           compress simple,                    4264388
 silesia.tar,                        uncompressed literals,              compress simple,                    4861423
@@ -46,27 +36,15 @@ github.tar,                         huffman literals,                   compress
 silesia,                            level -5,                           compress cctx,                      6737607
 silesia,                            level -3,                           compress cctx,                      6444677
 silesia,                            level -1,                           compress cctx,                      6178460
-<<<<<<< HEAD
 silesia,                            level 0,                            compress cctx,                      4849551
 silesia,                            level 1,                            compress cctx,                      5313202
 silesia,                            level 3,                            compress cctx,                      4849551
 silesia,                            level 4,                            compress cctx,                      4786969
-silesia,                            level 5,                            compress cctx,                      4707790
-silesia,                            level 6,                            compress cctx,                      4666383
-silesia,                            level 7,                            compress cctx,                      4603381
-silesia,                            level 9,                            compress cctx,                      4546005
-silesia,                            level 13,                           compress cctx,                      4482131
-=======
-silesia,                            level 0,                            compress cctx,                      4849552
-silesia,                            level 1,                            compress cctx,                      5313204
-silesia,                            level 3,                            compress cctx,                      4849552
-silesia,                            level 4,                            compress cctx,                      4786970
-silesia,                            level 5,                            compress cctx,                      4638959
+silesia,                            level 5,                            compress cctx,                      4638960
 silesia,                            level 6,                            compress cctx,                      4605369
-silesia,                            level 7,                            compress cctx,                      4567207
-silesia,                            level 9,                            compress cctx,                      4543310
-silesia,                            level 13,                           compress cctx,                      4482135
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia,                            level 7,                            compress cctx,                      4567203
+silesia,                            level 9,                            compress cctx,                      4543311
+silesia,                            level 13,                           compress cctx,                      4482131
 silesia,                            level 16,                           compress cctx,                      4360251
 silesia,                            level 19,                           compress cctx,                      4283236
 silesia,                            long distance mode,                 compress cctx,                      4849551
@@ -122,27 +100,15 @@ github,                             multithreaded with advanced params, compress
 silesia,                            level -5,                           zstdcli,                            6737655
 silesia,                            level -3,                           zstdcli,                            6444725
 silesia,                            level -1,                           zstdcli,                            6178508
-<<<<<<< HEAD
 silesia,                            level 0,                            zstdcli,                            4849599
 silesia,                            level 1,                            zstdcli,                            5313250
 silesia,                            level 3,                            zstdcli,                            4849599
 silesia,                            level 4,                            zstdcli,                            4787017
-silesia,                            level 5,                            zstdcli,                            4707838
-silesia,                            level 6,                            zstdcli,                            4666431
-silesia,                            level 7,                            zstdcli,                            4603429
-silesia,                            level 9,                            zstdcli,                            4546053
-silesia,                            level 13,                           zstdcli,                            4482179
-=======
-silesia,                            level 0,                            zstdcli,                            4849600
-silesia,                            level 1,                            zstdcli,                            5313252
-silesia,                            level 3,                            zstdcli,                            4849600
-silesia,                            level 4,                            zstdcli,                            4787018
-silesia,                            level 5,                            zstdcli,                            4639007
+silesia,                            level 5,                            zstdcli,                            4639008
 silesia,                            level 6,                            zstdcli,                            4605417
-silesia,                            level 7,                            zstdcli,                            4567255
-silesia,                            level 9,                            zstdcli,                            4543358
-silesia,                            level 13,                           zstdcli,                            4482183
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia,                            level 7,                            zstdcli,                            4567251
+silesia,                            level 9,                            zstdcli,                            4543359
+silesia,                            level 13,                           zstdcli,                            4482179
 silesia,                            level 16,                           zstdcli,                            4360299
 silesia,                            level 19,                           zstdcli,                            4283284
 silesia,                            long distance mode,                 zstdcli,                            4840807
@@ -163,19 +129,11 @@ silesia.tar,                        level 0,                            zstdcli,
 silesia.tar,                        level 1,                            zstdcli,                            5336318
 silesia.tar,                        level 3,                            zstdcli,                            4861511
 silesia.tar,                        level 4,                            zstdcli,                            4800529
-<<<<<<< HEAD
-silesia.tar,                        level 5,                            zstdcli,                            4720121
-silesia.tar,                        level 6,                            zstdcli,                            4678663
-silesia.tar,                        level 7,                            zstdcli,                            4614426
-silesia.tar,                        level 9,                            zstdcli,                            4556062
-silesia.tar,                        level 13,                           zstdcli,                            4491772
-=======
-silesia.tar,                        level 5,                            zstdcli,                            4651160
-silesia.tar,                        level 6,                            zstdcli,                            4618403
+silesia.tar,                        level 5,                            zstdcli,                            4651159
+silesia.tar,                        level 6,                            zstdcli,                            4618402
 silesia.tar,                        level 7,                            zstdcli,                            4578883
-silesia.tar,                        level 9,                            zstdcli,                            4553500
-silesia.tar,                        level 13,                           zstdcli,                            4491768
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia.tar,                        level 9,                            zstdcli,                            4553498
+silesia.tar,                        level 13,                           zstdcli,                            4491772
 silesia.tar,                        level 16,                           zstdcli,                            4356838
 silesia.tar,                        level 19,                           zstdcli,                            4264392
 silesia.tar,                        no source size,                     zstdcli,                            4861507
@@ -273,41 +231,23 @@ github.tar,                         multithreaded with advanced params, zstdcli,
 silesia,                            level -5,                           advanced one pass,                  6737607
 silesia,                            level -3,                           advanced one pass,                  6444677
 silesia,                            level -1,                           advanced one pass,                  6178460
-<<<<<<< HEAD
 silesia,                            level 0,                            advanced one pass,                  4849551
 silesia,                            level 1,                            advanced one pass,                  5313202
 silesia,                            level 3,                            advanced one pass,                  4849551
 silesia,                            level 4,                            advanced one pass,                  4786969
-silesia,                            level 5 row 1,                      advanced one pass,                  4710233
-silesia,                            level 5 row 2,                      advanced one pass,                  4707790
-silesia,                            level 5,                            advanced one pass,                  4707790
-silesia,                            level 6,                            advanced one pass,                  4666383
-silesia,                            level 7 row 1,                      advanced one pass,                  4596297
-silesia,                            level 7 row 2,                      advanced one pass,                  4603381
-silesia,                            level 7,                            advanced one pass,                  4603381
-silesia,                            level 9,                            advanced one pass,                  4546005
-silesia,                            level 12 row 1,                     advanced one pass,                  4519288
-silesia,                            level 12 row 2,                     advanced one pass,                  4521406
-silesia,                            level 13,                           advanced one pass,                  4482131
-=======
-silesia,                            level 0,                            advanced one pass,                  4849552
-silesia,                            level 1,                            advanced one pass,                  5313204
-silesia,                            level 3,                            advanced one pass,                  4849552
-silesia,                            level 4,                            advanced one pass,                  4786970
-silesia,                            level 5 row 1,                      advanced one pass,                  4640752
-silesia,                            level 5 row 2,                      advanced one pass,                  4638959
-silesia,                            level 5,                            advanced one pass,                  4638959
+silesia,                            level 5 row 1,                      advanced one pass,                  4640753
+silesia,                            level 5 row 2,                      advanced one pass,                  4638960
+silesia,                            level 5,                            advanced one pass,                  4638960
 silesia,                            level 6,                            advanced one pass,                  4605369
-silesia,                            level 7 row 1,                      advanced one pass,                  4564867
-silesia,                            level 7 row 2,                      advanced one pass,                  4567207
-silesia,                            level 7,                            advanced one pass,                  4567207
-silesia,                            level 9,                            advanced one pass,                  4543310
+silesia,                            level 7 row 1,                      advanced one pass,                  4564870
+silesia,                            level 7 row 2,                      advanced one pass,                  4567203
+silesia,                            level 7,                            advanced one pass,                  4567203
+silesia,                            level 9,                            advanced one pass,                  4543311
 silesia,                            level 11 row 1,                     advanced one pass,                  4519288
-silesia,                            level 11 row 2,                     advanced one pass,                  4521397
-silesia,                            level 12 row 1,                     advanced one pass,                  4503116
-silesia,                            level 12 row 2,                     advanced one pass,                  4505151
-silesia,                            level 13,                           advanced one pass,                  4482135
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia,                            level 11 row 2,                     advanced one pass,                  4521406
+silesia,                            level 12 row 1,                     advanced one pass,                  4503117
+silesia,                            level 12 row 2,                     advanced one pass,                  4505152
+silesia,                            level 13,                           advanced one pass,                  4482131
 silesia,                            level 16,                           advanced one pass,                  4360251
 silesia,                            level 19,                           advanced one pass,                  4283236
 silesia,                            no source size,                     advanced one pass,                  4849551
@@ -327,37 +267,21 @@ silesia.tar,                        level -3,                           advanced
 silesia.tar,                        level -1,                           advanced one pass,                  6186042
 silesia.tar,                        level 0,                            advanced one pass,                  4861423
 silesia.tar,                        level 1,                            advanced one pass,                  5334885
-<<<<<<< HEAD
 silesia.tar,                        level 3,                            advanced one pass,                  4861423
 silesia.tar,                        level 4,                            advanced one pass,                  4799632
-silesia.tar,                        level 5 row 1,                      advanced one pass,                  4722324
-silesia.tar,                        level 5 row 2,                      advanced one pass,                  4719256
-silesia.tar,                        level 5,                            advanced one pass,                  4719256
-silesia.tar,                        level 6,                            advanced one pass,                  4677724
-silesia.tar,                        level 7 row 1,                      advanced one pass,                  4606716
-silesia.tar,                        level 7 row 2,                      advanced one pass,                  4613545
-silesia.tar,                        level 7,                            advanced one pass,                  4613545
-silesia.tar,                        level 9,                            advanced one pass,                  4555426
-silesia.tar,                        level 12 row 1,                     advanced one pass,                  4529458
-silesia.tar,                        level 12 row 2,                     advanced one pass,                  4530257
-silesia.tar,                        level 13,                           advanced one pass,                  4491768
-=======
-silesia.tar,                        level 3,                            advanced one pass,                  4861425
-silesia.tar,                        level 4,                            advanced one pass,                  4799630
-silesia.tar,                        level 5 row 1,                      advanced one pass,                  4652860
-silesia.tar,                        level 5 row 2,                      advanced one pass,                  4650203
-silesia.tar,                        level 5,                            advanced one pass,                  4650203
+silesia.tar,                        level 5 row 1,                      advanced one pass,                  4652862
+silesia.tar,                        level 5 row 2,                      advanced one pass,                  4650202
+silesia.tar,                        level 5,                            advanced one pass,                  4650202
 silesia.tar,                        level 6,                            advanced one pass,                  4616811
 silesia.tar,                        level 7 row 1,                      advanced one pass,                  4575392
-silesia.tar,                        level 7 row 2,                      advanced one pass,                  4576830
-silesia.tar,                        level 7,                            advanced one pass,                  4576830
-silesia.tar,                        level 9,                            advanced one pass,                  4552585
-silesia.tar,                        level 11 row 1,                     advanced one pass,                  4529459
-silesia.tar,                        level 11 row 2,                     advanced one pass,                  4530256
-silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513605
-silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514567
-silesia.tar,                        level 13,                           advanced one pass,                  4491764
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia.tar,                        level 7 row 2,                      advanced one pass,                  4576828
+silesia.tar,                        level 7,                            advanced one pass,                  4576828
+silesia.tar,                        level 9,                            advanced one pass,                  4552584
+silesia.tar,                        level 11 row 1,                     advanced one pass,                  4529458
+silesia.tar,                        level 11 row 2,                     advanced one pass,                  4530257
+silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513603
+silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514568
+silesia.tar,                        level 13,                           advanced one pass,                  4491768
 silesia.tar,                        level 16,                           advanced one pass,                  4356834
 silesia.tar,                        level 19,                           advanced one pass,                  4264388
 silesia.tar,                        no source size,                     advanced one pass,                  4861423
@@ -625,41 +549,23 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           advanced one pass small out,        6737607
 silesia,                            level -3,                           advanced one pass small out,        6444677
 silesia,                            level -1,                           advanced one pass small out,        6178460
-<<<<<<< HEAD
 silesia,                            level 0,                            advanced one pass small out,        4849551
 silesia,                            level 1,                            advanced one pass small out,        5313202
 silesia,                            level 3,                            advanced one pass small out,        4849551
 silesia,                            level 4,                            advanced one pass small out,        4786969
-silesia,                            level 5 row 1,                      advanced one pass small out,        4710233
-silesia,                            level 5 row 2,                      advanced one pass small out,        4707790
-silesia,                            level 5,                            advanced one pass small out,        4707790
-silesia,                            level 6,                            advanced one pass small out,        4666383
-silesia,                            level 7 row 1,                      advanced one pass small out,        4596297
-silesia,                            level 7 row 2,                      advanced one pass small out,        4603381
-silesia,                            level 7,                            advanced one pass small out,        4603381
-silesia,                            level 9,                            advanced one pass small out,        4546005
-silesia,                            level 12 row 1,                     advanced one pass small out,        4519288
-silesia,                            level 12 row 2,                     advanced one pass small out,        4521406
-silesia,                            level 13,                           advanced one pass small out,        4482131
-=======
-silesia,                            level 0,                            advanced one pass small out,        4849552
-silesia,                            level 1,                            advanced one pass small out,        5313204
-silesia,                            level 3,                            advanced one pass small out,        4849552
-silesia,                            level 4,                            advanced one pass small out,        4786970
-silesia,                            level 5 row 1,                      advanced one pass small out,        4640752
-silesia,                            level 5 row 2,                      advanced one pass small out,        4638959
-silesia,                            level 5,                            advanced one pass small out,        4638959
+silesia,                            level 5 row 1,                      advanced one pass small out,        4640753
+silesia,                            level 5 row 2,                      advanced one pass small out,        4638960
+silesia,                            level 5,                            advanced one pass small out,        4638960
 silesia,                            level 6,                            advanced one pass small out,        4605369
-silesia,                            level 7 row 1,                      advanced one pass small out,        4564867
-silesia,                            level 7 row 2,                      advanced one pass small out,        4567207
-silesia,                            level 7,                            advanced one pass small out,        4567207
-silesia,                            level 9,                            advanced one pass small out,        4543310
+silesia,                            level 7 row 1,                      advanced one pass small out,        4564870
+silesia,                            level 7 row 2,                      advanced one pass small out,        4567203
+silesia,                            level 7,                            advanced one pass small out,        4567203
+silesia,                            level 9,                            advanced one pass small out,        4543311
 silesia,                            level 11 row 1,                     advanced one pass small out,        4519288
-silesia,                            level 11 row 2,                     advanced one pass small out,        4521397
-silesia,                            level 12 row 1,                     advanced one pass small out,        4503116
-silesia,                            level 12 row 2,                     advanced one pass small out,        4505151
-silesia,                            level 13,                           advanced one pass small out,        4482135
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia,                            level 11 row 2,                     advanced one pass small out,        4521406
+silesia,                            level 12 row 1,                     advanced one pass small out,        4503117
+silesia,                            level 12 row 2,                     advanced one pass small out,        4505152
+silesia,                            level 13,                           advanced one pass small out,        4482131
 silesia,                            level 16,                           advanced one pass small out,        4360251
 silesia,                            level 19,                           advanced one pass small out,        4283236
 silesia,                            no source size,                     advanced one pass small out,        4849551
@@ -679,37 +585,21 @@ silesia.tar,                        level -3,                           advanced
 silesia.tar,                        level -1,                           advanced one pass small out,        6186042
 silesia.tar,                        level 0,                            advanced one pass small out,        4861423
 silesia.tar,                        level 1,                            advanced one pass small out,        5334885
-<<<<<<< HEAD
 silesia.tar,                        level 3,                            advanced one pass small out,        4861423
 silesia.tar,                        level 4,                            advanced one pass small out,        4799632
-silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4722324
-silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4719256
-silesia.tar,                        level 5,                            advanced one pass small out,        4719256
-silesia.tar,                        level 6,                            advanced one pass small out,        4677724
-silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4606716
-silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4613545
-silesia.tar,                        level 7,                            advanced one pass small out,        4613545
-silesia.tar,                        level 9,                            advanced one pass small out,        4555426
-silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4529458
-silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4530257
-silesia.tar,                        level 13,                           advanced one pass small out,        4491768
-=======
-silesia.tar,                        level 3,                            advanced one pass small out,        4861425
-silesia.tar,                        level 4,                            advanced one pass small out,        4799630
-silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4652860
-silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4650203
-silesia.tar,                        level 5,                            advanced one pass small out,        4650203
+silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4652862
+silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4650202
+silesia.tar,                        level 5,                            advanced one pass small out,        4650202
 silesia.tar,                        level 6,                            advanced one pass small out,        4616811
 silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4575392
-silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4576830
-silesia.tar,                        level 7,                            advanced one pass small out,        4576830
-silesia.tar,                        level 9,                            advanced one pass small out,        4552585
-silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4529459
-silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4530256
-silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513605
-silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514567
-silesia.tar,                        level 13,                           advanced one pass small out,        4491764
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4576828
+silesia.tar,                        level 7,                            advanced one pass small out,        4576828
+silesia.tar,                        level 9,                            advanced one pass small out,        4552584
+silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4529458
+silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4530257
+silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513603
+silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514568
+silesia.tar,                        level 13,                           advanced one pass small out,        4491768
 silesia.tar,                        level 16,                           advanced one pass small out,        4356834
 silesia.tar,                        level 19,                           advanced one pass small out,        4264388
 silesia.tar,                        no source size,                     advanced one pass small out,        4861423
@@ -977,41 +867,23 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           advanced streaming,                 6882505
 silesia,                            level -3,                           advanced streaming,                 6568376
 silesia,                            level -1,                           advanced streaming,                 6183403
-<<<<<<< HEAD
 silesia,                            level 0,                            advanced streaming,                 4849551
 silesia,                            level 1,                            advanced streaming,                 5314161
 silesia,                            level 3,                            advanced streaming,                 4849551
 silesia,                            level 4,                            advanced streaming,                 4786969
-silesia,                            level 5 row 1,                      advanced streaming,                 4710233
-silesia,                            level 5 row 2,                      advanced streaming,                 4707790
-silesia,                            level 5,                            advanced streaming,                 4707790
-silesia,                            level 6,                            advanced streaming,                 4666383
-silesia,                            level 7 row 1,                      advanced streaming,                 4596297
-silesia,                            level 7 row 2,                      advanced streaming,                 4603381
-silesia,                            level 7,                            advanced streaming,                 4603381
-silesia,                            level 9,                            advanced streaming,                 4546005
-silesia,                            level 12 row 1,                     advanced streaming,                 4519288
-silesia,                            level 12 row 2,                     advanced streaming,                 4521406
-silesia,                            level 13,                           advanced streaming,                 4482131
-=======
-silesia,                            level 0,                            advanced streaming,                 4849552
-silesia,                            level 1,                            advanced streaming,                 5314162
-silesia,                            level 3,                            advanced streaming,                 4849552
-silesia,                            level 4,                            advanced streaming,                 4786970
-silesia,                            level 5 row 1,                      advanced streaming,                 4640752
-silesia,                            level 5 row 2,                      advanced streaming,                 4638959
-silesia,                            level 5,                            advanced streaming,                 4638959
+silesia,                            level 5 row 1,                      advanced streaming,                 4640753
+silesia,                            level 5 row 2,                      advanced streaming,                 4638960
+silesia,                            level 5,                            advanced streaming,                 4638960
 silesia,                            level 6,                            advanced streaming,                 4605369
-silesia,                            level 7 row 1,                      advanced streaming,                 4564867
-silesia,                            level 7 row 2,                      advanced streaming,                 4567207
-silesia,                            level 7,                            advanced streaming,                 4567207
-silesia,                            level 9,                            advanced streaming,                 4543310
+silesia,                            level 7 row 1,                      advanced streaming,                 4564870
+silesia,                            level 7 row 2,                      advanced streaming,                 4567203
+silesia,                            level 7,                            advanced streaming,                 4567203
+silesia,                            level 9,                            advanced streaming,                 4543311
 silesia,                            level 11 row 1,                     advanced streaming,                 4519288
-silesia,                            level 11 row 2,                     advanced streaming,                 4521397
-silesia,                            level 12 row 1,                     advanced streaming,                 4503116
-silesia,                            level 12 row 2,                     advanced streaming,                 4505151
-silesia,                            level 13,                           advanced streaming,                 4482135
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia,                            level 11 row 2,                     advanced streaming,                 4521406
+silesia,                            level 12 row 1,                     advanced streaming,                 4503117
+silesia,                            level 12 row 2,                     advanced streaming,                 4505152
+silesia,                            level 13,                           advanced streaming,                 4482131
 silesia,                            level 16,                           advanced streaming,                 4360251
 silesia,                            level 19,                           advanced streaming,                 4283236
 silesia,                            no source size,                     advanced streaming,                 4849515
@@ -1029,41 +901,23 @@ silesia,                            multithreaded with advanced params, advanced
 silesia.tar,                        level -5,                           advanced streaming,                 6982759
 silesia.tar,                        level -3,                           advanced streaming,                 6641283
 silesia.tar,                        level -1,                           advanced streaming,                 6190795
-<<<<<<< HEAD
 silesia.tar,                        level 0,                            advanced streaming,                 4861425
 silesia.tar,                        level 1,                            advanced streaming,                 5336941
 silesia.tar,                        level 3,                            advanced streaming,                 4861425
 silesia.tar,                        level 4,                            advanced streaming,                 4799632
-silesia.tar,                        level 5 row 1,                      advanced streaming,                 4722329
-silesia.tar,                        level 5 row 2,                      advanced streaming,                 4719261
-silesia.tar,                        level 5,                            advanced streaming,                 4719261
-silesia.tar,                        level 6,                            advanced streaming,                 4677732
-silesia.tar,                        level 7 row 1,                      advanced streaming,                 4606717
-silesia.tar,                        level 7 row 2,                      advanced streaming,                 4613548
-silesia.tar,                        level 7,                            advanced streaming,                 4613548
-silesia.tar,                        level 9,                            advanced streaming,                 4555432
-silesia.tar,                        level 12 row 1,                     advanced streaming,                 4529458
-silesia.tar,                        level 12 row 2,                     advanced streaming,                 4530259
-silesia.tar,                        level 13,                           advanced streaming,                 4491769
-=======
-silesia.tar,                        level 0,                            advanced streaming,                 4861427
-silesia.tar,                        level 1,                            advanced streaming,                 5336939
-silesia.tar,                        level 3,                            advanced streaming,                 4861427
-silesia.tar,                        level 4,                            advanced streaming,                 4799630
-silesia.tar,                        level 5 row 1,                      advanced streaming,                 4652864
-silesia.tar,                        level 5 row 2,                      advanced streaming,                 4650208
-silesia.tar,                        level 5,                            advanced streaming,                 4650208
+silesia.tar,                        level 5 row 1,                      advanced streaming,                 4652866
+silesia.tar,                        level 5 row 2,                      advanced streaming,                 4650207
+silesia.tar,                        level 5,                            advanced streaming,                 4650207
 silesia.tar,                        level 6,                            advanced streaming,                 4616816
 silesia.tar,                        level 7 row 1,                      advanced streaming,                 4575393
-silesia.tar,                        level 7 row 2,                      advanced streaming,                 4576832
-silesia.tar,                        level 7,                            advanced streaming,                 4576832
-silesia.tar,                        level 9,                            advanced streaming,                 4552591
-silesia.tar,                        level 11 row 1,                     advanced streaming,                 4529459
-silesia.tar,                        level 11 row 2,                     advanced streaming,                 4530258
-silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513605
-silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514567
-silesia.tar,                        level 13,                           advanced streaming,                 4491765
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia.tar,                        level 7 row 2,                      advanced streaming,                 4576830
+silesia.tar,                        level 7,                            advanced streaming,                 4576830
+silesia.tar,                        level 9,                            advanced streaming,                 4552590
+silesia.tar,                        level 11 row 1,                     advanced streaming,                 4529458
+silesia.tar,                        level 11 row 2,                     advanced streaming,                 4530259
+silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513603
+silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514569
+silesia.tar,                        level 13,                           advanced streaming,                 4491769
 silesia.tar,                        level 16,                           advanced streaming,                 4356834
 silesia.tar,                        level 19,                           advanced streaming,                 4264388
 silesia.tar,                        no source size,                     advanced streaming,                 4861421
@@ -1331,27 +1185,15 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           old streaming,                      6882505
 silesia,                            level -3,                           old streaming,                      6568376
 silesia,                            level -1,                           old streaming,                      6183403
-<<<<<<< HEAD
 silesia,                            level 0,                            old streaming,                      4849551
 silesia,                            level 1,                            old streaming,                      5314161
 silesia,                            level 3,                            old streaming,                      4849551
 silesia,                            level 4,                            old streaming,                      4786969
-silesia,                            level 5,                            old streaming,                      4707790
-silesia,                            level 6,                            old streaming,                      4666383
-silesia,                            level 7,                            old streaming,                      4603381
-silesia,                            level 9,                            old streaming,                      4546005
-silesia,                            level 13,                           old streaming,                      4482131
-=======
-silesia,                            level 0,                            old streaming,                      4849552
-silesia,                            level 1,                            old streaming,                      5314162
-silesia,                            level 3,                            old streaming,                      4849552
-silesia,                            level 4,                            old streaming,                      4786970
-silesia,                            level 5,                            old streaming,                      4638959
+silesia,                            level 5,                            old streaming,                      4638960
 silesia,                            level 6,                            old streaming,                      4605369
-silesia,                            level 7,                            old streaming,                      4567207
-silesia,                            level 9,                            old streaming,                      4543310
-silesia,                            level 13,                           old streaming,                      4482135
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia,                            level 7,                            old streaming,                      4567203
+silesia,                            level 9,                            old streaming,                      4543311
+silesia,                            level 13,                           old streaming,                      4482131
 silesia,                            level 16,                           old streaming,                      4360251
 silesia,                            level 19,                           old streaming,                      4283236
 silesia,                            no source size,                     old streaming,                      4849515
@@ -1361,27 +1203,15 @@ silesia,                            huffman literals,                   old stre
 silesia.tar,                        level -5,                           old streaming,                      6982759
 silesia.tar,                        level -3,                           old streaming,                      6641283
 silesia.tar,                        level -1,                           old streaming,                      6190795
-<<<<<<< HEAD
 silesia.tar,                        level 0,                            old streaming,                      4861425
 silesia.tar,                        level 1,                            old streaming,                      5336941
 silesia.tar,                        level 3,                            old streaming,                      4861425
 silesia.tar,                        level 4,                            old streaming,                      4799632
-silesia.tar,                        level 5,                            old streaming,                      4719261
-silesia.tar,                        level 6,                            old streaming,                      4677732
-silesia.tar,                        level 7,                            old streaming,                      4613548
-silesia.tar,                        level 9,                            old streaming,                      4555432
-silesia.tar,                        level 13,                           old streaming,                      4491769
-=======
-silesia.tar,                        level 0,                            old streaming,                      4861427
-silesia.tar,                        level 1,                            old streaming,                      5336939
-silesia.tar,                        level 3,                            old streaming,                      4861427
-silesia.tar,                        level 4,                            old streaming,                      4799630
-silesia.tar,                        level 5,                            old streaming,                      4650208
+silesia.tar,                        level 5,                            old streaming,                      4650207
 silesia.tar,                        level 6,                            old streaming,                      4616816
-silesia.tar,                        level 7,                            old streaming,                      4576832
-silesia.tar,                        level 9,                            old streaming,                      4552591
-silesia.tar,                        level 13,                           old streaming,                      4491765
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia.tar,                        level 7,                            old streaming,                      4576830
+silesia.tar,                        level 9,                            old streaming,                      4552590
+silesia.tar,                        level 13,                           old streaming,                      4491769
 silesia.tar,                        level 16,                           old streaming,                      4356834
 silesia.tar,                        level 19,                           old streaming,                      4264388
 silesia.tar,                        no source size,                     old streaming,                      4861421
@@ -1457,27 +1287,15 @@ github.tar,                         huffman literals,                   old stre
 silesia,                            level -5,                           old streaming advanced,             6882505
 silesia,                            level -3,                           old streaming advanced,             6568376
 silesia,                            level -1,                           old streaming advanced,             6183403
-<<<<<<< HEAD
 silesia,                            level 0,                            old streaming advanced,             4849551
 silesia,                            level 1,                            old streaming advanced,             5314161
 silesia,                            level 3,                            old streaming advanced,             4849551
 silesia,                            level 4,                            old streaming advanced,             4786969
-silesia,                            level 5,                            old streaming advanced,             4707790
-silesia,                            level 6,                            old streaming advanced,             4666383
-silesia,                            level 7,                            old streaming advanced,             4603381
-silesia,                            level 9,                            old streaming advanced,             4546005
-silesia,                            level 13,                           old streaming advanced,             4482131
-=======
-silesia,                            level 0,                            old streaming advanced,             4849552
-silesia,                            level 1,                            old streaming advanced,             5314162
-silesia,                            level 3,                            old streaming advanced,             4849552
-silesia,                            level 4,                            old streaming advanced,             4786970
-silesia,                            level 5,                            old streaming advanced,             4638959
+silesia,                            level 5,                            old streaming advanced,             4638960
 silesia,                            level 6,                            old streaming advanced,             4605369
-silesia,                            level 7,                            old streaming advanced,             4567207
-silesia,                            level 9,                            old streaming advanced,             4543310
-silesia,                            level 13,                           old streaming advanced,             4482135
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia,                            level 7,                            old streaming advanced,             4567203
+silesia,                            level 9,                            old streaming advanced,             4543311
+silesia,                            level 13,                           old streaming advanced,             4482131
 silesia,                            level 16,                           old streaming advanced,             4360251
 silesia,                            level 19,                           old streaming advanced,             4283236
 silesia,                            no source size,                     old streaming advanced,             4849515
@@ -1495,27 +1313,15 @@ silesia,                            multithreaded with advanced params, old stre
 silesia.tar,                        level -5,                           old streaming advanced,             6982759
 silesia.tar,                        level -3,                           old streaming advanced,             6641283
 silesia.tar,                        level -1,                           old streaming advanced,             6190795
-<<<<<<< HEAD
 silesia.tar,                        level 0,                            old streaming advanced,             4861425
 silesia.tar,                        level 1,                            old streaming advanced,             5336941
 silesia.tar,                        level 3,                            old streaming advanced,             4861425
 silesia.tar,                        level 4,                            old streaming advanced,             4799632
-silesia.tar,                        level 5,                            old streaming advanced,             4719261
-silesia.tar,                        level 6,                            old streaming advanced,             4677732
-silesia.tar,                        level 7,                            old streaming advanced,             4613548
-silesia.tar,                        level 9,                            old streaming advanced,             4555432
-silesia.tar,                        level 13,                           old streaming advanced,             4491769
-=======
-silesia.tar,                        level 0,                            old streaming advanced,             4861427
-silesia.tar,                        level 1,                            old streaming advanced,             5336939
-silesia.tar,                        level 3,                            old streaming advanced,             4861427
-silesia.tar,                        level 4,                            old streaming advanced,             4799630
-silesia.tar,                        level 5,                            old streaming advanced,             4650208
+silesia.tar,                        level 5,                            old streaming advanced,             4650207
 silesia.tar,                        level 6,                            old streaming advanced,             4616816
-silesia.tar,                        level 7,                            old streaming advanced,             4576832
-silesia.tar,                        level 9,                            old streaming advanced,             4552591
-silesia.tar,                        level 13,                           old streaming advanced,             4491765
->>>>>>> 546c2250 (Add 64 row entry support for lazy)
+silesia.tar,                        level 7,                            old streaming advanced,             4576830
+silesia.tar,                        level 9,                            old streaming advanced,             4552590
+silesia.tar,                        level 13,                           old streaming advanced,             4491769
 silesia.tar,                        level 16,                           old streaming advanced,             4356834
 silesia.tar,                        level 19,                           old streaming advanced,             4264388
 silesia.tar,                        no source size,                     old streaming advanced,             4861421

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -4,6 +4,7 @@ silesia.tar,                        level -3,                           compress
 silesia.tar,                        level -1,                           compress simple,                    6186042
 silesia.tar,                        level 0,                            compress simple,                    4861423
 silesia.tar,                        level 1,                            compress simple,                    5334885
+<<<<<<< HEAD
 silesia.tar,                        level 3,                            compress simple,                    4861423
 silesia.tar,                        level 4,                            compress simple,                    4799632
 silesia.tar,                        level 5,                            compress simple,                    4719256
@@ -11,6 +12,15 @@ silesia.tar,                        level 6,                            compress
 silesia.tar,                        level 7,                            compress simple,                    4613545
 silesia.tar,                        level 9,                            compress simple,                    4555426
 silesia.tar,                        level 13,                           compress simple,                    4491768
+=======
+silesia.tar,                        level 3,                            compress simple,                    4861425
+silesia.tar,                        level 4,                            compress simple,                    4799630
+silesia.tar,                        level 5,                            compress simple,                    4650203
+silesia.tar,                        level 6,                            compress simple,                    4616811
+silesia.tar,                        level 7,                            compress simple,                    4576830
+silesia.tar,                        level 9,                            compress simple,                    4552585
+silesia.tar,                        level 13,                           compress simple,                    4491764
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia.tar,                        level 16,                           compress simple,                    4356834
 silesia.tar,                        level 19,                           compress simple,                    4264388
 silesia.tar,                        uncompressed literals,              compress simple,                    4861423
@@ -23,10 +33,10 @@ github.tar,                         level 0,                            compress
 github.tar,                         level 1,                            compress simple,                    39265
 github.tar,                         level 3,                            compress simple,                    38441
 github.tar,                         level 4,                            compress simple,                    38467
-github.tar,                         level 5,                            compress simple,                    39693
-github.tar,                         level 6,                            compress simple,                    39621
-github.tar,                         level 7,                            compress simple,                    39213
-github.tar,                         level 9,                            compress simple,                    36758
+github.tar,                         level 5,                            compress simple,                    38376
+github.tar,                         level 6,                            compress simple,                    38610
+github.tar,                         level 7,                            compress simple,                    38073
+github.tar,                         level 9,                            compress simple,                    36767
 github.tar,                         level 13,                           compress simple,                    35621
 github.tar,                         level 16,                           compress simple,                    40255
 github.tar,                         level 19,                           compress simple,                    32837
@@ -36,6 +46,7 @@ github.tar,                         huffman literals,                   compress
 silesia,                            level -5,                           compress cctx,                      6737607
 silesia,                            level -3,                           compress cctx,                      6444677
 silesia,                            level -1,                           compress cctx,                      6178460
+<<<<<<< HEAD
 silesia,                            level 0,                            compress cctx,                      4849551
 silesia,                            level 1,                            compress cctx,                      5313202
 silesia,                            level 3,                            compress cctx,                      4849551
@@ -45,6 +56,17 @@ silesia,                            level 6,                            compress
 silesia,                            level 7,                            compress cctx,                      4603381
 silesia,                            level 9,                            compress cctx,                      4546005
 silesia,                            level 13,                           compress cctx,                      4482131
+=======
+silesia,                            level 0,                            compress cctx,                      4849552
+silesia,                            level 1,                            compress cctx,                      5313204
+silesia,                            level 3,                            compress cctx,                      4849552
+silesia,                            level 4,                            compress cctx,                      4786970
+silesia,                            level 5,                            compress cctx,                      4638959
+silesia,                            level 6,                            compress cctx,                      4605369
+silesia,                            level 7,                            compress cctx,                      4567207
+silesia,                            level 9,                            compress cctx,                      4543310
+silesia,                            level 13,                           compress cctx,                      4482135
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia,                            level 16,                           compress cctx,                      4360251
 silesia,                            level 19,                           compress cctx,                      4283236
 silesia,                            long distance mode,                 compress cctx,                      4849551
@@ -100,6 +122,7 @@ github,                             multithreaded with advanced params, compress
 silesia,                            level -5,                           zstdcli,                            6737655
 silesia,                            level -3,                           zstdcli,                            6444725
 silesia,                            level -1,                           zstdcli,                            6178508
+<<<<<<< HEAD
 silesia,                            level 0,                            zstdcli,                            4849599
 silesia,                            level 1,                            zstdcli,                            5313250
 silesia,                            level 3,                            zstdcli,                            4849599
@@ -109,6 +132,17 @@ silesia,                            level 6,                            zstdcli,
 silesia,                            level 7,                            zstdcli,                            4603429
 silesia,                            level 9,                            zstdcli,                            4546053
 silesia,                            level 13,                           zstdcli,                            4482179
+=======
+silesia,                            level 0,                            zstdcli,                            4849600
+silesia,                            level 1,                            zstdcli,                            5313252
+silesia,                            level 3,                            zstdcli,                            4849600
+silesia,                            level 4,                            zstdcli,                            4787018
+silesia,                            level 5,                            zstdcli,                            4639007
+silesia,                            level 6,                            zstdcli,                            4605417
+silesia,                            level 7,                            zstdcli,                            4567255
+silesia,                            level 9,                            zstdcli,                            4543358
+silesia,                            level 13,                           zstdcli,                            4482183
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia,                            level 16,                           zstdcli,                            4360299
 silesia,                            level 19,                           zstdcli,                            4283284
 silesia,                            long distance mode,                 zstdcli,                            4840807
@@ -129,11 +163,19 @@ silesia.tar,                        level 0,                            zstdcli,
 silesia.tar,                        level 1,                            zstdcli,                            5336318
 silesia.tar,                        level 3,                            zstdcli,                            4861511
 silesia.tar,                        level 4,                            zstdcli,                            4800529
+<<<<<<< HEAD
 silesia.tar,                        level 5,                            zstdcli,                            4720121
 silesia.tar,                        level 6,                            zstdcli,                            4678663
 silesia.tar,                        level 7,                            zstdcli,                            4614426
 silesia.tar,                        level 9,                            zstdcli,                            4556062
 silesia.tar,                        level 13,                           zstdcli,                            4491772
+=======
+silesia.tar,                        level 5,                            zstdcli,                            4651160
+silesia.tar,                        level 6,                            zstdcli,                            4618403
+silesia.tar,                        level 7,                            zstdcli,                            4578883
+silesia.tar,                        level 9,                            zstdcli,                            4553500
+silesia.tar,                        level 13,                           zstdcli,                            4491768
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia.tar,                        level 16,                           zstdcli,                            4356838
 silesia.tar,                        level 19,                           zstdcli,                            4264392
 silesia.tar,                        no source size,                     zstdcli,                            4861507
@@ -165,11 +207,11 @@ github,                             level 4 with dict,                  zstdcli,
 github,                             level 5,                            zstdcli,                            137121
 github,                             level 5 with dict,                  zstdcli,                            40728
 github,                             level 6,                            zstdcli,                            137122
-github,                             level 6 with dict,                  zstdcli,                            40630
+github,                             level 6 with dict,                  zstdcli,                            40636
 github,                             level 7,                            zstdcli,                            137122
-github,                             level 7 with dict,                  zstdcli,                            40747
+github,                             level 7 with dict,                  zstdcli,                            40745
 github,                             level 9,                            zstdcli,                            137122
-github,                             level 9 with dict,                  zstdcli,                            41338
+github,                             level 9 with dict,                  zstdcli,                            41393
 github,                             level 13,                           zstdcli,                            136064
 github,                             level 13 with dict,                 zstdcli,                            41743
 github,                             level 16,                           zstdcli,                            136064
@@ -201,14 +243,14 @@ github.tar,                         level 3,                            zstdcli,
 github.tar,                         level 3 with dict,                  zstdcli,                            37999
 github.tar,                         level 4,                            zstdcli,                            38471
 github.tar,                         level 4 with dict,                  zstdcli,                            37952
-github.tar,                         level 5,                            zstdcli,                            39697
+github.tar,                         level 5,                            zstdcli,                            38380
 github.tar,                         level 5 with dict,                  zstdcli,                            39032
-github.tar,                         level 6,                            zstdcli,                            39625
+github.tar,                         level 6,                            zstdcli,                            38614
 github.tar,                         level 6 with dict,                  zstdcli,                            38614
-github.tar,                         level 7,                            zstdcli,                            39217
-github.tar,                         level 7 with dict,                  zstdcli,                            37871
-github.tar,                         level 9,                            zstdcli,                            36762
-github.tar,                         level 9 with dict,                  zstdcli,                            36641
+github.tar,                         level 7,                            zstdcli,                            38077
+github.tar,                         level 7 with dict,                  zstdcli,                            37873
+github.tar,                         level 9,                            zstdcli,                            36771
+github.tar,                         level 9 with dict,                  zstdcli,                            36623
 github.tar,                         level 13,                           zstdcli,                            35625
 github.tar,                         level 13 with dict,                 zstdcli,                            38730
 github.tar,                         level 16,                           zstdcli,                            40259
@@ -231,6 +273,7 @@ github.tar,                         multithreaded with advanced params, zstdcli,
 silesia,                            level -5,                           advanced one pass,                  6737607
 silesia,                            level -3,                           advanced one pass,                  6444677
 silesia,                            level -1,                           advanced one pass,                  6178460
+<<<<<<< HEAD
 silesia,                            level 0,                            advanced one pass,                  4849551
 silesia,                            level 1,                            advanced one pass,                  5313202
 silesia,                            level 3,                            advanced one pass,                  4849551
@@ -246,6 +289,25 @@ silesia,                            level 9,                            advanced
 silesia,                            level 12 row 1,                     advanced one pass,                  4519288
 silesia,                            level 12 row 2,                     advanced one pass,                  4521406
 silesia,                            level 13,                           advanced one pass,                  4482131
+=======
+silesia,                            level 0,                            advanced one pass,                  4849552
+silesia,                            level 1,                            advanced one pass,                  5313204
+silesia,                            level 3,                            advanced one pass,                  4849552
+silesia,                            level 4,                            advanced one pass,                  4786970
+silesia,                            level 5 row 1,                      advanced one pass,                  4640752
+silesia,                            level 5 row 2,                      advanced one pass,                  4638959
+silesia,                            level 5,                            advanced one pass,                  4638959
+silesia,                            level 6,                            advanced one pass,                  4605369
+silesia,                            level 7 row 1,                      advanced one pass,                  4564867
+silesia,                            level 7 row 2,                      advanced one pass,                  4567207
+silesia,                            level 7,                            advanced one pass,                  4567207
+silesia,                            level 9,                            advanced one pass,                  4543310
+silesia,                            level 11 row 1,                     advanced one pass,                  4519288
+silesia,                            level 11 row 2,                     advanced one pass,                  4521397
+silesia,                            level 12 row 1,                     advanced one pass,                  4503116
+silesia,                            level 12 row 2,                     advanced one pass,                  4505151
+silesia,                            level 13,                           advanced one pass,                  4482135
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia,                            level 16,                           advanced one pass,                  4360251
 silesia,                            level 19,                           advanced one pass,                  4283236
 silesia,                            no source size,                     advanced one pass,                  4849551
@@ -265,6 +327,7 @@ silesia.tar,                        level -3,                           advanced
 silesia.tar,                        level -1,                           advanced one pass,                  6186042
 silesia.tar,                        level 0,                            advanced one pass,                  4861423
 silesia.tar,                        level 1,                            advanced one pass,                  5334885
+<<<<<<< HEAD
 silesia.tar,                        level 3,                            advanced one pass,                  4861423
 silesia.tar,                        level 4,                            advanced one pass,                  4799632
 silesia.tar,                        level 5 row 1,                      advanced one pass,                  4722324
@@ -278,6 +341,23 @@ silesia.tar,                        level 9,                            advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass,                  4529458
 silesia.tar,                        level 12 row 2,                     advanced one pass,                  4530257
 silesia.tar,                        level 13,                           advanced one pass,                  4491768
+=======
+silesia.tar,                        level 3,                            advanced one pass,                  4861425
+silesia.tar,                        level 4,                            advanced one pass,                  4799630
+silesia.tar,                        level 5 row 1,                      advanced one pass,                  4652860
+silesia.tar,                        level 5 row 2,                      advanced one pass,                  4650203
+silesia.tar,                        level 5,                            advanced one pass,                  4650203
+silesia.tar,                        level 6,                            advanced one pass,                  4616811
+silesia.tar,                        level 7 row 1,                      advanced one pass,                  4575392
+silesia.tar,                        level 7 row 2,                      advanced one pass,                  4576830
+silesia.tar,                        level 7,                            advanced one pass,                  4576830
+silesia.tar,                        level 9,                            advanced one pass,                  4552585
+silesia.tar,                        level 11 row 1,                     advanced one pass,                  4529459
+silesia.tar,                        level 11 row 2,                     advanced one pass,                  4530256
+silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513605
+silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514567
+silesia.tar,                        level 13,                           advanced one pass,                  4491764
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia.tar,                        level 16,                           advanced one pass,                  4356834
 silesia.tar,                        level 19,                           advanced one pass,                  4264388
 silesia.tar,                        no source size,                     advanced one pass,                  4861423
@@ -341,31 +421,41 @@ github,                             level 5 with dict load,             advanced
 github,                             level 6,                            advanced one pass,                  135122
 github,                             level 6 with dict,                  advanced one pass,                  38671
 github,                             level 6 with dict dms,              advanced one pass,                  38671
-github,                             level 6 with dict dds,              advanced one pass,                  38630
+github,                             level 6 with dict dds,              advanced one pass,                  38636
 github,                             level 6 with dict copy,             advanced one pass,                  38669
 github,                             level 6 with dict load,             advanced one pass,                  40695
 github,                             level 7 row 1,                      advanced one pass,                  135122
-github,                             level 7 row 1 with dict dms,        advanced one pass,                  38771
-github,                             level 7 row 1 with dict dds,        advanced one pass,                  38771
-github,                             level 7 row 1 with dict copy,       advanced one pass,                  38745
+github,                             level 7 row 1 with dict dms,        advanced one pass,                  38860
+github,                             level 7 row 1 with dict dds,        advanced one pass,                  38766
+github,                             level 7 row 1 with dict copy,       advanced one pass,                  38834
 github,                             level 7 row 1 with dict load,       advanced one pass,                  40695
 github,                             level 7 row 2,                      advanced one pass,                  134584
 github,                             level 7 row 2 with dict dms,        advanced one pass,                  38758
-github,                             level 7 row 2 with dict dds,        advanced one pass,                  38747
+github,                             level 7 row 2 with dict dds,        advanced one pass,                  38745
 github,                             level 7 row 2 with dict copy,       advanced one pass,                  38755
-github,                             level 7 row 2 with dict load,       advanced one pass,                  41030
+github,                             level 7 row 2 with dict load,       advanced one pass,                  43154
 github,                             level 7,                            advanced one pass,                  135122
 github,                             level 7 with dict,                  advanced one pass,                  38758
 github,                             level 7 with dict dms,              advanced one pass,                  38758
-github,                             level 7 with dict dds,              advanced one pass,                  38747
+github,                             level 7 with dict dds,              advanced one pass,                  38745
 github,                             level 7 with dict copy,             advanced one pass,                  38755
 github,                             level 7 with dict load,             advanced one pass,                  40695
 github,                             level 9,                            advanced one pass,                  135122
 github,                             level 9 with dict,                  advanced one pass,                  39437
 github,                             level 9 with dict dms,              advanced one pass,                  39437
-github,                             level 9 with dict dds,              advanced one pass,                  39338
+github,                             level 9 with dict dds,              advanced one pass,                  39393
 github,                             level 9 with dict copy,             advanced one pass,                  39398
 github,                             level 9 with dict load,             advanced one pass,                  41710
+github,                             level 11 row 1,                     advanced one pass,                  135119
+github,                             level 11 row 1 with dict dms,       advanced one pass,                  39671
+github,                             level 11 row 1 with dict dds,       advanced one pass,                  39671
+github,                             level 11 row 1 with dict copy,      advanced one pass,                  39651
+github,                             level 11 row 1 with dict load,      advanced one pass,                  41360
+github,                             level 11 row 2,                     advanced one pass,                  135119
+github,                             level 11 row 2 with dict dms,       advanced one pass,                  39671
+github,                             level 11 row 2 with dict dds,       advanced one pass,                  39671
+github,                             level 11 row 2 with dict copy,      advanced one pass,                  39651
+github,                             level 11 row 2 with dict load,      advanced one pass,                  41360
 github,                             level 12 row 1,                     advanced one pass,                  134180
 github,                             level 12 row 1 with dict dms,       advanced one pass,                  39677
 github,                             level 12 row 1 with dict dds,       advanced one pass,                  39677
@@ -437,60 +527,70 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass,                  37954
 github.tar,                         level 4 with dict copy,             advanced one pass,                  37948
 github.tar,                         level 4 with dict load,             advanced one pass,                  37927
-github.tar,                         level 5 row 1,                      advanced one pass,                  39788
+github.tar,                         level 5 row 1,                      advanced one pass,                  38534
 github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39365
 github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39233
 github.tar,                         level 5 row 1 with dict copy,       advanced one pass,                  39715
-github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  39209
-github.tar,                         level 5 row 2,                      advanced one pass,                  39693
+github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  38019
+github.tar,                         level 5 row 2,                      advanced one pass,                  38376
 github.tar,                         level 5 row 2 with dict dms,        advanced one pass,                  39024
 github.tar,                         level 5 row 2 with dict dds,        advanced one pass,                  39028
 github.tar,                         level 5 row 2 with dict copy,       advanced one pass,                  39040
-github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  39037
-github.tar,                         level 5,                            advanced one pass,                  39693
+github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  37600
+github.tar,                         level 5,                            advanced one pass,                  38376
 github.tar,                         level 5 with dict,                  advanced one pass,                  39040
 github.tar,                         level 5 with dict dms,              advanced one pass,                  39024
 github.tar,                         level 5 with dict dds,              advanced one pass,                  39028
 github.tar,                         level 5 with dict copy,             advanced one pass,                  39040
-github.tar,                         level 5 with dict load,             advanced one pass,                  39037
-github.tar,                         level 6,                            advanced one pass,                  39621
+github.tar,                         level 5 with dict load,             advanced one pass,                  37600
+github.tar,                         level 6,                            advanced one pass,                  38610
 github.tar,                         level 6 with dict,                  advanced one pass,                  38622
 github.tar,                         level 6 with dict dms,              advanced one pass,                  38608
 github.tar,                         level 6 with dict dds,              advanced one pass,                  38610
 github.tar,                         level 6 with dict copy,             advanced one pass,                  38622
-github.tar,                         level 6 with dict load,             advanced one pass,                  38962
-github.tar,                         level 7 row 1,                      advanced one pass,                  39206
-github.tar,                         level 7 row 1 with dict dms,        advanced one pass,                  37954
-github.tar,                         level 7 row 1 with dict dds,        advanced one pass,                  37954
-github.tar,                         level 7 row 1 with dict copy,       advanced one pass,                  38071
-github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  38584
-github.tar,                         level 7 row 2,                      advanced one pass,                  39213
+github.tar,                         level 6 with dict load,             advanced one pass,                  37829
+github.tar,                         level 7 row 1,                      advanced one pass,                  38077
+github.tar,                         level 7 row 1 with dict dms,        advanced one pass,                  38012
+github.tar,                         level 7 row 1 with dict dds,        advanced one pass,                  38014
+github.tar,                         level 7 row 1 with dict copy,       advanced one pass,                  38101
+github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  37402
+github.tar,                         level 7 row 2,                      advanced one pass,                  38073
 github.tar,                         level 7 row 2 with dict dms,        advanced one pass,                  37848
-github.tar,                         level 7 row 2 with dict dds,        advanced one pass,                  37867
+github.tar,                         level 7 row 2 with dict dds,        advanced one pass,                  37869
 github.tar,                         level 7 row 2 with dict copy,       advanced one pass,                  37848
-github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  38582
-github.tar,                         level 7,                            advanced one pass,                  39213
+github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  37371
+github.tar,                         level 7,                            advanced one pass,                  38073
 github.tar,                         level 7 with dict,                  advanced one pass,                  37848
 github.tar,                         level 7 with dict dms,              advanced one pass,                  37848
-github.tar,                         level 7 with dict dds,              advanced one pass,                  37867
+github.tar,                         level 7 with dict dds,              advanced one pass,                  37869
 github.tar,                         level 7 with dict copy,             advanced one pass,                  37848
-github.tar,                         level 7 with dict load,             advanced one pass,                  38582
-github.tar,                         level 9,                            advanced one pass,                  36758
+github.tar,                         level 7 with dict load,             advanced one pass,                  37371
+github.tar,                         level 9,                            advanced one pass,                  36767
 github.tar,                         level 9 with dict,                  advanced one pass,                  36457
 github.tar,                         level 9 with dict dms,              advanced one pass,                  36549
-github.tar,                         level 9 with dict dds,              advanced one pass,                  36637
+github.tar,                         level 9 with dict dds,              advanced one pass,                  36619
 github.tar,                         level 9 with dict copy,             advanced one pass,                  36457
-github.tar,                         level 9 with dict load,             advanced one pass,                  36350
-github.tar,                         level 12 row 1,                     advanced one pass,                  36435
+github.tar,                         level 9 with dict load,             advanced one pass,                  36352
+github.tar,                         level 11 row 1,                     advanced one pass,                  36435
+github.tar,                         level 11 row 1 with dict dms,       advanced one pass,                  36963
+github.tar,                         level 11 row 1 with dict dds,       advanced one pass,                  36963
+github.tar,                         level 11 row 1 with dict copy,      advanced one pass,                  36557
+github.tar,                         level 11 row 1 with dict load,      advanced one pass,                  36419
+github.tar,                         level 11 row 2,                     advanced one pass,                  36435
+github.tar,                         level 11 row 2 with dict dms,       advanced one pass,                  36963
+github.tar,                         level 11 row 2 with dict dds,       advanced one pass,                  36963
+github.tar,                         level 11 row 2 with dict copy,      advanced one pass,                  36557
+github.tar,                         level 11 row 2 with dict load,      advanced one pass,                  36424
+github.tar,                         level 12 row 1,                     advanced one pass,                  36110
 github.tar,                         level 12 row 1 with dict dms,       advanced one pass,                  36986
 github.tar,                         level 12 row 1 with dict dds,       advanced one pass,                  36986
 github.tar,                         level 12 row 1 with dict copy,      advanced one pass,                  36609
-github.tar,                         level 12 row 1 with dict load,      advanced one pass,                  36419
-github.tar,                         level 12 row 2,                     advanced one pass,                  36435
+github.tar,                         level 12 row 1 with dict load,      advanced one pass,                  36459
+github.tar,                         level 12 row 2,                     advanced one pass,                  36105
 github.tar,                         level 12 row 2 with dict dms,       advanced one pass,                  36986
 github.tar,                         level 12 row 2 with dict dds,       advanced one pass,                  36986
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass,                  36609
-github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36424
+github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36460
 github.tar,                         level 13,                           advanced one pass,                  35621
 github.tar,                         level 13 with dict,                 advanced one pass,                  38726
 github.tar,                         level 13 with dict dms,             advanced one pass,                  38903
@@ -525,6 +625,7 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           advanced one pass small out,        6737607
 silesia,                            level -3,                           advanced one pass small out,        6444677
 silesia,                            level -1,                           advanced one pass small out,        6178460
+<<<<<<< HEAD
 silesia,                            level 0,                            advanced one pass small out,        4849551
 silesia,                            level 1,                            advanced one pass small out,        5313202
 silesia,                            level 3,                            advanced one pass small out,        4849551
@@ -540,6 +641,25 @@ silesia,                            level 9,                            advanced
 silesia,                            level 12 row 1,                     advanced one pass small out,        4519288
 silesia,                            level 12 row 2,                     advanced one pass small out,        4521406
 silesia,                            level 13,                           advanced one pass small out,        4482131
+=======
+silesia,                            level 0,                            advanced one pass small out,        4849552
+silesia,                            level 1,                            advanced one pass small out,        5313204
+silesia,                            level 3,                            advanced one pass small out,        4849552
+silesia,                            level 4,                            advanced one pass small out,        4786970
+silesia,                            level 5 row 1,                      advanced one pass small out,        4640752
+silesia,                            level 5 row 2,                      advanced one pass small out,        4638959
+silesia,                            level 5,                            advanced one pass small out,        4638959
+silesia,                            level 6,                            advanced one pass small out,        4605369
+silesia,                            level 7 row 1,                      advanced one pass small out,        4564867
+silesia,                            level 7 row 2,                      advanced one pass small out,        4567207
+silesia,                            level 7,                            advanced one pass small out,        4567207
+silesia,                            level 9,                            advanced one pass small out,        4543310
+silesia,                            level 11 row 1,                     advanced one pass small out,        4519288
+silesia,                            level 11 row 2,                     advanced one pass small out,        4521397
+silesia,                            level 12 row 1,                     advanced one pass small out,        4503116
+silesia,                            level 12 row 2,                     advanced one pass small out,        4505151
+silesia,                            level 13,                           advanced one pass small out,        4482135
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia,                            level 16,                           advanced one pass small out,        4360251
 silesia,                            level 19,                           advanced one pass small out,        4283236
 silesia,                            no source size,                     advanced one pass small out,        4849551
@@ -559,6 +679,7 @@ silesia.tar,                        level -3,                           advanced
 silesia.tar,                        level -1,                           advanced one pass small out,        6186042
 silesia.tar,                        level 0,                            advanced one pass small out,        4861423
 silesia.tar,                        level 1,                            advanced one pass small out,        5334885
+<<<<<<< HEAD
 silesia.tar,                        level 3,                            advanced one pass small out,        4861423
 silesia.tar,                        level 4,                            advanced one pass small out,        4799632
 silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4722324
@@ -572,6 +693,23 @@ silesia.tar,                        level 9,                            advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4529458
 silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4530257
 silesia.tar,                        level 13,                           advanced one pass small out,        4491768
+=======
+silesia.tar,                        level 3,                            advanced one pass small out,        4861425
+silesia.tar,                        level 4,                            advanced one pass small out,        4799630
+silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4652860
+silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4650203
+silesia.tar,                        level 5,                            advanced one pass small out,        4650203
+silesia.tar,                        level 6,                            advanced one pass small out,        4616811
+silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4575392
+silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4576830
+silesia.tar,                        level 7,                            advanced one pass small out,        4576830
+silesia.tar,                        level 9,                            advanced one pass small out,        4552585
+silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4529459
+silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4530256
+silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513605
+silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514567
+silesia.tar,                        level 13,                           advanced one pass small out,        4491764
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia.tar,                        level 16,                           advanced one pass small out,        4356834
 silesia.tar,                        level 19,                           advanced one pass small out,        4264388
 silesia.tar,                        no source size,                     advanced one pass small out,        4861423
@@ -635,31 +773,41 @@ github,                             level 5 with dict load,             advanced
 github,                             level 6,                            advanced one pass small out,        135122
 github,                             level 6 with dict,                  advanced one pass small out,        38671
 github,                             level 6 with dict dms,              advanced one pass small out,        38671
-github,                             level 6 with dict dds,              advanced one pass small out,        38630
+github,                             level 6 with dict dds,              advanced one pass small out,        38636
 github,                             level 6 with dict copy,             advanced one pass small out,        38669
 github,                             level 6 with dict load,             advanced one pass small out,        40695
 github,                             level 7 row 1,                      advanced one pass small out,        135122
-github,                             level 7 row 1 with dict dms,        advanced one pass small out,        38771
-github,                             level 7 row 1 with dict dds,        advanced one pass small out,        38771
-github,                             level 7 row 1 with dict copy,       advanced one pass small out,        38745
+github,                             level 7 row 1 with dict dms,        advanced one pass small out,        38860
+github,                             level 7 row 1 with dict dds,        advanced one pass small out,        38766
+github,                             level 7 row 1 with dict copy,       advanced one pass small out,        38834
 github,                             level 7 row 1 with dict load,       advanced one pass small out,        40695
 github,                             level 7 row 2,                      advanced one pass small out,        134584
 github,                             level 7 row 2 with dict dms,        advanced one pass small out,        38758
-github,                             level 7 row 2 with dict dds,        advanced one pass small out,        38747
+github,                             level 7 row 2 with dict dds,        advanced one pass small out,        38745
 github,                             level 7 row 2 with dict copy,       advanced one pass small out,        38755
-github,                             level 7 row 2 with dict load,       advanced one pass small out,        41030
+github,                             level 7 row 2 with dict load,       advanced one pass small out,        43154
 github,                             level 7,                            advanced one pass small out,        135122
 github,                             level 7 with dict,                  advanced one pass small out,        38758
 github,                             level 7 with dict dms,              advanced one pass small out,        38758
-github,                             level 7 with dict dds,              advanced one pass small out,        38747
+github,                             level 7 with dict dds,              advanced one pass small out,        38745
 github,                             level 7 with dict copy,             advanced one pass small out,        38755
 github,                             level 7 with dict load,             advanced one pass small out,        40695
 github,                             level 9,                            advanced one pass small out,        135122
 github,                             level 9 with dict,                  advanced one pass small out,        39437
 github,                             level 9 with dict dms,              advanced one pass small out,        39437
-github,                             level 9 with dict dds,              advanced one pass small out,        39338
+github,                             level 9 with dict dds,              advanced one pass small out,        39393
 github,                             level 9 with dict copy,             advanced one pass small out,        39398
 github,                             level 9 with dict load,             advanced one pass small out,        41710
+github,                             level 11 row 1,                     advanced one pass small out,        135119
+github,                             level 11 row 1 with dict dms,       advanced one pass small out,        39671
+github,                             level 11 row 1 with dict dds,       advanced one pass small out,        39671
+github,                             level 11 row 1 with dict copy,      advanced one pass small out,        39651
+github,                             level 11 row 1 with dict load,      advanced one pass small out,        41360
+github,                             level 11 row 2,                     advanced one pass small out,        135119
+github,                             level 11 row 2 with dict dms,       advanced one pass small out,        39671
+github,                             level 11 row 2 with dict dds,       advanced one pass small out,        39671
+github,                             level 11 row 2 with dict copy,      advanced one pass small out,        39651
+github,                             level 11 row 2 with dict load,      advanced one pass small out,        41360
 github,                             level 12 row 1,                     advanced one pass small out,        134180
 github,                             level 12 row 1 with dict dms,       advanced one pass small out,        39677
 github,                             level 12 row 1 with dict dds,       advanced one pass small out,        39677
@@ -731,60 +879,70 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass small out,        37954
 github.tar,                         level 4 with dict copy,             advanced one pass small out,        37948
 github.tar,                         level 4 with dict load,             advanced one pass small out,        37927
-github.tar,                         level 5 row 1,                      advanced one pass small out,        39788
+github.tar,                         level 5 row 1,                      advanced one pass small out,        38534
 github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39365
 github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39233
 github.tar,                         level 5 row 1 with dict copy,       advanced one pass small out,        39715
-github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        39209
-github.tar,                         level 5 row 2,                      advanced one pass small out,        39693
+github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        38019
+github.tar,                         level 5 row 2,                      advanced one pass small out,        38376
 github.tar,                         level 5 row 2 with dict dms,        advanced one pass small out,        39024
 github.tar,                         level 5 row 2 with dict dds,        advanced one pass small out,        39028
 github.tar,                         level 5 row 2 with dict copy,       advanced one pass small out,        39040
-github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        39037
-github.tar,                         level 5,                            advanced one pass small out,        39693
+github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        37600
+github.tar,                         level 5,                            advanced one pass small out,        38376
 github.tar,                         level 5 with dict,                  advanced one pass small out,        39040
 github.tar,                         level 5 with dict dms,              advanced one pass small out,        39024
 github.tar,                         level 5 with dict dds,              advanced one pass small out,        39028
 github.tar,                         level 5 with dict copy,             advanced one pass small out,        39040
-github.tar,                         level 5 with dict load,             advanced one pass small out,        39037
-github.tar,                         level 6,                            advanced one pass small out,        39621
+github.tar,                         level 5 with dict load,             advanced one pass small out,        37600
+github.tar,                         level 6,                            advanced one pass small out,        38610
 github.tar,                         level 6 with dict,                  advanced one pass small out,        38622
 github.tar,                         level 6 with dict dms,              advanced one pass small out,        38608
 github.tar,                         level 6 with dict dds,              advanced one pass small out,        38610
 github.tar,                         level 6 with dict copy,             advanced one pass small out,        38622
-github.tar,                         level 6 with dict load,             advanced one pass small out,        38962
-github.tar,                         level 7 row 1,                      advanced one pass small out,        39206
-github.tar,                         level 7 row 1 with dict dms,        advanced one pass small out,        37954
-github.tar,                         level 7 row 1 with dict dds,        advanced one pass small out,        37954
-github.tar,                         level 7 row 1 with dict copy,       advanced one pass small out,        38071
-github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        38584
-github.tar,                         level 7 row 2,                      advanced one pass small out,        39213
+github.tar,                         level 6 with dict load,             advanced one pass small out,        37829
+github.tar,                         level 7 row 1,                      advanced one pass small out,        38077
+github.tar,                         level 7 row 1 with dict dms,        advanced one pass small out,        38012
+github.tar,                         level 7 row 1 with dict dds,        advanced one pass small out,        38014
+github.tar,                         level 7 row 1 with dict copy,       advanced one pass small out,        38101
+github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        37402
+github.tar,                         level 7 row 2,                      advanced one pass small out,        38073
 github.tar,                         level 7 row 2 with dict dms,        advanced one pass small out,        37848
-github.tar,                         level 7 row 2 with dict dds,        advanced one pass small out,        37867
+github.tar,                         level 7 row 2 with dict dds,        advanced one pass small out,        37869
 github.tar,                         level 7 row 2 with dict copy,       advanced one pass small out,        37848
-github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        38582
-github.tar,                         level 7,                            advanced one pass small out,        39213
+github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        37371
+github.tar,                         level 7,                            advanced one pass small out,        38073
 github.tar,                         level 7 with dict,                  advanced one pass small out,        37848
 github.tar,                         level 7 with dict dms,              advanced one pass small out,        37848
-github.tar,                         level 7 with dict dds,              advanced one pass small out,        37867
+github.tar,                         level 7 with dict dds,              advanced one pass small out,        37869
 github.tar,                         level 7 with dict copy,             advanced one pass small out,        37848
-github.tar,                         level 7 with dict load,             advanced one pass small out,        38582
-github.tar,                         level 9,                            advanced one pass small out,        36758
+github.tar,                         level 7 with dict load,             advanced one pass small out,        37371
+github.tar,                         level 9,                            advanced one pass small out,        36767
 github.tar,                         level 9 with dict,                  advanced one pass small out,        36457
 github.tar,                         level 9 with dict dms,              advanced one pass small out,        36549
-github.tar,                         level 9 with dict dds,              advanced one pass small out,        36637
+github.tar,                         level 9 with dict dds,              advanced one pass small out,        36619
 github.tar,                         level 9 with dict copy,             advanced one pass small out,        36457
-github.tar,                         level 9 with dict load,             advanced one pass small out,        36350
-github.tar,                         level 12 row 1,                     advanced one pass small out,        36435
+github.tar,                         level 9 with dict load,             advanced one pass small out,        36352
+github.tar,                         level 11 row 1,                     advanced one pass small out,        36435
+github.tar,                         level 11 row 1 with dict dms,       advanced one pass small out,        36963
+github.tar,                         level 11 row 1 with dict dds,       advanced one pass small out,        36963
+github.tar,                         level 11 row 1 with dict copy,      advanced one pass small out,        36557
+github.tar,                         level 11 row 1 with dict load,      advanced one pass small out,        36419
+github.tar,                         level 11 row 2,                     advanced one pass small out,        36435
+github.tar,                         level 11 row 2 with dict dms,       advanced one pass small out,        36963
+github.tar,                         level 11 row 2 with dict dds,       advanced one pass small out,        36963
+github.tar,                         level 11 row 2 with dict copy,      advanced one pass small out,        36557
+github.tar,                         level 11 row 2 with dict load,      advanced one pass small out,        36424
+github.tar,                         level 12 row 1,                     advanced one pass small out,        36110
 github.tar,                         level 12 row 1 with dict dms,       advanced one pass small out,        36986
 github.tar,                         level 12 row 1 with dict dds,       advanced one pass small out,        36986
 github.tar,                         level 12 row 1 with dict copy,      advanced one pass small out,        36609
-github.tar,                         level 12 row 1 with dict load,      advanced one pass small out,        36419
-github.tar,                         level 12 row 2,                     advanced one pass small out,        36435
+github.tar,                         level 12 row 1 with dict load,      advanced one pass small out,        36459
+github.tar,                         level 12 row 2,                     advanced one pass small out,        36105
 github.tar,                         level 12 row 2 with dict dms,       advanced one pass small out,        36986
 github.tar,                         level 12 row 2 with dict dds,       advanced one pass small out,        36986
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass small out,        36609
-github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36424
+github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36460
 github.tar,                         level 13,                           advanced one pass small out,        35621
 github.tar,                         level 13 with dict,                 advanced one pass small out,        38726
 github.tar,                         level 13 with dict dms,             advanced one pass small out,        38903
@@ -819,6 +977,7 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           advanced streaming,                 6882505
 silesia,                            level -3,                           advanced streaming,                 6568376
 silesia,                            level -1,                           advanced streaming,                 6183403
+<<<<<<< HEAD
 silesia,                            level 0,                            advanced streaming,                 4849551
 silesia,                            level 1,                            advanced streaming,                 5314161
 silesia,                            level 3,                            advanced streaming,                 4849551
@@ -834,6 +993,25 @@ silesia,                            level 9,                            advanced
 silesia,                            level 12 row 1,                     advanced streaming,                 4519288
 silesia,                            level 12 row 2,                     advanced streaming,                 4521406
 silesia,                            level 13,                           advanced streaming,                 4482131
+=======
+silesia,                            level 0,                            advanced streaming,                 4849552
+silesia,                            level 1,                            advanced streaming,                 5314162
+silesia,                            level 3,                            advanced streaming,                 4849552
+silesia,                            level 4,                            advanced streaming,                 4786970
+silesia,                            level 5 row 1,                      advanced streaming,                 4640752
+silesia,                            level 5 row 2,                      advanced streaming,                 4638959
+silesia,                            level 5,                            advanced streaming,                 4638959
+silesia,                            level 6,                            advanced streaming,                 4605369
+silesia,                            level 7 row 1,                      advanced streaming,                 4564867
+silesia,                            level 7 row 2,                      advanced streaming,                 4567207
+silesia,                            level 7,                            advanced streaming,                 4567207
+silesia,                            level 9,                            advanced streaming,                 4543310
+silesia,                            level 11 row 1,                     advanced streaming,                 4519288
+silesia,                            level 11 row 2,                     advanced streaming,                 4521397
+silesia,                            level 12 row 1,                     advanced streaming,                 4503116
+silesia,                            level 12 row 2,                     advanced streaming,                 4505151
+silesia,                            level 13,                           advanced streaming,                 4482135
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia,                            level 16,                           advanced streaming,                 4360251
 silesia,                            level 19,                           advanced streaming,                 4283236
 silesia,                            no source size,                     advanced streaming,                 4849515
@@ -851,6 +1029,7 @@ silesia,                            multithreaded with advanced params, advanced
 silesia.tar,                        level -5,                           advanced streaming,                 6982759
 silesia.tar,                        level -3,                           advanced streaming,                 6641283
 silesia.tar,                        level -1,                           advanced streaming,                 6190795
+<<<<<<< HEAD
 silesia.tar,                        level 0,                            advanced streaming,                 4861425
 silesia.tar,                        level 1,                            advanced streaming,                 5336941
 silesia.tar,                        level 3,                            advanced streaming,                 4861425
@@ -866,6 +1045,25 @@ silesia.tar,                        level 9,                            advanced
 silesia.tar,                        level 12 row 1,                     advanced streaming,                 4529458
 silesia.tar,                        level 12 row 2,                     advanced streaming,                 4530259
 silesia.tar,                        level 13,                           advanced streaming,                 4491769
+=======
+silesia.tar,                        level 0,                            advanced streaming,                 4861427
+silesia.tar,                        level 1,                            advanced streaming,                 5336939
+silesia.tar,                        level 3,                            advanced streaming,                 4861427
+silesia.tar,                        level 4,                            advanced streaming,                 4799630
+silesia.tar,                        level 5 row 1,                      advanced streaming,                 4652864
+silesia.tar,                        level 5 row 2,                      advanced streaming,                 4650208
+silesia.tar,                        level 5,                            advanced streaming,                 4650208
+silesia.tar,                        level 6,                            advanced streaming,                 4616816
+silesia.tar,                        level 7 row 1,                      advanced streaming,                 4575393
+silesia.tar,                        level 7 row 2,                      advanced streaming,                 4576832
+silesia.tar,                        level 7,                            advanced streaming,                 4576832
+silesia.tar,                        level 9,                            advanced streaming,                 4552591
+silesia.tar,                        level 11 row 1,                     advanced streaming,                 4529459
+silesia.tar,                        level 11 row 2,                     advanced streaming,                 4530258
+silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513605
+silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514567
+silesia.tar,                        level 13,                           advanced streaming,                 4491765
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia.tar,                        level 16,                           advanced streaming,                 4356834
 silesia.tar,                        level 19,                           advanced streaming,                 4264388
 silesia.tar,                        no source size,                     advanced streaming,                 4861421
@@ -929,31 +1127,41 @@ github,                             level 5 with dict load,             advanced
 github,                             level 6,                            advanced streaming,                 135122
 github,                             level 6 with dict,                  advanced streaming,                 38671
 github,                             level 6 with dict dms,              advanced streaming,                 38671
-github,                             level 6 with dict dds,              advanced streaming,                 38630
+github,                             level 6 with dict dds,              advanced streaming,                 38636
 github,                             level 6 with dict copy,             advanced streaming,                 38669
 github,                             level 6 with dict load,             advanced streaming,                 40695
 github,                             level 7 row 1,                      advanced streaming,                 135122
-github,                             level 7 row 1 with dict dms,        advanced streaming,                 38771
-github,                             level 7 row 1 with dict dds,        advanced streaming,                 38771
-github,                             level 7 row 1 with dict copy,       advanced streaming,                 38745
+github,                             level 7 row 1 with dict dms,        advanced streaming,                 38860
+github,                             level 7 row 1 with dict dds,        advanced streaming,                 38766
+github,                             level 7 row 1 with dict copy,       advanced streaming,                 38834
 github,                             level 7 row 1 with dict load,       advanced streaming,                 40695
 github,                             level 7 row 2,                      advanced streaming,                 134584
 github,                             level 7 row 2 with dict dms,        advanced streaming,                 38758
-github,                             level 7 row 2 with dict dds,        advanced streaming,                 38747
+github,                             level 7 row 2 with dict dds,        advanced streaming,                 38745
 github,                             level 7 row 2 with dict copy,       advanced streaming,                 38755
-github,                             level 7 row 2 with dict load,       advanced streaming,                 41030
+github,                             level 7 row 2 with dict load,       advanced streaming,                 43154
 github,                             level 7,                            advanced streaming,                 135122
 github,                             level 7 with dict,                  advanced streaming,                 38758
 github,                             level 7 with dict dms,              advanced streaming,                 38758
-github,                             level 7 with dict dds,              advanced streaming,                 38747
+github,                             level 7 with dict dds,              advanced streaming,                 38745
 github,                             level 7 with dict copy,             advanced streaming,                 38755
 github,                             level 7 with dict load,             advanced streaming,                 40695
 github,                             level 9,                            advanced streaming,                 135122
 github,                             level 9 with dict,                  advanced streaming,                 39437
 github,                             level 9 with dict dms,              advanced streaming,                 39437
-github,                             level 9 with dict dds,              advanced streaming,                 39338
+github,                             level 9 with dict dds,              advanced streaming,                 39393
 github,                             level 9 with dict copy,             advanced streaming,                 39398
 github,                             level 9 with dict load,             advanced streaming,                 41710
+github,                             level 11 row 1,                     advanced streaming,                 135119
+github,                             level 11 row 1 with dict dms,       advanced streaming,                 39671
+github,                             level 11 row 1 with dict dds,       advanced streaming,                 39671
+github,                             level 11 row 1 with dict copy,      advanced streaming,                 39651
+github,                             level 11 row 1 with dict load,      advanced streaming,                 41360
+github,                             level 11 row 2,                     advanced streaming,                 135119
+github,                             level 11 row 2 with dict dms,       advanced streaming,                 39671
+github,                             level 11 row 2 with dict dds,       advanced streaming,                 39671
+github,                             level 11 row 2 with dict copy,      advanced streaming,                 39651
+github,                             level 11 row 2 with dict load,      advanced streaming,                 41360
 github,                             level 12 row 1,                     advanced streaming,                 134180
 github,                             level 12 row 1 with dict dms,       advanced streaming,                 39677
 github,                             level 12 row 1 with dict dds,       advanced streaming,                 39677
@@ -1025,60 +1233,70 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced streaming,                 37954
 github.tar,                         level 4 with dict copy,             advanced streaming,                 37948
 github.tar,                         level 4 with dict load,             advanced streaming,                 37927
-github.tar,                         level 5 row 1,                      advanced streaming,                 39788
+github.tar,                         level 5 row 1,                      advanced streaming,                 38534
 github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39365
 github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39233
 github.tar,                         level 5 row 1 with dict copy,       advanced streaming,                 39715
-github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 39209
-github.tar,                         level 5 row 2,                      advanced streaming,                 39693
+github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 38019
+github.tar,                         level 5 row 2,                      advanced streaming,                 38376
 github.tar,                         level 5 row 2 with dict dms,        advanced streaming,                 39024
 github.tar,                         level 5 row 2 with dict dds,        advanced streaming,                 39028
 github.tar,                         level 5 row 2 with dict copy,       advanced streaming,                 39040
-github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 39037
-github.tar,                         level 5,                            advanced streaming,                 39693
+github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 37600
+github.tar,                         level 5,                            advanced streaming,                 38376
 github.tar,                         level 5 with dict,                  advanced streaming,                 39040
 github.tar,                         level 5 with dict dms,              advanced streaming,                 39024
 github.tar,                         level 5 with dict dds,              advanced streaming,                 39028
 github.tar,                         level 5 with dict copy,             advanced streaming,                 39040
-github.tar,                         level 5 with dict load,             advanced streaming,                 39037
-github.tar,                         level 6,                            advanced streaming,                 39621
+github.tar,                         level 5 with dict load,             advanced streaming,                 37600
+github.tar,                         level 6,                            advanced streaming,                 38610
 github.tar,                         level 6 with dict,                  advanced streaming,                 38622
 github.tar,                         level 6 with dict dms,              advanced streaming,                 38608
 github.tar,                         level 6 with dict dds,              advanced streaming,                 38610
 github.tar,                         level 6 with dict copy,             advanced streaming,                 38622
-github.tar,                         level 6 with dict load,             advanced streaming,                 38962
-github.tar,                         level 7 row 1,                      advanced streaming,                 39206
-github.tar,                         level 7 row 1 with dict dms,        advanced streaming,                 37954
-github.tar,                         level 7 row 1 with dict dds,        advanced streaming,                 37954
-github.tar,                         level 7 row 1 with dict copy,       advanced streaming,                 38071
-github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 38584
-github.tar,                         level 7 row 2,                      advanced streaming,                 39213
+github.tar,                         level 6 with dict load,             advanced streaming,                 37829
+github.tar,                         level 7 row 1,                      advanced streaming,                 38077
+github.tar,                         level 7 row 1 with dict dms,        advanced streaming,                 38012
+github.tar,                         level 7 row 1 with dict dds,        advanced streaming,                 38014
+github.tar,                         level 7 row 1 with dict copy,       advanced streaming,                 38101
+github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 37402
+github.tar,                         level 7 row 2,                      advanced streaming,                 38073
 github.tar,                         level 7 row 2 with dict dms,        advanced streaming,                 37848
-github.tar,                         level 7 row 2 with dict dds,        advanced streaming,                 37867
+github.tar,                         level 7 row 2 with dict dds,        advanced streaming,                 37869
 github.tar,                         level 7 row 2 with dict copy,       advanced streaming,                 37848
-github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 38582
-github.tar,                         level 7,                            advanced streaming,                 39213
+github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 37371
+github.tar,                         level 7,                            advanced streaming,                 38073
 github.tar,                         level 7 with dict,                  advanced streaming,                 37848
 github.tar,                         level 7 with dict dms,              advanced streaming,                 37848
-github.tar,                         level 7 with dict dds,              advanced streaming,                 37867
+github.tar,                         level 7 with dict dds,              advanced streaming,                 37869
 github.tar,                         level 7 with dict copy,             advanced streaming,                 37848
-github.tar,                         level 7 with dict load,             advanced streaming,                 38582
-github.tar,                         level 9,                            advanced streaming,                 36758
+github.tar,                         level 7 with dict load,             advanced streaming,                 37371
+github.tar,                         level 9,                            advanced streaming,                 36767
 github.tar,                         level 9 with dict,                  advanced streaming,                 36457
 github.tar,                         level 9 with dict dms,              advanced streaming,                 36549
-github.tar,                         level 9 with dict dds,              advanced streaming,                 36637
+github.tar,                         level 9 with dict dds,              advanced streaming,                 36619
 github.tar,                         level 9 with dict copy,             advanced streaming,                 36457
-github.tar,                         level 9 with dict load,             advanced streaming,                 36350
-github.tar,                         level 12 row 1,                     advanced streaming,                 36435
+github.tar,                         level 9 with dict load,             advanced streaming,                 36352
+github.tar,                         level 11 row 1,                     advanced streaming,                 36435
+github.tar,                         level 11 row 1 with dict dms,       advanced streaming,                 36963
+github.tar,                         level 11 row 1 with dict dds,       advanced streaming,                 36963
+github.tar,                         level 11 row 1 with dict copy,      advanced streaming,                 36557
+github.tar,                         level 11 row 1 with dict load,      advanced streaming,                 36419
+github.tar,                         level 11 row 2,                     advanced streaming,                 36435
+github.tar,                         level 11 row 2 with dict dms,       advanced streaming,                 36963
+github.tar,                         level 11 row 2 with dict dds,       advanced streaming,                 36963
+github.tar,                         level 11 row 2 with dict copy,      advanced streaming,                 36557
+github.tar,                         level 11 row 2 with dict load,      advanced streaming,                 36424
+github.tar,                         level 12 row 1,                     advanced streaming,                 36110
 github.tar,                         level 12 row 1 with dict dms,       advanced streaming,                 36986
 github.tar,                         level 12 row 1 with dict dds,       advanced streaming,                 36986
 github.tar,                         level 12 row 1 with dict copy,      advanced streaming,                 36609
-github.tar,                         level 12 row 1 with dict load,      advanced streaming,                 36419
-github.tar,                         level 12 row 2,                     advanced streaming,                 36435
+github.tar,                         level 12 row 1 with dict load,      advanced streaming,                 36459
+github.tar,                         level 12 row 2,                     advanced streaming,                 36105
 github.tar,                         level 12 row 2 with dict dms,       advanced streaming,                 36986
 github.tar,                         level 12 row 2 with dict dds,       advanced streaming,                 36986
 github.tar,                         level 12 row 2 with dict copy,      advanced streaming,                 36609
-github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36424
+github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36460
 github.tar,                         level 13,                           advanced streaming,                 35621
 github.tar,                         level 13 with dict,                 advanced streaming,                 38726
 github.tar,                         level 13 with dict dms,             advanced streaming,                 38903
@@ -1113,6 +1331,7 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           old streaming,                      6882505
 silesia,                            level -3,                           old streaming,                      6568376
 silesia,                            level -1,                           old streaming,                      6183403
+<<<<<<< HEAD
 silesia,                            level 0,                            old streaming,                      4849551
 silesia,                            level 1,                            old streaming,                      5314161
 silesia,                            level 3,                            old streaming,                      4849551
@@ -1122,6 +1341,17 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming,                      4603381
 silesia,                            level 9,                            old streaming,                      4546005
 silesia,                            level 13,                           old streaming,                      4482131
+=======
+silesia,                            level 0,                            old streaming,                      4849552
+silesia,                            level 1,                            old streaming,                      5314162
+silesia,                            level 3,                            old streaming,                      4849552
+silesia,                            level 4,                            old streaming,                      4786970
+silesia,                            level 5,                            old streaming,                      4638959
+silesia,                            level 6,                            old streaming,                      4605369
+silesia,                            level 7,                            old streaming,                      4567207
+silesia,                            level 9,                            old streaming,                      4543310
+silesia,                            level 13,                           old streaming,                      4482135
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia,                            level 16,                           old streaming,                      4360251
 silesia,                            level 19,                           old streaming,                      4283236
 silesia,                            no source size,                     old streaming,                      4849515
@@ -1131,6 +1361,7 @@ silesia,                            huffman literals,                   old stre
 silesia.tar,                        level -5,                           old streaming,                      6982759
 silesia.tar,                        level -3,                           old streaming,                      6641283
 silesia.tar,                        level -1,                           old streaming,                      6190795
+<<<<<<< HEAD
 silesia.tar,                        level 0,                            old streaming,                      4861425
 silesia.tar,                        level 1,                            old streaming,                      5336941
 silesia.tar,                        level 3,                            old streaming,                      4861425
@@ -1140,6 +1371,17 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming,                      4613548
 silesia.tar,                        level 9,                            old streaming,                      4555432
 silesia.tar,                        level 13,                           old streaming,                      4491769
+=======
+silesia.tar,                        level 0,                            old streaming,                      4861427
+silesia.tar,                        level 1,                            old streaming,                      5336939
+silesia.tar,                        level 3,                            old streaming,                      4861427
+silesia.tar,                        level 4,                            old streaming,                      4799630
+silesia.tar,                        level 5,                            old streaming,                      4650208
+silesia.tar,                        level 6,                            old streaming,                      4616816
+silesia.tar,                        level 7,                            old streaming,                      4576832
+silesia.tar,                        level 9,                            old streaming,                      4552591
+silesia.tar,                        level 13,                           old streaming,                      4491765
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia.tar,                        level 16,                           old streaming,                      4356834
 silesia.tar,                        level 19,                           old streaming,                      4264388
 silesia.tar,                        no source size,                     old streaming,                      4861421
@@ -1193,13 +1435,13 @@ github.tar,                         level 3,                            old stre
 github.tar,                         level 3 with dict,                  old streaming,                      37995
 github.tar,                         level 4,                            old streaming,                      38467
 github.tar,                         level 4 with dict,                  old streaming,                      37948
-github.tar,                         level 5,                            old streaming,                      39693
+github.tar,                         level 5,                            old streaming,                      38376
 github.tar,                         level 5 with dict,                  old streaming,                      39040
-github.tar,                         level 6,                            old streaming,                      39621
+github.tar,                         level 6,                            old streaming,                      38610
 github.tar,                         level 6 with dict,                  old streaming,                      38622
-github.tar,                         level 7,                            old streaming,                      39213
+github.tar,                         level 7,                            old streaming,                      38073
 github.tar,                         level 7 with dict,                  old streaming,                      37848
-github.tar,                         level 9,                            old streaming,                      36758
+github.tar,                         level 9,                            old streaming,                      36767
 github.tar,                         level 9 with dict,                  old streaming,                      36457
 github.tar,                         level 13,                           old streaming,                      35621
 github.tar,                         level 13 with dict,                 old streaming,                      38726
@@ -1215,6 +1457,7 @@ github.tar,                         huffman literals,                   old stre
 silesia,                            level -5,                           old streaming advanced,             6882505
 silesia,                            level -3,                           old streaming advanced,             6568376
 silesia,                            level -1,                           old streaming advanced,             6183403
+<<<<<<< HEAD
 silesia,                            level 0,                            old streaming advanced,             4849551
 silesia,                            level 1,                            old streaming advanced,             5314161
 silesia,                            level 3,                            old streaming advanced,             4849551
@@ -1224,6 +1467,17 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming advanced,             4603381
 silesia,                            level 9,                            old streaming advanced,             4546005
 silesia,                            level 13,                           old streaming advanced,             4482131
+=======
+silesia,                            level 0,                            old streaming advanced,             4849552
+silesia,                            level 1,                            old streaming advanced,             5314162
+silesia,                            level 3,                            old streaming advanced,             4849552
+silesia,                            level 4,                            old streaming advanced,             4786970
+silesia,                            level 5,                            old streaming advanced,             4638959
+silesia,                            level 6,                            old streaming advanced,             4605369
+silesia,                            level 7,                            old streaming advanced,             4567207
+silesia,                            level 9,                            old streaming advanced,             4543310
+silesia,                            level 13,                           old streaming advanced,             4482135
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia,                            level 16,                           old streaming advanced,             4360251
 silesia,                            level 19,                           old streaming advanced,             4283236
 silesia,                            no source size,                     old streaming advanced,             4849515
@@ -1241,6 +1495,7 @@ silesia,                            multithreaded with advanced params, old stre
 silesia.tar,                        level -5,                           old streaming advanced,             6982759
 silesia.tar,                        level -3,                           old streaming advanced,             6641283
 silesia.tar,                        level -1,                           old streaming advanced,             6190795
+<<<<<<< HEAD
 silesia.tar,                        level 0,                            old streaming advanced,             4861425
 silesia.tar,                        level 1,                            old streaming advanced,             5336941
 silesia.tar,                        level 3,                            old streaming advanced,             4861425
@@ -1250,6 +1505,17 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming advanced,             4613548
 silesia.tar,                        level 9,                            old streaming advanced,             4555432
 silesia.tar,                        level 13,                           old streaming advanced,             4491769
+=======
+silesia.tar,                        level 0,                            old streaming advanced,             4861427
+silesia.tar,                        level 1,                            old streaming advanced,             5336939
+silesia.tar,                        level 3,                            old streaming advanced,             4861427
+silesia.tar,                        level 4,                            old streaming advanced,             4799630
+silesia.tar,                        level 5,                            old streaming advanced,             4650208
+silesia.tar,                        level 6,                            old streaming advanced,             4616816
+silesia.tar,                        level 7,                            old streaming advanced,             4576832
+silesia.tar,                        level 9,                            old streaming advanced,             4552591
+silesia.tar,                        level 13,                           old streaming advanced,             4491765
+>>>>>>> 546c2250 (Add 64 row entry support for lazy)
 silesia.tar,                        level 16,                           old streaming advanced,             4356834
 silesia.tar,                        level 19,                           old streaming advanced,             4264388
 silesia.tar,                        no source size,                     old streaming advanced,             4861421
@@ -1278,12 +1544,12 @@ github,                             level 3,                            old stre
 github,                             level 3 with dict,                  old streaming advanced,             41113
 github,                             level 4,                            old streaming advanced,             141104
 github,                             level 4 with dict,                  old streaming advanced,             41084
-github,                             level 5,                            old streaming advanced,             139399
-github,                             level 5 with dict,                  old streaming advanced,             38633
+github,                             level 5,                            old streaming advanced,             139402
+github,                             level 5 with dict,                  old streaming advanced,             38805
 github,                             level 6,                            old streaming advanced,             139402
-github,                             level 6 with dict,                  old streaming advanced,             38723
+github,                             level 6 with dict,                  old streaming advanced,             39363
 github,                             level 7,                            old streaming advanced,             138676
-github,                             level 7 with dict,                  old streaming advanced,             38744
+github,                             level 7 with dict,                  old streaming advanced,             38924
 github,                             level 9,                            old streaming advanced,             138676
 github,                             level 9 with dict,                  old streaming advanced,             38981
 github,                             level 13,                           old streaming advanced,             138676
@@ -1319,13 +1585,13 @@ github.tar,                         level 3,                            old stre
 github.tar,                         level 3 with dict,                  old streaming advanced,             38013
 github.tar,                         level 4,                            old streaming advanced,             38467
 github.tar,                         level 4 with dict,                  old streaming advanced,             38063
-github.tar,                         level 5,                            old streaming advanced,             39693
-github.tar,                         level 5 with dict,                  old streaming advanced,             39049
-github.tar,                         level 6,                            old streaming advanced,             39621
-github.tar,                         level 6 with dict,                  old streaming advanced,             38959
-github.tar,                         level 7,                            old streaming advanced,             39213
-github.tar,                         level 7 with dict,                  old streaming advanced,             38573
-github.tar,                         level 9,                            old streaming advanced,             36758
+github.tar,                         level 5,                            old streaming advanced,             38376
+github.tar,                         level 5 with dict,                  old streaming advanced,             37677
+github.tar,                         level 6,                            old streaming advanced,             38610
+github.tar,                         level 6 with dict,                  old streaming advanced,             37786
+github.tar,                         level 7,                            old streaming advanced,             38073
+github.tar,                         level 7 with dict,                  old streaming advanced,             37322
+github.tar,                         level 9,                            old streaming advanced,             36767
 github.tar,                         level 9 with dict,                  old streaming advanced,             36233
 github.tar,                         level 13,                           old streaming advanced,             35621
 github.tar,                         level 13 with dict,                 old streaming advanced,             36035
@@ -1368,10 +1634,10 @@ github.tar,                         level 0 with dict,                  old stre
 github.tar,                         level 1 with dict,                  old streaming cdict,                38766
 github.tar,                         level 3 with dict,                  old streaming cdict,                37956
 github.tar,                         level 4 with dict,                  old streaming cdict,                37927
-github.tar,                         level 5 with dict,                  old streaming cdict,                39037
-github.tar,                         level 6 with dict,                  old streaming cdict,                38962
-github.tar,                         level 7 with dict,                  old streaming cdict,                38582
-github.tar,                         level 9 with dict,                  old streaming cdict,                36350
+github.tar,                         level 5 with dict,                  old streaming cdict,                37600
+github.tar,                         level 6 with dict,                  old streaming cdict,                37829
+github.tar,                         level 7 with dict,                  old streaming cdict,                37371
+github.tar,                         level 9 with dict,                  old streaming cdict,                36352
 github.tar,                         level 13 with dict,                 old streaming cdict,                36372
 github.tar,                         level 16 with dict,                 old streaming cdict,                39353
 github.tar,                         level 19 with dict,                 old streaming cdict,                32676
@@ -1383,9 +1649,9 @@ github,                             level 0 with dict,                  old stre
 github,                             level 1 with dict,                  old streaming advanced cdict,       42430
 github,                             level 3 with dict,                  old streaming advanced cdict,       41113
 github,                             level 4 with dict,                  old streaming advanced cdict,       41084
-github,                             level 5 with dict,                  old streaming advanced cdict,       38633
-github,                             level 6 with dict,                  old streaming advanced cdict,       38723
-github,                             level 7 with dict,                  old streaming advanced cdict,       38744
+github,                             level 5 with dict,                  old streaming advanced cdict,       38805
+github,                             level 6 with dict,                  old streaming advanced cdict,       39363
+github,                             level 7 with dict,                  old streaming advanced cdict,       38924
 github,                             level 9 with dict,                  old streaming advanced cdict,       38981
 github,                             level 13 with dict,                 old streaming advanced cdict,       39731
 github,                             level 16 with dict,                 old streaming advanced cdict,       40789
@@ -1398,9 +1664,9 @@ github.tar,                         level 0 with dict,                  old stre
 github.tar,                         level 1 with dict,                  old streaming advanced cdict,       39002
 github.tar,                         level 3 with dict,                  old streaming advanced cdict,       38013
 github.tar,                         level 4 with dict,                  old streaming advanced cdict,       38063
-github.tar,                         level 5 with dict,                  old streaming advanced cdict,       39049
-github.tar,                         level 6 with dict,                  old streaming advanced cdict,       38959
-github.tar,                         level 7 with dict,                  old streaming advanced cdict,       38573
+github.tar,                         level 5 with dict,                  old streaming advanced cdict,       37677
+github.tar,                         level 6 with dict,                  old streaming advanced cdict,       37786
+github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37322
 github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36233
 github.tar,                         level 13 with dict,                 old streaming advanced cdict,       36035
 github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38736


### PR DESCRIPTION
This PR rebalances some of the CParams for the middle compression levels to smooth out the ratio/speed curve a little bit. The methodology used was letting `paramgrill` give us some initial ideas to begin with, then do some manual tuning based on what the old curve looked like, trying to keep memory usage mostly in check, and maintaining monotonically increasing `wLog`. The file used was `silesia.tar` (will check against other files too, but this is the main one for tuning).

Currently, this only changes the > 256KB params.

I've provided some figures for how ratio and speed changes as we move through the compression levels.

**>256K**
Old curve 1.4.9:
```
 4#silesia.tar       : 211957760 ->  65507109 (3.236), 178.1 MB/s ,1030.8 MB/s 
 5#silesia.tar       : 211957760 ->  63995214 (3.312), 100.8 MB/s ,1011.5 MB/s R: +2.3%, speed: -43%
 6#silesia.tar       : 211957760 ->  62897118 (3.370),  80.3 MB/s ,1027.2 MB/s R: +1.2%, speed: -20%
 7#silesia.tar       : 211957760 ->  61341367 (3.455),  58.2 MB/s ,1100.3 MB/s R: +2.5%, speed: -27.5%
 8#silesia.tar       : 211957760 ->  60761795 (3.488),  46.9 MB/s ,1129.9 MB/s R: +0.9%, speed: -19.5%
 9#silesia.tar       : 211957760 ->  60191375 (3.521),  35.4 MB/s ,1139.7 MB/s R: +0.9%, speed: -25%
10#silesia.tar       : 211957760 ->  59537903 (3.560),  30.5 MB/s ,1130.5 MB/s R: +1.1%, speed: -14%
11#silesia.tar       : 211957760 ->  59244498 (3.578),  25.0 MB/s ,1131.5 MB/s R: +0.5%, speed: -18%
12#silesia.tar       : 211957760 ->  58778847 (3.606),  17.3 MB/s ,1142.3 MB/s R: +0.78%, speed: -30%
13#silesia.tar       : 211957760 ->  58144787 (3.645),  12.6 MB/s ,1126.6 MB/s R: +1%, speed: -29%
```

Ratio/speed for 1.5.0 release (for reference):
```
 4#silesia.tar       : 211957760 ->  65507109 (3.236), 179.5 MB/s , 984.0 MB/s 
 5#silesia.tar       : 211957760 ->  63807763 (3.322), 125.9 MB/s , 972.6 MB/s 
 6#silesia.tar       : 211957760 ->  62981592 (3.365), 120.7 MB/s , 993.3 MB/s 
 7#silesia.tar       : 211957760 ->  61485353 (3.447),  85.1 MB/s ,1060.9 MB/s 
 8#silesia.tar       : 211957760 ->  60918801 (3.479),  67.8 MB/s ,1088.6 MB/s 
 9#silesia.tar       : 211957760 ->  59932279 (3.537),  55.5 MB/s ,1096.2 MB/s 
10#silesia.tar       : 211957760 ->  59299234 (3.574),  51.6 MB/s ,1091.6 MB/s 
11#silesia.tar       : 211957760 ->  59157938 (3.583),  47.2 MB/s ,1090.5 MB/s 
12#silesia.tar       : 211957760 ->  58644580 (3.614),  36.8 MB/s ,1104.6 MB/s
```

Proposed ratio/speed:
```
 4#silesia.tar       : 211957760 ->  65507109 (3.236), 176.7 MB/s , 982.9 MB/s 
 5#silesia.tar       : 211957760 ->  62473463 (3.393), 118.4 MB/s ,1067.1 MB/s R: +4.8%, speed: -33%
 6#silesia.tar       : 211957760 ->  61461315 (3.449),  90.2 MB/s ,1008.8 MB/s R: +1.6%, speed: -24%
 7#silesia.tar       : 211957760 ->  60459438 (3.506),  71.7 MB/s ,1069.5 MB/s R: +1.2%, speed: -21%
 8#silesia.tar       : 211957760 ->  59989973 (3.533),  57.9 MB/s ,1083.3 MB/s R: +0.7%, speed: -20%
 9#silesia.tar       : 211957760 ->  59707605 (3.550),  51.7 MB/s ,1093.6 MB/s R: +0.4%, speed: -11%
10#silesia.tar       : 211957760 ->  59157938 (3.583),  46.7 MB/s ,1090.4 MB/s R: +0.9%, speed: -10%
11#silesia.tar       : 211957760 ->  58644580 (3.614),  37.1 MB/s ,1098.2 MB/s R: +0.8% speed: -21%
12#silesia.tar       : 211957760 ->  58590098 (3.618),  35.0 MB/s ,1098.8 MB/s R: +0.1% speed: -6%
13#silesia.tar       : 211957760 ->  58093348 (3.649),  12.3 MB/s ,1118.1 MB/s
```

Notes:
- The main issue with the new proposed curve is just that levels 11 and 12 are nearly identical. I'll have to play around a bit more with the parameters to distribute it a bit more evenly (since `paramgrill` was mostly useful for levels 5-8ish), but I'm putting this PR up for now for any comments or suggestions.
- I've also toyed around with LDM and block splitting, but LDM actually hurts compression ratio when `wLog ~= 22`, and we don't want to artificially increase `wLog` to 27 just for the sake of LDM.
- The speed dropoff from level 12 to 13 is not really possible to bridge - row hash doesn't really get any slower even at extreme parameter settings. I think this mostly signals that `btlazy2` has some room for improvement, speed-wise. 

The smaller srcSize parameters also get some slight modifications to smooth out the curve a bit and fix redundant levels. There is less of an emphasis on shifting to compression ratio though, since that was already present.

**<=256K**
1.5.0:
```
 3#silesia.tar       : 211957760 ->  69920109 (3.031), 171.5 MB/s , 922.1 MB/s 
 4#silesia.tar       : 211957760 ->  68090094 (3.113), 124.2 MB/s , 994.1 MB/s 
 5#silesia.tar       : 211957760 ->  67413125 (3.144), 118.1 MB/s ,1012.2 MB/s 
 6#silesia.tar       : 211957760 ->  66219074 (3.201),  83.9 MB/s ,1058.9 MB/s 
 7#silesia.tar       : 211957760 ->  65481211 (3.237),  67.0 MB/s ,1000.1 MB/s 
 8#silesia.tar       : 211957760 ->  65039023 (3.259),  53.7 MB/s ,1026.1 MB/s 
 9#silesia.tar       : 211957760 ->  64715335 (3.275),  45.5 MB/s ,1041.0 MB/s 
10#silesia.tar       : 211957760 ->  64715335 (3.275),  45.5 MB/s ,1041.0 MB/s 
11#silesia.tar       : 211957760 ->  64254016 (3.299),  17.8 MB/s ,1055.5 MB/s
```
new proposal:
```
 3#silesia.tar       : 211957760 ->  69920109 (3.031), 171.4 MB/s , 921.7 MB/s (dfast)
 4#silesia.tar       : 211957760 ->  67558139 (3.137), 118.3 MB/s ,1012.1 MB/s 
 5#silesia.tar       : 211957760 ->  67086391 (3.159), 113.0 MB/s ,1024.2 MB/s 
 6#silesia.tar       : 211957760 ->  66786627 (3.174), 101.6 MB/s ,1033.8 MB/s 
 7#silesia.tar       : 211957760 ->  65987628 (3.212),  76.1 MB/s , 980.5 MB/s 
 8#silesia.tar       : 211957760 ->  65481211 (3.237),  67.0 MB/s ,1001.3 MB/s 
 9#silesia.tar       : 211957760 ->  65039023 (3.259),  53.7 MB/s ,1027.3 MB/s 
10#silesia.tar       : 211957760 ->  64715335 (3.275),  45.5 MB/s ,1042.2 MB/s 
11#silesia.tar       : 211957760 ->  64254016 (3.299),  17.8 MB/s ,1056.9 MB/s (btlazy2)
```
**<=128K**
1.5.0:
```
 4#silesia.tar       : 211957760 ->  71259831 (2.974), 168.4 MB/s , 910.2 MB/s  (dfast)
 5#silesia.tar       : 211957760 ->  69243649 (3.061), 115.8 MB/s , 905.5 MB/s 
 6#silesia.tar       : 211957760 ->  67767332 (3.128),  78.1 MB/s , 964.5 MB/s 
 7#silesia.tar       : 211957760 ->  67305272 (3.149),  65.4 MB/s , 988.4 MB/s 
 8#silesia.tar       : 211957760 ->  66948973 (3.166),  56.3 MB/s ,1004.1 MB/s 
 9#silesia.tar       : 211957760 ->  66689276 (3.178),  49.2 MB/s ,1016.5 MB/s 
10#silesia.tar       : 211957760 ->  66689276 (3.178),  49.2 MB/s ,1016.6 MB/s
11#silesia.tar       : 211957760 ->  66344747 (3.195),  20.1 MB/s ,1027.4 MB/s (btlazy2)
```
new proposed:
```
 4#silesia.tar       : 211957760 ->  71259831 (2.974), 168.4 MB/s , 910.4 MB/s (dfast)
 5#silesia.tar       : 211957760 ->  68812273 (3.080), 108.7 MB/s , 920.2 MB/s 
 6#silesia.tar       : 211957760 ->  68494934 (3.095),  98.6 MB/s , 931.4 MB/s 
 7#silesia.tar       : 211957760 ->  67375761 (3.146),  69.7 MB/s , 980.9 MB/s 
 8#silesia.tar       : 211957760 ->  67088863 (3.159),  62.9 MB/s , 993.8 MB/s 
 9#silesia.tar       : 211957760 ->  66948973 (3.166),  56.3 MB/s ,1004.4 MB/s 
10#silesia.tar       : 211957760 ->  66689276 (3.178),  49.2 MB/s ,1016.8 MB/s 
11#silesia.tar       : 211957760 ->  66344747 (3.195),  20.1 MB/s ,1027.4 MB/s (btlazy2)
```
Params <= 16K are unchanged, since we don't use the row matchfinder by default for those levels.