### PR TITLE
[easy] Fix zstd bench error message

### DIFF
--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -805,6 +805,10 @@ BMK_benchOutcome_t BMK_benchFilesAdvanced(
         RETURN_ERROR(15, BMK_benchOutcome_t, "Invalid Compression Level");
     }
 
+    if (totalSizeToLoad == UTIL_FILESIZE_UNKNOWN) {
+        RETURN_ERROR(9, BMK_benchOutcome_t, "Error loading files");
+    }
+
     fileSizes = (size_t*)calloc(nbFiles, sizeof(size_t));
     if (!fileSizes) RETURN_ERROR(12, BMK_benchOutcome_t, "not enough memory for fileSizes");
 


### PR DESCRIPTION
I remember this confusing me the first time I saw it, so should probably fix it.
Prior to this fix, if you ran
```
./zstd -b1 nonexistent_file
Not enough memory; testing 0 MB only...
Error 12 : not enough memory 
```
Now the message is more accurate
```
Error 9 : Error loading files
```