### PR TITLE
Remove folder when done with test

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -325,6 +325,7 @@ zstd --long --rm -r precompressedFilterTestDir
 # Files should get compressed again without the --exclude-compressed flag.
 test -f precompressedFilterTestDir/input.5.zst.zst
 test -f precompressedFilterTestDir/input.6.zst.zst
+rm -rf precompressedFilterTestDir
 println "Test completed"
 
 


### PR DESCRIPTION
The CLI tests were leaving behind this `precompressedFilterTestDir` folder.