### PR TITLE
Reduce size of dctx by reutilizing dst buffer

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -155,6 +155,12 @@ The file structure is designed to make this selection manually achievable for an
 - The build macro `ZSTD_NO_INTRINSICS` can be defined to disable all explicit intrinsics.
   Compiler builtins are still used.
 
+- The build macro `ZSTD_LITBUFFEREXTRASIZE` can be set to control the amount of extra memory used
+  during decompression to store literals.  This defaults to 64kB.  Reducing it can reduce the
+  memory footprint required for decompression by increasing the portion of the literal buffer that
+  is stored in the unwritten portion of the dst buffer, at the cost of performance impact for
+  decompression.
+
 
 #### Windows : using MinGW+MSYS to create DLL
 

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -181,7 +181,7 @@ static void ZSTD_copy16(void* dst, const void* src) {
 #if defined(ZSTD_ARCH_ARM_NEON)
     vst1q_u8((uint8_t*)dst, vld1q_u8((const uint8_t*)src));
 #else
-    ZSTD_memcpy(dst, src, 16);
+    ZSTD_memmove(dst, src, 16);
 #endif
 }
 #define COPY16(d,s) { ZSTD_copy16(d,s); d+=16; s+=16; }
@@ -209,8 +209,6 @@ void ZSTD_wildcopy(void* dst, const void* src, ptrdiff_t length, ZSTD_overlap_e 
     const BYTE* ip = (const BYTE*)src;
     BYTE* op = (BYTE*)dst;
     BYTE* const oend = op + length;
-
-    assert(diff >= 8 || (ovtype == ZSTD_no_overlap && diff <= -WILDCOPY_VECLEN));
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -191,8 +191,8 @@ static void ZSTD_copy16(void* dst, const void* src) {
 
 typedef enum {
     ZSTD_no_overlap,
-    ZSTD_overlap_src_before_dst
-    /*  ZSTD_overlap_dst_before_src, */
+    ZSTD_overlap_src_before_dst,
+    ZSTD_overlap_dst_before_src
 } ZSTD_overlap_e;
 
 /*! ZSTD_wildcopy() :
@@ -210,7 +210,7 @@ void ZSTD_wildcopy(void* dst, const void* src, ptrdiff_t length, ZSTD_overlap_e 
     BYTE* op = (BYTE*)dst;
     BYTE* const oend = op + length;
 
-    assert(diff >= 8 || (ovtype == ZSTD_no_overlap && diff <= -WILDCOPY_VECLEN));
+    assert(diff >= 8 || ((ovtype == ZSTD_no_overlap || ovtype == ZSTD_overlap_dst_before_src) && diff <= -WILDCOPY_VECLEN));
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -191,8 +191,8 @@ static void ZSTD_copy16(void* dst, const void* src) {
 
 typedef enum {
     ZSTD_no_overlap,
-    ZSTD_overlap_src_before_dst,
-    ZSTD_overlap_dst_before_src
+    ZSTD_overlap_src_before_dst
+    /*  ZSTD_overlap_dst_before_src, */
 } ZSTD_overlap_e;
 
 /*! ZSTD_wildcopy() :
@@ -210,7 +210,7 @@ void ZSTD_wildcopy(void* dst, const void* src, ptrdiff_t length, ZSTD_overlap_e 
     BYTE* op = (BYTE*)dst;
     BYTE* const oend = op + length;
 
-    assert(diff >= 8 || ((ovtype == ZSTD_no_overlap || ovtype == ZSTD_overlap_dst_before_src) && diff <= -WILDCOPY_VECLEN));
+    assert(diff >= 8 || (ovtype == ZSTD_no_overlap && diff <= -WILDCOPY_VECLEN));
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -916,7 +916,7 @@ static size_t ZSTD_decompressFrame(ZSTD_DCtx* dctx,
         switch(blockProperties.blockType)
         {
         case bt_compressed:
-            decodedSize = ZSTD_decompressBlock_internal(dctx, op, (size_t)(oend-op), ip, cBlockSize, /* frame */ 1);
+            decodedSize = ZSTD_decompressBlock_internal(dctx, op, (size_t)(oend-op), ip, cBlockSize, /* frame */ 1, 0);
             break;
         case bt_raw :
             decodedSize = ZSTD_copyRawBlock(op, (size_t)(oend-op), ip, cBlockSize);
@@ -1229,7 +1229,7 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity, c
             {
             case bt_compressed:
                 DEBUGLOG(5, "ZSTD_decompressContinue: case bt_compressed");
-                rSize = ZSTD_decompressBlock_internal(dctx, dst, dstCapacity, src, srcSize, /* frame */ 1);
+                rSize = ZSTD_decompressBlock_internal(dctx, dst, dstCapacity, src, srcSize, /* frame */ 1, 1);
                 dctx->expected = 0;  /* Streaming not supported */
                 break;
             case bt_raw :

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -916,7 +916,7 @@ static size_t ZSTD_decompressFrame(ZSTD_DCtx* dctx,
         switch(blockProperties.blockType)
         {
         case bt_compressed:
-            decodedSize = ZSTD_decompressBlock_internal(dctx, op, (size_t)(oend-op), ip, cBlockSize, /* frame */ 1, 0);
+            decodedSize = ZSTD_decompressBlock_internal(dctx, op, (size_t)(oend-op), ip, cBlockSize, /* frame */ 1, not_streaming);
             break;
         case bt_raw :
             decodedSize = ZSTD_copyRawBlock(op, (size_t)(oend-op), ip, cBlockSize);
@@ -1229,7 +1229,7 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity, c
             {
             case bt_compressed:
                 DEBUGLOG(5, "ZSTD_decompressContinue: case bt_compressed");
-                rSize = ZSTD_decompressBlock_internal(dctx, dst, dstCapacity, src, srcSize, /* frame */ 1, 1);
+                rSize = ZSTD_decompressBlock_internal(dctx, dst, dstCapacity, src, srcSize, /* frame */ 1, is_streaming);
                 dctx->expected = 0;  /* Streaming not supported */
                 break;
             case bt_raw :
@@ -1824,6 +1824,7 @@ size_t ZSTD_sizeof_DStream(const ZSTD_DStream* dctx)
 size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long long frameContentSize)
 {
     size_t const blockSize = (size_t) MIN(windowSize, ZSTD_BLOCKSIZE_MAX);
+    /* space is needed to store the litbuffer after the output of a given block without stomping the extDict of a previous run, as well as to cover both windows against wildcopy*/
     unsigned long long const neededRBSize = windowSize + blockSize + ZSTD_BLOCKSIZE_MAX + (WILDCOPY_OVERLENGTH * 2);
     unsigned long long const neededSize = MIN(frameContentSize, neededRBSize);
     size_t const minRBSize = (size_t) neededSize;

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1824,7 +1824,7 @@ size_t ZSTD_sizeof_DStream(const ZSTD_DStream* dctx)
 size_t ZSTD_decodingBufferSize_min(unsigned long long windowSize, unsigned long long frameContentSize)
 {
     size_t const blockSize = (size_t) MIN(windowSize, ZSTD_BLOCKSIZE_MAX);
-    unsigned long long const neededRBSize = windowSize + blockSize + (WILDCOPY_OVERLENGTH * 2);
+    unsigned long long const neededRBSize = windowSize + blockSize + ZSTD_BLOCKSIZE_MAX + (WILDCOPY_OVERLENGTH * 2);
     unsigned long long const neededSize = MIN(frameContentSize, neededRBSize);
     size_t const minRBSize = (size_t) neededSize;
     RETURN_ERROR_IF((unsigned long long)minRBSize != neededSize,

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -70,8 +70,8 @@ size_t ZSTD_getcBlockSize(const void* src, size_t srcSize,
 }
 
 /* Allocate buffer for literals, either overlapping current dst, or split between dst and litExtraBuffer, or stored entirely within litExtraBuffer */
-static void ZSTD_allocateLiteralsBuffer(const streaming_operation streaming, void* const dst, const size_t dstCapacity, const size_t litSize,
-    ZSTD_DCtx* dctx, const size_t expectedWriteSize, const unsigned splitImmediately)
+static void ZSTD_allocateLiteralsBuffer(ZSTD_DCtx* dctx, void* const dst, const size_t dstCapacity, const size_t litSize,
+    const streaming_operation streaming, const size_t expectedWriteSize, const unsigned splitImmediately)
 {
     if (streaming == not_streaming && dstCapacity > ZSTD_BLOCKSIZE_MAX + WILDCOPY_OVERLENGTH + litSize + WILDCOPY_OVERLENGTH)
     {
@@ -167,7 +167,7 @@ size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
                 RETURN_ERROR_IF(litSize > ZSTD_BLOCKSIZE_MAX, corruption_detected, "");
                 RETURN_ERROR_IF(litCSize + lhSize > srcSize, corruption_detected, "");
                 RETURN_ERROR_IF(expectedWriteSize < litSize , dstSize_tooSmall, "");
-                ZSTD_allocateLiteralsBuffer(streaming, dst, dstCapacity, litSize, dctx, expectedWriteSize, 0);
+                ZSTD_allocateLiteralsBuffer(dctx, dst, dstCapacity, litSize, streaming, expectedWriteSize, 0);
 
                 /* prefetch huffman table if cold */
                 if (dctx->ddictIsCold && (litSize > 768 /* heuristic */)) {
@@ -243,7 +243,7 @@ size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
 
                 RETURN_ERROR_IF(litSize > 0 && dst == NULL, dstSize_tooSmall, "NULL not handled");
                 RETURN_ERROR_IF(expectedWriteSize < litSize, dstSize_tooSmall, "");
-                ZSTD_allocateLiteralsBuffer(streaming, dst, dstCapacity, litSize, dctx, expectedWriteSize, 1);
+                ZSTD_allocateLiteralsBuffer(dctx, dst, dstCapacity, litSize, streaming, expectedWriteSize, 1);
                 if (lhSize+litSize+WILDCOPY_OVERLENGTH > srcSize) {  /* risk reading beyond src buffer with wildcopy */
                     RETURN_ERROR_IF(litSize+lhSize > srcSize, corruption_detected, "");
                     if (dctx->splitLitBuffer)
@@ -290,7 +290,7 @@ size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
                 RETURN_ERROR_IF(litSize > 0 && dst == NULL, dstSize_tooSmall, "NULL not handled");
                 RETURN_ERROR_IF(litSize > ZSTD_BLOCKSIZE_MAX, corruption_detected, "");
                 RETURN_ERROR_IF(expectedWriteSize < litSize, dstSize_tooSmall, "");
-                ZSTD_allocateLiteralsBuffer(streaming, dst, dstCapacity, litSize, dctx, expectedWriteSize, 1);
+                ZSTD_allocateLiteralsBuffer(dctx, dst, dstCapacity, litSize, streaming, expectedWriteSize, 1);
                 if (dctx->splitLitBuffer)
                 {
                     ZSTD_memset(dctx->litBuffer, istart[lhSize], litSize - ZSTD_LITBUFFEREXTRASIZE);

--- a/lib/decompress/zstd_decompress_block.h
+++ b/lib/decompress/zstd_decompress_block.h
@@ -33,6 +33,12 @@
  */
 
 
+ /* Streaming state is used to inform allocation of the literal buffer */
+typedef enum {
+    not_streaming = 0,
+    is_streaming = 1
+} streaming_operation;
+
 /* ZSTD_decompressBlock_internal() :
  * decompress block, starting at `src`,
  * into destination buffer `dst`.
@@ -41,7 +47,7 @@
  */
 size_t ZSTD_decompressBlock_internal(ZSTD_DCtx* dctx,
                                void* dst, size_t dstCapacity,
-                         const void* src, size_t srcSize, const int frame, const unsigned streaming);
+                         const void* src, size_t srcSize, const int frame, const streaming_operation streaming);
 
 /* ZSTD_buildFSETable() :
  * generate FSE decoding table for one symbol (ll, ml or off)

--- a/lib/decompress/zstd_decompress_block.h
+++ b/lib/decompress/zstd_decompress_block.h
@@ -41,7 +41,7 @@
  */
 size_t ZSTD_decompressBlock_internal(ZSTD_DCtx* dctx,
                                void* dst, size_t dstCapacity,
-                         const void* src, size_t srcSize, const int frame);
+                         const void* src, size_t srcSize, const int frame, const unsigned streaming);
 
 /* ZSTD_buildFSETable() :
  * generate FSE decoding table for one symbol (ll, ml or off)

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -106,6 +106,8 @@ typedef struct {
     size_t ddictPtrCount;
 } ZSTD_DDictHashSet;
 
+#define ZSTD_LITBUFFEREXTRASIZE    4096 /* extra buffer reduces amount of dst required to store litBuffer */
+
 struct ZSTD_DCtx_s
 {
     const ZSTD_seqSymbol* LLTptr;
@@ -171,7 +173,9 @@ struct ZSTD_DCtx_s
     ZSTD_outBuffer expectedOutBuffer;
 
     /* workspace */
-    BYTE litBuffer[ZSTD_BLOCKSIZE_MAX + WILDCOPY_OVERLENGTH];
+    BYTE* litBuffer;
+    const BYTE* litBufferEnd;
+    BYTE litExtraBuffer[ZSTD_LITBUFFEREXTRASIZE + WILDCOPY_OVERLENGTH];
     BYTE headerBuffer[ZSTD_FRAMEHEADERSIZE_MAX];
 
     size_t oversizedDuration;

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -176,7 +176,7 @@ struct ZSTD_DCtx_s
     BYTE* litBuffer;
     const BYTE* litBufferEnd;
     unsigned splitLitBuffer;
-    BYTE litExtraBuffer[ZSTD_LITBUFFEREXTRASIZE + WILDCOPY_OVERLENGTH];
+    BYTE litExtraBuffer[ZSTD_LITBUFFEREXTRASIZE + WILDCOPY_OVERLENGTH]; /* literal buffer can be split between storage within dst and within this scratch buffer */
     BYTE headerBuffer[ZSTD_FRAMEHEADERSIZE_MAX];
 
     size_t oversizedDuration;

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -175,6 +175,7 @@ struct ZSTD_DCtx_s
     /* workspace */
     BYTE* litBuffer;
     const BYTE* litBufferEnd;
+    unsigned splitLitBuffer;
     BYTE litExtraBuffer[ZSTD_LITBUFFEREXTRASIZE + WILDCOPY_OVERLENGTH];
     BYTE headerBuffer[ZSTD_FRAMEHEADERSIZE_MAX];
 

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -107,8 +107,14 @@ typedef struct {
 } ZSTD_DDictHashSet;
 
 #ifndef ZSTD_LITBUFFEREXTRASIZE
-#define ZSTD_LITBUFFEREXTRASIZE    16384 /* extra buffer reduces amount of dst required to store litBuffer */
+#define ZSTD_LITBUFFEREXTRASIZE    (1 << 15) /* extra buffer reduces amount of dst required to store litBuffer */
 #endif
+
+typedef enum {
+    ZSTD_not_in_dst = 0,  /* Stored entirely within litExtraBuffer */
+    ZSTD_in_dst = 1,           /* Stored entirely within dst (in memory after current output write) */
+    ZSTD_split = 2            /* Split between litExtraBuffer and dst */
+} ZSTD_litLocation_e;
 
 struct ZSTD_DCtx_s
 {
@@ -177,7 +183,7 @@ struct ZSTD_DCtx_s
     /* workspace */
     BYTE* litBuffer;
     const BYTE* litBufferEnd;
-    unsigned splitLitBuffer;
+    ZSTD_litLocation_e litBufferLocation;
     BYTE litExtraBuffer[ZSTD_LITBUFFEREXTRASIZE + WILDCOPY_OVERLENGTH]; /* literal buffer can be split between storage within dst and within this scratch buffer */
     BYTE headerBuffer[ZSTD_FRAMEHEADERSIZE_MAX];
 

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -106,7 +106,7 @@ typedef struct {
     size_t ddictPtrCount;
 } ZSTD_DDictHashSet;
 
-#define ZSTD_LITBUFFEREXTRASIZE    16384 /* extra buffer reduces amount of dst required to store litBuffer */
+#define ZSTD_LITBUFFEREXTRASIZE    32768 /* extra buffer reduces amount of dst required to store litBuffer */
 
 struct ZSTD_DCtx_s
 {

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -106,7 +106,7 @@ typedef struct {
     size_t ddictPtrCount;
 } ZSTD_DDictHashSet;
 
-#define ZSTD_LITBUFFEREXTRASIZE    4096 /* extra buffer reduces amount of dst required to store litBuffer */
+#define ZSTD_LITBUFFEREXTRASIZE    8192 /* extra buffer reduces amount of dst required to store litBuffer */
 
 struct ZSTD_DCtx_s
 {

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -107,7 +107,7 @@ typedef struct {
 } ZSTD_DDictHashSet;
 
 #ifndef ZSTD_LITBUFFEREXTRASIZE
-#define ZSTD_LITBUFFEREXTRASIZE    (1 << 15) /* extra buffer reduces amount of dst required to store litBuffer */
+#define ZSTD_LITBUFFEREXTRASIZE    (1 << 16) /* extra buffer reduces amount of dst required to store litBuffer */
 #endif
 
 typedef enum {

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -106,7 +106,9 @@ typedef struct {
     size_t ddictPtrCount;
 } ZSTD_DDictHashSet;
 
+#ifndef ZSTD_LITBUFFEREXTRASIZE
 #define ZSTD_LITBUFFEREXTRASIZE    16384 /* extra buffer reduces amount of dst required to store litBuffer */
+#endif
 
 struct ZSTD_DCtx_s
 {

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -106,7 +106,7 @@ typedef struct {
     size_t ddictPtrCount;
 } ZSTD_DDictHashSet;
 
-#define ZSTD_LITBUFFEREXTRASIZE    32768 /* extra buffer reduces amount of dst required to store litBuffer */
+#define ZSTD_LITBUFFEREXTRASIZE    16384 /* extra buffer reduces amount of dst required to store litBuffer */
 
 struct ZSTD_DCtx_s
 {

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -106,7 +106,7 @@ typedef struct {
     size_t ddictPtrCount;
 } ZSTD_DDictHashSet;
 
-#define ZSTD_LITBUFFEREXTRASIZE    8192 /* extra buffer reduces amount of dst required to store litBuffer */
+#define ZSTD_LITBUFFEREXTRASIZE    16384 /* extra buffer reduces amount of dst required to store litBuffer */
 
 struct ZSTD_DCtx_s
 {

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -123,11 +123,11 @@ static size_t local_ZSTD_decompress(const void* src, size_t srcSize,
 static ZSTD_DCtx* g_zdc = NULL;
 
 #ifndef ZSTD_DLL_IMPORT
-extern size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* ctx, const void* src, size_t srcSize);
+extern size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* ctx, const void* src, size_t srcSize, void* dst, size_t dstCapacity);
 static size_t local_ZSTD_decodeLiteralsBlock(const void* src, size_t srcSize, void* dst, size_t dstSize, void* buff2)
 {
     (void)src; (void)srcSize; (void)dst; (void)dstSize;
-    return ZSTD_decodeLiteralsBlock(g_zdc, buff2, g_cSize);
+    return ZSTD_decodeLiteralsBlock(g_zdc, buff2, g_cSize, dst, dstSize);
 }
 
 static size_t local_ZSTD_decodeSeqHeaders(const void* src, size_t srcSize, void* dst, size_t dstSize, void* buff2)
@@ -577,7 +577,7 @@ static int benchMem(unsigned benchNb,
             ip += ZSTD_blockHeaderSize;    /* skip block header */
             ZSTD_decompressBegin(g_zdc);
             CONTROL(iend > ip);
-            ip += ZSTD_decodeLiteralsBlock(g_zdc, ip, (size_t)(iend-ip));   /* skip literal segment */
+            ip += ZSTD_decodeLiteralsBlock(g_zdc, ip, (size_t)(iend-ip), dstBuff, dstBuffSize);   /* skip literal segment */
             g_cSize = (size_t)(iend-ip);
             memcpy(dstBuff2, ip, g_cSize);   /* copy rest of block (it starts by SeqHeader) */
             srcSize = srcSize > 128 KB ? 128 KB : srcSize;   /* speed relative to block */


### PR DESCRIPTION
WIP, this round of optimizations has gotten performance much closer to parity, though it has introduced a checksum error in the 270MB file test I'm still tracking down.  This however hasn't affected the smaller size tests; benchmarks indicate that in some cases we now see performance improvements on top of the memory reduction due to the improved cache behavior.  However there's other cases, at low file sizes and high compressibility, where we are still about 1% behind parity.

<details>
<summary>Benchmark</summary>

old performance

./tests/fullbench -b2 -B1000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :  4987.5 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :   612.0 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :   585.8 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :  2597.8 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :  2635.7 MB/s  (    1000) 
./tests/fullbench -b2 -B10000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   : 36167.5 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  1292.4 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  1671.9 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  3205.2 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  6179.7 MB/s  (   10000) 
./tests/fullbench -b2 -B100000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   : 51880.0 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  1237.1 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  2151.4 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  3193.0 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  7095.5 MB/s  (  100000) 
./tests/fullbench -b2 -B1000000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   : 34106.0 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   :  1309.3 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   :  1973.5 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   :  2637.8 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   : 14852.5 MB/s  ( 1000000) 





new performance

./tests/fullbench -b2 -B1000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :  4999.4 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :   609.1 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :   583.5 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :  2402.1 MB/s  (    1000) 
./tests/fullbench -b2 -B1000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000 bytes :                                                  
 2#decompress                   :  2587.4 MB/s  (    1000) 
./tests/fullbench -b2 -B10000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   : 37441.8 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  1297.5 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  1656.7 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  3081.0 MB/s  (   10000) 
./tests/fullbench -b2 -B10000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 10000 bytes :                                                 
 2#decompress                   :  6127.2 MB/s  (   10000) 
./tests/fullbench -b2 -B100000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   : 52215.9 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  1252.2 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  2146.6 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  3614.6 MB/s  (  100000) 
./tests/fullbench -b2 -B100000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 100000 bytes :                                                
 2#decompress                   :  7084.7 MB/s  (  100000) 
./tests/fullbench -b2 -B1000000 -P0
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   : 33857.1 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P10
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   :  1288.9 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P50
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   :  2095.4 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P90
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   :  2786.2 MB/s  ( 1000000) 
./tests/fullbench -b2 -B1000000 -P100
*** Zstandard speed analyzer 1.5.0 64-bits, by Yann Collet (Aug 19 2021) ***
 Sample 1000000 bytes :                                               
 2#decompress                   : 15258.4 MB/s  ( 1000000) 

</details>