### PR TITLE
Make the CLI summary data use a human readable format instead of raw bytes

### DIFF
--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -388,6 +388,8 @@ BMK_benchMemAdvancedNoAlloc(
 #       define NB_MARKS 4
         const char* marks[NB_MARKS] = { " |", " /", " =", " \\" };
         U32 markNb = 0;
+		char inputSizeStr[8]  = "";
+		char outputSizeStr[8] = "";
         int compressionCompleted = (adv->mode == BMK_decodeOnly);
         int decompressionCompleted = (adv->mode == BMK_compressOnly);
         BMK_benchParams_t cbp, dbp;
@@ -429,8 +431,10 @@ BMK_benchMemAdvancedNoAlloc(
         dctxprep.dictBuffer = dictBuffer;
         dctxprep.dictBufferSize = dictBufferSize;
 
+		humanSize((unsigned)srcSize, inputSizeStr);
+
         DISPLAYLEVEL(2, "\r%70s\r", "");   /* blank line */
-        DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->\r", marks[markNb], displayName, (unsigned)srcSize);
+        DISPLAYLEVEL(2, "%2s-%-17.17s : %s -> \r", marks[markNb], displayName, inputSizeStr);
 
         while (!(compressionCompleted && decompressionCompleted)) {
             if (!compressionCompleted) {
@@ -451,9 +455,13 @@ BMK_benchMemAdvancedNoAlloc(
                 }   }
 
                 {   int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
-                    DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f),%6.*f MB/s\r",
+
+					humanSize((unsigned)srcSize, inputSizeStr);
+					humanSize((unsigned)cSize, outputSizeStr);
+
+                    DISPLAYLEVEL(2, "%2s-%-17.17s : %s -> %s (%5.*f),%6.*f MB/s\r",
                             marks[markNb], displayName,
-                            (unsigned)srcSize, (unsigned)cSize,
+                            inputSizeStr, outputSizeStr,
                             ratioAccuracy, ratio,
                             benchResult.cSpeed < (10 MB) ? 2 : 1, (double)benchResult.cSpeed / MB_UNIT);
                 }
@@ -474,9 +482,13 @@ BMK_benchMemAdvancedNoAlloc(
                 }
 
                 {   int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
-                    DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f),%6.*f MB/s ,%6.1f MB/s \r",
+
+					humanSize((unsigned)srcSize, inputSizeStr);
+					humanSize((unsigned)cSize, outputSizeStr);
+
+                    DISPLAYLEVEL(2, "%2s-%-17.17s : %s -> %s (%5.*f),%6.*f MB/s ,%6.1f MB/s \r",
                             marks[markNb], displayName,
-                            (unsigned)srcSize, (unsigned)cSize,
+                            inputSizeStr, outputSizeStr,
                             ratioAccuracy, ratio,
                             benchResult.cSpeed < (10 MB) ? 2 : 1, (double)benchResult.cSpeed / MB_UNIT,
                             (double)benchResult.dSpeed / MB_UNIT);

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -388,8 +388,8 @@ BMK_benchMemAdvancedNoAlloc(
 #       define NB_MARKS 4
         const char* marks[NB_MARKS] = { " |", " /", " =", " \\" };
         U32 markNb = 0;
-		char inputSizeStr[8]  = "";
-		char outputSizeStr[8] = "";
+        char inputSizeStr[8]  = "";
+        char outputSizeStr[8] = "";
         int compressionCompleted = (adv->mode == BMK_decodeOnly);
         int decompressionCompleted = (adv->mode == BMK_compressOnly);
         BMK_benchParams_t cbp, dbp;
@@ -431,7 +431,7 @@ BMK_benchMemAdvancedNoAlloc(
         dctxprep.dictBuffer = dictBuffer;
         dctxprep.dictBufferSize = dictBufferSize;
 
-		humanSize((unsigned)srcSize, inputSizeStr);
+        humanSize((unsigned)srcSize, inputSizeStr);
 
         DISPLAYLEVEL(2, "\r%70s\r", "");   /* blank line */
         DISPLAYLEVEL(2, "%2s-%-17.17s : %s -> \r", marks[markNb], displayName, inputSizeStr);
@@ -456,8 +456,8 @@ BMK_benchMemAdvancedNoAlloc(
 
                 {   int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
 
-					humanSize((unsigned)srcSize, inputSizeStr);
-					humanSize((unsigned)cSize, outputSizeStr);
+                    humanSize((unsigned)srcSize, inputSizeStr);
+                    humanSize((unsigned)cSize, outputSizeStr);
 
                     DISPLAYLEVEL(2, "%2s-%-17.17s : %s -> %s (%5.*f),%6.*f MB/s\r",
                             marks[markNb], displayName,
@@ -483,8 +483,8 @@ BMK_benchMemAdvancedNoAlloc(
 
                 {   int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
 
-					humanSize((unsigned)srcSize, inputSizeStr);
-					humanSize((unsigned)cSize, outputSizeStr);
+                    humanSize((unsigned)srcSize, inputSizeStr);
+                    humanSize((unsigned)cSize, outputSizeStr);
 
                     DISPLAYLEVEL(2, "%2s-%-17.17s : %s -> %s (%5.*f),%6.*f MB/s ,%6.1f MB/s \r",
                             marks[markNb], displayName,

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1544,6 +1544,9 @@ FIO_compressFilename_internal(FIO_ctx_t* const fCtx,
     U64 readsize = 0;
     U64 compressedfilesize = 0;
     U64 const fileSize = UTIL_getFileSize(srcFileName);
+	char inputSizeStr[8]  = "";
+	char outputSizeStr[8] = "";
+
     DISPLAYLEVEL(5, "%s: %llu bytes \n", srcFileName, (unsigned long long)fileSize);
 
     /* compression format selection */
@@ -1598,10 +1601,7 @@ FIO_compressFilename_internal(FIO_ctx_t* const fCtx,
                 (unsigned long long)readsize, (unsigned long long) compressedfilesize,
                 dstFileName);
         } else {
-			char inputSizeStr[8] = "";
 			humanSize((unsigned long long) readsize, inputSizeStr);
-
-			char outputSizeStr[8] = "";
 			humanSize((unsigned long long) compressedfilesize, outputSizeStr);
 
             DISPLAYLEVEL(2,"%-20s :%6.2f%%   (%s => %s, %s) \n",

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1544,8 +1544,8 @@ FIO_compressFilename_internal(FIO_ctx_t* const fCtx,
     U64 readsize = 0;
     U64 compressedfilesize = 0;
     U64 const fileSize = UTIL_getFileSize(srcFileName);
-	char inputSizeStr[8]  = "";
-	char outputSizeStr[8] = "";
+    char inputSizeStr[8]  = "";
+    char outputSizeStr[8] = "";
 
     DISPLAYLEVEL(5, "%s: %llu bytes \n", srcFileName, (unsigned long long)fileSize);
 
@@ -1601,8 +1601,8 @@ FIO_compressFilename_internal(FIO_ctx_t* const fCtx,
                 (unsigned long long)readsize, (unsigned long long) compressedfilesize,
                 dstFileName);
         } else {
-			humanSize((unsigned long long) readsize, inputSizeStr);
-			humanSize((unsigned long long) compressedfilesize, outputSizeStr);
+            humanSize((unsigned long long) readsize, inputSizeStr);
+            humanSize((unsigned long long) compressedfilesize, outputSizeStr);
 
             DISPLAYLEVEL(2,"%-20s :%6.2f%%   (%s => %s, %s) \n",
                 srcFileName,
@@ -1841,8 +1841,8 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
 {
     int status;
     int error = 0;
-	char inputSizeStr[8]  = "";
-	char outputSizeStr[8] = "";
+    char inputSizeStr[8]  = "";
+    char outputSizeStr[8] = "";
     cRess_t ress = FIO_createCResources(prefs, dictFileName,
         FIO_getLargestFileSize(inFileNamesTable, (unsigned)fCtx->nbFilesTotal),
         compressionLevel, comprParams);
@@ -1898,8 +1898,8 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
     }
 
     if (fCtx->nbFilesProcessed >= 1 && fCtx->nbFilesTotal > 1 && fCtx->totalBytesInput != 0) {
-		humanSize((unsigned long long) fCtx->totalBytesInput, inputSizeStr);
-		humanSize((unsigned long long) fCtx->totalBytesOutput, outputSizeStr);
+        humanSize((unsigned long long) fCtx->totalBytesInput, inputSizeStr);
+        humanSize((unsigned long long) fCtx->totalBytesOutput, outputSizeStr);
 
         DISPLAYLEVEL(2, "\r%79s\r", "");
         DISPLAYLEVEL(2, "%3d files compressed : %.2f%%   (%s => %s bytes)\n", fCtx->nbFilesProcessed,

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1598,16 +1598,16 @@ FIO_compressFilename_internal(FIO_ctx_t* const fCtx,
                 (unsigned long long)readsize, (unsigned long long) compressedfilesize,
                 dstFileName);
         } else {
-			char input_size_str[8] = "";
-			human_size((unsigned long long) readsize, input_size_str);
+			char inputSizeStr[8] = "";
+			humanSize((unsigned long long) readsize, inputSizeStr);
 
-			char output_size_str[8] = "";
-			human_size((unsigned long long) compressedfilesize, output_size_str);
+			char outputSizeStr[8] = "";
+			humanSize((unsigned long long) compressedfilesize, outputSizeStr);
 
             DISPLAYLEVEL(2,"%-20s :%6.2f%%   (%s => %s, %s) \n",
                 srcFileName,
                 (double)compressedfilesize / (double)readsize * 100,
-                input_size_str, output_size_str,
+                inputSizeStr, outputSizeStr,
                 dstFileName);
         }
     }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1841,6 +1841,8 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
 {
     int status;
     int error = 0;
+	char inputSizeStr[8]  = "";
+	char outputSizeStr[8] = "";
     cRess_t ress = FIO_createCResources(prefs, dictFileName,
         FIO_getLargestFileSize(inFileNamesTable, (unsigned)fCtx->nbFilesTotal),
         compressionLevel, comprParams);
@@ -1896,10 +1898,13 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
     }
 
     if (fCtx->nbFilesProcessed >= 1 && fCtx->nbFilesTotal > 1 && fCtx->totalBytesInput != 0) {
+		humanSize((unsigned long long) fCtx->totalBytesInput, inputSizeStr);
+		humanSize((unsigned long long) fCtx->totalBytesOutput, outputSizeStr);
+
         DISPLAYLEVEL(2, "\r%79s\r", "");
-        DISPLAYLEVEL(2, "%d files compressed : %.2f%%  (%6zu => %6zu bytes)\n", fCtx->nbFilesProcessed,
+        DISPLAYLEVEL(2, "%3d files compressed : %.2f%%   (%s => %s bytes)\n", fCtx->nbFilesProcessed,
                         (double)fCtx->totalBytesOutput/((double)fCtx->totalBytesInput)*100,
-                        fCtx->totalBytesInput, fCtx->totalBytesOutput);
+                        inputSizeStr, outputSizeStr);
     }
 
     FIO_freeCResources(&ress);

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1527,26 +1527,6 @@ FIO_compressZstdFrame(FIO_ctx_t* const fCtx,
     return compressedfilesize;
 }
 
-char* human_size(long size, char* str) {
-	if (size > 1125899906842624L) {
-		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
-	} else if (size > 1099511627776L) {
-		snprintf(str, 7, "%.1fT", (float)size / 1099511627776L);
-	} else if (size > 1073741824L) {
-		snprintf(str, 7, "%.1fG", (float)size / 1073741824L);
-	} else if (size > 1048576L) {
-		snprintf(str, 7, "%.1fM", (float)size / 1048576L);
-	} else if (size > 1024) {
-		snprintf(str, 7, "%.1fK", (float)size / 1024);
-	} else if (size >= 0) {
-		snprintf(str, 7, "%dB", size);
-	} else {
-		str[0] = '\0';
-	}
-
-	return str;
-}
-
 /*! FIO_compressFilename_internal() :
  *  same as FIO_compressFilename_extRess(), with `ress.desFile` already opened.
  *  @return : 0 : compression completed correctly,

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1527,6 +1527,26 @@ FIO_compressZstdFrame(FIO_ctx_t* const fCtx,
     return compressedfilesize;
 }
 
+char* human_size(long size, char* str) {
+	if (size > 1125899906842624L) {
+		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
+	} else if (size > 1099511627776L) {
+		snprintf(str, 7, "%.1fT", (float)size / 1099511627776L);
+	} else if (size > 1073741824L) {
+		snprintf(str, 7, "%.1fG", (float)size / 1073741824L);
+	} else if (size > 1048576L) {
+		snprintf(str, 7, "%.1fM", (float)size / 1048576L);
+	} else if (size > 1024) {
+		snprintf(str, 7, "%.1fK", (float)size / 1024);
+	} else if (size >= 0) {
+		snprintf(str, 7, "%dB", size);
+	} else {
+		str[0] = '\0';
+	}
+
+	return str;
+}
+
 /*! FIO_compressFilename_internal() :
  *  same as FIO_compressFilename_extRess(), with `ress.desFile` already opened.
  *  @return : 0 : compression completed correctly,
@@ -1598,10 +1618,16 @@ FIO_compressFilename_internal(FIO_ctx_t* const fCtx,
                 (unsigned long long)readsize, (unsigned long long) compressedfilesize,
                 dstFileName);
         } else {
-            DISPLAYLEVEL(2,"%-20s :%6.2f%%   (%6llu => %6llu bytes, %s) \n",
+			char input_size_str[8] = "";
+			human_size((unsigned long long) readsize, input_size_str);
+
+			char output_size_str[8] = "";
+			human_size((unsigned long long) compressedfilesize, output_size_str);
+
+            DISPLAYLEVEL(2,"%-20s :%6.2f%%   (%s => %s, %s) \n",
                 srcFileName,
                 (double)compressedfilesize / (double)readsize * 100,
-                (unsigned long long)readsize, (unsigned long long) compressedfilesize,
+                input_size_str, output_size_str,
                 dstFileName);
         }
     }

--- a/programs/util.c
+++ b/programs/util.c
@@ -121,8 +121,14 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 *  Functions
 ***************************************/
 
+/*
+ * Take a size in bytes and output a human readable string. Maximum
+ * buffer size is 8 but it's usually 7. Example: "123.4G"
+*/
 char* humanSize(unsigned long long size, char* str) {
-    if (size > 1125899906842624L) {
+    if (size > 1152921504606846976L) {
+        snprintf(str, 7, "%.1fE", (float)size / 1152921504606846976L);
+	} else if (size > 1125899906842624L) {
         snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
     } else if (size > 1099511627776L) {
         snprintf(str, 7, "%.1fT", (float)size / 1099511627776L);
@@ -134,8 +140,6 @@ char* humanSize(unsigned long long size, char* str) {
         snprintf(str, 7, "%.1fK", (float)size / 1024);
     } else if (size <= 1024) {
         snprintf(str, 7, "%lluB", size);
-    } else {
-        str[0] = '\0';
     }
 
     return str;

--- a/programs/util.c
+++ b/programs/util.c
@@ -139,7 +139,7 @@ char* humanSize(unsigned long long size, char* str) {
     } else if (size > 1024) {
         snprintf(str, 7, "%.1fK", (float)size / 1024);
     } else if (size <= 1024) {
-        snprintf(str, 7, "%lluB", size);
+        snprintf(str, 7, "%uB", (unsigned)size);
     }
 
     return str;

--- a/programs/util.c
+++ b/programs/util.c
@@ -121,7 +121,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 *  Functions
 ***************************************/
 
-char* human_size(long size, char* str) {
+char* humanSize(long size, char* str) {
 	if (size > 1125899906842624L) {
 		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
 	} else if (size > 1099511627776L) {

--- a/programs/util.c
+++ b/programs/util.c
@@ -122,27 +122,23 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 ***************************************/
 
 char* humanSize(unsigned long long size, char* str) {
-	/* This only works on 64 bit platforms so I commented it out for now */
-	/*
-	if (size > 1125899906842624L) {
-		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
-	} else if (size > 1099511627776L) {
-		snprintf(str, 7, "%.1fT", (float)size / 1099511627776L);
-	*/
+    if (size > 1125899906842624L) {
+        snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
+    } else if (size > 1099511627776L) {
+        snprintf(str, 7, "%.1fT", (float)size / 1099511627776L);
+    } else if (size > 1073741824L) {
+        snprintf(str, 7, "%.1fG", (float)size / 1073741824L);
+    } else if (size > 1048576L) {
+        snprintf(str, 7, "%.1fM", (float)size / 1048576L);
+    } else if (size > 1024) {
+        snprintf(str, 7, "%.1fK", (float)size / 1024);
+    } else if (size <= 1024) {
+        snprintf(str, 7, "%lluB", size);
+    } else {
+        str[0] = '\0';
+    }
 
-	if (size > 1073741824L) {
-		snprintf(str, 7, "%.1fG", (float)size / 1073741824L);
-	} else if (size > 1048576L) {
-		snprintf(str, 7, "%.1fM", (float)size / 1048576L);
-	} else if (size > 1024) {
-		snprintf(str, 7, "%.1fK", (float)size / 1024);
-	} else if (size <= 1024) {
-		snprintf(str, 7, "%lluB", size);
-	} else {
-		str[0] = '\0';
-	}
-
-	return str;
+    return str;
 }
 
 

--- a/programs/util.c
+++ b/programs/util.c
@@ -121,7 +121,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 *  Functions
 ***************************************/
 
-char* humanSize(size_t size, char* str) {
+char* humanSize(unsigned long size, char* str) {
 	if (size > 1125899906842624L) {
 		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
 	} else if (size > 1099511627776L) {

--- a/programs/util.c
+++ b/programs/util.c
@@ -133,7 +133,7 @@ char* humanSize(long size, char* str) {
 	} else if (size > 1024) {
 		snprintf(str, 7, "%.1fK", (float)size / 1024);
 	} else if (size >= 0) {
-		snprintf(str, 7, "%dB", size);
+		snprintf(str, 7, "%dB", 0);
 	} else {
 		str[0] = '\0';
 	}

--- a/programs/util.c
+++ b/programs/util.c
@@ -122,11 +122,15 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 ***************************************/
 
 char* humanSize(unsigned long size, char* str) {
+	/* This only works on 64 bit platforms so I commented it out for now */
+	/*
 	if (size > 1125899906842624L) {
 		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
 	} else if (size > 1099511627776L) {
 		snprintf(str, 7, "%.1fT", (float)size / 1099511627776L);
-	} else if (size > 1073741824L) {
+	*/
+
+	if (size > 1073741824L) {
 		snprintf(str, 7, "%.1fG", (float)size / 1073741824L);
 	} else if (size > 1048576L) {
 		snprintf(str, 7, "%.1fM", (float)size / 1048576L);

--- a/programs/util.c
+++ b/programs/util.c
@@ -121,7 +121,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 *  Functions
 ***************************************/
 
-char* humanSize(unsigned long size, char* str) {
+char* humanSize(unsigned long long size, char* str) {
 	/* This only works on 64 bit platforms so I commented it out for now */
 	/*
 	if (size > 1125899906842624L) {
@@ -137,7 +137,7 @@ char* humanSize(unsigned long size, char* str) {
 	} else if (size > 1024) {
 		snprintf(str, 7, "%.1fK", (float)size / 1024);
 	} else if (size <= 1024) {
-		snprintf(str, 7, "%luB", size);
+		snprintf(str, 7, "%lluB", size);
 	} else {
 		str[0] = '\0';
 	}

--- a/programs/util.c
+++ b/programs/util.c
@@ -121,7 +121,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 *  Functions
 ***************************************/
 
-char* humanSize(long size, char* str) {
+char* humanSize(size_t size, char* str) {
 	if (size > 1125899906842624L) {
 		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
 	} else if (size > 1099511627776L) {
@@ -132,8 +132,8 @@ char* humanSize(long size, char* str) {
 		snprintf(str, 7, "%.1fM", (float)size / 1048576L);
 	} else if (size > 1024) {
 		snprintf(str, 7, "%.1fK", (float)size / 1024);
-	} else if (size >= 0) {
-		snprintf(str, 7, "%dB", 0);
+	} else if (size <= 1024) {
+		snprintf(str, 7, "%luB", size);
 	} else {
 		str[0] = '\0';
 	}

--- a/programs/util.c
+++ b/programs/util.c
@@ -121,6 +121,27 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg,
 *  Functions
 ***************************************/
 
+char* human_size(long size, char* str) {
+	if (size > 1125899906842624L) {
+		snprintf(str, 7, "%.1fP", (float)size / 1125899906842624L);
+	} else if (size > 1099511627776L) {
+		snprintf(str, 7, "%.1fT", (float)size / 1099511627776L);
+	} else if (size > 1073741824L) {
+		snprintf(str, 7, "%.1fG", (float)size / 1073741824L);
+	} else if (size > 1048576L) {
+		snprintf(str, 7, "%.1fM", (float)size / 1048576L);
+	} else if (size > 1024) {
+		snprintf(str, 7, "%.1fK", (float)size / 1024);
+	} else if (size >= 0) {
+		snprintf(str, 7, "%dB", size);
+	} else {
+		str[0] = '\0';
+	}
+
+	return str;
+}
+
+
 int UTIL_stat(const char* filename, stat_t* statbuf)
 {
 #if defined(_MSC_VER)

--- a/programs/util.h
+++ b/programs/util.h
@@ -122,6 +122,10 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const
 #define STRDUP(s) strdup(s)
 #endif
 
+/*
+ * Take a size in bytes and output a human readable string. Maximum
+ * buffer size is 8 but it's usually 7. Example: "123.4G"
+*/
 char* humanSize(unsigned long long size, char* str);
 
 /**

--- a/programs/util.h
+++ b/programs/util.h
@@ -122,7 +122,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const
 #define STRDUP(s) strdup(s)
 #endif
 
-char* humanSize(long size, char* str);
+char* humanSize(size_t size, char* str);
 
 /**
  * Calls platform's equivalent of stat() on filename and writes info to statbuf.

--- a/programs/util.h
+++ b/programs/util.h
@@ -122,7 +122,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const
 #define STRDUP(s) strdup(s)
 #endif
 
-char* human_size(long size, char* str);
+char* humanSize(long size, char* str);
 
 /**
  * Calls platform's equivalent of stat() on filename and writes info to statbuf.

--- a/programs/util.h
+++ b/programs/util.h
@@ -122,7 +122,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const
 #define STRDUP(s) strdup(s)
 #endif
 
-char* humanSize(size_t size, char* str);
+char* humanSize(unsigned long size, char* str);
 
 /**
  * Calls platform's equivalent of stat() on filename and writes info to statbuf.

--- a/programs/util.h
+++ b/programs/util.h
@@ -122,6 +122,8 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const
 #define STRDUP(s) strdup(s)
 #endif
 
+char* human_size(long size, char* str);
+
 /**
  * Calls platform's equivalent of stat() on filename and writes info to statbuf.
  * Returns success (1) or failure (0).

--- a/programs/util.h
+++ b/programs/util.h
@@ -122,7 +122,7 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const
 #define STRDUP(s) strdup(s)
 #endif
 
-char* humanSize(unsigned long size, char* str);
+char* humanSize(unsigned long long size, char* str);
 
 /**
  * Calls platform's equivalent of stat() on filename and writes info to statbuf.


### PR DESCRIPTION
This PR changes the CLI output summary from bytes to a more human readable string format. This should address issue #2694.

**Before:**
```
:zstd -f /tmp/foo.bin 
/tmp/foo.bin         :  2.94%   (280708256 => 8264707 bytes, /tmp/foo.bin.zst) 
```

**After:**
```
:./zstd -f /tmp/foo.bin 
/tmp/foo.bin         :  2.94%   (267.7M => 7.9M, /tmp/foo.bin.zst)      
```

This PR adds a `humanSize()` function to `util.c`. I wasn't sure where best to put it, but that seemed like a good place. Then it modifies the `sprintf()` calls for outputting the summary after a file is compressed. It also modifies the `sprintf()` benchmark code.

Things I checked before landing this code:

1. Code is space indented not tabs
2. Functions and variables are camelCase
3. Variable declarations are grouped with other variables
3. Code should be C89 compatible
4. Make test runs without errors on x86_64
5. Code compiles and outputs the correct format for summary, benchmark, and multiple files

I will probably need some help modifying this to work on ARM or other platforms.