### PR TITLE
Set mtime on Output Files

### DIFF
--- a/programs/util.h
+++ b/programs/util.h
@@ -136,6 +136,14 @@ int UTIL_stat(const char* filename, stat_t* statbuf);
  */
 int UTIL_setFileStat(const char* filename, const stat_t* statbuf);
 
+/**
+ * Set atime to now and mtime to the st_mtim in statbuf.
+ *
+ * Directly wraps utime() or utimensat(). Returns -1 on error.
+ * Does not validate filename is valid.
+ */
+int UTIL_utime(const char* filename, const stat_t *statbuf);
+
 /*
  * These helpers operate on a pre-populated stat_t, i.e., the result of
  * calling one of the above functions.

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -597,11 +597,10 @@ fi
 
 println "\n===>  zstd created file timestamp tests"
 datagen > tmp
-sleep 1 # could also use touch -t but I don't know how portable that is.
+touch -m -t 200001010000.00 tmp
 println "test : copy mtime in file -> file compression "
 zstd -f tmp -o tmp.zst
 assertSameMTime tmp tmp.zst
-sleep 1 # could also use touch -t but I don't know how portable that is.
 println "test : copy mtime in file -> file decompression "
 zstd -f -d tmp.zst -o tmp.out
 assertSameMTime tmp.zst tmp.out


### PR DESCRIPTION
In changing how permission bits were set on created files, #2525 introduced a regression, no longer updating the mtime on output files. This PR fixes this regression, by calling `utime()` on destination files.

This addresses #2739.