### PR TITLE
Add support for MCST LCC compiler

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -150,7 +150,8 @@
 }
 
 /* vectorization
- * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax */
+ * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax,
+ * and some compilers, like Intel ICC and MCST LCC, do not support it at all. */
 #if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__)
 #  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
 #    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -79,13 +79,6 @@
 #  define UNUSED_ATTR
 #endif
 
-/* CONST_ARGC tells the compiler correct const argc specificator for -Wmain. */
-#if !defined(__LCC__)
-#  define CONST_ARGC const
-#else
-#  define CONST_ARGC
-#endif
-
 /* force no inlining */
 #ifdef _MSC_VER
 #  define FORCE_NOINLINE static __declspec(noinline)

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -79,6 +79,13 @@
 #  define UNUSED_ATTR
 #endif
 
+/* CONST_ARGC tells the compiler correct const argc specificator for -Wmain. */
+#if !defined(__LCC__)
+#  define CONST_ARGC const
+#else
+#  define CONST_ARGC
+#endif
+
 /* force no inlining */
 #ifdef _MSC_VER
 #  define FORCE_NOINLINE static __declspec(noinline)
@@ -151,7 +158,7 @@
 
 /* vectorization
  * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax */
-#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__)
+#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__)
 #  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
 #    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
 #  else

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -741,7 +741,7 @@ typedef enum { zom_compress, zom_decompress, zom_test, zom_bench, zom_train, zom
 # define MAXCLEVEL  ZSTD_maxCLevel()
 #endif
 
-int main(int const argCount, const char* argv[])
+int main(int CONST_ARGC argCount, const char* argv[])
 {
     int argNb,
         followLinks = 0,

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -741,7 +741,7 @@ typedef enum { zom_compress, zom_decompress, zom_test, zom_bench, zom_train, zom
 # define MAXCLEVEL  ZSTD_maxCLevel()
 #endif
 
-int main(int CONST_ARGC argCount, const char* argv[])
+int main(int argCount, const char* argv[])
 {
     int argNb,
         followLinks = 0,


### PR DESCRIPTION
I'd like to introduce support for MCST LCC compiler based on EDG front end. It is primarily used to build software for computers based on Russian [Elbrus](https://en.wikipedia.org/wiki/Elbrus-8S) CPUs.

The main two fixes I introduce here, are:
* there is no `optimize("no-tree-vectorize")` support in said compiler;
* it generates a `-Wmain` warning (or error on `-Werror`) while testing zstd because of `argc` is specified as `const` in `main()` of `zstdcli`.

Contribution guidelines followed:
* CLA is signed.
* Tests (both `shortest` and `test`) performed successfully, both on x86_64 with gcc-9 and e2k (Elbrus) with lcc 1.25.
* Travis build is [OK](https://travis-ci.com/github/makise-homura/zstd).
* AppVeyor [build](https://ci.appveyor.com/project/makise-homura/zstd) failed in mingw tasks: looks like it isn't properly configured (`The system cannot find the path specified.` while preparing the build environment).
* Static analyzer (`scan-build` from `clang-tools-10`) found 59 bugs, but somehow 71 were found for current `dev` upstream branch. No one of them, by the way, related to parts of code I modified.