### PR TITLE
Z_PREFIX zError Function

### DIFF
--- a/zlibWrapper/zstd_zlibwrapper.c
+++ b/zlibWrapper/zstd_zlibwrapper.c
@@ -1189,3 +1189,10 @@ ZEXTERN const z_crc_t FAR * ZEXPORT z_get_crc_table    OF((void))
     return get_crc_table();
 }
 #endif
+
+                        /* Error function */
+ZEXTERN const char * ZEXPORT z_zError OF((err))
+{
+    /* Just use zlib Error function */
+    return zError(err);
+}


### PR DESCRIPTION
Just use zlib Error function
When Z_PREFIX defined,old project that use zError function will compile fail,because linker can not find z_zError Function.