### PR TITLE
[HUF] Improve Huffman sorting algorithm

### DIFF
--- a/lib/common/huf.h
+++ b/lib/common/huf.h
@@ -90,7 +90,7 @@ HUF_PUBLIC_API size_t HUF_compress2 (void* dst, size_t dstCapacity,
 /** HUF_compress4X_wksp() :
  *  Same as HUF_compress2(), but uses externally allocated `workSpace`.
  * `workspace` must be at least as large as HUF_WORKSPACE_SIZE */
-#define HUF_WORKSPACE_SIZE ((8 << 10) + 256)
+#define HUF_WORKSPACE_SIZE ((8 << 10) + 512 /* sorting scratch space */)
 #define HUF_WORKSPACE_SIZE_U64 (HUF_WORKSPACE_SIZE / sizeof(U64))
 HUF_PUBLIC_API size_t HUF_compress4X_wksp (void* dst, size_t dstCapacity,
                                      const void* src, size_t srcSize,

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -2,19 +2,19 @@ Data,                               Config,                             Method, 
 silesia.tar,                        level -5,                           compress simple,                    6738593
 silesia.tar,                        level -3,                           compress simple,                    6446372
 silesia.tar,                        level -1,                           compress simple,                    6186042
-silesia.tar,                        level 0,                            compress simple,                    4861425
+silesia.tar,                        level 0,                            compress simple,                    4861423
 silesia.tar,                        level 1,                            compress simple,                    5334885
-silesia.tar,                        level 3,                            compress simple,                    4861425
-silesia.tar,                        level 4,                            compress simple,                    4799630
+silesia.tar,                        level 3,                            compress simple,                    4861423
+silesia.tar,                        level 4,                            compress simple,                    4799632
 silesia.tar,                        level 5,                            compress simple,                    4719256
-silesia.tar,                        level 6,                            compress simple,                    4677721
-silesia.tar,                        level 7,                            compress simple,                    4613541
+silesia.tar,                        level 6,                            compress simple,                    4677724
+silesia.tar,                        level 7,                            compress simple,                    4613545
 silesia.tar,                        level 9,                            compress simple,                    4555426
-silesia.tar,                        level 13,                           compress simple,                    4491764
+silesia.tar,                        level 13,                           compress simple,                    4491768
 silesia.tar,                        level 16,                           compress simple,                    4356834
-silesia.tar,                        level 19,                           compress simple,                    4264392
-silesia.tar,                        uncompressed literals,              compress simple,                    4861425
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264392
+silesia.tar,                        level 19,                           compress simple,                    4264388
+silesia.tar,                        uncompressed literals,              compress simple,                    4861423
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264388
 silesia.tar,                        huffman literals,                   compress simple,                    6186042
 github.tar,                         level -5,                           compress simple,                    46856
 github.tar,                         level -3,                           compress simple,                    43754
@@ -36,28 +36,28 @@ github.tar,                         huffman literals,                   compress
 silesia,                            level -5,                           compress cctx,                      6737607
 silesia,                            level -3,                           compress cctx,                      6444677
 silesia,                            level -1,                           compress cctx,                      6178460
-silesia,                            level 0,                            compress cctx,                      4849552
-silesia,                            level 1,                            compress cctx,                      5313204
-silesia,                            level 3,                            compress cctx,                      4849552
-silesia,                            level 4,                            compress cctx,                      4786970
-silesia,                            level 5,                            compress cctx,                      4707794
+silesia,                            level 0,                            compress cctx,                      4849551
+silesia,                            level 1,                            compress cctx,                      5313202
+silesia,                            level 3,                            compress cctx,                      4849551
+silesia,                            level 4,                            compress cctx,                      4786969
+silesia,                            level 5,                            compress cctx,                      4707790
 silesia,                            level 6,                            compress cctx,                      4666383
 silesia,                            level 7,                            compress cctx,                      4603381
-silesia,                            level 9,                            compress cctx,                      4546001
-silesia,                            level 13,                           compress cctx,                      4482135
+silesia,                            level 9,                            compress cctx,                      4546005
+silesia,                            level 13,                           compress cctx,                      4482131
 silesia,                            level 16,                           compress cctx,                      4360251
-silesia,                            level 19,                           compress cctx,                      4283237
-silesia,                            long distance mode,                 compress cctx,                      4849552
-silesia,                            multithreaded,                      compress cctx,                      4849552
-silesia,                            multithreaded long distance mode,   compress cctx,                      4849552
+silesia,                            level 19,                           compress cctx,                      4283236
+silesia,                            long distance mode,                 compress cctx,                      4849551
+silesia,                            multithreaded,                      compress cctx,                      4849551
+silesia,                            multithreaded long distance mode,   compress cctx,                      4849551
 silesia,                            small window log,                   compress cctx,                      7084179
 silesia,                            small hash log,                     compress cctx,                      6526141
-silesia,                            small chain log,                    compress cctx,                      4912197
-silesia,                            explicit params,                    compress cctx,                      4794479
-silesia,                            uncompressed literals,              compress cctx,                      4849552
-silesia,                            uncompressed literals optimal,      compress cctx,                      4283237
+silesia,                            small chain log,                    compress cctx,                      4912199
+silesia,                            explicit params,                    compress cctx,                      4794480
+silesia,                            uncompressed literals,              compress cctx,                      4849551
+silesia,                            uncompressed literals optimal,      compress cctx,                      4283236
 silesia,                            huffman literals,                   compress cctx,                      6178460
-silesia,                            multithreaded with advanced params, compress cctx,                      4849552
+silesia,                            multithreaded with advanced params, compress cctx,                      4849551
 github,                             level -5,                           compress cctx,                      205285
 github,                             level -5 with dict,                 compress cctx,                      47294
 github,                             level -3,                           compress cctx,                      190643
@@ -100,50 +100,50 @@ github,                             multithreaded with advanced params, compress
 silesia,                            level -5,                           zstdcli,                            6737655
 silesia,                            level -3,                           zstdcli,                            6444725
 silesia,                            level -1,                           zstdcli,                            6178508
-silesia,                            level 0,                            zstdcli,                            4849600
-silesia,                            level 1,                            zstdcli,                            5313252
-silesia,                            level 3,                            zstdcli,                            4849600
-silesia,                            level 4,                            zstdcli,                            4787018
-silesia,                            level 5,                            zstdcli,                            4707842
+silesia,                            level 0,                            zstdcli,                            4849599
+silesia,                            level 1,                            zstdcli,                            5313250
+silesia,                            level 3,                            zstdcli,                            4849599
+silesia,                            level 4,                            zstdcli,                            4787017
+silesia,                            level 5,                            zstdcli,                            4707838
 silesia,                            level 6,                            zstdcli,                            4666431
 silesia,                            level 7,                            zstdcli,                            4603429
-silesia,                            level 9,                            zstdcli,                            4546049
-silesia,                            level 13,                           zstdcli,                            4482183
+silesia,                            level 9,                            zstdcli,                            4546053
+silesia,                            level 13,                           zstdcli,                            4482179
 silesia,                            level 16,                           zstdcli,                            4360299
-silesia,                            level 19,                           zstdcli,                            4283285
-silesia,                            long distance mode,                 zstdcli,                            4840806
-silesia,                            multithreaded,                      zstdcli,                            4849600
-silesia,                            multithreaded long distance mode,   zstdcli,                            4840806
+silesia,                            level 19,                           zstdcli,                            4283284
+silesia,                            long distance mode,                 zstdcli,                            4840807
+silesia,                            multithreaded,                      zstdcli,                            4849599
+silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
 silesia,                            small window log,                   zstdcli,                            7095967
 silesia,                            small hash log,                     zstdcli,                            6526189
-silesia,                            small chain log,                    zstdcli,                            4912245
+silesia,                            small chain log,                    zstdcli,                            4912247
 silesia,                            explicit params,                    zstdcli,                            4795856
 silesia,                            uncompressed literals,              zstdcli,                            5128030
 silesia,                            uncompressed literals optimal,      zstdcli,                            4317944
-silesia,                            huffman literals,                   zstdcli,                            5326316
+silesia,                            huffman literals,                   zstdcli,                            5326317
 silesia,                            multithreaded with advanced params, zstdcli,                            5128030
 silesia.tar,                        level -5,                           zstdcli,                            6738934
 silesia.tar,                        level -3,                           zstdcli,                            6448419
 silesia.tar,                        level -1,                           zstdcli,                            6186912
-silesia.tar,                        level 0,                            zstdcli,                            4861512
+silesia.tar,                        level 0,                            zstdcli,                            4861511
 silesia.tar,                        level 1,                            zstdcli,                            5336318
-silesia.tar,                        level 3,                            zstdcli,                            4861512
+silesia.tar,                        level 3,                            zstdcli,                            4861511
 silesia.tar,                        level 4,                            zstdcli,                            4800529
 silesia.tar,                        level 5,                            zstdcli,                            4720121
-silesia.tar,                        level 6,                            zstdcli,                            4678661
-silesia.tar,                        level 7,                            zstdcli,                            4614424
+silesia.tar,                        level 6,                            zstdcli,                            4678663
+silesia.tar,                        level 7,                            zstdcli,                            4614426
 silesia.tar,                        level 9,                            zstdcli,                            4556062
-silesia.tar,                        level 13,                           zstdcli,                            4491768
+silesia.tar,                        level 13,                           zstdcli,                            4491772
 silesia.tar,                        level 16,                           zstdcli,                            4356838
-silesia.tar,                        level 19,                           zstdcli,                            4264396
-silesia.tar,                        no source size,                     zstdcli,                            4861508
-silesia.tar,                        long distance mode,                 zstdcli,                            4853226
-silesia.tar,                        multithreaded,                      zstdcli,                            4861512
-silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4853226
+silesia.tar,                        level 19,                           zstdcli,                            4264392
+silesia.tar,                        no source size,                     zstdcli,                            4861507
+silesia.tar,                        long distance mode,                 zstdcli,                            4853225
+silesia.tar,                        multithreaded,                      zstdcli,                            4861511
+silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4853225
 silesia.tar,                        small window log,                   zstdcli,                            7101576
-silesia.tar,                        small hash log,                     zstdcli,                            6529290
-silesia.tar,                        small chain log,                    zstdcli,                            4917022
-silesia.tar,                        explicit params,                    zstdcli,                            4821274
+silesia.tar,                        small hash log,                     zstdcli,                            6529286
+silesia.tar,                        small chain log,                    zstdcli,                            4917020
+silesia.tar,                        explicit params,                    zstdcli,                            4821277
 silesia.tar,                        uncompressed literals,              zstdcli,                            5129559
 silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4307404
 silesia.tar,                        huffman literals,                   zstdcli,                            5347610
@@ -231,63 +231,63 @@ github.tar,                         multithreaded with advanced params, zstdcli,
 silesia,                            level -5,                           advanced one pass,                  6737607
 silesia,                            level -3,                           advanced one pass,                  6444677
 silesia,                            level -1,                           advanced one pass,                  6178460
-silesia,                            level 0,                            advanced one pass,                  4849552
-silesia,                            level 1,                            advanced one pass,                  5313204
-silesia,                            level 3,                            advanced one pass,                  4849552
-silesia,                            level 4,                            advanced one pass,                  4786970
-silesia,                            level 5 row 1,                      advanced one pass,                  4710236
-silesia,                            level 5 row 2,                      advanced one pass,                  4707794
-silesia,                            level 5,                            advanced one pass,                  4707794
+silesia,                            level 0,                            advanced one pass,                  4849551
+silesia,                            level 1,                            advanced one pass,                  5313202
+silesia,                            level 3,                            advanced one pass,                  4849551
+silesia,                            level 4,                            advanced one pass,                  4786969
+silesia,                            level 5 row 1,                      advanced one pass,                  4710233
+silesia,                            level 5 row 2,                      advanced one pass,                  4707790
+silesia,                            level 5,                            advanced one pass,                  4707790
 silesia,                            level 6,                            advanced one pass,                  4666383
-silesia,                            level 7 row 1,                      advanced one pass,                  4596296
+silesia,                            level 7 row 1,                      advanced one pass,                  4596297
 silesia,                            level 7 row 2,                      advanced one pass,                  4603381
 silesia,                            level 7,                            advanced one pass,                  4603381
-silesia,                            level 9,                            advanced one pass,                  4546001
+silesia,                            level 9,                            advanced one pass,                  4546005
 silesia,                            level 12 row 1,                     advanced one pass,                  4519288
-silesia,                            level 12 row 2,                     advanced one pass,                  4521397
-silesia,                            level 13,                           advanced one pass,                  4482135
+silesia,                            level 12 row 2,                     advanced one pass,                  4521406
+silesia,                            level 13,                           advanced one pass,                  4482131
 silesia,                            level 16,                           advanced one pass,                  4360251
-silesia,                            level 19,                           advanced one pass,                  4283237
-silesia,                            no source size,                     advanced one pass,                  4849552
+silesia,                            level 19,                           advanced one pass,                  4283236
+silesia,                            no source size,                     advanced one pass,                  4849551
 silesia,                            long distance mode,                 advanced one pass,                  4840738
-silesia,                            multithreaded,                      advanced one pass,                  4849552
-silesia,                            multithreaded long distance mode,   advanced one pass,                  4840758
+silesia,                            multithreaded,                      advanced one pass,                  4849551
+silesia,                            multithreaded long distance mode,   advanced one pass,                  4840759
 silesia,                            small window log,                   advanced one pass,                  7095919
 silesia,                            small hash log,                     advanced one pass,                  6526141
-silesia,                            small chain log,                    advanced one pass,                  4912197
+silesia,                            small chain log,                    advanced one pass,                  4912199
 silesia,                            explicit params,                    advanced one pass,                  4795856
 silesia,                            uncompressed literals,              advanced one pass,                  5127982
 silesia,                            uncompressed literals optimal,      advanced one pass,                  4317896
-silesia,                            huffman literals,                   advanced one pass,                  5326268
+silesia,                            huffman literals,                   advanced one pass,                  5326269
 silesia,                            multithreaded with advanced params, advanced one pass,                  5127982
 silesia.tar,                        level -5,                           advanced one pass,                  6738593
 silesia.tar,                        level -3,                           advanced one pass,                  6446372
 silesia.tar,                        level -1,                           advanced one pass,                  6186042
-silesia.tar,                        level 0,                            advanced one pass,                  4861425
+silesia.tar,                        level 0,                            advanced one pass,                  4861423
 silesia.tar,                        level 1,                            advanced one pass,                  5334885
-silesia.tar,                        level 3,                            advanced one pass,                  4861425
-silesia.tar,                        level 4,                            advanced one pass,                  4799630
+silesia.tar,                        level 3,                            advanced one pass,                  4861423
+silesia.tar,                        level 4,                            advanced one pass,                  4799632
 silesia.tar,                        level 5 row 1,                      advanced one pass,                  4722324
 silesia.tar,                        level 5 row 2,                      advanced one pass,                  4719256
 silesia.tar,                        level 5,                            advanced one pass,                  4719256
-silesia.tar,                        level 6,                            advanced one pass,                  4677721
-silesia.tar,                        level 7 row 1,                      advanced one pass,                  4606715
-silesia.tar,                        level 7 row 2,                      advanced one pass,                  4613541
-silesia.tar,                        level 7,                            advanced one pass,                  4613541
+silesia.tar,                        level 6,                            advanced one pass,                  4677724
+silesia.tar,                        level 7 row 1,                      advanced one pass,                  4606716
+silesia.tar,                        level 7 row 2,                      advanced one pass,                  4613545
+silesia.tar,                        level 7,                            advanced one pass,                  4613545
 silesia.tar,                        level 9,                            advanced one pass,                  4555426
-silesia.tar,                        level 12 row 1,                     advanced one pass,                  4529459
-silesia.tar,                        level 12 row 2,                     advanced one pass,                  4530256
-silesia.tar,                        level 13,                           advanced one pass,                  4491764
+silesia.tar,                        level 12 row 1,                     advanced one pass,                  4529458
+silesia.tar,                        level 12 row 2,                     advanced one pass,                  4530257
+silesia.tar,                        level 13,                           advanced one pass,                  4491768
 silesia.tar,                        level 16,                           advanced one pass,                  4356834
-silesia.tar,                        level 19,                           advanced one pass,                  4264392
-silesia.tar,                        no source size,                     advanced one pass,                  4861425
-silesia.tar,                        long distance mode,                 advanced one pass,                  4847754
-silesia.tar,                        multithreaded,                      advanced one pass,                  4861508
-silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4853222
+silesia.tar,                        level 19,                           advanced one pass,                  4264388
+silesia.tar,                        no source size,                     advanced one pass,                  4861423
+silesia.tar,                        long distance mode,                 advanced one pass,                  4847753
+silesia.tar,                        multithreaded,                      advanced one pass,                  4861507
+silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4853221
 silesia.tar,                        small window log,                   advanced one pass,                  7101530
-silesia.tar,                        small hash log,                     advanced one pass,                  6529232
-silesia.tar,                        small chain log,                    advanced one pass,                  4917041
-silesia.tar,                        explicit params,                    advanced one pass,                  4807380
+silesia.tar,                        small hash log,                     advanced one pass,                  6529228
+silesia.tar,                        small chain log,                    advanced one pass,                  4917039
+silesia.tar,                        explicit params,                    advanced one pass,                  4807383
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5129458
 silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4307400
 silesia.tar,                        huffman literals,                   advanced one pass,                  5347335
@@ -525,63 +525,63 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           advanced one pass small out,        6737607
 silesia,                            level -3,                           advanced one pass small out,        6444677
 silesia,                            level -1,                           advanced one pass small out,        6178460
-silesia,                            level 0,                            advanced one pass small out,        4849552
-silesia,                            level 1,                            advanced one pass small out,        5313204
-silesia,                            level 3,                            advanced one pass small out,        4849552
-silesia,                            level 4,                            advanced one pass small out,        4786970
-silesia,                            level 5 row 1,                      advanced one pass small out,        4710236
-silesia,                            level 5 row 2,                      advanced one pass small out,        4707794
-silesia,                            level 5,                            advanced one pass small out,        4707794
+silesia,                            level 0,                            advanced one pass small out,        4849551
+silesia,                            level 1,                            advanced one pass small out,        5313202
+silesia,                            level 3,                            advanced one pass small out,        4849551
+silesia,                            level 4,                            advanced one pass small out,        4786969
+silesia,                            level 5 row 1,                      advanced one pass small out,        4710233
+silesia,                            level 5 row 2,                      advanced one pass small out,        4707790
+silesia,                            level 5,                            advanced one pass small out,        4707790
 silesia,                            level 6,                            advanced one pass small out,        4666383
-silesia,                            level 7 row 1,                      advanced one pass small out,        4596296
+silesia,                            level 7 row 1,                      advanced one pass small out,        4596297
 silesia,                            level 7 row 2,                      advanced one pass small out,        4603381
 silesia,                            level 7,                            advanced one pass small out,        4603381
-silesia,                            level 9,                            advanced one pass small out,        4546001
+silesia,                            level 9,                            advanced one pass small out,        4546005
 silesia,                            level 12 row 1,                     advanced one pass small out,        4519288
-silesia,                            level 12 row 2,                     advanced one pass small out,        4521397
-silesia,                            level 13,                           advanced one pass small out,        4482135
+silesia,                            level 12 row 2,                     advanced one pass small out,        4521406
+silesia,                            level 13,                           advanced one pass small out,        4482131
 silesia,                            level 16,                           advanced one pass small out,        4360251
-silesia,                            level 19,                           advanced one pass small out,        4283237
-silesia,                            no source size,                     advanced one pass small out,        4849552
+silesia,                            level 19,                           advanced one pass small out,        4283236
+silesia,                            no source size,                     advanced one pass small out,        4849551
 silesia,                            long distance mode,                 advanced one pass small out,        4840738
-silesia,                            multithreaded,                      advanced one pass small out,        4849552
-silesia,                            multithreaded long distance mode,   advanced one pass small out,        4840758
+silesia,                            multithreaded,                      advanced one pass small out,        4849551
+silesia,                            multithreaded long distance mode,   advanced one pass small out,        4840759
 silesia,                            small window log,                   advanced one pass small out,        7095919
 silesia,                            small hash log,                     advanced one pass small out,        6526141
-silesia,                            small chain log,                    advanced one pass small out,        4912197
+silesia,                            small chain log,                    advanced one pass small out,        4912199
 silesia,                            explicit params,                    advanced one pass small out,        4795856
 silesia,                            uncompressed literals,              advanced one pass small out,        5127982
 silesia,                            uncompressed literals optimal,      advanced one pass small out,        4317896
-silesia,                            huffman literals,                   advanced one pass small out,        5326268
+silesia,                            huffman literals,                   advanced one pass small out,        5326269
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5127982
 silesia.tar,                        level -5,                           advanced one pass small out,        6738593
 silesia.tar,                        level -3,                           advanced one pass small out,        6446372
 silesia.tar,                        level -1,                           advanced one pass small out,        6186042
-silesia.tar,                        level 0,                            advanced one pass small out,        4861425
+silesia.tar,                        level 0,                            advanced one pass small out,        4861423
 silesia.tar,                        level 1,                            advanced one pass small out,        5334885
-silesia.tar,                        level 3,                            advanced one pass small out,        4861425
-silesia.tar,                        level 4,                            advanced one pass small out,        4799630
+silesia.tar,                        level 3,                            advanced one pass small out,        4861423
+silesia.tar,                        level 4,                            advanced one pass small out,        4799632
 silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4722324
 silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4719256
 silesia.tar,                        level 5,                            advanced one pass small out,        4719256
-silesia.tar,                        level 6,                            advanced one pass small out,        4677721
-silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4606715
-silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4613541
-silesia.tar,                        level 7,                            advanced one pass small out,        4613541
+silesia.tar,                        level 6,                            advanced one pass small out,        4677724
+silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4606716
+silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4613545
+silesia.tar,                        level 7,                            advanced one pass small out,        4613545
 silesia.tar,                        level 9,                            advanced one pass small out,        4555426
-silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4529459
-silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4530256
-silesia.tar,                        level 13,                           advanced one pass small out,        4491764
+silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4529458
+silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4530257
+silesia.tar,                        level 13,                           advanced one pass small out,        4491768
 silesia.tar,                        level 16,                           advanced one pass small out,        4356834
-silesia.tar,                        level 19,                           advanced one pass small out,        4264392
-silesia.tar,                        no source size,                     advanced one pass small out,        4861425
-silesia.tar,                        long distance mode,                 advanced one pass small out,        4847754
-silesia.tar,                        multithreaded,                      advanced one pass small out,        4861508
-silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4853222
+silesia.tar,                        level 19,                           advanced one pass small out,        4264388
+silesia.tar,                        no source size,                     advanced one pass small out,        4861423
+silesia.tar,                        long distance mode,                 advanced one pass small out,        4847753
+silesia.tar,                        multithreaded,                      advanced one pass small out,        4861507
+silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4853221
 silesia.tar,                        small window log,                   advanced one pass small out,        7101530
-silesia.tar,                        small hash log,                     advanced one pass small out,        6529232
-silesia.tar,                        small chain log,                    advanced one pass small out,        4917041
-silesia.tar,                        explicit params,                    advanced one pass small out,        4807380
+silesia.tar,                        small hash log,                     advanced one pass small out,        6529228
+silesia.tar,                        small chain log,                    advanced one pass small out,        4917039
+silesia.tar,                        explicit params,                    advanced one pass small out,        4807383
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5129458
 silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4307400
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5347335
@@ -819,63 +819,63 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           advanced streaming,                 6882505
 silesia,                            level -3,                           advanced streaming,                 6568376
 silesia,                            level -1,                           advanced streaming,                 6183403
-silesia,                            level 0,                            advanced streaming,                 4849552
-silesia,                            level 1,                            advanced streaming,                 5314162
-silesia,                            level 3,                            advanced streaming,                 4849552
-silesia,                            level 4,                            advanced streaming,                 4786970
-silesia,                            level 5 row 1,                      advanced streaming,                 4710236
-silesia,                            level 5 row 2,                      advanced streaming,                 4707794
-silesia,                            level 5,                            advanced streaming,                 4707794
+silesia,                            level 0,                            advanced streaming,                 4849551
+silesia,                            level 1,                            advanced streaming,                 5314161
+silesia,                            level 3,                            advanced streaming,                 4849551
+silesia,                            level 4,                            advanced streaming,                 4786969
+silesia,                            level 5 row 1,                      advanced streaming,                 4710233
+silesia,                            level 5 row 2,                      advanced streaming,                 4707790
+silesia,                            level 5,                            advanced streaming,                 4707790
 silesia,                            level 6,                            advanced streaming,                 4666383
-silesia,                            level 7 row 1,                      advanced streaming,                 4596296
+silesia,                            level 7 row 1,                      advanced streaming,                 4596297
 silesia,                            level 7 row 2,                      advanced streaming,                 4603381
 silesia,                            level 7,                            advanced streaming,                 4603381
-silesia,                            level 9,                            advanced streaming,                 4546001
+silesia,                            level 9,                            advanced streaming,                 4546005
 silesia,                            level 12 row 1,                     advanced streaming,                 4519288
-silesia,                            level 12 row 2,                     advanced streaming,                 4521397
-silesia,                            level 13,                           advanced streaming,                 4482135
+silesia,                            level 12 row 2,                     advanced streaming,                 4521406
+silesia,                            level 13,                           advanced streaming,                 4482131
 silesia,                            level 16,                           advanced streaming,                 4360251
-silesia,                            level 19,                           advanced streaming,                 4283237
-silesia,                            no source size,                     advanced streaming,                 4849516
+silesia,                            level 19,                           advanced streaming,                 4283236
+silesia,                            no source size,                     advanced streaming,                 4849515
 silesia,                            long distance mode,                 advanced streaming,                 4840738
-silesia,                            multithreaded,                      advanced streaming,                 4849552
-silesia,                            multithreaded long distance mode,   advanced streaming,                 4840758
+silesia,                            multithreaded,                      advanced streaming,                 4849551
+silesia,                            multithreaded long distance mode,   advanced streaming,                 4840759
 silesia,                            small window log,                   advanced streaming,                 7112062
 silesia,                            small hash log,                     advanced streaming,                 6526141
-silesia,                            small chain log,                    advanced streaming,                 4912197
+silesia,                            small chain log,                    advanced streaming,                 4912199
 silesia,                            explicit params,                    advanced streaming,                 4795884
 silesia,                            uncompressed literals,              advanced streaming,                 5127982
 silesia,                            uncompressed literals optimal,      advanced streaming,                 4317896
-silesia,                            huffman literals,                   advanced streaming,                 5331168
+silesia,                            huffman literals,                   advanced streaming,                 5331171
 silesia,                            multithreaded with advanced params, advanced streaming,                 5127982
 silesia.tar,                        level -5,                           advanced streaming,                 6982759
 silesia.tar,                        level -3,                           advanced streaming,                 6641283
 silesia.tar,                        level -1,                           advanced streaming,                 6190795
-silesia.tar,                        level 0,                            advanced streaming,                 4861427
-silesia.tar,                        level 1,                            advanced streaming,                 5336939
-silesia.tar,                        level 3,                            advanced streaming,                 4861427
-silesia.tar,                        level 4,                            advanced streaming,                 4799630
+silesia.tar,                        level 0,                            advanced streaming,                 4861425
+silesia.tar,                        level 1,                            advanced streaming,                 5336941
+silesia.tar,                        level 3,                            advanced streaming,                 4861425
+silesia.tar,                        level 4,                            advanced streaming,                 4799632
 silesia.tar,                        level 5 row 1,                      advanced streaming,                 4722329
 silesia.tar,                        level 5 row 2,                      advanced streaming,                 4719261
 silesia.tar,                        level 5,                            advanced streaming,                 4719261
-silesia.tar,                        level 6,                            advanced streaming,                 4677729
-silesia.tar,                        level 7 row 1,                      advanced streaming,                 4606715
-silesia.tar,                        level 7 row 2,                      advanced streaming,                 4613544
-silesia.tar,                        level 7,                            advanced streaming,                 4613544
+silesia.tar,                        level 6,                            advanced streaming,                 4677732
+silesia.tar,                        level 7 row 1,                      advanced streaming,                 4606717
+silesia.tar,                        level 7 row 2,                      advanced streaming,                 4613548
+silesia.tar,                        level 7,                            advanced streaming,                 4613548
 silesia.tar,                        level 9,                            advanced streaming,                 4555432
-silesia.tar,                        level 12 row 1,                     advanced streaming,                 4529459
-silesia.tar,                        level 12 row 2,                     advanced streaming,                 4530258
-silesia.tar,                        level 13,                           advanced streaming,                 4491765
+silesia.tar,                        level 12 row 1,                     advanced streaming,                 4529458
+silesia.tar,                        level 12 row 2,                     advanced streaming,                 4530259
+silesia.tar,                        level 13,                           advanced streaming,                 4491769
 silesia.tar,                        level 16,                           advanced streaming,                 4356834
-silesia.tar,                        level 19,                           advanced streaming,                 4264392
-silesia.tar,                        no source size,                     advanced streaming,                 4861423
-silesia.tar,                        long distance mode,                 advanced streaming,                 4847754
-silesia.tar,                        multithreaded,                      advanced streaming,                 4861508
-silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4853222
+silesia.tar,                        level 19,                           advanced streaming,                 4264388
+silesia.tar,                        no source size,                     advanced streaming,                 4861421
+silesia.tar,                        long distance mode,                 advanced streaming,                 4847753
+silesia.tar,                        multithreaded,                      advanced streaming,                 4861507
+silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4853221
 silesia.tar,                        small window log,                   advanced streaming,                 7118769
-silesia.tar,                        small hash log,                     advanced streaming,                 6529235
-silesia.tar,                        small chain log,                    advanced streaming,                 4917021
-silesia.tar,                        explicit params,                    advanced streaming,                 4807399
+silesia.tar,                        small hash log,                     advanced streaming,                 6529231
+silesia.tar,                        small chain log,                    advanced streaming,                 4917019
+silesia.tar,                        explicit params,                    advanced streaming,                 4807403
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5129461
 silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4307400
 silesia.tar,                        huffman literals,                   advanced streaming,                 5352360
@@ -1113,38 +1113,38 @@ github.tar,                         multithreaded with advanced params, advanced
 silesia,                            level -5,                           old streaming,                      6882505
 silesia,                            level -3,                           old streaming,                      6568376
 silesia,                            level -1,                           old streaming,                      6183403
-silesia,                            level 0,                            old streaming,                      4849552
-silesia,                            level 1,                            old streaming,                      5314162
-silesia,                            level 3,                            old streaming,                      4849552
-silesia,                            level 4,                            old streaming,                      4786970
-silesia,                            level 5,                            old streaming,                      4707794
+silesia,                            level 0,                            old streaming,                      4849551
+silesia,                            level 1,                            old streaming,                      5314161
+silesia,                            level 3,                            old streaming,                      4849551
+silesia,                            level 4,                            old streaming,                      4786969
+silesia,                            level 5,                            old streaming,                      4707790
 silesia,                            level 6,                            old streaming,                      4666383
 silesia,                            level 7,                            old streaming,                      4603381
-silesia,                            level 9,                            old streaming,                      4546001
-silesia,                            level 13,                           old streaming,                      4482135
+silesia,                            level 9,                            old streaming,                      4546005
+silesia,                            level 13,                           old streaming,                      4482131
 silesia,                            level 16,                           old streaming,                      4360251
-silesia,                            level 19,                           old streaming,                      4283237
-silesia,                            no source size,                     old streaming,                      4849516
-silesia,                            uncompressed literals,              old streaming,                      4849552
-silesia,                            uncompressed literals optimal,      old streaming,                      4283237
+silesia,                            level 19,                           old streaming,                      4283236
+silesia,                            no source size,                     old streaming,                      4849515
+silesia,                            uncompressed literals,              old streaming,                      4849551
+silesia,                            uncompressed literals optimal,      old streaming,                      4283236
 silesia,                            huffman literals,                   old streaming,                      6183403
 silesia.tar,                        level -5,                           old streaming,                      6982759
 silesia.tar,                        level -3,                           old streaming,                      6641283
 silesia.tar,                        level -1,                           old streaming,                      6190795
-silesia.tar,                        level 0,                            old streaming,                      4861427
-silesia.tar,                        level 1,                            old streaming,                      5336939
-silesia.tar,                        level 3,                            old streaming,                      4861427
-silesia.tar,                        level 4,                            old streaming,                      4799630
+silesia.tar,                        level 0,                            old streaming,                      4861425
+silesia.tar,                        level 1,                            old streaming,                      5336941
+silesia.tar,                        level 3,                            old streaming,                      4861425
+silesia.tar,                        level 4,                            old streaming,                      4799632
 silesia.tar,                        level 5,                            old streaming,                      4719261
-silesia.tar,                        level 6,                            old streaming,                      4677729
-silesia.tar,                        level 7,                            old streaming,                      4613544
+silesia.tar,                        level 6,                            old streaming,                      4677732
+silesia.tar,                        level 7,                            old streaming,                      4613548
 silesia.tar,                        level 9,                            old streaming,                      4555432
-silesia.tar,                        level 13,                           old streaming,                      4491765
+silesia.tar,                        level 13,                           old streaming,                      4491769
 silesia.tar,                        level 16,                           old streaming,                      4356834
-silesia.tar,                        level 19,                           old streaming,                      4264392
-silesia.tar,                        no source size,                     old streaming,                      4861423
-silesia.tar,                        uncompressed literals,              old streaming,                      4861427
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4264392
+silesia.tar,                        level 19,                           old streaming,                      4264388
+silesia.tar,                        no source size,                     old streaming,                      4861421
+silesia.tar,                        uncompressed literals,              old streaming,                      4861425
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4264388
 silesia.tar,                        huffman literals,                   old streaming,                      6190795
 github,                             level -5,                           old streaming,                      205285
 github,                             level -5 with dict,                 old streaming,                      46718
@@ -1215,55 +1215,55 @@ github.tar,                         huffman literals,                   old stre
 silesia,                            level -5,                           old streaming advanced,             6882505
 silesia,                            level -3,                           old streaming advanced,             6568376
 silesia,                            level -1,                           old streaming advanced,             6183403
-silesia,                            level 0,                            old streaming advanced,             4849552
-silesia,                            level 1,                            old streaming advanced,             5314162
-silesia,                            level 3,                            old streaming advanced,             4849552
-silesia,                            level 4,                            old streaming advanced,             4786970
-silesia,                            level 5,                            old streaming advanced,             4707794
+silesia,                            level 0,                            old streaming advanced,             4849551
+silesia,                            level 1,                            old streaming advanced,             5314161
+silesia,                            level 3,                            old streaming advanced,             4849551
+silesia,                            level 4,                            old streaming advanced,             4786969
+silesia,                            level 5,                            old streaming advanced,             4707790
 silesia,                            level 6,                            old streaming advanced,             4666383
 silesia,                            level 7,                            old streaming advanced,             4603381
-silesia,                            level 9,                            old streaming advanced,             4546001
-silesia,                            level 13,                           old streaming advanced,             4482135
+silesia,                            level 9,                            old streaming advanced,             4546005
+silesia,                            level 13,                           old streaming advanced,             4482131
 silesia,                            level 16,                           old streaming advanced,             4360251
-silesia,                            level 19,                           old streaming advanced,             4283237
-silesia,                            no source size,                     old streaming advanced,             4849516
-silesia,                            long distance mode,                 old streaming advanced,             4849552
-silesia,                            multithreaded,                      old streaming advanced,             4849552
-silesia,                            multithreaded long distance mode,   old streaming advanced,             4849552
+silesia,                            level 19,                           old streaming advanced,             4283236
+silesia,                            no source size,                     old streaming advanced,             4849515
+silesia,                            long distance mode,                 old streaming advanced,             4849551
+silesia,                            multithreaded,                      old streaming advanced,             4849551
+silesia,                            multithreaded long distance mode,   old streaming advanced,             4849551
 silesia,                            small window log,                   old streaming advanced,             7112062
 silesia,                            small hash log,                     old streaming advanced,             6526141
-silesia,                            small chain log,                    old streaming advanced,             4912197
+silesia,                            small chain log,                    old streaming advanced,             4912199
 silesia,                            explicit params,                    old streaming advanced,             4795884
-silesia,                            uncompressed literals,              old streaming advanced,             4849552
-silesia,                            uncompressed literals optimal,      old streaming advanced,             4283237
+silesia,                            uncompressed literals,              old streaming advanced,             4849551
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4283236
 silesia,                            huffman literals,                   old streaming advanced,             6183403
-silesia,                            multithreaded with advanced params, old streaming advanced,             4849552
+silesia,                            multithreaded with advanced params, old streaming advanced,             4849551
 silesia.tar,                        level -5,                           old streaming advanced,             6982759
 silesia.tar,                        level -3,                           old streaming advanced,             6641283
 silesia.tar,                        level -1,                           old streaming advanced,             6190795
-silesia.tar,                        level 0,                            old streaming advanced,             4861427
-silesia.tar,                        level 1,                            old streaming advanced,             5336939
-silesia.tar,                        level 3,                            old streaming advanced,             4861427
-silesia.tar,                        level 4,                            old streaming advanced,             4799630
+silesia.tar,                        level 0,                            old streaming advanced,             4861425
+silesia.tar,                        level 1,                            old streaming advanced,             5336941
+silesia.tar,                        level 3,                            old streaming advanced,             4861425
+silesia.tar,                        level 4,                            old streaming advanced,             4799632
 silesia.tar,                        level 5,                            old streaming advanced,             4719261
-silesia.tar,                        level 6,                            old streaming advanced,             4677729
-silesia.tar,                        level 7,                            old streaming advanced,             4613544
+silesia.tar,                        level 6,                            old streaming advanced,             4677732
+silesia.tar,                        level 7,                            old streaming advanced,             4613548
 silesia.tar,                        level 9,                            old streaming advanced,             4555432
-silesia.tar,                        level 13,                           old streaming advanced,             4491765
+silesia.tar,                        level 13,                           old streaming advanced,             4491769
 silesia.tar,                        level 16,                           old streaming advanced,             4356834
-silesia.tar,                        level 19,                           old streaming advanced,             4264392
-silesia.tar,                        no source size,                     old streaming advanced,             4861423
-silesia.tar,                        long distance mode,                 old streaming advanced,             4861427
-silesia.tar,                        multithreaded,                      old streaming advanced,             4861427
-silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861427
+silesia.tar,                        level 19,                           old streaming advanced,             4264388
+silesia.tar,                        no source size,                     old streaming advanced,             4861421
+silesia.tar,                        long distance mode,                 old streaming advanced,             4861425
+silesia.tar,                        multithreaded,                      old streaming advanced,             4861425
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861425
 silesia.tar,                        small window log,                   old streaming advanced,             7118772
-silesia.tar,                        small hash log,                     old streaming advanced,             6529235
-silesia.tar,                        small chain log,                    old streaming advanced,             4917021
-silesia.tar,                        explicit params,                    old streaming advanced,             4807399
-silesia.tar,                        uncompressed literals,              old streaming advanced,             4861427
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4264392
+silesia.tar,                        small hash log,                     old streaming advanced,             6529231
+silesia.tar,                        small chain log,                    old streaming advanced,             4917019
+silesia.tar,                        explicit params,                    old streaming advanced,             4807403
+silesia.tar,                        uncompressed literals,              old streaming advanced,             4861425
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4264388
 silesia.tar,                        huffman literals,                   old streaming advanced,             6190795
-silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861427
+silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861425
 github,                             level -5,                           old streaming advanced,             216734
 github,                             level -5 with dict,                 old streaming advanced,             49562
 github,                             level -3,                           old streaming advanced,             192160


### PR DESCRIPTION
This PR improves the current huffman sorting strategy, mostly on small blocks, by doing the following:

- Decoupling bucketing and sorting into separate steps.
- Skip attempts to sort buckets that are 0 or 1-sized. (e.g. silesia/dickens has a lot of 0-count symbols).
- Use 128 buckets that are split into distinct count buckets that don't need to be sorted, and the typical log2 bucketing
  - This reduces the number of buckets we actually need to sort to at most 11, and reduces the avg nb of elements per bucket.
- Use quicksort

Using @terrelln's nifty benchmarking tool, we see the following improvements:
|     Benchmark     | Config  |  Dataset   | Ratio (dev) | Ratio (huf_sort_improvement) | Ratio (huf_sort_improvement - dev) | Speed MB/s (dev) | Speed MB/s (huf_sort_improvement) | Speed MB/s (huf_sort_improvement - dev) |
|-------------------|---------|------------|-------------|------------------------------|------------------------------------|------------------|-----------------------------------|-----------------------------------------|
| compress          | level_1 | silesia    | 2.88        | 2.88                         | -0.0%                              | 347.03           | 347.49                            | 0.1%                                    |
| compress          | level_1 | silesia_4k | 2.31        | 2.31                         | 0.0%                               | 183.02           | 200.93                            | 9.8%                                    |
| compress_literals | level_1 | silesia    | 1.28        | 1.28                         | -0.0%                              | 755.42           | 780.19                            | 3.3%                                    |
| compress_literals | level_1 | silesia_4k | 1.30        | 1.30                         | 0.0%                               | 233.50           | 330.14                            | 41.4%                                   |
| compress_literals | level_7 | silesia    | 1.11        | 1.11                         | -0.0%                              | 677.14           | 746.20                            | 10.2%                                   |

- Nearly 10% speedup for 4KB block compression, 40% literal compression speedup.
- Neutral e2e compression speed on 128K blocks, with improvements to literal compression.
- Very small perturbations to compressed size (since quicksort is not stable).