### PR TITLE
Skip most long matches in lazy hash table update

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1011,61 +1011,65 @@ FORCE_INLINE_TEMPLATE U32 ZSTD_row_nextCachedHash(U32* cache, U32 const* hashTab
     }
 }
 
-/* ZSTD_row_update_internal():
- * Inserts the byte at ip into the appropriate position in the hash table.
- * Determines the relative row, and the position within the {16, 32} entry row to insert at.
+/* ZSTD_row_update_internalImpl():
+ * Updates the hash table with positions starting from updateStartIdx until updateEndIdx.
  */
-FORCE_INLINE_TEMPLATE void ZSTD_row_update_internal(ZSTD_matchState_t* ms, const BYTE* ip,
-                                                    U32 const mls, U32 const rowLog,
-                                                    U32 const rowMask, U32 const useCache)
+FORCE_INLINE_TEMPLATE void ZSTD_row_update_internalImpl(ZSTD_matchState_t* ms,
+                                                        U32 updateStartIdx, U32 const updateEndIdx,
+                                                        U32 const mls, U32 const rowLog,
+                                                        U32 const rowMask, U32 const useCache)
 {
     U32* const hashTable = ms->hashTable;
     U16* const tagTable = ms->tagTable;
     U32 const hashLog = ms->rowHashLog;
-    U32 idx = ms->nextToUpdate;
     const BYTE* const base = ms->window.base;
-    const U32 target = (U32)(ip - base);
-    const U32 kMaxPositionsToUpdate = 128;
 
-    assert(target >= idx);
-    if (useCache) {
-        /* Only skip positions when using hash cache, i.e. 
-         * if we are loading a dict, don't skip anything.
-         */
-        if (UNLIKELY(target - idx > kMaxPositionsToUpdate)) {
-            U32 const bound = idx + 3*kMaxPositionsToUpdate/4;
-            for (; idx < bound; ++idx) {
-                U32 const hash = useCache ? ZSTD_row_nextCachedHash(ms->hashCache, hashTable, tagTable, base, idx, hashLog, rowLog, mls)
-                                        : (U32)ZSTD_hashPtr(base + idx, hashLog + ZSTD_ROW_HASH_TAG_BITS, mls);
-                U32 const relRow = (hash >> ZSTD_ROW_HASH_TAG_BITS) << rowLog;
-                U32* const row = hashTable + relRow;
-                BYTE* tagRow = (BYTE*)(tagTable + relRow);  /* Though tagTable is laid out as a table of U16, each tag is only 1 byte.
-                                                            Explicit cast allows us to get exact desired position within each row */
-                U32 const pos = ZSTD_row_nextIndex(tagRow, rowMask);
-
-                assert(hash == ZSTD_hashPtr(base + idx, hashLog + ZSTD_ROW_HASH_TAG_BITS, mls));
-                tagRow[pos + ZSTD_ROW_HASH_TAG_OFFSET] = hash & ZSTD_ROW_HASH_TAG_MASK;
-                row[pos] = idx;
-            }
-            idx = target - kMaxPositionsToUpdate/4;
-            ZSTD_row_fillHashCache(ms, base, rowLog, mls, idx, ip+1);
-        }
-    }
-
-    DEBUGLOG(6, "ZSTD_row_update_internal(): nextToUpdate=%u, current=%u", idx, target);
-    for (; idx < target; ++idx) {
-        U32 const hash = useCache ? ZSTD_row_nextCachedHash(ms->hashCache, hashTable, tagTable, base, idx, hashLog, rowLog, mls)
-                                  : (U32)ZSTD_hashPtr(base + idx, hashLog + ZSTD_ROW_HASH_TAG_BITS, mls);
+    DEBUGLOG(6, "ZSTD_row_update_internalImpl(): updateStartIdx=%u, updateEndIdx=%u", updateStartIdx, updateEndIdx);
+    for (; updateStartIdx < updateEndIdx; ++updateStartIdx) {
+        U32 const hash = useCache ? ZSTD_row_nextCachedHash(ms->hashCache, hashTable, tagTable, base, updateStartIdx, hashLog, rowLog, mls)
+                                  : (U32)ZSTD_hashPtr(base + updateStartIdx, hashLog + ZSTD_ROW_HASH_TAG_BITS, mls);
         U32 const relRow = (hash >> ZSTD_ROW_HASH_TAG_BITS) << rowLog;
         U32* const row = hashTable + relRow;
         BYTE* tagRow = (BYTE*)(tagTable + relRow);  /* Though tagTable is laid out as a table of U16, each tag is only 1 byte.
                                                        Explicit cast allows us to get exact desired position within each row */
         U32 const pos = ZSTD_row_nextIndex(tagRow, rowMask);
 
-        assert(hash == ZSTD_hashPtr(base + idx, hashLog + ZSTD_ROW_HASH_TAG_BITS, mls));
-        tagRow[pos + ZSTD_ROW_HASH_TAG_OFFSET] = hash & ZSTD_ROW_HASH_TAG_MASK;
-        row[pos] = idx;
+        assert(hash == ZSTD_hashPtr(base + updateStartIdx, hashLog + ZSTD_ROW_HASH_TAG_BITS, mls));
+        ((BYTE*)tagRow)[pos + ZSTD_ROW_HASH_TAG_OFFSET] = hash & ZSTD_ROW_HASH_TAG_MASK;
+        row[pos] = updateStartIdx;
     }
+}
+
+/* ZSTD_row_update_internal():
+ * Inserts the byte at ip into the appropriate position in the hash table, and updates ms->nextToUpdate.
+ * Skips sections of long matches as is necessary.
+ */
+FORCE_INLINE_TEMPLATE void ZSTD_row_update_internal(ZSTD_matchState_t* ms, const BYTE* ip,
+                                                    U32 const mls, U32 const rowLog,
+                                                    U32 const rowMask, U32 const useCache)
+{
+    U32 idx = ms->nextToUpdate;
+    const BYTE* const base = ms->window.base;
+    const U32 target = (U32)(ip - base);
+    const U32 kSkipThreshold = 384;
+    const U32 kMaxMatchStartPositionsToUpdate = 96;
+    const U32 kMaxMatchEndPositionsToUpdate = 32;
+
+    if (useCache) {
+        /* Only skip positions when using hash cache, i.e. 
+         * if we are loading a dict, don't skip anything.
+         * If we decide to skip, then we only update a set number
+         * of positions at the beginning and end of the match.
+         */
+        if (UNLIKELY(target - idx > kSkipThreshold)) {
+            U32 const bound = idx + kMaxMatchStartPositionsToUpdate;
+            ZSTD_row_update_internalImpl(ms, idx, bound, mls, rowLog, rowMask, useCache);
+            idx = target - kMaxMatchEndPositionsToUpdate;
+            ZSTD_row_fillHashCache(ms, base, rowLog, mls, idx, ip+1);
+        }
+    }
+    assert(target >= idx);
+    ZSTD_row_update_internalImpl(ms, idx, target, mls, rowLog, rowMask, useCache);
     ms->nextToUpdate = target;
 }
 

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -1,72 +1,72 @@
 Data,                               Config,                             Method,                             Total compressed size
-silesia.tar,                        level -5,                           compress simple,                    6738593
-silesia.tar,                        level -3,                           compress simple,                    6446372
-silesia.tar,                        level -1,                           compress simple,                    6186042
-silesia.tar,                        level 0,                            compress simple,                    4861423
-silesia.tar,                        level 1,                            compress simple,                    5334885
-silesia.tar,                        level 3,                            compress simple,                    4861423
+silesia.tar,                        level -5,                           compress simple,                    7359401
+silesia.tar,                        level -3,                           compress simple,                    6901672
+silesia.tar,                        level -1,                           compress simple,                    6182241
+silesia.tar,                        level 0,                            compress simple,                    4861424
+silesia.tar,                        level 1,                            compress simple,                    5331946
+silesia.tar,                        level 3,                            compress simple,                    4861424
 silesia.tar,                        level 4,                            compress simple,                    4799632
-silesia.tar,                        level 5,                            compress simple,                    4650387
-silesia.tar,                        level 6,                            compress simple,                    4617089
-silesia.tar,                        level 7,                            compress simple,                    4576951
-silesia.tar,                        level 9,                            compress simple,                    4552638
-silesia.tar,                        level 13,                           compress simple,                    4491768
-silesia.tar,                        level 16,                           compress simple,                    4356834
-silesia.tar,                        level 19,                           compress simple,                    4264388
-silesia.tar,                        uncompressed literals,              compress simple,                    4861423
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264388
-silesia.tar,                        huffman literals,                   compress simple,                    6186042
-github.tar,                         level -5,                           compress simple,                    46856
-github.tar,                         level -3,                           compress simple,                    43754
-github.tar,                         level -1,                           compress simple,                    42490
+silesia.tar,                        level 5,                            compress simple,                    4649987
+silesia.tar,                        level 6,                            compress simple,                    4616797
+silesia.tar,                        level 7,                            compress simple,                    4576661
+silesia.tar,                        level 9,                            compress simple,                    4552381
+silesia.tar,                        level 13,                           compress simple,                    4502956
+silesia.tar,                        level 16,                           compress simple,                    4360527
+silesia.tar,                        level 19,                           compress simple,                    4267266
+silesia.tar,                        uncompressed literals,              compress simple,                    4861424
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4267266
+silesia.tar,                        huffman literals,                   compress simple,                    6182241
+github.tar,                         level -5,                           compress simple,                    66914
+github.tar,                         level -3,                           compress simple,                    52127
+github.tar,                         level -1,                           compress simple,                    42560
 github.tar,                         level 0,                            compress simple,                    38441
-github.tar,                         level 1,                            compress simple,                    39265
+github.tar,                         level 1,                            compress simple,                    39200
 github.tar,                         level 3,                            compress simple,                    38441
 github.tar,                         level 4,                            compress simple,                    38467
-github.tar,                         level 5,                            compress simple,                    38394
-github.tar,                         level 6,                            compress simple,                    38669
-github.tar,                         level 7,                            compress simple,                    38153
-github.tar,                         level 9,                            compress simple,                    36768
-github.tar,                         level 13,                           compress simple,                    35621
-github.tar,                         level 16,                           compress simple,                    40255
-github.tar,                         level 19,                           compress simple,                    32837
+github.tar,                         level 5,                            compress simple,                    38366
+github.tar,                         level 6,                            compress simple,                    38648
+github.tar,                         level 7,                            compress simple,                    38110
+github.tar,                         level 9,                            compress simple,                    36760
+github.tar,                         level 13,                           compress simple,                    35501
+github.tar,                         level 16,                           compress simple,                    40471
+github.tar,                         level 19,                           compress simple,                    32134
 github.tar,                         uncompressed literals,              compress simple,                    38441
-github.tar,                         uncompressed literals optimal,      compress simple,                    32837
-github.tar,                         huffman literals,                   compress simple,                    42490
-silesia,                            level -5,                           compress cctx,                      6737607
-silesia,                            level -3,                           compress cctx,                      6444677
-silesia,                            level -1,                           compress cctx,                      6178460
-silesia,                            level 0,                            compress cctx,                      4849551
-silesia,                            level 1,                            compress cctx,                      5313202
-silesia,                            level 3,                            compress cctx,                      4849551
-silesia,                            level 4,                            compress cctx,                      4786969
-silesia,                            level 5,                            compress cctx,                      4639132
-silesia,                            level 6,                            compress cctx,                      4605629
-silesia,                            level 7,                            compress cctx,                      4567307
-silesia,                            level 9,                            compress cctx,                      4543330
-silesia,                            level 13,                           compress cctx,                      4482131
-silesia,                            level 16,                           compress cctx,                      4360251
-silesia,                            level 19,                           compress cctx,                      4283236
-silesia,                            long distance mode,                 compress cctx,                      4849551
-silesia,                            multithreaded,                      compress cctx,                      4849551
-silesia,                            multithreaded long distance mode,   compress cctx,                      4849551
+github.tar,                         uncompressed literals optimal,      compress simple,                    32134
+github.tar,                         huffman literals,                   compress simple,                    42560
+silesia,                            level -5,                           compress cctx,                      7354675
+silesia,                            level -3,                           compress cctx,                      6902374
+silesia,                            level -1,                           compress cctx,                      6177565
+silesia,                            level 0,                            compress cctx,                      4849553
+silesia,                            level 1,                            compress cctx,                      5309098
+silesia,                            level 3,                            compress cctx,                      4849553
+silesia,                            level 4,                            compress cctx,                      4786968
+silesia,                            level 5,                            compress cctx,                      4638691
+silesia,                            level 6,                            compress cctx,                      4605296
+silesia,                            level 7,                            compress cctx,                      4566984
+silesia,                            level 9,                            compress cctx,                      4543018
+silesia,                            level 13,                           compress cctx,                      4493990
+silesia,                            level 16,                           compress cctx,                      4359864
+silesia,                            level 19,                           compress cctx,                      4296880
+silesia,                            long distance mode,                 compress cctx,                      4849553
+silesia,                            multithreaded,                      compress cctx,                      4849553
+silesia,                            multithreaded long distance mode,   compress cctx,                      4849553
 silesia,                            small window log,                   compress cctx,                      7084179
 silesia,                            small hash log,                     compress cctx,                      6526141
-silesia,                            small chain log,                    compress cctx,                      4912199
-silesia,                            explicit params,                    compress cctx,                      4794917
-silesia,                            uncompressed literals,              compress cctx,                      4849551
-silesia,                            uncompressed literals optimal,      compress cctx,                      4283236
-silesia,                            huffman literals,                   compress cctx,                      6178460
-silesia,                            multithreaded with advanced params, compress cctx,                      4849551
-github,                             level -5,                           compress cctx,                      205285
+silesia,                            small chain log,                    compress cctx,                      4912197
+silesia,                            explicit params,                    compress cctx,                      4794052
+silesia,                            uncompressed literals,              compress cctx,                      4849553
+silesia,                            uncompressed literals optimal,      compress cctx,                      4296880
+silesia,                            huffman literals,                   compress cctx,                      6177565
+silesia,                            multithreaded with advanced params, compress cctx,                      4849553
+github,                             level -5,                           compress cctx,                      232315
 github,                             level -5 with dict,                 compress cctx,                      47294
-github,                             level -3,                           compress cctx,                      190643
+github,                             level -3,                           compress cctx,                      220760
 github,                             level -3 with dict,                 compress cctx,                      48047
-github,                             level -1,                           compress cctx,                      175568
+github,                             level -1,                           compress cctx,                      175468
 github,                             level -1 with dict,                 compress cctx,                      43527
 github,                             level 0,                            compress cctx,                      136335
 github,                             level 0 with dict,                  compress cctx,                      41534
-github,                             level 1,                            compress cctx,                      142465
+github,                             level 1,                            compress cctx,                      142365
 github,                             level 1 with dict,                  compress cctx,                      42157
 github,                             level 3,                            compress cctx,                      136335
 github,                             level 3 with dict,                  compress cctx,                      41534
@@ -95,68 +95,68 @@ github,                             small chain log,                    compress
 github,                             explicit params,                    compress cctx,                      140932
 github,                             uncompressed literals,              compress cctx,                      136335
 github,                             uncompressed literals optimal,      compress cctx,                      134064
-github,                             huffman literals,                   compress cctx,                      175568
+github,                             huffman literals,                   compress cctx,                      175468
 github,                             multithreaded with advanced params, compress cctx,                      141102
-silesia,                            level -5,                           zstdcli,                            6737655
-silesia,                            level -3,                           zstdcli,                            6444725
-silesia,                            level -1,                           zstdcli,                            6178508
-silesia,                            level 0,                            zstdcli,                            4849599
-silesia,                            level 1,                            zstdcli,                            5313250
-silesia,                            level 3,                            zstdcli,                            4849599
-silesia,                            level 4,                            zstdcli,                            4787017
-silesia,                            level 5,                            zstdcli,                            4639180
-silesia,                            level 6,                            zstdcli,                            4605677
-silesia,                            level 7,                            zstdcli,                            4567355
-silesia,                            level 9,                            zstdcli,                            4543378
-silesia,                            level 13,                           zstdcli,                            4482179
-silesia,                            level 16,                           zstdcli,                            4360299
-silesia,                            level 19,                           zstdcli,                            4283284
+silesia,                            level -5,                           zstdcli,                            7354723
+silesia,                            level -3,                           zstdcli,                            6902422
+silesia,                            level -1,                           zstdcli,                            6177613
+silesia,                            level 0,                            zstdcli,                            4849601
+silesia,                            level 1,                            zstdcli,                            5309146
+silesia,                            level 3,                            zstdcli,                            4849601
+silesia,                            level 4,                            zstdcli,                            4787016
+silesia,                            level 5,                            zstdcli,                            4638739
+silesia,                            level 6,                            zstdcli,                            4605344
+silesia,                            level 7,                            zstdcli,                            4567032
+silesia,                            level 9,                            zstdcli,                            4543066
+silesia,                            level 13,                           zstdcli,                            4494038
+silesia,                            level 16,                           zstdcli,                            4359912
+silesia,                            level 19,                           zstdcli,                            4296928
 silesia,                            long distance mode,                 zstdcli,                            4840807
-silesia,                            multithreaded,                      zstdcli,                            4849599
+silesia,                            multithreaded,                      zstdcli,                            4849601
 silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
 silesia,                            small window log,                   zstdcli,                            7095967
 silesia,                            small hash log,                     zstdcli,                            6526189
-silesia,                            small chain log,                    zstdcli,                            4912247
-silesia,                            explicit params,                    zstdcli,                            4796282
+silesia,                            small chain log,                    zstdcli,                            4912245
+silesia,                            explicit params,                    zstdcli,                            4795432
 silesia,                            uncompressed literals,              zstdcli,                            5128030
-silesia,                            uncompressed literals optimal,      zstdcli,                            4317944
-silesia,                            huffman literals,                   zstdcli,                            5326317
+silesia,                            uncompressed literals optimal,      zstdcli,                            4319566
+silesia,                            huffman literals,                   zstdcli,                            5326394
 silesia,                            multithreaded with advanced params, zstdcli,                            5128030
-silesia.tar,                        level -5,                           zstdcli,                            6738934
-silesia.tar,                        level -3,                           zstdcli,                            6448419
-silesia.tar,                        level -1,                           zstdcli,                            6186912
-silesia.tar,                        level 0,                            zstdcli,                            4861511
-silesia.tar,                        level 1,                            zstdcli,                            5336318
-silesia.tar,                        level 3,                            zstdcli,                            4861511
-silesia.tar,                        level 4,                            zstdcli,                            4800529
-silesia.tar,                        level 5,                            zstdcli,                            4651342
-silesia.tar,                        level 6,                            zstdcli,                            4618674
-silesia.tar,                        level 7,                            zstdcli,                            4579009
-silesia.tar,                        level 9,                            zstdcli,                            4553551
-silesia.tar,                        level 13,                           zstdcli,                            4491772
-silesia.tar,                        level 16,                           zstdcli,                            4356838
-silesia.tar,                        level 19,                           zstdcli,                            4264392
-silesia.tar,                        no source size,                     zstdcli,                            4861507
+silesia.tar,                        level -5,                           zstdcli,                            7363866
+silesia.tar,                        level -3,                           zstdcli,                            6902158
+silesia.tar,                        level -1,                           zstdcli,                            6182939
+silesia.tar,                        level 0,                            zstdcli,                            4861512
+silesia.tar,                        level 1,                            zstdcli,                            5333183
+silesia.tar,                        level 3,                            zstdcli,                            4861512
+silesia.tar,                        level 4,                            zstdcli,                            4800528
+silesia.tar,                        level 5,                            zstdcli,                            4650946
+silesia.tar,                        level 6,                            zstdcli,                            4618390
+silesia.tar,                        level 7,                            zstdcli,                            4578719
+silesia.tar,                        level 9,                            zstdcli,                            4553299
+silesia.tar,                        level 13,                           zstdcli,                            4502960
+silesia.tar,                        level 16,                           zstdcli,                            4360531
+silesia.tar,                        level 19,                           zstdcli,                            4267270
+silesia.tar,                        no source size,                     zstdcli,                            4861508
 silesia.tar,                        long distance mode,                 zstdcli,                            4853225
-silesia.tar,                        multithreaded,                      zstdcli,                            4861511
+silesia.tar,                        multithreaded,                      zstdcli,                            4861512
 silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4853225
 silesia.tar,                        small window log,                   zstdcli,                            7101576
-silesia.tar,                        small hash log,                     zstdcli,                            6529286
-silesia.tar,                        small chain log,                    zstdcli,                            4917020
-silesia.tar,                        explicit params,                    zstdcli,                            4821593
+silesia.tar,                        small hash log,                     zstdcli,                            6529289
+silesia.tar,                        small chain log,                    zstdcli,                            4917022
+silesia.tar,                        explicit params,                    zstdcli,                            4820713
 silesia.tar,                        uncompressed literals,              zstdcli,                            5129559
-silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4307404
-silesia.tar,                        huffman literals,                   zstdcli,                            5347610
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4310145
+silesia.tar,                        huffman literals,                   zstdcli,                            5344915
 silesia.tar,                        multithreaded with advanced params, zstdcli,                            5129559
-github,                             level -5,                           zstdcli,                            207285
+github,                             level -5,                           zstdcli,                            234315
 github,                             level -5 with dict,                 zstdcli,                            48718
-github,                             level -3,                           zstdcli,                            192643
+github,                             level -3,                           zstdcli,                            222760
 github,                             level -3 with dict,                 zstdcli,                            47395
-github,                             level -1,                           zstdcli,                            177568
+github,                             level -1,                           zstdcli,                            177468
 github,                             level -1 with dict,                 zstdcli,                            45170
 github,                             level 0,                            zstdcli,                            138335
 github,                             level 0 with dict,                  zstdcli,                            43148
-github,                             level 1,                            zstdcli,                            144465
+github,                             level 1,                            zstdcli,                            144365
 github,                             level 1 with dict,                  zstdcli,                            43682
 github,                             level 3,                            zstdcli,                            138335
 github,                             level 3 with dict,                  zstdcli,                            43148
@@ -185,36 +185,36 @@ github,                             small chain log,                    zstdcli,
 github,                             explicit params,                    zstdcli,                            136197
 github,                             uncompressed literals,              zstdcli,                            167915
 github,                             uncompressed literals optimal,      zstdcli,                            159227
-github,                             huffman literals,                   zstdcli,                            144465
+github,                             huffman literals,                   zstdcli,                            144365
 github,                             multithreaded with advanced params, zstdcli,                            167915
-github.tar,                         level -5,                           zstdcli,                            46860
-github.tar,                         level -5 with dict,                 zstdcli,                            44575
-github.tar,                         level -3,                           zstdcli,                            43758
-github.tar,                         level -3 with dict,                 zstdcli,                            41451
-github.tar,                         level -1,                           zstdcli,                            42494
-github.tar,                         level -1 with dict,                 zstdcli,                            41135
+github.tar,                         level -5,                           zstdcli,                            66918
+github.tar,                         level -5 with dict,                 zstdcli,                            51529
+github.tar,                         level -3,                           zstdcli,                            52131
+github.tar,                         level -3 with dict,                 zstdcli,                            44246
+github.tar,                         level -1,                           zstdcli,                            42564
+github.tar,                         level -1 with dict,                 zstdcli,                            41140
 github.tar,                         level 0,                            zstdcli,                            38445
 github.tar,                         level 0 with dict,                  zstdcli,                            37999
-github.tar,                         level 1,                            zstdcli,                            39269
-github.tar,                         level 1 with dict,                  zstdcli,                            38284
+github.tar,                         level 1,                            zstdcli,                            39204
+github.tar,                         level 1 with dict,                  zstdcli,                            38288
 github.tar,                         level 3,                            zstdcli,                            38445
 github.tar,                         level 3 with dict,                  zstdcli,                            37999
 github.tar,                         level 4,                            zstdcli,                            38471
 github.tar,                         level 4 with dict,                  zstdcli,                            37952
-github.tar,                         level 5,                            zstdcli,                            38398
-github.tar,                         level 5 with dict,                  zstdcli,                            39048
-github.tar,                         level 6,                            zstdcli,                            38673
-github.tar,                         level 6 with dict,                  zstdcli,                            38660
-github.tar,                         level 7,                            zstdcli,                            38157
-github.tar,                         level 7 with dict,                  zstdcli,                            37914
-github.tar,                         level 9,                            zstdcli,                            36772
-github.tar,                         level 9 with dict,                  zstdcli,                            36650
-github.tar,                         level 13,                           zstdcli,                            35625
-github.tar,                         level 13 with dict,                 zstdcli,                            38730
-github.tar,                         level 16,                           zstdcli,                            40259
-github.tar,                         level 16 with dict,                 zstdcli,                            33643
-github.tar,                         level 19,                           zstdcli,                            32841
-github.tar,                         level 19 with dict,                 zstdcli,                            32899
+github.tar,                         level 5,                            zstdcli,                            38370
+github.tar,                         level 5 with dict,                  zstdcli,                            39071
+github.tar,                         level 6,                            zstdcli,                            38652
+github.tar,                         level 6 with dict,                  zstdcli,                            38638
+github.tar,                         level 7,                            zstdcli,                            38114
+github.tar,                         level 7 with dict,                  zstdcli,                            37886
+github.tar,                         level 9,                            zstdcli,                            36764
+github.tar,                         level 9 with dict,                  zstdcli,                            36632
+github.tar,                         level 13,                           zstdcli,                            35505
+github.tar,                         level 13 with dict,                 zstdcli,                            37134
+github.tar,                         level 16,                           zstdcli,                            40475
+github.tar,                         level 16 with dict,                 zstdcli,                            33382
+github.tar,                         level 19,                           zstdcli,                            32138
+github.tar,                         level 19 with dict,                 zstdcli,                            32713
 github.tar,                         no source size,                     zstdcli,                            38442
 github.tar,                         no source size with dict,           zstdcli,                            38004
 github.tar,                         long distance mode,                 zstdcli,                            39730
@@ -223,84 +223,84 @@ github.tar,                         multithreaded long distance mode,   zstdcli,
 github.tar,                         small window log,                   zstdcli,                            198544
 github.tar,                         small hash log,                     zstdcli,                            129874
 github.tar,                         small chain log,                    zstdcli,                            41673
-github.tar,                         explicit params,                    zstdcli,                            41350
+github.tar,                         explicit params,                    zstdcli,                            41385
 github.tar,                         uncompressed literals,              zstdcli,                            41126
-github.tar,                         uncompressed literals optimal,      zstdcli,                            35392
-github.tar,                         huffman literals,                   zstdcli,                            38781
+github.tar,                         uncompressed literals optimal,      zstdcli,                            35401
+github.tar,                         huffman literals,                   zstdcli,                            38857
 github.tar,                         multithreaded with advanced params, zstdcli,                            41126
-silesia,                            level -5,                           advanced one pass,                  6737607
-silesia,                            level -3,                           advanced one pass,                  6444677
-silesia,                            level -1,                           advanced one pass,                  6178460
-silesia,                            level 0,                            advanced one pass,                  4849551
-silesia,                            level 1,                            advanced one pass,                  5313202
-silesia,                            level 3,                            advanced one pass,                  4849551
-silesia,                            level 4,                            advanced one pass,                  4786969
-silesia,                            level 5 row 1,                      advanced one pass,                  4640753
-silesia,                            level 5 row 2,                      advanced one pass,                  4639132
-silesia,                            level 5,                            advanced one pass,                  4639132
-silesia,                            level 6,                            advanced one pass,                  4605629
-silesia,                            level 7 row 1,                      advanced one pass,                  4564870
-silesia,                            level 7 row 2,                      advanced one pass,                  4567307
-silesia,                            level 7,                            advanced one pass,                  4567307
-silesia,                            level 9,                            advanced one pass,                  4543330
-silesia,                            level 11 row 1,                     advanced one pass,                  4519288
-silesia,                            level 11 row 2,                     advanced one pass,                  4521524
-silesia,                            level 12 row 1,                     advanced one pass,                  4503117
-silesia,                            level 12 row 2,                     advanced one pass,                  4505093
-silesia,                            level 13,                           advanced one pass,                  4482131
-silesia,                            level 16,                           advanced one pass,                  4360251
-silesia,                            level 19,                           advanced one pass,                  4283236
-silesia,                            no source size,                     advanced one pass,                  4849551
-silesia,                            long distance mode,                 advanced one pass,                  4840738
-silesia,                            multithreaded,                      advanced one pass,                  4849551
+silesia,                            level -5,                           advanced one pass,                  7354675
+silesia,                            level -3,                           advanced one pass,                  6902374
+silesia,                            level -1,                           advanced one pass,                  6177565
+silesia,                            level 0,                            advanced one pass,                  4849553
+silesia,                            level 1,                            advanced one pass,                  5309098
+silesia,                            level 3,                            advanced one pass,                  4849553
+silesia,                            level 4,                            advanced one pass,                  4786968
+silesia,                            level 5 row 1,                      advanced one pass,                  4638691
+silesia,                            level 5 row 2,                      advanced one pass,                  4640752
+silesia,                            level 5,                            advanced one pass,                  4638691
+silesia,                            level 6,                            advanced one pass,                  4605296
+silesia,                            level 7 row 1,                      advanced one pass,                  4566984
+silesia,                            level 7 row 2,                      advanced one pass,                  4564868
+silesia,                            level 7,                            advanced one pass,                  4566984
+silesia,                            level 9,                            advanced one pass,                  4543018
+silesia,                            level 11 row 1,                     advanced one pass,                  4521323
+silesia,                            level 11 row 2,                     advanced one pass,                  4519288
+silesia,                            level 12 row 1,                     advanced one pass,                  4505046
+silesia,                            level 12 row 2,                     advanced one pass,                  4503116
+silesia,                            level 13,                           advanced one pass,                  4493990
+silesia,                            level 16,                           advanced one pass,                  4359864
+silesia,                            level 19,                           advanced one pass,                  4296880
+silesia,                            no source size,                     advanced one pass,                  4849553
+silesia,                            long distance mode,                 advanced one pass,                  4840737
+silesia,                            multithreaded,                      advanced one pass,                  4849553
 silesia,                            multithreaded long distance mode,   advanced one pass,                  4840759
 silesia,                            small window log,                   advanced one pass,                  7095919
 silesia,                            small hash log,                     advanced one pass,                  6526141
-silesia,                            small chain log,                    advanced one pass,                  4912199
-silesia,                            explicit params,                    advanced one pass,                  4796282
+silesia,                            small chain log,                    advanced one pass,                  4912197
+silesia,                            explicit params,                    advanced one pass,                  4795432
 silesia,                            uncompressed literals,              advanced one pass,                  5127982
-silesia,                            uncompressed literals optimal,      advanced one pass,                  4317896
-silesia,                            huffman literals,                   advanced one pass,                  5326269
+silesia,                            uncompressed literals optimal,      advanced one pass,                  4319518
+silesia,                            huffman literals,                   advanced one pass,                  5326346
 silesia,                            multithreaded with advanced params, advanced one pass,                  5127982
-silesia.tar,                        level -5,                           advanced one pass,                  6738593
-silesia.tar,                        level -3,                           advanced one pass,                  6446372
-silesia.tar,                        level -1,                           advanced one pass,                  6186042
-silesia.tar,                        level 0,                            advanced one pass,                  4861423
-silesia.tar,                        level 1,                            advanced one pass,                  5334885
-silesia.tar,                        level 3,                            advanced one pass,                  4861423
+silesia.tar,                        level -5,                           advanced one pass,                  7359401
+silesia.tar,                        level -3,                           advanced one pass,                  6901672
+silesia.tar,                        level -1,                           advanced one pass,                  6182241
+silesia.tar,                        level 0,                            advanced one pass,                  4861424
+silesia.tar,                        level 1,                            advanced one pass,                  5331946
+silesia.tar,                        level 3,                            advanced one pass,                  4861424
 silesia.tar,                        level 4,                            advanced one pass,                  4799632
-silesia.tar,                        level 5 row 1,                      advanced one pass,                  4652862
-silesia.tar,                        level 5 row 2,                      advanced one pass,                  4650387
-silesia.tar,                        level 5,                            advanced one pass,                  4650387
-silesia.tar,                        level 6,                            advanced one pass,                  4617089
-silesia.tar,                        level 7 row 1,                      advanced one pass,                  4575392
-silesia.tar,                        level 7 row 2,                      advanced one pass,                  4576951
-silesia.tar,                        level 7,                            advanced one pass,                  4576951
-silesia.tar,                        level 9,                            advanced one pass,                  4552638
-silesia.tar,                        level 11 row 1,                     advanced one pass,                  4529458
-silesia.tar,                        level 11 row 2,                     advanced one pass,                  4530416
-silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513603
-silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514499
-silesia.tar,                        level 13,                           advanced one pass,                  4491768
-silesia.tar,                        level 16,                           advanced one pass,                  4356834
-silesia.tar,                        level 19,                           advanced one pass,                  4264388
-silesia.tar,                        no source size,                     advanced one pass,                  4861423
-silesia.tar,                        long distance mode,                 advanced one pass,                  4847753
-silesia.tar,                        multithreaded,                      advanced one pass,                  4861507
+silesia.tar,                        level 5 row 1,                      advanced one pass,                  4649987
+silesia.tar,                        level 5 row 2,                      advanced one pass,                  4652862
+silesia.tar,                        level 5,                            advanced one pass,                  4649987
+silesia.tar,                        level 6,                            advanced one pass,                  4616797
+silesia.tar,                        level 7 row 1,                      advanced one pass,                  4576661
+silesia.tar,                        level 7 row 2,                      advanced one pass,                  4575393
+silesia.tar,                        level 7,                            advanced one pass,                  4576661
+silesia.tar,                        level 9,                            advanced one pass,                  4552381
+silesia.tar,                        level 11 row 1,                     advanced one pass,                  4530241
+silesia.tar,                        level 11 row 2,                     advanced one pass,                  4529461
+silesia.tar,                        level 12 row 1,                     advanced one pass,                  4514432
+silesia.tar,                        level 12 row 2,                     advanced one pass,                  4513604
+silesia.tar,                        level 13,                           advanced one pass,                  4502956
+silesia.tar,                        level 16,                           advanced one pass,                  4360527
+silesia.tar,                        level 19,                           advanced one pass,                  4267266
+silesia.tar,                        no source size,                     advanced one pass,                  4861424
+silesia.tar,                        long distance mode,                 advanced one pass,                  4847752
+silesia.tar,                        multithreaded,                      advanced one pass,                  4861508
 silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4853221
 silesia.tar,                        small window log,                   advanced one pass,                  7101530
-silesia.tar,                        small hash log,                     advanced one pass,                  6529228
-silesia.tar,                        small chain log,                    advanced one pass,                  4917039
-silesia.tar,                        explicit params,                    advanced one pass,                  4807675
+silesia.tar,                        small hash log,                     advanced one pass,                  6529231
+silesia.tar,                        small chain log,                    advanced one pass,                  4917041
+silesia.tar,                        explicit params,                    advanced one pass,                  4806855
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4307400
-silesia.tar,                        huffman literals,                   advanced one pass,                  5347335
+silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4310141
+silesia.tar,                        huffman literals,                   advanced one pass,                  5344545
 silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5129555
-github,                             level -5,                           advanced one pass,                  205285
+github,                             level -5,                           advanced one pass,                  232315
 github,                             level -5 with dict,                 advanced one pass,                  46718
-github,                             level -3,                           advanced one pass,                  190643
+github,                             level -3,                           advanced one pass,                  220760
 github,                             level -3 with dict,                 advanced one pass,                  45395
-github,                             level -1,                           advanced one pass,                  175568
+github,                             level -1,                           advanced one pass,                  175468
 github,                             level -1 with dict,                 advanced one pass,                  43170
 github,                             level 0,                            advanced one pass,                  136335
 github,                             level 0 with dict,                  advanced one pass,                  41148
@@ -308,7 +308,7 @@ github,                             level 0 with dict dms,              advanced
 github,                             level 0 with dict dds,              advanced one pass,                  41148
 github,                             level 0 with dict copy,             advanced one pass,                  41124
 github,                             level 0 with dict load,             advanced one pass,                  42252
-github,                             level 1,                            advanced one pass,                  142465
+github,                             level 1,                            advanced one pass,                  142365
 github,                             level 1 with dict,                  advanced one pass,                  41682
 github,                             level 1 with dict dms,              advanced one pass,                  41682
 github,                             level 1 with dict dds,              advanced one pass,                  41682
@@ -326,16 +326,16 @@ github,                             level 4 with dict dms,              advanced
 github,                             level 4 with dict dds,              advanced one pass,                  41251
 github,                             level 4 with dict copy,             advanced one pass,                  41216
 github,                             level 4 with dict load,             advanced one pass,                  41159
-github,                             level 5 row 1,                      advanced one pass,                  135121
-github,                             level 5 row 1 with dict dms,        advanced one pass,                  38938
-github,                             level 5 row 1 with dict dds,        advanced one pass,                  38732
-github,                             level 5 row 1 with dict copy,       advanced one pass,                  38934
-github,                             level 5 row 1 with dict load,       advanced one pass,                  40725
-github,                             level 5 row 2,                      advanced one pass,                  134584
-github,                             level 5 row 2 with dict dms,        advanced one pass,                  38758
-github,                             level 5 row 2 with dict dds,        advanced one pass,                  38728
-github,                             level 5 row 2 with dict copy,       advanced one pass,                  38759
-github,                             level 5 row 2 with dict load,       advanced one pass,                  41518
+github,                             level 5 row 1,                      advanced one pass,                  134584
+github,                             level 5 row 1 with dict dms,        advanced one pass,                  38758
+github,                             level 5 row 1 with dict dds,        advanced one pass,                  38728
+github,                             level 5 row 1 with dict copy,       advanced one pass,                  38759
+github,                             level 5 row 1 with dict load,       advanced one pass,                  41518
+github,                             level 5 row 2,                      advanced one pass,                  135121
+github,                             level 5 row 2 with dict dms,        advanced one pass,                  38938
+github,                             level 5 row 2 with dict dds,        advanced one pass,                  38732
+github,                             level 5 row 2 with dict copy,       advanced one pass,                  38934
+github,                             level 5 row 2 with dict load,       advanced one pass,                  40725
 github,                             level 5,                            advanced one pass,                  135121
 github,                             level 5 with dict,                  advanced one pass,                  38758
 github,                             level 5 with dict dms,              advanced one pass,                  38758
@@ -348,16 +348,16 @@ github,                             level 6 with dict dms,              advanced
 github,                             level 6 with dict dds,              advanced one pass,                  38636
 github,                             level 6 with dict copy,             advanced one pass,                  38669
 github,                             level 6 with dict load,             advanced one pass,                  40695
-github,                             level 7 row 1,                      advanced one pass,                  135122
-github,                             level 7 row 1 with dict dms,        advanced one pass,                  38860
-github,                             level 7 row 1 with dict dds,        advanced one pass,                  38766
-github,                             level 7 row 1 with dict copy,       advanced one pass,                  38834
-github,                             level 7 row 1 with dict load,       advanced one pass,                  40695
-github,                             level 7 row 2,                      advanced one pass,                  134584
-github,                             level 7 row 2 with dict dms,        advanced one pass,                  38758
-github,                             level 7 row 2 with dict dds,        advanced one pass,                  38745
-github,                             level 7 row 2 with dict copy,       advanced one pass,                  38755
-github,                             level 7 row 2 with dict load,       advanced one pass,                  43154
+github,                             level 7 row 1,                      advanced one pass,                  134584
+github,                             level 7 row 1 with dict dms,        advanced one pass,                  38758
+github,                             level 7 row 1 with dict dds,        advanced one pass,                  38745
+github,                             level 7 row 1 with dict copy,       advanced one pass,                  38755
+github,                             level 7 row 1 with dict load,       advanced one pass,                  43154
+github,                             level 7 row 2,                      advanced one pass,                  135122
+github,                             level 7 row 2 with dict dms,        advanced one pass,                  38860
+github,                             level 7 row 2 with dict dds,        advanced one pass,                  38766
+github,                             level 7 row 2 with dict copy,       advanced one pass,                  38834
+github,                             level 7 row 2 with dict load,       advanced one pass,                  40695
 github,                             level 7,                            advanced one pass,                  135122
 github,                             level 7 with dict,                  advanced one pass,                  38758
 github,                             level 7 with dict dms,              advanced one pass,                  38758
@@ -419,26 +419,26 @@ github,                             small chain log,                    advanced
 github,                             explicit params,                    advanced one pass,                  137727
 github,                             uncompressed literals,              advanced one pass,                  165915
 github,                             uncompressed literals optimal,      advanced one pass,                  157227
-github,                             huffman literals,                   advanced one pass,                  142465
+github,                             huffman literals,                   advanced one pass,                  142365
 github,                             multithreaded with advanced params, advanced one pass,                  165915
-github.tar,                         level -5,                           advanced one pass,                  46856
-github.tar,                         level -5 with dict,                 advanced one pass,                  44571
-github.tar,                         level -3,                           advanced one pass,                  43754
-github.tar,                         level -3 with dict,                 advanced one pass,                  41447
-github.tar,                         level -1,                           advanced one pass,                  42490
-github.tar,                         level -1 with dict,                 advanced one pass,                  41131
+github.tar,                         level -5,                           advanced one pass,                  66914
+github.tar,                         level -5 with dict,                 advanced one pass,                  51525
+github.tar,                         level -3,                           advanced one pass,                  52127
+github.tar,                         level -3 with dict,                 advanced one pass,                  44242
+github.tar,                         level -1,                           advanced one pass,                  42560
+github.tar,                         level -1 with dict,                 advanced one pass,                  41136
 github.tar,                         level 0,                            advanced one pass,                  38441
 github.tar,                         level 0 with dict,                  advanced one pass,                  37995
 github.tar,                         level 0 with dict dms,              advanced one pass,                  38003
 github.tar,                         level 0 with dict dds,              advanced one pass,                  38003
 github.tar,                         level 0 with dict copy,             advanced one pass,                  37995
 github.tar,                         level 0 with dict load,             advanced one pass,                  37956
-github.tar,                         level 1,                            advanced one pass,                  39265
-github.tar,                         level 1 with dict,                  advanced one pass,                  38280
-github.tar,                         level 1 with dict dms,              advanced one pass,                  38290
-github.tar,                         level 1 with dict dds,              advanced one pass,                  38290
-github.tar,                         level 1 with dict copy,             advanced one pass,                  38280
-github.tar,                         level 1 with dict load,             advanced one pass,                  38729
+github.tar,                         level 1,                            advanced one pass,                  39200
+github.tar,                         level 1 with dict,                  advanced one pass,                  38284
+github.tar,                         level 1 with dict dms,              advanced one pass,                  38294
+github.tar,                         level 1 with dict dds,              advanced one pass,                  38294
+github.tar,                         level 1 with dict copy,             advanced one pass,                  38284
+github.tar,                         level 1 with dict load,             advanced one pass,                  38724
 github.tar,                         level 3,                            advanced one pass,                  38441
 github.tar,                         level 3 with dict,                  advanced one pass,                  37995
 github.tar,                         level 3 with dict dms,              advanced one pass,                  38003
@@ -451,88 +451,88 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass,                  37954
 github.tar,                         level 4 with dict copy,             advanced one pass,                  37948
 github.tar,                         level 4 with dict load,             advanced one pass,                  37927
-github.tar,                         level 5 row 1,                      advanced one pass,                  38534
-github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39365
-github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39233
-github.tar,                         level 5 row 1 with dict copy,       advanced one pass,                  39715
-github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  38019
-github.tar,                         level 5 row 2,                      advanced one pass,                  38394
-github.tar,                         level 5 row 2 with dict dms,        advanced one pass,                  39048
-github.tar,                         level 5 row 2 with dict dds,        advanced one pass,                  39044
-github.tar,                         level 5 row 2 with dict copy,       advanced one pass,                  39074
-github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  37665
-github.tar,                         level 5,                            advanced one pass,                  38394
-github.tar,                         level 5 with dict,                  advanced one pass,                  39074
-github.tar,                         level 5 with dict dms,              advanced one pass,                  39048
-github.tar,                         level 5 with dict dds,              advanced one pass,                  39044
-github.tar,                         level 5 with dict copy,             advanced one pass,                  39074
-github.tar,                         level 5 with dict load,             advanced one pass,                  37665
-github.tar,                         level 6,                            advanced one pass,                  38669
-github.tar,                         level 6 with dict,                  advanced one pass,                  38660
-github.tar,                         level 6 with dict dms,              advanced one pass,                  38654
-github.tar,                         level 6 with dict dds,              advanced one pass,                  38656
-github.tar,                         level 6 with dict copy,             advanced one pass,                  38660
-github.tar,                         level 6 with dict load,             advanced one pass,                  37889
-github.tar,                         level 7 row 1,                      advanced one pass,                  38077
-github.tar,                         level 7 row 1 with dict dms,        advanced one pass,                  38012
-github.tar,                         level 7 row 1 with dict dds,        advanced one pass,                  38014
-github.tar,                         level 7 row 1 with dict copy,       advanced one pass,                  38101
-github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  37402
-github.tar,                         level 7 row 2,                      advanced one pass,                  38153
-github.tar,                         level 7 row 2 with dict dms,        advanced one pass,                  37888
-github.tar,                         level 7 row 2 with dict dds,        advanced one pass,                  37910
-github.tar,                         level 7 row 2 with dict copy,       advanced one pass,                  37892
-github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  37457
-github.tar,                         level 7,                            advanced one pass,                  38153
-github.tar,                         level 7 with dict,                  advanced one pass,                  37892
-github.tar,                         level 7 with dict dms,              advanced one pass,                  37888
-github.tar,                         level 7 with dict dds,              advanced one pass,                  37910
-github.tar,                         level 7 with dict copy,             advanced one pass,                  37892
-github.tar,                         level 7 with dict load,             advanced one pass,                  37457
-github.tar,                         level 9,                            advanced one pass,                  36768
-github.tar,                         level 9 with dict,                  advanced one pass,                  36510
-github.tar,                         level 9 with dict dms,              advanced one pass,                  36584
-github.tar,                         level 9 with dict dds,              advanced one pass,                  36646
-github.tar,                         level 9 with dict copy,             advanced one pass,                  36510
-github.tar,                         level 9 with dict load,             advanced one pass,                  36383
-github.tar,                         level 11 row 1,                     advanced one pass,                  36435
+github.tar,                         level 5 row 1,                      advanced one pass,                  38366
+github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39059
+github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39067
+github.tar,                         level 5 row 1 with dict copy,       advanced one pass,                  39082
+github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  37656
+github.tar,                         level 5 row 2,                      advanced one pass,                  38534
+github.tar,                         level 5 row 2 with dict dms,        advanced one pass,                  39365
+github.tar,                         level 5 row 2 with dict dds,        advanced one pass,                  39233
+github.tar,                         level 5 row 2 with dict copy,       advanced one pass,                  39715
+github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  38019
+github.tar,                         level 5,                            advanced one pass,                  38366
+github.tar,                         level 5 with dict,                  advanced one pass,                  39082
+github.tar,                         level 5 with dict dms,              advanced one pass,                  39059
+github.tar,                         level 5 with dict dds,              advanced one pass,                  39067
+github.tar,                         level 5 with dict copy,             advanced one pass,                  39082
+github.tar,                         level 5 with dict load,             advanced one pass,                  37656
+github.tar,                         level 6,                            advanced one pass,                  38648
+github.tar,                         level 6 with dict,                  advanced one pass,                  38656
+github.tar,                         level 6 with dict dms,              advanced one pass,                  38636
+github.tar,                         level 6 with dict dds,              advanced one pass,                  38634
+github.tar,                         level 6 with dict copy,             advanced one pass,                  38656
+github.tar,                         level 6 with dict load,             advanced one pass,                  37865
+github.tar,                         level 7 row 1,                      advanced one pass,                  38110
+github.tar,                         level 7 row 1 with dict dms,        advanced one pass,                  37858
+github.tar,                         level 7 row 1 with dict dds,        advanced one pass,                  37882
+github.tar,                         level 7 row 1 with dict copy,       advanced one pass,                  37865
+github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  37436
+github.tar,                         level 7 row 2,                      advanced one pass,                  38077
+github.tar,                         level 7 row 2 with dict dms,        advanced one pass,                  38012
+github.tar,                         level 7 row 2 with dict dds,        advanced one pass,                  38014
+github.tar,                         level 7 row 2 with dict copy,       advanced one pass,                  38101
+github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  37402
+github.tar,                         level 7,                            advanced one pass,                  38110
+github.tar,                         level 7 with dict,                  advanced one pass,                  37865
+github.tar,                         level 7 with dict dms,              advanced one pass,                  37858
+github.tar,                         level 7 with dict dds,              advanced one pass,                  37882
+github.tar,                         level 7 with dict copy,             advanced one pass,                  37865
+github.tar,                         level 7 with dict load,             advanced one pass,                  37436
+github.tar,                         level 9,                            advanced one pass,                  36760
+github.tar,                         level 9 with dict,                  advanced one pass,                  36484
+github.tar,                         level 9 with dict dms,              advanced one pass,                  36567
+github.tar,                         level 9 with dict dds,              advanced one pass,                  36628
+github.tar,                         level 9 with dict copy,             advanced one pass,                  36484
+github.tar,                         level 9 with dict load,             advanced one pass,                  36401
+github.tar,                         level 11 row 1,                     advanced one pass,                  36452
 github.tar,                         level 11 row 1 with dict dms,       advanced one pass,                  36963
 github.tar,                         level 11 row 1 with dict dds,       advanced one pass,                  36963
 github.tar,                         level 11 row 1 with dict copy,      advanced one pass,                  36557
-github.tar,                         level 11 row 1 with dict load,      advanced one pass,                  36419
-github.tar,                         level 11 row 2,                     advanced one pass,                  36412
+github.tar,                         level 11 row 1 with dict load,      advanced one pass,                  36455
+github.tar,                         level 11 row 2,                     advanced one pass,                  36435
 github.tar,                         level 11 row 2 with dict dms,       advanced one pass,                  36963
 github.tar,                         level 11 row 2 with dict dds,       advanced one pass,                  36963
 github.tar,                         level 11 row 2 with dict copy,      advanced one pass,                  36557
-github.tar,                         level 11 row 2 with dict load,      advanced one pass,                  36439
-github.tar,                         level 12 row 1,                     advanced one pass,                  36110
+github.tar,                         level 11 row 2 with dict load,      advanced one pass,                  36419
+github.tar,                         level 12 row 1,                     advanced one pass,                  36081
 github.tar,                         level 12 row 1 with dict dms,       advanced one pass,                  36986
 github.tar,                         level 12 row 1 with dict dds,       advanced one pass,                  36986
 github.tar,                         level 12 row 1 with dict copy,      advanced one pass,                  36609
-github.tar,                         level 12 row 1 with dict load,      advanced one pass,                  36459
-github.tar,                         level 12 row 2,                     advanced one pass,                  36062
+github.tar,                         level 12 row 1 with dict load,      advanced one pass,                  36434
+github.tar,                         level 12 row 2,                     advanced one pass,                  36110
 github.tar,                         level 12 row 2 with dict dms,       advanced one pass,                  36986
 github.tar,                         level 12 row 2 with dict dds,       advanced one pass,                  36986
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass,                  36609
-github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36392
-github.tar,                         level 13,                           advanced one pass,                  35621
-github.tar,                         level 13 with dict,                 advanced one pass,                  38726
-github.tar,                         level 13 with dict dms,             advanced one pass,                  38903
-github.tar,                         level 13 with dict dds,             advanced one pass,                  38903
-github.tar,                         level 13 with dict copy,            advanced one pass,                  38726
-github.tar,                         level 13 with dict load,            advanced one pass,                  36372
-github.tar,                         level 16,                           advanced one pass,                  40255
-github.tar,                         level 16 with dict,                 advanced one pass,                  33639
-github.tar,                         level 16 with dict dms,             advanced one pass,                  33544
-github.tar,                         level 16 with dict dds,             advanced one pass,                  33544
-github.tar,                         level 16 with dict copy,            advanced one pass,                  33639
-github.tar,                         level 16 with dict load,            advanced one pass,                  39353
-github.tar,                         level 19,                           advanced one pass,                  32837
-github.tar,                         level 19 with dict,                 advanced one pass,                  32895
-github.tar,                         level 19 with dict dms,             advanced one pass,                  32672
-github.tar,                         level 19 with dict dds,             advanced one pass,                  32672
-github.tar,                         level 19 with dict copy,            advanced one pass,                  32895
-github.tar,                         level 19 with dict load,            advanced one pass,                  32676
+github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36459
+github.tar,                         level 13,                           advanced one pass,                  35501
+github.tar,                         level 13 with dict,                 advanced one pass,                  37130
+github.tar,                         level 13 with dict dms,             advanced one pass,                  37267
+github.tar,                         level 13 with dict dds,             advanced one pass,                  37267
+github.tar,                         level 13 with dict copy,            advanced one pass,                  37130
+github.tar,                         level 13 with dict load,            advanced one pass,                  36010
+github.tar,                         level 16,                           advanced one pass,                  40471
+github.tar,                         level 16 with dict,                 advanced one pass,                  33378
+github.tar,                         level 16 with dict dms,             advanced one pass,                  33213
+github.tar,                         level 16 with dict dds,             advanced one pass,                  33213
+github.tar,                         level 16 with dict copy,            advanced one pass,                  33378
+github.tar,                         level 16 with dict load,            advanced one pass,                  39081
+github.tar,                         level 19,                           advanced one pass,                  32134
+github.tar,                         level 19 with dict,                 advanced one pass,                  32709
+github.tar,                         level 19 with dict dms,             advanced one pass,                  32553
+github.tar,                         level 19 with dict dds,             advanced one pass,                  32553
+github.tar,                         level 19 with dict copy,            advanced one pass,                  32709
+github.tar,                         level 19 with dict load,            advanced one pass,                  32474
 github.tar,                         no source size,                     advanced one pass,                  38441
 github.tar,                         no source size with dict,           advanced one pass,                  37995
 github.tar,                         long distance mode,                 advanced one pass,                  39757
@@ -541,84 +541,84 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced one pass,                  198540
 github.tar,                         small hash log,                     advanced one pass,                  129870
 github.tar,                         small chain log,                    advanced one pass,                  41669
-github.tar,                         explicit params,                    advanced one pass,                  41350
+github.tar,                         explicit params,                    advanced one pass,                  41385
 github.tar,                         uncompressed literals,              advanced one pass,                  41122
-github.tar,                         uncompressed literals optimal,      advanced one pass,                  35388
-github.tar,                         huffman literals,                   advanced one pass,                  38777
+github.tar,                         uncompressed literals optimal,      advanced one pass,                  35397
+github.tar,                         huffman literals,                   advanced one pass,                  38853
 github.tar,                         multithreaded with advanced params, advanced one pass,                  41122
-silesia,                            level -5,                           advanced one pass small out,        6737607
-silesia,                            level -3,                           advanced one pass small out,        6444677
-silesia,                            level -1,                           advanced one pass small out,        6178460
-silesia,                            level 0,                            advanced one pass small out,        4849551
-silesia,                            level 1,                            advanced one pass small out,        5313202
-silesia,                            level 3,                            advanced one pass small out,        4849551
-silesia,                            level 4,                            advanced one pass small out,        4786969
-silesia,                            level 5 row 1,                      advanced one pass small out,        4640753
-silesia,                            level 5 row 2,                      advanced one pass small out,        4639132
-silesia,                            level 5,                            advanced one pass small out,        4639132
-silesia,                            level 6,                            advanced one pass small out,        4605629
-silesia,                            level 7 row 1,                      advanced one pass small out,        4564870
-silesia,                            level 7 row 2,                      advanced one pass small out,        4567307
-silesia,                            level 7,                            advanced one pass small out,        4567307
-silesia,                            level 9,                            advanced one pass small out,        4543330
-silesia,                            level 11 row 1,                     advanced one pass small out,        4519288
-silesia,                            level 11 row 2,                     advanced one pass small out,        4521524
-silesia,                            level 12 row 1,                     advanced one pass small out,        4503117
-silesia,                            level 12 row 2,                     advanced one pass small out,        4505093
-silesia,                            level 13,                           advanced one pass small out,        4482131
-silesia,                            level 16,                           advanced one pass small out,        4360251
-silesia,                            level 19,                           advanced one pass small out,        4283236
-silesia,                            no source size,                     advanced one pass small out,        4849551
-silesia,                            long distance mode,                 advanced one pass small out,        4840738
-silesia,                            multithreaded,                      advanced one pass small out,        4849551
+silesia,                            level -5,                           advanced one pass small out,        7354675
+silesia,                            level -3,                           advanced one pass small out,        6902374
+silesia,                            level -1,                           advanced one pass small out,        6177565
+silesia,                            level 0,                            advanced one pass small out,        4849553
+silesia,                            level 1,                            advanced one pass small out,        5309098
+silesia,                            level 3,                            advanced one pass small out,        4849553
+silesia,                            level 4,                            advanced one pass small out,        4786968
+silesia,                            level 5 row 1,                      advanced one pass small out,        4638691
+silesia,                            level 5 row 2,                      advanced one pass small out,        4640752
+silesia,                            level 5,                            advanced one pass small out,        4638691
+silesia,                            level 6,                            advanced one pass small out,        4605296
+silesia,                            level 7 row 1,                      advanced one pass small out,        4566984
+silesia,                            level 7 row 2,                      advanced one pass small out,        4564868
+silesia,                            level 7,                            advanced one pass small out,        4566984
+silesia,                            level 9,                            advanced one pass small out,        4543018
+silesia,                            level 11 row 1,                     advanced one pass small out,        4521323
+silesia,                            level 11 row 2,                     advanced one pass small out,        4519288
+silesia,                            level 12 row 1,                     advanced one pass small out,        4505046
+silesia,                            level 12 row 2,                     advanced one pass small out,        4503116
+silesia,                            level 13,                           advanced one pass small out,        4493990
+silesia,                            level 16,                           advanced one pass small out,        4359864
+silesia,                            level 19,                           advanced one pass small out,        4296880
+silesia,                            no source size,                     advanced one pass small out,        4849553
+silesia,                            long distance mode,                 advanced one pass small out,        4840737
+silesia,                            multithreaded,                      advanced one pass small out,        4849553
 silesia,                            multithreaded long distance mode,   advanced one pass small out,        4840759
 silesia,                            small window log,                   advanced one pass small out,        7095919
 silesia,                            small hash log,                     advanced one pass small out,        6526141
-silesia,                            small chain log,                    advanced one pass small out,        4912199
-silesia,                            explicit params,                    advanced one pass small out,        4796282
+silesia,                            small chain log,                    advanced one pass small out,        4912197
+silesia,                            explicit params,                    advanced one pass small out,        4795432
 silesia,                            uncompressed literals,              advanced one pass small out,        5127982
-silesia,                            uncompressed literals optimal,      advanced one pass small out,        4317896
-silesia,                            huffman literals,                   advanced one pass small out,        5326269
+silesia,                            uncompressed literals optimal,      advanced one pass small out,        4319518
+silesia,                            huffman literals,                   advanced one pass small out,        5326346
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5127982
-silesia.tar,                        level -5,                           advanced one pass small out,        6738593
-silesia.tar,                        level -3,                           advanced one pass small out,        6446372
-silesia.tar,                        level -1,                           advanced one pass small out,        6186042
-silesia.tar,                        level 0,                            advanced one pass small out,        4861423
-silesia.tar,                        level 1,                            advanced one pass small out,        5334885
-silesia.tar,                        level 3,                            advanced one pass small out,        4861423
+silesia.tar,                        level -5,                           advanced one pass small out,        7359401
+silesia.tar,                        level -3,                           advanced one pass small out,        6901672
+silesia.tar,                        level -1,                           advanced one pass small out,        6182241
+silesia.tar,                        level 0,                            advanced one pass small out,        4861424
+silesia.tar,                        level 1,                            advanced one pass small out,        5331946
+silesia.tar,                        level 3,                            advanced one pass small out,        4861424
 silesia.tar,                        level 4,                            advanced one pass small out,        4799632
-silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4652862
-silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4650387
-silesia.tar,                        level 5,                            advanced one pass small out,        4650387
-silesia.tar,                        level 6,                            advanced one pass small out,        4617089
-silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4575392
-silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4576951
-silesia.tar,                        level 7,                            advanced one pass small out,        4576951
-silesia.tar,                        level 9,                            advanced one pass small out,        4552638
-silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4529458
-silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4530416
-silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513603
-silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514499
-silesia.tar,                        level 13,                           advanced one pass small out,        4491768
-silesia.tar,                        level 16,                           advanced one pass small out,        4356834
-silesia.tar,                        level 19,                           advanced one pass small out,        4264388
-silesia.tar,                        no source size,                     advanced one pass small out,        4861423
-silesia.tar,                        long distance mode,                 advanced one pass small out,        4847753
-silesia.tar,                        multithreaded,                      advanced one pass small out,        4861507
+silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4649987
+silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4652862
+silesia.tar,                        level 5,                            advanced one pass small out,        4649987
+silesia.tar,                        level 6,                            advanced one pass small out,        4616797
+silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4576661
+silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4575393
+silesia.tar,                        level 7,                            advanced one pass small out,        4576661
+silesia.tar,                        level 9,                            advanced one pass small out,        4552381
+silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4530241
+silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4529461
+silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4514432
+silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4513604
+silesia.tar,                        level 13,                           advanced one pass small out,        4502956
+silesia.tar,                        level 16,                           advanced one pass small out,        4360527
+silesia.tar,                        level 19,                           advanced one pass small out,        4267266
+silesia.tar,                        no source size,                     advanced one pass small out,        4861424
+silesia.tar,                        long distance mode,                 advanced one pass small out,        4847752
+silesia.tar,                        multithreaded,                      advanced one pass small out,        4861508
 silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4853221
 silesia.tar,                        small window log,                   advanced one pass small out,        7101530
-silesia.tar,                        small hash log,                     advanced one pass small out,        6529228
-silesia.tar,                        small chain log,                    advanced one pass small out,        4917039
-silesia.tar,                        explicit params,                    advanced one pass small out,        4807675
+silesia.tar,                        small hash log,                     advanced one pass small out,        6529231
+silesia.tar,                        small chain log,                    advanced one pass small out,        4917041
+silesia.tar,                        explicit params,                    advanced one pass small out,        4806855
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4307400
-silesia.tar,                        huffman literals,                   advanced one pass small out,        5347335
+silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4310141
+silesia.tar,                        huffman literals,                   advanced one pass small out,        5344545
 silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5129555
-github,                             level -5,                           advanced one pass small out,        205285
+github,                             level -5,                           advanced one pass small out,        232315
 github,                             level -5 with dict,                 advanced one pass small out,        46718
-github,                             level -3,                           advanced one pass small out,        190643
+github,                             level -3,                           advanced one pass small out,        220760
 github,                             level -3 with dict,                 advanced one pass small out,        45395
-github,                             level -1,                           advanced one pass small out,        175568
+github,                             level -1,                           advanced one pass small out,        175468
 github,                             level -1 with dict,                 advanced one pass small out,        43170
 github,                             level 0,                            advanced one pass small out,        136335
 github,                             level 0 with dict,                  advanced one pass small out,        41148
@@ -626,7 +626,7 @@ github,                             level 0 with dict dms,              advanced
 github,                             level 0 with dict dds,              advanced one pass small out,        41148
 github,                             level 0 with dict copy,             advanced one pass small out,        41124
 github,                             level 0 with dict load,             advanced one pass small out,        42252
-github,                             level 1,                            advanced one pass small out,        142465
+github,                             level 1,                            advanced one pass small out,        142365
 github,                             level 1 with dict,                  advanced one pass small out,        41682
 github,                             level 1 with dict dms,              advanced one pass small out,        41682
 github,                             level 1 with dict dds,              advanced one pass small out,        41682
@@ -644,16 +644,16 @@ github,                             level 4 with dict dms,              advanced
 github,                             level 4 with dict dds,              advanced one pass small out,        41251
 github,                             level 4 with dict copy,             advanced one pass small out,        41216
 github,                             level 4 with dict load,             advanced one pass small out,        41159
-github,                             level 5 row 1,                      advanced one pass small out,        135121
-github,                             level 5 row 1 with dict dms,        advanced one pass small out,        38938
-github,                             level 5 row 1 with dict dds,        advanced one pass small out,        38732
-github,                             level 5 row 1 with dict copy,       advanced one pass small out,        38934
-github,                             level 5 row 1 with dict load,       advanced one pass small out,        40725
-github,                             level 5 row 2,                      advanced one pass small out,        134584
-github,                             level 5 row 2 with dict dms,        advanced one pass small out,        38758
-github,                             level 5 row 2 with dict dds,        advanced one pass small out,        38728
-github,                             level 5 row 2 with dict copy,       advanced one pass small out,        38759
-github,                             level 5 row 2 with dict load,       advanced one pass small out,        41518
+github,                             level 5 row 1,                      advanced one pass small out,        134584
+github,                             level 5 row 1 with dict dms,        advanced one pass small out,        38758
+github,                             level 5 row 1 with dict dds,        advanced one pass small out,        38728
+github,                             level 5 row 1 with dict copy,       advanced one pass small out,        38759
+github,                             level 5 row 1 with dict load,       advanced one pass small out,        41518
+github,                             level 5 row 2,                      advanced one pass small out,        135121
+github,                             level 5 row 2 with dict dms,        advanced one pass small out,        38938
+github,                             level 5 row 2 with dict dds,        advanced one pass small out,        38732
+github,                             level 5 row 2 with dict copy,       advanced one pass small out,        38934
+github,                             level 5 row 2 with dict load,       advanced one pass small out,        40725
 github,                             level 5,                            advanced one pass small out,        135121
 github,                             level 5 with dict,                  advanced one pass small out,        38758
 github,                             level 5 with dict dms,              advanced one pass small out,        38758
@@ -666,16 +666,16 @@ github,                             level 6 with dict dms,              advanced
 github,                             level 6 with dict dds,              advanced one pass small out,        38636
 github,                             level 6 with dict copy,             advanced one pass small out,        38669
 github,                             level 6 with dict load,             advanced one pass small out,        40695
-github,                             level 7 row 1,                      advanced one pass small out,        135122
-github,                             level 7 row 1 with dict dms,        advanced one pass small out,        38860
-github,                             level 7 row 1 with dict dds,        advanced one pass small out,        38766
-github,                             level 7 row 1 with dict copy,       advanced one pass small out,        38834
-github,                             level 7 row 1 with dict load,       advanced one pass small out,        40695
-github,                             level 7 row 2,                      advanced one pass small out,        134584
-github,                             level 7 row 2 with dict dms,        advanced one pass small out,        38758
-github,                             level 7 row 2 with dict dds,        advanced one pass small out,        38745
-github,                             level 7 row 2 with dict copy,       advanced one pass small out,        38755
-github,                             level 7 row 2 with dict load,       advanced one pass small out,        43154
+github,                             level 7 row 1,                      advanced one pass small out,        134584
+github,                             level 7 row 1 with dict dms,        advanced one pass small out,        38758
+github,                             level 7 row 1 with dict dds,        advanced one pass small out,        38745
+github,                             level 7 row 1 with dict copy,       advanced one pass small out,        38755
+github,                             level 7 row 1 with dict load,       advanced one pass small out,        43154
+github,                             level 7 row 2,                      advanced one pass small out,        135122
+github,                             level 7 row 2 with dict dms,        advanced one pass small out,        38860
+github,                             level 7 row 2 with dict dds,        advanced one pass small out,        38766
+github,                             level 7 row 2 with dict copy,       advanced one pass small out,        38834
+github,                             level 7 row 2 with dict load,       advanced one pass small out,        40695
 github,                             level 7,                            advanced one pass small out,        135122
 github,                             level 7 with dict,                  advanced one pass small out,        38758
 github,                             level 7 with dict dms,              advanced one pass small out,        38758
@@ -737,26 +737,26 @@ github,                             small chain log,                    advanced
 github,                             explicit params,                    advanced one pass small out,        137727
 github,                             uncompressed literals,              advanced one pass small out,        165915
 github,                             uncompressed literals optimal,      advanced one pass small out,        157227
-github,                             huffman literals,                   advanced one pass small out,        142465
+github,                             huffman literals,                   advanced one pass small out,        142365
 github,                             multithreaded with advanced params, advanced one pass small out,        165915
-github.tar,                         level -5,                           advanced one pass small out,        46856
-github.tar,                         level -5 with dict,                 advanced one pass small out,        44571
-github.tar,                         level -3,                           advanced one pass small out,        43754
-github.tar,                         level -3 with dict,                 advanced one pass small out,        41447
-github.tar,                         level -1,                           advanced one pass small out,        42490
-github.tar,                         level -1 with dict,                 advanced one pass small out,        41131
+github.tar,                         level -5,                           advanced one pass small out,        66914
+github.tar,                         level -5 with dict,                 advanced one pass small out,        51525
+github.tar,                         level -3,                           advanced one pass small out,        52127
+github.tar,                         level -3 with dict,                 advanced one pass small out,        44242
+github.tar,                         level -1,                           advanced one pass small out,        42560
+github.tar,                         level -1 with dict,                 advanced one pass small out,        41136
 github.tar,                         level 0,                            advanced one pass small out,        38441
 github.tar,                         level 0 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 0 with dict dms,              advanced one pass small out,        38003
 github.tar,                         level 0 with dict dds,              advanced one pass small out,        38003
 github.tar,                         level 0 with dict copy,             advanced one pass small out,        37995
 github.tar,                         level 0 with dict load,             advanced one pass small out,        37956
-github.tar,                         level 1,                            advanced one pass small out,        39265
-github.tar,                         level 1 with dict,                  advanced one pass small out,        38280
-github.tar,                         level 1 with dict dms,              advanced one pass small out,        38290
-github.tar,                         level 1 with dict dds,              advanced one pass small out,        38290
-github.tar,                         level 1 with dict copy,             advanced one pass small out,        38280
-github.tar,                         level 1 with dict load,             advanced one pass small out,        38729
+github.tar,                         level 1,                            advanced one pass small out,        39200
+github.tar,                         level 1 with dict,                  advanced one pass small out,        38284
+github.tar,                         level 1 with dict dms,              advanced one pass small out,        38294
+github.tar,                         level 1 with dict dds,              advanced one pass small out,        38294
+github.tar,                         level 1 with dict copy,             advanced one pass small out,        38284
+github.tar,                         level 1 with dict load,             advanced one pass small out,        38724
 github.tar,                         level 3,                            advanced one pass small out,        38441
 github.tar,                         level 3 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 3 with dict dms,              advanced one pass small out,        38003
@@ -769,88 +769,88 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass small out,        37954
 github.tar,                         level 4 with dict copy,             advanced one pass small out,        37948
 github.tar,                         level 4 with dict load,             advanced one pass small out,        37927
-github.tar,                         level 5 row 1,                      advanced one pass small out,        38534
-github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39365
-github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39233
-github.tar,                         level 5 row 1 with dict copy,       advanced one pass small out,        39715
-github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        38019
-github.tar,                         level 5 row 2,                      advanced one pass small out,        38394
-github.tar,                         level 5 row 2 with dict dms,        advanced one pass small out,        39048
-github.tar,                         level 5 row 2 with dict dds,        advanced one pass small out,        39044
-github.tar,                         level 5 row 2 with dict copy,       advanced one pass small out,        39074
-github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        37665
-github.tar,                         level 5,                            advanced one pass small out,        38394
-github.tar,                         level 5 with dict,                  advanced one pass small out,        39074
-github.tar,                         level 5 with dict dms,              advanced one pass small out,        39048
-github.tar,                         level 5 with dict dds,              advanced one pass small out,        39044
-github.tar,                         level 5 with dict copy,             advanced one pass small out,        39074
-github.tar,                         level 5 with dict load,             advanced one pass small out,        37665
-github.tar,                         level 6,                            advanced one pass small out,        38669
-github.tar,                         level 6 with dict,                  advanced one pass small out,        38660
-github.tar,                         level 6 with dict dms,              advanced one pass small out,        38654
-github.tar,                         level 6 with dict dds,              advanced one pass small out,        38656
-github.tar,                         level 6 with dict copy,             advanced one pass small out,        38660
-github.tar,                         level 6 with dict load,             advanced one pass small out,        37889
-github.tar,                         level 7 row 1,                      advanced one pass small out,        38077
-github.tar,                         level 7 row 1 with dict dms,        advanced one pass small out,        38012
-github.tar,                         level 7 row 1 with dict dds,        advanced one pass small out,        38014
-github.tar,                         level 7 row 1 with dict copy,       advanced one pass small out,        38101
-github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        37402
-github.tar,                         level 7 row 2,                      advanced one pass small out,        38153
-github.tar,                         level 7 row 2 with dict dms,        advanced one pass small out,        37888
-github.tar,                         level 7 row 2 with dict dds,        advanced one pass small out,        37910
-github.tar,                         level 7 row 2 with dict copy,       advanced one pass small out,        37892
-github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        37457
-github.tar,                         level 7,                            advanced one pass small out,        38153
-github.tar,                         level 7 with dict,                  advanced one pass small out,        37892
-github.tar,                         level 7 with dict dms,              advanced one pass small out,        37888
-github.tar,                         level 7 with dict dds,              advanced one pass small out,        37910
-github.tar,                         level 7 with dict copy,             advanced one pass small out,        37892
-github.tar,                         level 7 with dict load,             advanced one pass small out,        37457
-github.tar,                         level 9,                            advanced one pass small out,        36768
-github.tar,                         level 9 with dict,                  advanced one pass small out,        36510
-github.tar,                         level 9 with dict dms,              advanced one pass small out,        36584
-github.tar,                         level 9 with dict dds,              advanced one pass small out,        36646
-github.tar,                         level 9 with dict copy,             advanced one pass small out,        36510
-github.tar,                         level 9 with dict load,             advanced one pass small out,        36383
-github.tar,                         level 11 row 1,                     advanced one pass small out,        36435
+github.tar,                         level 5 row 1,                      advanced one pass small out,        38366
+github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39059
+github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39067
+github.tar,                         level 5 row 1 with dict copy,       advanced one pass small out,        39082
+github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        37656
+github.tar,                         level 5 row 2,                      advanced one pass small out,        38534
+github.tar,                         level 5 row 2 with dict dms,        advanced one pass small out,        39365
+github.tar,                         level 5 row 2 with dict dds,        advanced one pass small out,        39233
+github.tar,                         level 5 row 2 with dict copy,       advanced one pass small out,        39715
+github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        38019
+github.tar,                         level 5,                            advanced one pass small out,        38366
+github.tar,                         level 5 with dict,                  advanced one pass small out,        39082
+github.tar,                         level 5 with dict dms,              advanced one pass small out,        39059
+github.tar,                         level 5 with dict dds,              advanced one pass small out,        39067
+github.tar,                         level 5 with dict copy,             advanced one pass small out,        39082
+github.tar,                         level 5 with dict load,             advanced one pass small out,        37656
+github.tar,                         level 6,                            advanced one pass small out,        38648
+github.tar,                         level 6 with dict,                  advanced one pass small out,        38656
+github.tar,                         level 6 with dict dms,              advanced one pass small out,        38636
+github.tar,                         level 6 with dict dds,              advanced one pass small out,        38634
+github.tar,                         level 6 with dict copy,             advanced one pass small out,        38656
+github.tar,                         level 6 with dict load,             advanced one pass small out,        37865
+github.tar,                         level 7 row 1,                      advanced one pass small out,        38110
+github.tar,                         level 7 row 1 with dict dms,        advanced one pass small out,        37858
+github.tar,                         level 7 row 1 with dict dds,        advanced one pass small out,        37882
+github.tar,                         level 7 row 1 with dict copy,       advanced one pass small out,        37865
+github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        37436
+github.tar,                         level 7 row 2,                      advanced one pass small out,        38077
+github.tar,                         level 7 row 2 with dict dms,        advanced one pass small out,        38012
+github.tar,                         level 7 row 2 with dict dds,        advanced one pass small out,        38014
+github.tar,                         level 7 row 2 with dict copy,       advanced one pass small out,        38101
+github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        37402
+github.tar,                         level 7,                            advanced one pass small out,        38110
+github.tar,                         level 7 with dict,                  advanced one pass small out,        37865
+github.tar,                         level 7 with dict dms,              advanced one pass small out,        37858
+github.tar,                         level 7 with dict dds,              advanced one pass small out,        37882
+github.tar,                         level 7 with dict copy,             advanced one pass small out,        37865
+github.tar,                         level 7 with dict load,             advanced one pass small out,        37436
+github.tar,                         level 9,                            advanced one pass small out,        36760
+github.tar,                         level 9 with dict,                  advanced one pass small out,        36484
+github.tar,                         level 9 with dict dms,              advanced one pass small out,        36567
+github.tar,                         level 9 with dict dds,              advanced one pass small out,        36628
+github.tar,                         level 9 with dict copy,             advanced one pass small out,        36484
+github.tar,                         level 9 with dict load,             advanced one pass small out,        36401
+github.tar,                         level 11 row 1,                     advanced one pass small out,        36452
 github.tar,                         level 11 row 1 with dict dms,       advanced one pass small out,        36963
 github.tar,                         level 11 row 1 with dict dds,       advanced one pass small out,        36963
 github.tar,                         level 11 row 1 with dict copy,      advanced one pass small out,        36557
-github.tar,                         level 11 row 1 with dict load,      advanced one pass small out,        36419
-github.tar,                         level 11 row 2,                     advanced one pass small out,        36412
+github.tar,                         level 11 row 1 with dict load,      advanced one pass small out,        36455
+github.tar,                         level 11 row 2,                     advanced one pass small out,        36435
 github.tar,                         level 11 row 2 with dict dms,       advanced one pass small out,        36963
 github.tar,                         level 11 row 2 with dict dds,       advanced one pass small out,        36963
 github.tar,                         level 11 row 2 with dict copy,      advanced one pass small out,        36557
-github.tar,                         level 11 row 2 with dict load,      advanced one pass small out,        36439
-github.tar,                         level 12 row 1,                     advanced one pass small out,        36110
+github.tar,                         level 11 row 2 with dict load,      advanced one pass small out,        36419
+github.tar,                         level 12 row 1,                     advanced one pass small out,        36081
 github.tar,                         level 12 row 1 with dict dms,       advanced one pass small out,        36986
 github.tar,                         level 12 row 1 with dict dds,       advanced one pass small out,        36986
 github.tar,                         level 12 row 1 with dict copy,      advanced one pass small out,        36609
-github.tar,                         level 12 row 1 with dict load,      advanced one pass small out,        36459
-github.tar,                         level 12 row 2,                     advanced one pass small out,        36062
+github.tar,                         level 12 row 1 with dict load,      advanced one pass small out,        36434
+github.tar,                         level 12 row 2,                     advanced one pass small out,        36110
 github.tar,                         level 12 row 2 with dict dms,       advanced one pass small out,        36986
 github.tar,                         level 12 row 2 with dict dds,       advanced one pass small out,        36986
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass small out,        36609
-github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36392
-github.tar,                         level 13,                           advanced one pass small out,        35621
-github.tar,                         level 13 with dict,                 advanced one pass small out,        38726
-github.tar,                         level 13 with dict dms,             advanced one pass small out,        38903
-github.tar,                         level 13 with dict dds,             advanced one pass small out,        38903
-github.tar,                         level 13 with dict copy,            advanced one pass small out,        38726
-github.tar,                         level 13 with dict load,            advanced one pass small out,        36372
-github.tar,                         level 16,                           advanced one pass small out,        40255
-github.tar,                         level 16 with dict,                 advanced one pass small out,        33639
-github.tar,                         level 16 with dict dms,             advanced one pass small out,        33544
-github.tar,                         level 16 with dict dds,             advanced one pass small out,        33544
-github.tar,                         level 16 with dict copy,            advanced one pass small out,        33639
-github.tar,                         level 16 with dict load,            advanced one pass small out,        39353
-github.tar,                         level 19,                           advanced one pass small out,        32837
-github.tar,                         level 19 with dict,                 advanced one pass small out,        32895
-github.tar,                         level 19 with dict dms,             advanced one pass small out,        32672
-github.tar,                         level 19 with dict dds,             advanced one pass small out,        32672
-github.tar,                         level 19 with dict copy,            advanced one pass small out,        32895
-github.tar,                         level 19 with dict load,            advanced one pass small out,        32676
+github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36459
+github.tar,                         level 13,                           advanced one pass small out,        35501
+github.tar,                         level 13 with dict,                 advanced one pass small out,        37130
+github.tar,                         level 13 with dict dms,             advanced one pass small out,        37267
+github.tar,                         level 13 with dict dds,             advanced one pass small out,        37267
+github.tar,                         level 13 with dict copy,            advanced one pass small out,        37130
+github.tar,                         level 13 with dict load,            advanced one pass small out,        36010
+github.tar,                         level 16,                           advanced one pass small out,        40471
+github.tar,                         level 16 with dict,                 advanced one pass small out,        33378
+github.tar,                         level 16 with dict dms,             advanced one pass small out,        33213
+github.tar,                         level 16 with dict dds,             advanced one pass small out,        33213
+github.tar,                         level 16 with dict copy,            advanced one pass small out,        33378
+github.tar,                         level 16 with dict load,            advanced one pass small out,        39081
+github.tar,                         level 19,                           advanced one pass small out,        32134
+github.tar,                         level 19 with dict,                 advanced one pass small out,        32709
+github.tar,                         level 19 with dict dms,             advanced one pass small out,        32553
+github.tar,                         level 19 with dict dds,             advanced one pass small out,        32553
+github.tar,                         level 19 with dict copy,            advanced one pass small out,        32709
+github.tar,                         level 19 with dict load,            advanced one pass small out,        32474
 github.tar,                         no source size,                     advanced one pass small out,        38441
 github.tar,                         no source size with dict,           advanced one pass small out,        37995
 github.tar,                         long distance mode,                 advanced one pass small out,        39757
@@ -859,84 +859,84 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced one pass small out,        198540
 github.tar,                         small hash log,                     advanced one pass small out,        129870
 github.tar,                         small chain log,                    advanced one pass small out,        41669
-github.tar,                         explicit params,                    advanced one pass small out,        41350
+github.tar,                         explicit params,                    advanced one pass small out,        41385
 github.tar,                         uncompressed literals,              advanced one pass small out,        41122
-github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35388
-github.tar,                         huffman literals,                   advanced one pass small out,        38777
+github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35397
+github.tar,                         huffman literals,                   advanced one pass small out,        38853
 github.tar,                         multithreaded with advanced params, advanced one pass small out,        41122
-silesia,                            level -5,                           advanced streaming,                 6882505
-silesia,                            level -3,                           advanced streaming,                 6568376
-silesia,                            level -1,                           advanced streaming,                 6183403
-silesia,                            level 0,                            advanced streaming,                 4849551
-silesia,                            level 1,                            advanced streaming,                 5314161
-silesia,                            level 3,                            advanced streaming,                 4849551
-silesia,                            level 4,                            advanced streaming,                 4786969
-silesia,                            level 5 row 1,                      advanced streaming,                 4640753
-silesia,                            level 5 row 2,                      advanced streaming,                 4639132
-silesia,                            level 5,                            advanced streaming,                 4639132
-silesia,                            level 6,                            advanced streaming,                 4605629
-silesia,                            level 7 row 1,                      advanced streaming,                 4564870
-silesia,                            level 7 row 2,                      advanced streaming,                 4567307
-silesia,                            level 7,                            advanced streaming,                 4567307
-silesia,                            level 9,                            advanced streaming,                 4543330
-silesia,                            level 11 row 1,                     advanced streaming,                 4519288
-silesia,                            level 11 row 2,                     advanced streaming,                 4521524
-silesia,                            level 12 row 1,                     advanced streaming,                 4503117
-silesia,                            level 12 row 2,                     advanced streaming,                 4505093
-silesia,                            level 13,                           advanced streaming,                 4482131
-silesia,                            level 16,                           advanced streaming,                 4360251
-silesia,                            level 19,                           advanced streaming,                 4283236
-silesia,                            no source size,                     advanced streaming,                 4849515
-silesia,                            long distance mode,                 advanced streaming,                 4840738
-silesia,                            multithreaded,                      advanced streaming,                 4849551
+silesia,                            level -5,                           advanced streaming,                 7292053
+silesia,                            level -3,                           advanced streaming,                 6867875
+silesia,                            level -1,                           advanced streaming,                 6183923
+silesia,                            level 0,                            advanced streaming,                 4849553
+silesia,                            level 1,                            advanced streaming,                 5312694
+silesia,                            level 3,                            advanced streaming,                 4849553
+silesia,                            level 4,                            advanced streaming,                 4786968
+silesia,                            level 5 row 1,                      advanced streaming,                 4638691
+silesia,                            level 5 row 2,                      advanced streaming,                 4640752
+silesia,                            level 5,                            advanced streaming,                 4638691
+silesia,                            level 6,                            advanced streaming,                 4605296
+silesia,                            level 7 row 1,                      advanced streaming,                 4566984
+silesia,                            level 7 row 2,                      advanced streaming,                 4564868
+silesia,                            level 7,                            advanced streaming,                 4566984
+silesia,                            level 9,                            advanced streaming,                 4543018
+silesia,                            level 11 row 1,                     advanced streaming,                 4521323
+silesia,                            level 11 row 2,                     advanced streaming,                 4519288
+silesia,                            level 12 row 1,                     advanced streaming,                 4505046
+silesia,                            level 12 row 2,                     advanced streaming,                 4503116
+silesia,                            level 13,                           advanced streaming,                 4493990
+silesia,                            level 16,                           advanced streaming,                 4359864
+silesia,                            level 19,                           advanced streaming,                 4296880
+silesia,                            no source size,                     advanced streaming,                 4849517
+silesia,                            long distance mode,                 advanced streaming,                 4840737
+silesia,                            multithreaded,                      advanced streaming,                 4849553
 silesia,                            multithreaded long distance mode,   advanced streaming,                 4840759
 silesia,                            small window log,                   advanced streaming,                 7112062
 silesia,                            small hash log,                     advanced streaming,                 6526141
-silesia,                            small chain log,                    advanced streaming,                 4912199
-silesia,                            explicit params,                    advanced streaming,                 4796309
+silesia,                            small chain log,                    advanced streaming,                 4912197
+silesia,                            explicit params,                    advanced streaming,                 4795452
 silesia,                            uncompressed literals,              advanced streaming,                 5127982
-silesia,                            uncompressed literals optimal,      advanced streaming,                 4317896
-silesia,                            huffman literals,                   advanced streaming,                 5331171
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4319518
+silesia,                            huffman literals,                   advanced streaming,                 5332234
 silesia,                            multithreaded with advanced params, advanced streaming,                 5127982
-silesia.tar,                        level -5,                           advanced streaming,                 6982759
-silesia.tar,                        level -3,                           advanced streaming,                 6641283
-silesia.tar,                        level -1,                           advanced streaming,                 6190795
-silesia.tar,                        level 0,                            advanced streaming,                 4861425
-silesia.tar,                        level 1,                            advanced streaming,                 5336941
-silesia.tar,                        level 3,                            advanced streaming,                 4861425
+silesia.tar,                        level -5,                           advanced streaming,                 7260007
+silesia.tar,                        level -3,                           advanced streaming,                 6845151
+silesia.tar,                        level -1,                           advanced streaming,                 6187938
+silesia.tar,                        level 0,                            advanced streaming,                 4861426
+silesia.tar,                        level 1,                            advanced streaming,                 5334890
+silesia.tar,                        level 3,                            advanced streaming,                 4861426
 silesia.tar,                        level 4,                            advanced streaming,                 4799632
-silesia.tar,                        level 5 row 1,                      advanced streaming,                 4652866
-silesia.tar,                        level 5 row 2,                      advanced streaming,                 4650392
-silesia.tar,                        level 5,                            advanced streaming,                 4650392
-silesia.tar,                        level 6,                            advanced streaming,                 4617097
-silesia.tar,                        level 7 row 1,                      advanced streaming,                 4575393
-silesia.tar,                        level 7 row 2,                      advanced streaming,                 4576953
-silesia.tar,                        level 7,                            advanced streaming,                 4576953
-silesia.tar,                        level 9,                            advanced streaming,                 4552646
-silesia.tar,                        level 11 row 1,                     advanced streaming,                 4529458
-silesia.tar,                        level 11 row 2,                     advanced streaming,                 4530417
-silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513603
-silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514500
-silesia.tar,                        level 13,                           advanced streaming,                 4491769
-silesia.tar,                        level 16,                           advanced streaming,                 4356834
-silesia.tar,                        level 19,                           advanced streaming,                 4264388
-silesia.tar,                        no source size,                     advanced streaming,                 4861421
-silesia.tar,                        long distance mode,                 advanced streaming,                 4847753
-silesia.tar,                        multithreaded,                      advanced streaming,                 4861507
+silesia.tar,                        level 5 row 1,                      advanced streaming,                 4649992
+silesia.tar,                        level 5 row 2,                      advanced streaming,                 4652866
+silesia.tar,                        level 5,                            advanced streaming,                 4649992
+silesia.tar,                        level 6,                            advanced streaming,                 4616803
+silesia.tar,                        level 7 row 1,                      advanced streaming,                 4576664
+silesia.tar,                        level 7 row 2,                      advanced streaming,                 4575394
+silesia.tar,                        level 7,                            advanced streaming,                 4576664
+silesia.tar,                        level 9,                            advanced streaming,                 4552386
+silesia.tar,                        level 11 row 1,                     advanced streaming,                 4530243
+silesia.tar,                        level 11 row 2,                     advanced streaming,                 4529461
+silesia.tar,                        level 12 row 1,                     advanced streaming,                 4514433
+silesia.tar,                        level 12 row 2,                     advanced streaming,                 4513604
+silesia.tar,                        level 13,                           advanced streaming,                 4502956
+silesia.tar,                        level 16,                           advanced streaming,                 4360527
+silesia.tar,                        level 19,                           advanced streaming,                 4267266
+silesia.tar,                        no source size,                     advanced streaming,                 4861422
+silesia.tar,                        long distance mode,                 advanced streaming,                 4847752
+silesia.tar,                        multithreaded,                      advanced streaming,                 4861508
 silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4853221
 silesia.tar,                        small window log,                   advanced streaming,                 7118769
-silesia.tar,                        small hash log,                     advanced streaming,                 6529231
-silesia.tar,                        small chain log,                    advanced streaming,                 4917019
-silesia.tar,                        explicit params,                    advanced streaming,                 4807688
+silesia.tar,                        small hash log,                     advanced streaming,                 6529234
+silesia.tar,                        small chain log,                    advanced streaming,                 4917021
+silesia.tar,                        explicit params,                    advanced streaming,                 4806873
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5129461
-silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4307400
-silesia.tar,                        huffman literals,                   advanced streaming,                 5352360
+silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4310141
+silesia.tar,                        huffman literals,                   advanced streaming,                 5350519
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5129555
-github,                             level -5,                           advanced streaming,                 205285
+github,                             level -5,                           advanced streaming,                 232315
 github,                             level -5 with dict,                 advanced streaming,                 46718
-github,                             level -3,                           advanced streaming,                 190643
+github,                             level -3,                           advanced streaming,                 220760
 github,                             level -3 with dict,                 advanced streaming,                 45395
-github,                             level -1,                           advanced streaming,                 175568
+github,                             level -1,                           advanced streaming,                 175468
 github,                             level -1 with dict,                 advanced streaming,                 43170
 github,                             level 0,                            advanced streaming,                 136335
 github,                             level 0 with dict,                  advanced streaming,                 41148
@@ -944,7 +944,7 @@ github,                             level 0 with dict dms,              advanced
 github,                             level 0 with dict dds,              advanced streaming,                 41148
 github,                             level 0 with dict copy,             advanced streaming,                 41124
 github,                             level 0 with dict load,             advanced streaming,                 42252
-github,                             level 1,                            advanced streaming,                 142465
+github,                             level 1,                            advanced streaming,                 142365
 github,                             level 1 with dict,                  advanced streaming,                 41682
 github,                             level 1 with dict dms,              advanced streaming,                 41682
 github,                             level 1 with dict dds,              advanced streaming,                 41682
@@ -962,16 +962,16 @@ github,                             level 4 with dict dms,              advanced
 github,                             level 4 with dict dds,              advanced streaming,                 41251
 github,                             level 4 with dict copy,             advanced streaming,                 41216
 github,                             level 4 with dict load,             advanced streaming,                 41159
-github,                             level 5 row 1,                      advanced streaming,                 135121
-github,                             level 5 row 1 with dict dms,        advanced streaming,                 38938
-github,                             level 5 row 1 with dict dds,        advanced streaming,                 38732
-github,                             level 5 row 1 with dict copy,       advanced streaming,                 38934
-github,                             level 5 row 1 with dict load,       advanced streaming,                 40725
-github,                             level 5 row 2,                      advanced streaming,                 134584
-github,                             level 5 row 2 with dict dms,        advanced streaming,                 38758
-github,                             level 5 row 2 with dict dds,        advanced streaming,                 38728
-github,                             level 5 row 2 with dict copy,       advanced streaming,                 38759
-github,                             level 5 row 2 with dict load,       advanced streaming,                 41518
+github,                             level 5 row 1,                      advanced streaming,                 134584
+github,                             level 5 row 1 with dict dms,        advanced streaming,                 38758
+github,                             level 5 row 1 with dict dds,        advanced streaming,                 38728
+github,                             level 5 row 1 with dict copy,       advanced streaming,                 38759
+github,                             level 5 row 1 with dict load,       advanced streaming,                 41518
+github,                             level 5 row 2,                      advanced streaming,                 135121
+github,                             level 5 row 2 with dict dms,        advanced streaming,                 38938
+github,                             level 5 row 2 with dict dds,        advanced streaming,                 38732
+github,                             level 5 row 2 with dict copy,       advanced streaming,                 38934
+github,                             level 5 row 2 with dict load,       advanced streaming,                 40725
 github,                             level 5,                            advanced streaming,                 135121
 github,                             level 5 with dict,                  advanced streaming,                 38758
 github,                             level 5 with dict dms,              advanced streaming,                 38758
@@ -984,16 +984,16 @@ github,                             level 6 with dict dms,              advanced
 github,                             level 6 with dict dds,              advanced streaming,                 38636
 github,                             level 6 with dict copy,             advanced streaming,                 38669
 github,                             level 6 with dict load,             advanced streaming,                 40695
-github,                             level 7 row 1,                      advanced streaming,                 135122
-github,                             level 7 row 1 with dict dms,        advanced streaming,                 38860
-github,                             level 7 row 1 with dict dds,        advanced streaming,                 38766
-github,                             level 7 row 1 with dict copy,       advanced streaming,                 38834
-github,                             level 7 row 1 with dict load,       advanced streaming,                 40695
-github,                             level 7 row 2,                      advanced streaming,                 134584
-github,                             level 7 row 2 with dict dms,        advanced streaming,                 38758
-github,                             level 7 row 2 with dict dds,        advanced streaming,                 38745
-github,                             level 7 row 2 with dict copy,       advanced streaming,                 38755
-github,                             level 7 row 2 with dict load,       advanced streaming,                 43154
+github,                             level 7 row 1,                      advanced streaming,                 134584
+github,                             level 7 row 1 with dict dms,        advanced streaming,                 38758
+github,                             level 7 row 1 with dict dds,        advanced streaming,                 38745
+github,                             level 7 row 1 with dict copy,       advanced streaming,                 38755
+github,                             level 7 row 1 with dict load,       advanced streaming,                 43154
+github,                             level 7 row 2,                      advanced streaming,                 135122
+github,                             level 7 row 2 with dict dms,        advanced streaming,                 38860
+github,                             level 7 row 2 with dict dds,        advanced streaming,                 38766
+github,                             level 7 row 2 with dict copy,       advanced streaming,                 38834
+github,                             level 7 row 2 with dict load,       advanced streaming,                 40695
 github,                             level 7,                            advanced streaming,                 135122
 github,                             level 7 with dict,                  advanced streaming,                 38758
 github,                             level 7 with dict dms,              advanced streaming,                 38758
@@ -1055,26 +1055,26 @@ github,                             small chain log,                    advanced
 github,                             explicit params,                    advanced streaming,                 137727
 github,                             uncompressed literals,              advanced streaming,                 165915
 github,                             uncompressed literals optimal,      advanced streaming,                 157227
-github,                             huffman literals,                   advanced streaming,                 142465
+github,                             huffman literals,                   advanced streaming,                 142365
 github,                             multithreaded with advanced params, advanced streaming,                 165915
-github.tar,                         level -5,                           advanced streaming,                 46747
-github.tar,                         level -5 with dict,                 advanced streaming,                 44440
-github.tar,                         level -3,                           advanced streaming,                 43537
-github.tar,                         level -3 with dict,                 advanced streaming,                 41112
-github.tar,                         level -1,                           advanced streaming,                 42465
-github.tar,                         level -1 with dict,                 advanced streaming,                 41196
+github.tar,                         level -5,                           advanced streaming,                 64132
+github.tar,                         level -5 with dict,                 advanced streaming,                 48642
+github.tar,                         level -3,                           advanced streaming,                 50964
+github.tar,                         level -3 with dict,                 advanced streaming,                 42750
+github.tar,                         level -1,                           advanced streaming,                 42536
+github.tar,                         level -1 with dict,                 advanced streaming,                 41198
 github.tar,                         level 0,                            advanced streaming,                 38441
 github.tar,                         level 0 with dict,                  advanced streaming,                 37995
 github.tar,                         level 0 with dict dms,              advanced streaming,                 38003
 github.tar,                         level 0 with dict dds,              advanced streaming,                 38003
 github.tar,                         level 0 with dict copy,             advanced streaming,                 37995
 github.tar,                         level 0 with dict load,             advanced streaming,                 37956
-github.tar,                         level 1,                            advanced streaming,                 39342
-github.tar,                         level 1 with dict,                  advanced streaming,                 38293
-github.tar,                         level 1 with dict dms,              advanced streaming,                 38303
-github.tar,                         level 1 with dict dds,              advanced streaming,                 38303
-github.tar,                         level 1 with dict copy,             advanced streaming,                 38293
-github.tar,                         level 1 with dict load,             advanced streaming,                 38766
+github.tar,                         level 1,                            advanced streaming,                 39270
+github.tar,                         level 1 with dict,                  advanced streaming,                 38316
+github.tar,                         level 1 with dict dms,              advanced streaming,                 38326
+github.tar,                         level 1 with dict dds,              advanced streaming,                 38326
+github.tar,                         level 1 with dict copy,             advanced streaming,                 38316
+github.tar,                         level 1 with dict load,             advanced streaming,                 38761
 github.tar,                         level 3,                            advanced streaming,                 38441
 github.tar,                         level 3 with dict,                  advanced streaming,                 37995
 github.tar,                         level 3 with dict dms,              advanced streaming,                 38003
@@ -1087,88 +1087,88 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced streaming,                 37954
 github.tar,                         level 4 with dict copy,             advanced streaming,                 37948
 github.tar,                         level 4 with dict load,             advanced streaming,                 37927
-github.tar,                         level 5 row 1,                      advanced streaming,                 38534
-github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39365
-github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39233
-github.tar,                         level 5 row 1 with dict copy,       advanced streaming,                 39715
-github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 38019
-github.tar,                         level 5 row 2,                      advanced streaming,                 38394
-github.tar,                         level 5 row 2 with dict dms,        advanced streaming,                 39048
-github.tar,                         level 5 row 2 with dict dds,        advanced streaming,                 39044
-github.tar,                         level 5 row 2 with dict copy,       advanced streaming,                 39074
-github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 37665
-github.tar,                         level 5,                            advanced streaming,                 38394
-github.tar,                         level 5 with dict,                  advanced streaming,                 39074
-github.tar,                         level 5 with dict dms,              advanced streaming,                 39048
-github.tar,                         level 5 with dict dds,              advanced streaming,                 39044
-github.tar,                         level 5 with dict copy,             advanced streaming,                 39074
-github.tar,                         level 5 with dict load,             advanced streaming,                 37665
-github.tar,                         level 6,                            advanced streaming,                 38669
-github.tar,                         level 6 with dict,                  advanced streaming,                 38660
-github.tar,                         level 6 with dict dms,              advanced streaming,                 38654
-github.tar,                         level 6 with dict dds,              advanced streaming,                 38656
-github.tar,                         level 6 with dict copy,             advanced streaming,                 38660
-github.tar,                         level 6 with dict load,             advanced streaming,                 37889
-github.tar,                         level 7 row 1,                      advanced streaming,                 38077
-github.tar,                         level 7 row 1 with dict dms,        advanced streaming,                 38012
-github.tar,                         level 7 row 1 with dict dds,        advanced streaming,                 38014
-github.tar,                         level 7 row 1 with dict copy,       advanced streaming,                 38101
-github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 37402
-github.tar,                         level 7 row 2,                      advanced streaming,                 38153
-github.tar,                         level 7 row 2 with dict dms,        advanced streaming,                 37888
-github.tar,                         level 7 row 2 with dict dds,        advanced streaming,                 37910
-github.tar,                         level 7 row 2 with dict copy,       advanced streaming,                 37892
-github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 37457
-github.tar,                         level 7,                            advanced streaming,                 38153
-github.tar,                         level 7 with dict,                  advanced streaming,                 37892
-github.tar,                         level 7 with dict dms,              advanced streaming,                 37888
-github.tar,                         level 7 with dict dds,              advanced streaming,                 37910
-github.tar,                         level 7 with dict copy,             advanced streaming,                 37892
-github.tar,                         level 7 with dict load,             advanced streaming,                 37457
-github.tar,                         level 9,                            advanced streaming,                 36768
-github.tar,                         level 9 with dict,                  advanced streaming,                 36510
-github.tar,                         level 9 with dict dms,              advanced streaming,                 36584
-github.tar,                         level 9 with dict dds,              advanced streaming,                 36646
-github.tar,                         level 9 with dict copy,             advanced streaming,                 36510
-github.tar,                         level 9 with dict load,             advanced streaming,                 36383
-github.tar,                         level 11 row 1,                     advanced streaming,                 36435
+github.tar,                         level 5 row 1,                      advanced streaming,                 38366
+github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39059
+github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39067
+github.tar,                         level 5 row 1 with dict copy,       advanced streaming,                 39082
+github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 37656
+github.tar,                         level 5 row 2,                      advanced streaming,                 38534
+github.tar,                         level 5 row 2 with dict dms,        advanced streaming,                 39365
+github.tar,                         level 5 row 2 with dict dds,        advanced streaming,                 39233
+github.tar,                         level 5 row 2 with dict copy,       advanced streaming,                 39715
+github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 38019
+github.tar,                         level 5,                            advanced streaming,                 38366
+github.tar,                         level 5 with dict,                  advanced streaming,                 39082
+github.tar,                         level 5 with dict dms,              advanced streaming,                 39059
+github.tar,                         level 5 with dict dds,              advanced streaming,                 39067
+github.tar,                         level 5 with dict copy,             advanced streaming,                 39082
+github.tar,                         level 5 with dict load,             advanced streaming,                 37656
+github.tar,                         level 6,                            advanced streaming,                 38648
+github.tar,                         level 6 with dict,                  advanced streaming,                 38656
+github.tar,                         level 6 with dict dms,              advanced streaming,                 38636
+github.tar,                         level 6 with dict dds,              advanced streaming,                 38634
+github.tar,                         level 6 with dict copy,             advanced streaming,                 38656
+github.tar,                         level 6 with dict load,             advanced streaming,                 37865
+github.tar,                         level 7 row 1,                      advanced streaming,                 38110
+github.tar,                         level 7 row 1 with dict dms,        advanced streaming,                 37858
+github.tar,                         level 7 row 1 with dict dds,        advanced streaming,                 37882
+github.tar,                         level 7 row 1 with dict copy,       advanced streaming,                 37865
+github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 37436
+github.tar,                         level 7 row 2,                      advanced streaming,                 38077
+github.tar,                         level 7 row 2 with dict dms,        advanced streaming,                 38012
+github.tar,                         level 7 row 2 with dict dds,        advanced streaming,                 38014
+github.tar,                         level 7 row 2 with dict copy,       advanced streaming,                 38101
+github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 37402
+github.tar,                         level 7,                            advanced streaming,                 38110
+github.tar,                         level 7 with dict,                  advanced streaming,                 37865
+github.tar,                         level 7 with dict dms,              advanced streaming,                 37858
+github.tar,                         level 7 with dict dds,              advanced streaming,                 37882
+github.tar,                         level 7 with dict copy,             advanced streaming,                 37865
+github.tar,                         level 7 with dict load,             advanced streaming,                 37436
+github.tar,                         level 9,                            advanced streaming,                 36760
+github.tar,                         level 9 with dict,                  advanced streaming,                 36484
+github.tar,                         level 9 with dict dms,              advanced streaming,                 36567
+github.tar,                         level 9 with dict dds,              advanced streaming,                 36628
+github.tar,                         level 9 with dict copy,             advanced streaming,                 36484
+github.tar,                         level 9 with dict load,             advanced streaming,                 36401
+github.tar,                         level 11 row 1,                     advanced streaming,                 36452
 github.tar,                         level 11 row 1 with dict dms,       advanced streaming,                 36963
 github.tar,                         level 11 row 1 with dict dds,       advanced streaming,                 36963
 github.tar,                         level 11 row 1 with dict copy,      advanced streaming,                 36557
-github.tar,                         level 11 row 1 with dict load,      advanced streaming,                 36419
-github.tar,                         level 11 row 2,                     advanced streaming,                 36412
+github.tar,                         level 11 row 1 with dict load,      advanced streaming,                 36455
+github.tar,                         level 11 row 2,                     advanced streaming,                 36435
 github.tar,                         level 11 row 2 with dict dms,       advanced streaming,                 36963
 github.tar,                         level 11 row 2 with dict dds,       advanced streaming,                 36963
 github.tar,                         level 11 row 2 with dict copy,      advanced streaming,                 36557
-github.tar,                         level 11 row 2 with dict load,      advanced streaming,                 36439
-github.tar,                         level 12 row 1,                     advanced streaming,                 36110
+github.tar,                         level 11 row 2 with dict load,      advanced streaming,                 36419
+github.tar,                         level 12 row 1,                     advanced streaming,                 36081
 github.tar,                         level 12 row 1 with dict dms,       advanced streaming,                 36986
 github.tar,                         level 12 row 1 with dict dds,       advanced streaming,                 36986
 github.tar,                         level 12 row 1 with dict copy,      advanced streaming,                 36609
-github.tar,                         level 12 row 1 with dict load,      advanced streaming,                 36459
-github.tar,                         level 12 row 2,                     advanced streaming,                 36062
+github.tar,                         level 12 row 1 with dict load,      advanced streaming,                 36434
+github.tar,                         level 12 row 2,                     advanced streaming,                 36110
 github.tar,                         level 12 row 2 with dict dms,       advanced streaming,                 36986
 github.tar,                         level 12 row 2 with dict dds,       advanced streaming,                 36986
 github.tar,                         level 12 row 2 with dict copy,      advanced streaming,                 36609
-github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36392
-github.tar,                         level 13,                           advanced streaming,                 35621
-github.tar,                         level 13 with dict,                 advanced streaming,                 38726
-github.tar,                         level 13 with dict dms,             advanced streaming,                 38903
-github.tar,                         level 13 with dict dds,             advanced streaming,                 38903
-github.tar,                         level 13 with dict copy,            advanced streaming,                 38726
-github.tar,                         level 13 with dict load,            advanced streaming,                 36372
-github.tar,                         level 16,                           advanced streaming,                 40255
-github.tar,                         level 16 with dict,                 advanced streaming,                 33639
-github.tar,                         level 16 with dict dms,             advanced streaming,                 33544
-github.tar,                         level 16 with dict dds,             advanced streaming,                 33544
-github.tar,                         level 16 with dict copy,            advanced streaming,                 33639
-github.tar,                         level 16 with dict load,            advanced streaming,                 39353
-github.tar,                         level 19,                           advanced streaming,                 32837
-github.tar,                         level 19 with dict,                 advanced streaming,                 32895
-github.tar,                         level 19 with dict dms,             advanced streaming,                 32672
-github.tar,                         level 19 with dict dds,             advanced streaming,                 32672
-github.tar,                         level 19 with dict copy,            advanced streaming,                 32895
-github.tar,                         level 19 with dict load,            advanced streaming,                 32676
+github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36459
+github.tar,                         level 13,                           advanced streaming,                 35501
+github.tar,                         level 13 with dict,                 advanced streaming,                 37130
+github.tar,                         level 13 with dict dms,             advanced streaming,                 37267
+github.tar,                         level 13 with dict dds,             advanced streaming,                 37267
+github.tar,                         level 13 with dict copy,            advanced streaming,                 37130
+github.tar,                         level 13 with dict load,            advanced streaming,                 36010
+github.tar,                         level 16,                           advanced streaming,                 40471
+github.tar,                         level 16 with dict,                 advanced streaming,                 33378
+github.tar,                         level 16 with dict dms,             advanced streaming,                 33213
+github.tar,                         level 16 with dict dds,             advanced streaming,                 33213
+github.tar,                         level 16 with dict copy,            advanced streaming,                 33378
+github.tar,                         level 16 with dict load,            advanced streaming,                 39081
+github.tar,                         level 19,                           advanced streaming,                 32134
+github.tar,                         level 19 with dict,                 advanced streaming,                 32709
+github.tar,                         level 19 with dict dms,             advanced streaming,                 32553
+github.tar,                         level 19 with dict dds,             advanced streaming,                 32553
+github.tar,                         level 19 with dict copy,            advanced streaming,                 32709
+github.tar,                         level 19 with dict load,            advanced streaming,                 32474
 github.tar,                         no source size,                     advanced streaming,                 38438
 github.tar,                         no source size with dict,           advanced streaming,                 38000
 github.tar,                         long distance mode,                 advanced streaming,                 39757
@@ -1177,56 +1177,56 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced streaming,                 199558
 github.tar,                         small hash log,                     advanced streaming,                 129870
 github.tar,                         small chain log,                    advanced streaming,                 41669
-github.tar,                         explicit params,                    advanced streaming,                 41351
+github.tar,                         explicit params,                    advanced streaming,                 41385
 github.tar,                         uncompressed literals,              advanced streaming,                 41122
-github.tar,                         uncompressed literals optimal,      advanced streaming,                 35388
-github.tar,                         huffman literals,                   advanced streaming,                 38800
+github.tar,                         uncompressed literals optimal,      advanced streaming,                 35397
+github.tar,                         huffman literals,                   advanced streaming,                 38874
 github.tar,                         multithreaded with advanced params, advanced streaming,                 41122
-silesia,                            level -5,                           old streaming,                      6882505
-silesia,                            level -3,                           old streaming,                      6568376
-silesia,                            level -1,                           old streaming,                      6183403
-silesia,                            level 0,                            old streaming,                      4849551
-silesia,                            level 1,                            old streaming,                      5314161
-silesia,                            level 3,                            old streaming,                      4849551
-silesia,                            level 4,                            old streaming,                      4786969
-silesia,                            level 5,                            old streaming,                      4639132
-silesia,                            level 6,                            old streaming,                      4605629
-silesia,                            level 7,                            old streaming,                      4567307
-silesia,                            level 9,                            old streaming,                      4543330
-silesia,                            level 13,                           old streaming,                      4482131
-silesia,                            level 16,                           old streaming,                      4360251
-silesia,                            level 19,                           old streaming,                      4283236
-silesia,                            no source size,                     old streaming,                      4849515
-silesia,                            uncompressed literals,              old streaming,                      4849551
-silesia,                            uncompressed literals optimal,      old streaming,                      4283236
-silesia,                            huffman literals,                   old streaming,                      6183403
-silesia.tar,                        level -5,                           old streaming,                      6982759
-silesia.tar,                        level -3,                           old streaming,                      6641283
-silesia.tar,                        level -1,                           old streaming,                      6190795
-silesia.tar,                        level 0,                            old streaming,                      4861425
-silesia.tar,                        level 1,                            old streaming,                      5336941
-silesia.tar,                        level 3,                            old streaming,                      4861425
+silesia,                            level -5,                           old streaming,                      7292053
+silesia,                            level -3,                           old streaming,                      6867875
+silesia,                            level -1,                           old streaming,                      6183923
+silesia,                            level 0,                            old streaming,                      4849553
+silesia,                            level 1,                            old streaming,                      5312694
+silesia,                            level 3,                            old streaming,                      4849553
+silesia,                            level 4,                            old streaming,                      4786968
+silesia,                            level 5,                            old streaming,                      4638691
+silesia,                            level 6,                            old streaming,                      4605296
+silesia,                            level 7,                            old streaming,                      4566984
+silesia,                            level 9,                            old streaming,                      4543018
+silesia,                            level 13,                           old streaming,                      4493990
+silesia,                            level 16,                           old streaming,                      4359864
+silesia,                            level 19,                           old streaming,                      4296880
+silesia,                            no source size,                     old streaming,                      4849517
+silesia,                            uncompressed literals,              old streaming,                      4849553
+silesia,                            uncompressed literals optimal,      old streaming,                      4296880
+silesia,                            huffman literals,                   old streaming,                      6183923
+silesia.tar,                        level -5,                           old streaming,                      7260007
+silesia.tar,                        level -3,                           old streaming,                      6845151
+silesia.tar,                        level -1,                           old streaming,                      6187938
+silesia.tar,                        level 0,                            old streaming,                      4861426
+silesia.tar,                        level 1,                            old streaming,                      5334890
+silesia.tar,                        level 3,                            old streaming,                      4861426
 silesia.tar,                        level 4,                            old streaming,                      4799632
-silesia.tar,                        level 5,                            old streaming,                      4650392
-silesia.tar,                        level 6,                            old streaming,                      4617097
-silesia.tar,                        level 7,                            old streaming,                      4576953
-silesia.tar,                        level 9,                            old streaming,                      4552646
-silesia.tar,                        level 13,                           old streaming,                      4491769
-silesia.tar,                        level 16,                           old streaming,                      4356834
-silesia.tar,                        level 19,                           old streaming,                      4264388
-silesia.tar,                        no source size,                     old streaming,                      4861421
-silesia.tar,                        uncompressed literals,              old streaming,                      4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4264388
-silesia.tar,                        huffman literals,                   old streaming,                      6190795
-github,                             level -5,                           old streaming,                      205285
+silesia.tar,                        level 5,                            old streaming,                      4649992
+silesia.tar,                        level 6,                            old streaming,                      4616803
+silesia.tar,                        level 7,                            old streaming,                      4576664
+silesia.tar,                        level 9,                            old streaming,                      4552386
+silesia.tar,                        level 13,                           old streaming,                      4502956
+silesia.tar,                        level 16,                           old streaming,                      4360527
+silesia.tar,                        level 19,                           old streaming,                      4267266
+silesia.tar,                        no source size,                     old streaming,                      4861422
+silesia.tar,                        uncompressed literals,              old streaming,                      4861426
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4267266
+silesia.tar,                        huffman literals,                   old streaming,                      6187938
+github,                             level -5,                           old streaming,                      232315
 github,                             level -5 with dict,                 old streaming,                      46718
-github,                             level -3,                           old streaming,                      190643
+github,                             level -3,                           old streaming,                      220760
 github,                             level -3 with dict,                 old streaming,                      45395
-github,                             level -1,                           old streaming,                      175568
+github,                             level -1,                           old streaming,                      175468
 github,                             level -1 with dict,                 old streaming,                      43170
 github,                             level 0,                            old streaming,                      136335
 github,                             level 0 with dict,                  old streaming,                      41148
-github,                             level 1,                            old streaming,                      142465
+github,                             level 1,                            old streaming,                      142365
 github,                             level 1 with dict,                  old streaming,                      41682
 github,                             level 3,                            old streaming,                      136335
 github,                             level 3 with dict,                  old streaming,                      41148
@@ -1250,101 +1250,101 @@ github,                             no source size,                     old stre
 github,                             no source size with dict,           old streaming,                      40654
 github,                             uncompressed literals,              old streaming,                      136335
 github,                             uncompressed literals optimal,      old streaming,                      134064
-github,                             huffman literals,                   old streaming,                      175568
-github.tar,                         level -5,                           old streaming,                      46747
-github.tar,                         level -5 with dict,                 old streaming,                      44440
-github.tar,                         level -3,                           old streaming,                      43537
-github.tar,                         level -3 with dict,                 old streaming,                      41112
-github.tar,                         level -1,                           old streaming,                      42465
-github.tar,                         level -1 with dict,                 old streaming,                      41196
+github,                             huffman literals,                   old streaming,                      175468
+github.tar,                         level -5,                           old streaming,                      64132
+github.tar,                         level -5 with dict,                 old streaming,                      48642
+github.tar,                         level -3,                           old streaming,                      50964
+github.tar,                         level -3 with dict,                 old streaming,                      42750
+github.tar,                         level -1,                           old streaming,                      42536
+github.tar,                         level -1 with dict,                 old streaming,                      41198
 github.tar,                         level 0,                            old streaming,                      38441
 github.tar,                         level 0 with dict,                  old streaming,                      37995
-github.tar,                         level 1,                            old streaming,                      39342
-github.tar,                         level 1 with dict,                  old streaming,                      38293
+github.tar,                         level 1,                            old streaming,                      39270
+github.tar,                         level 1 with dict,                  old streaming,                      38316
 github.tar,                         level 3,                            old streaming,                      38441
 github.tar,                         level 3 with dict,                  old streaming,                      37995
 github.tar,                         level 4,                            old streaming,                      38467
 github.tar,                         level 4 with dict,                  old streaming,                      37948
-github.tar,                         level 5,                            old streaming,                      38394
-github.tar,                         level 5 with dict,                  old streaming,                      39074
-github.tar,                         level 6,                            old streaming,                      38669
-github.tar,                         level 6 with dict,                  old streaming,                      38660
-github.tar,                         level 7,                            old streaming,                      38153
-github.tar,                         level 7 with dict,                  old streaming,                      37892
-github.tar,                         level 9,                            old streaming,                      36768
-github.tar,                         level 9 with dict,                  old streaming,                      36510
-github.tar,                         level 13,                           old streaming,                      35621
-github.tar,                         level 13 with dict,                 old streaming,                      38726
-github.tar,                         level 16,                           old streaming,                      40255
-github.tar,                         level 16 with dict,                 old streaming,                      33639
-github.tar,                         level 19,                           old streaming,                      32837
-github.tar,                         level 19 with dict,                 old streaming,                      32895
+github.tar,                         level 5,                            old streaming,                      38366
+github.tar,                         level 5 with dict,                  old streaming,                      39082
+github.tar,                         level 6,                            old streaming,                      38648
+github.tar,                         level 6 with dict,                  old streaming,                      38656
+github.tar,                         level 7,                            old streaming,                      38110
+github.tar,                         level 7 with dict,                  old streaming,                      37865
+github.tar,                         level 9,                            old streaming,                      36760
+github.tar,                         level 9 with dict,                  old streaming,                      36484
+github.tar,                         level 13,                           old streaming,                      35501
+github.tar,                         level 13 with dict,                 old streaming,                      37130
+github.tar,                         level 16,                           old streaming,                      40471
+github.tar,                         level 16 with dict,                 old streaming,                      33378
+github.tar,                         level 19,                           old streaming,                      32134
+github.tar,                         level 19 with dict,                 old streaming,                      32709
 github.tar,                         no source size,                     old streaming,                      38438
 github.tar,                         no source size with dict,           old streaming,                      38000
 github.tar,                         uncompressed literals,              old streaming,                      38441
-github.tar,                         uncompressed literals optimal,      old streaming,                      32837
-github.tar,                         huffman literals,                   old streaming,                      42465
-silesia,                            level -5,                           old streaming advanced,             6882505
-silesia,                            level -3,                           old streaming advanced,             6568376
-silesia,                            level -1,                           old streaming advanced,             6183403
-silesia,                            level 0,                            old streaming advanced,             4849551
-silesia,                            level 1,                            old streaming advanced,             5314161
-silesia,                            level 3,                            old streaming advanced,             4849551
-silesia,                            level 4,                            old streaming advanced,             4786969
-silesia,                            level 5,                            old streaming advanced,             4639132
-silesia,                            level 6,                            old streaming advanced,             4605629
-silesia,                            level 7,                            old streaming advanced,             4567307
-silesia,                            level 9,                            old streaming advanced,             4543330
-silesia,                            level 13,                           old streaming advanced,             4482131
-silesia,                            level 16,                           old streaming advanced,             4360251
-silesia,                            level 19,                           old streaming advanced,             4283236
-silesia,                            no source size,                     old streaming advanced,             4849515
-silesia,                            long distance mode,                 old streaming advanced,             4849551
-silesia,                            multithreaded,                      old streaming advanced,             4849551
-silesia,                            multithreaded long distance mode,   old streaming advanced,             4849551
+github.tar,                         uncompressed literals optimal,      old streaming,                      32134
+github.tar,                         huffman literals,                   old streaming,                      42536
+silesia,                            level -5,                           old streaming advanced,             7292053
+silesia,                            level -3,                           old streaming advanced,             6867875
+silesia,                            level -1,                           old streaming advanced,             6183923
+silesia,                            level 0,                            old streaming advanced,             4849553
+silesia,                            level 1,                            old streaming advanced,             5312694
+silesia,                            level 3,                            old streaming advanced,             4849553
+silesia,                            level 4,                            old streaming advanced,             4786968
+silesia,                            level 5,                            old streaming advanced,             4638691
+silesia,                            level 6,                            old streaming advanced,             4605296
+silesia,                            level 7,                            old streaming advanced,             4566984
+silesia,                            level 9,                            old streaming advanced,             4543018
+silesia,                            level 13,                           old streaming advanced,             4493990
+silesia,                            level 16,                           old streaming advanced,             4359864
+silesia,                            level 19,                           old streaming advanced,             4296880
+silesia,                            no source size,                     old streaming advanced,             4849517
+silesia,                            long distance mode,                 old streaming advanced,             4849553
+silesia,                            multithreaded,                      old streaming advanced,             4849553
+silesia,                            multithreaded long distance mode,   old streaming advanced,             4849553
 silesia,                            small window log,                   old streaming advanced,             7112062
 silesia,                            small hash log,                     old streaming advanced,             6526141
-silesia,                            small chain log,                    old streaming advanced,             4912199
-silesia,                            explicit params,                    old streaming advanced,             4796309
-silesia,                            uncompressed literals,              old streaming advanced,             4849551
-silesia,                            uncompressed literals optimal,      old streaming advanced,             4283236
-silesia,                            huffman literals,                   old streaming advanced,             6183403
-silesia,                            multithreaded with advanced params, old streaming advanced,             4849551
-silesia.tar,                        level -5,                           old streaming advanced,             6982759
-silesia.tar,                        level -3,                           old streaming advanced,             6641283
-silesia.tar,                        level -1,                           old streaming advanced,             6190795
-silesia.tar,                        level 0,                            old streaming advanced,             4861425
-silesia.tar,                        level 1,                            old streaming advanced,             5336941
-silesia.tar,                        level 3,                            old streaming advanced,             4861425
+silesia,                            small chain log,                    old streaming advanced,             4912197
+silesia,                            explicit params,                    old streaming advanced,             4795452
+silesia,                            uncompressed literals,              old streaming advanced,             4849553
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4296880
+silesia,                            huffman literals,                   old streaming advanced,             6183923
+silesia,                            multithreaded with advanced params, old streaming advanced,             4849553
+silesia.tar,                        level -5,                           old streaming advanced,             7260007
+silesia.tar,                        level -3,                           old streaming advanced,             6845151
+silesia.tar,                        level -1,                           old streaming advanced,             6187938
+silesia.tar,                        level 0,                            old streaming advanced,             4861426
+silesia.tar,                        level 1,                            old streaming advanced,             5334890
+silesia.tar,                        level 3,                            old streaming advanced,             4861426
 silesia.tar,                        level 4,                            old streaming advanced,             4799632
-silesia.tar,                        level 5,                            old streaming advanced,             4650392
-silesia.tar,                        level 6,                            old streaming advanced,             4617097
-silesia.tar,                        level 7,                            old streaming advanced,             4576953
-silesia.tar,                        level 9,                            old streaming advanced,             4552646
-silesia.tar,                        level 13,                           old streaming advanced,             4491769
-silesia.tar,                        level 16,                           old streaming advanced,             4356834
-silesia.tar,                        level 19,                           old streaming advanced,             4264388
-silesia.tar,                        no source size,                     old streaming advanced,             4861421
-silesia.tar,                        long distance mode,                 old streaming advanced,             4861425
-silesia.tar,                        multithreaded,                      old streaming advanced,             4861425
-silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861425
+silesia.tar,                        level 5,                            old streaming advanced,             4649992
+silesia.tar,                        level 6,                            old streaming advanced,             4616803
+silesia.tar,                        level 7,                            old streaming advanced,             4576664
+silesia.tar,                        level 9,                            old streaming advanced,             4552386
+silesia.tar,                        level 13,                           old streaming advanced,             4502956
+silesia.tar,                        level 16,                           old streaming advanced,             4360527
+silesia.tar,                        level 19,                           old streaming advanced,             4267266
+silesia.tar,                        no source size,                     old streaming advanced,             4861422
+silesia.tar,                        long distance mode,                 old streaming advanced,             4861426
+silesia.tar,                        multithreaded,                      old streaming advanced,             4861426
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861426
 silesia.tar,                        small window log,                   old streaming advanced,             7118772
-silesia.tar,                        small hash log,                     old streaming advanced,             6529231
-silesia.tar,                        small chain log,                    old streaming advanced,             4917019
-silesia.tar,                        explicit params,                    old streaming advanced,             4807688
-silesia.tar,                        uncompressed literals,              old streaming advanced,             4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4264388
-silesia.tar,                        huffman literals,                   old streaming advanced,             6190795
-silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861425
-github,                             level -5,                           old streaming advanced,             216734
+silesia.tar,                        small hash log,                     old streaming advanced,             6529234
+silesia.tar,                        small chain log,                    old streaming advanced,             4917021
+silesia.tar,                        explicit params,                    old streaming advanced,             4806873
+silesia.tar,                        uncompressed literals,              old streaming advanced,             4861426
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4267266
+silesia.tar,                        huffman literals,                   old streaming advanced,             6187938
+silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861426
+github,                             level -5,                           old streaming advanced,             241214
 github,                             level -5 with dict,                 old streaming advanced,             49562
-github,                             level -3,                           old streaming advanced,             192160
+github,                             level -3,                           old streaming advanced,             222937
 github,                             level -3 with dict,                 old streaming advanced,             44956
-github,                             level -1,                           old streaming advanced,             181108
+github,                             level -1,                           old streaming advanced,             181107
 github,                             level -1 with dict,                 old streaming advanced,             42383
 github,                             level 0,                            old streaming advanced,             141104
 github,                             level 0 with dict,                  old streaming advanced,             41113
-github,                             level 1,                            old streaming advanced,             143692
+github,                             level 1,                            old streaming advanced,             143693
 github,                             level 1 with dict,                  old streaming advanced,             42430
 github,                             level 3,                            old streaming advanced,             141104
 github,                             level 3 with dict,                  old streaming advanced,             41113
@@ -1359,7 +1359,7 @@ github,                             level 7 with dict,                  old stre
 github,                             level 9,                            old streaming advanced,             138676
 github,                             level 9 with dict,                  old streaming advanced,             38981
 github,                             level 13,                           old streaming advanced,             138676
-github,                             level 13 with dict,                 old streaming advanced,             39731
+github,                             level 13 with dict,                 old streaming advanced,             39721
 github,                             level 16,                           old streaming advanced,             138676
 github,                             level 16 with dict,                 old streaming advanced,             40789
 github,                             level 19,                           old streaming advanced,             134064
@@ -1375,36 +1375,36 @@ github,                             small chain log,                    old stre
 github,                             explicit params,                    old streaming advanced,             140937
 github,                             uncompressed literals,              old streaming advanced,             141104
 github,                             uncompressed literals optimal,      old streaming advanced,             134064
-github,                             huffman literals,                   old streaming advanced,             181108
+github,                             huffman literals,                   old streaming advanced,             181107
 github,                             multithreaded with advanced params, old streaming advanced,             141104
-github.tar,                         level -5,                           old streaming advanced,             46747
-github.tar,                         level -5 with dict,                 old streaming advanced,             44824
-github.tar,                         level -3,                           old streaming advanced,             43537
-github.tar,                         level -3 with dict,                 old streaming advanced,             41800
-github.tar,                         level -1,                           old streaming advanced,             42465
-github.tar,                         level -1 with dict,                 old streaming advanced,             41471
+github.tar,                         level -5,                           old streaming advanced,             64132
+github.tar,                         level -5 with dict,                 old streaming advanced,             48982
+github.tar,                         level -3,                           old streaming advanced,             50964
+github.tar,                         level -3 with dict,                 old streaming advanced,             43357
+github.tar,                         level -1,                           old streaming advanced,             42536
+github.tar,                         level -1 with dict,                 old streaming advanced,             41494
 github.tar,                         level 0,                            old streaming advanced,             38441
 github.tar,                         level 0 with dict,                  old streaming advanced,             38013
-github.tar,                         level 1,                            old streaming advanced,             39342
-github.tar,                         level 1 with dict,                  old streaming advanced,             38940
+github.tar,                         level 1,                            old streaming advanced,             39270
+github.tar,                         level 1 with dict,                  old streaming advanced,             38934
 github.tar,                         level 3,                            old streaming advanced,             38441
 github.tar,                         level 3 with dict,                  old streaming advanced,             38013
 github.tar,                         level 4,                            old streaming advanced,             38467
 github.tar,                         level 4 with dict,                  old streaming advanced,             38063
-github.tar,                         level 5,                            old streaming advanced,             38394
-github.tar,                         level 5 with dict,                  old streaming advanced,             37763
-github.tar,                         level 6,                            old streaming advanced,             38669
-github.tar,                         level 6 with dict,                  old streaming advanced,             37851
-github.tar,                         level 7,                            old streaming advanced,             38153
-github.tar,                         level 7 with dict,                  old streaming advanced,             37406
-github.tar,                         level 9,                            old streaming advanced,             36768
-github.tar,                         level 9 with dict,                  old streaming advanced,             36304
-github.tar,                         level 13,                           old streaming advanced,             35621
-github.tar,                         level 13 with dict,                 old streaming advanced,             36035
-github.tar,                         level 16,                           old streaming advanced,             40255
-github.tar,                         level 16 with dict,                 old streaming advanced,             38736
-github.tar,                         level 19,                           old streaming advanced,             32837
-github.tar,                         level 19 with dict,                 old streaming advanced,             32876
+github.tar,                         level 5,                            old streaming advanced,             38366
+github.tar,                         level 5 with dict,                  old streaming advanced,             37728
+github.tar,                         level 6,                            old streaming advanced,             38648
+github.tar,                         level 6 with dict,                  old streaming advanced,             37820
+github.tar,                         level 7,                            old streaming advanced,             38110
+github.tar,                         level 7 with dict,                  old streaming advanced,             37387
+github.tar,                         level 9,                            old streaming advanced,             36760
+github.tar,                         level 9 with dict,                  old streaming advanced,             36312
+github.tar,                         level 13,                           old streaming advanced,             35501
+github.tar,                         level 13 with dict,                 old streaming advanced,             35807
+github.tar,                         level 16,                           old streaming advanced,             40471
+github.tar,                         level 16 with dict,                 old streaming advanced,             38578
+github.tar,                         level 19,                           old streaming advanced,             32134
+github.tar,                         level 19 with dict,                 old streaming advanced,             32702
 github.tar,                         no source size,                     old streaming advanced,             38438
 github.tar,                         no source size with dict,           old streaming advanced,             38015
 github.tar,                         long distance mode,                 old streaming advanced,             38441
@@ -1413,10 +1413,10 @@ github.tar,                         multithreaded long distance mode,   old stre
 github.tar,                         small window log,                   old streaming advanced,             199561
 github.tar,                         small hash log,                     old streaming advanced,             129870
 github.tar,                         small chain log,                    old streaming advanced,             41669
-github.tar,                         explicit params,                    old streaming advanced,             41351
+github.tar,                         explicit params,                    old streaming advanced,             41385
 github.tar,                         uncompressed literals,              old streaming advanced,             38441
-github.tar,                         uncompressed literals optimal,      old streaming advanced,             32837
-github.tar,                         huffman literals,                   old streaming advanced,             42465
+github.tar,                         uncompressed literals optimal,      old streaming advanced,             32134
+github.tar,                         huffman literals,                   old streaming advanced,             42536
 github.tar,                         multithreaded with advanced params, old streaming advanced,             38441
 github,                             level -5 with dict,                 old streaming cdict,                46718
 github,                             level -3 with dict,                 old streaming cdict,                45395
@@ -1433,20 +1433,20 @@ github,                             level 13 with dict,                 old stre
 github,                             level 16 with dict,                 old streaming cdict,                37577
 github,                             level 19 with dict,                 old streaming cdict,                37576
 github,                             no source size with dict,           old streaming cdict,                40654
-github.tar,                         level -5 with dict,                 old streaming cdict,                45018
-github.tar,                         level -3 with dict,                 old streaming cdict,                41886
-github.tar,                         level -1 with dict,                 old streaming cdict,                41636
+github.tar,                         level -5 with dict,                 old streaming cdict,                49146
+github.tar,                         level -3 with dict,                 old streaming cdict,                43468
+github.tar,                         level -1 with dict,                 old streaming cdict,                41662
 github.tar,                         level 0 with dict,                  old streaming cdict,                37956
-github.tar,                         level 1 with dict,                  old streaming cdict,                38766
+github.tar,                         level 1 with dict,                  old streaming cdict,                38761
 github.tar,                         level 3 with dict,                  old streaming cdict,                37956
 github.tar,                         level 4 with dict,                  old streaming cdict,                37927
-github.tar,                         level 5 with dict,                  old streaming cdict,                37665
-github.tar,                         level 6 with dict,                  old streaming cdict,                37889
-github.tar,                         level 7 with dict,                  old streaming cdict,                37457
-github.tar,                         level 9 with dict,                  old streaming cdict,                36383
-github.tar,                         level 13 with dict,                 old streaming cdict,                36372
-github.tar,                         level 16 with dict,                 old streaming cdict,                39353
-github.tar,                         level 19 with dict,                 old streaming cdict,                32676
+github.tar,                         level 5 with dict,                  old streaming cdict,                37656
+github.tar,                         level 6 with dict,                  old streaming cdict,                37865
+github.tar,                         level 7 with dict,                  old streaming cdict,                37436
+github.tar,                         level 9 with dict,                  old streaming cdict,                36401
+github.tar,                         level 13 with dict,                 old streaming cdict,                36010
+github.tar,                         level 16 with dict,                 old streaming cdict,                39081
+github.tar,                         level 19 with dict,                 old streaming cdict,                32474
 github.tar,                         no source size with dict,           old streaming cdict,                38000
 github,                             level -5 with dict,                 old streaming advanced cdict,       49562
 github,                             level -3 with dict,                 old streaming advanced cdict,       44956
@@ -1459,7 +1459,7 @@ github,                             level 5 with dict,                  old stre
 github,                             level 6 with dict,                  old streaming advanced cdict,       39363
 github,                             level 7 with dict,                  old streaming advanced cdict,       38924
 github,                             level 9 with dict,                  old streaming advanced cdict,       38981
-github,                             level 13 with dict,                 old streaming advanced cdict,       39731
+github,                             level 13 with dict,                 old streaming advanced cdict,       39721
 github,                             level 16 with dict,                 old streaming advanced cdict,       40789
 github,                             level 19 with dict,                 old streaming advanced cdict,       37576
 github,                             no source size with dict,           old streaming advanced cdict,       40608
@@ -1470,11 +1470,11 @@ github.tar,                         level 0 with dict,                  old stre
 github.tar,                         level 1 with dict,                  old streaming advanced cdict,       39002
 github.tar,                         level 3 with dict,                  old streaming advanced cdict,       38013
 github.tar,                         level 4 with dict,                  old streaming advanced cdict,       38063
-github.tar,                         level 5 with dict,                  old streaming advanced cdict,       37763
-github.tar,                         level 6 with dict,                  old streaming advanced cdict,       37851
-github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37406
-github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36304
-github.tar,                         level 13 with dict,                 old streaming advanced cdict,       36035
-github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38736
-github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32876
+github.tar,                         level 5 with dict,                  old streaming advanced cdict,       37728
+github.tar,                         level 6 with dict,                  old streaming advanced cdict,       37820
+github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37387
+github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36312
+github.tar,                         level 13 with dict,                 old streaming advanced cdict,       35807
+github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38578
+github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32702
 github.tar,                         no source size with dict,           old streaming advanced cdict,       38015

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -1,72 +1,72 @@
 Data,                               Config,                             Method,                             Total compressed size
-silesia.tar,                        level -5,                           compress simple,                    7359401
-silesia.tar,                        level -3,                           compress simple,                    6901672
-silesia.tar,                        level -1,                           compress simple,                    6182241
-silesia.tar,                        level 0,                            compress simple,                    4861424
-silesia.tar,                        level 1,                            compress simple,                    5331946
-silesia.tar,                        level 3,                            compress simple,                    4861424
+silesia.tar,                        level -5,                           compress simple,                    6738593
+silesia.tar,                        level -3,                           compress simple,                    6446372
+silesia.tar,                        level -1,                           compress simple,                    6186042
+silesia.tar,                        level 0,                            compress simple,                    4861423
+silesia.tar,                        level 1,                            compress simple,                    5334885
+silesia.tar,                        level 3,                            compress simple,                    4861423
 silesia.tar,                        level 4,                            compress simple,                    4799632
-silesia.tar,                        level 5,                            compress simple,                    4650202
-silesia.tar,                        level 6,                            compress simple,                    4616811
-silesia.tar,                        level 7,                            compress simple,                    4576829
-silesia.tar,                        level 9,                            compress simple,                    4552584
-silesia.tar,                        level 13,                           compress simple,                    4502956
-silesia.tar,                        level 16,                           compress simple,                    4360527
-silesia.tar,                        level 19,                           compress simple,                    4267266
-silesia.tar,                        uncompressed literals,              compress simple,                    4861424
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4267266
-silesia.tar,                        huffman literals,                   compress simple,                    6182241
-github.tar,                         level -5,                           compress simple,                    66914
-github.tar,                         level -3,                           compress simple,                    52127
-github.tar,                         level -1,                           compress simple,                    42560
+silesia.tar,                        level 5,                            compress simple,                    4650387
+silesia.tar,                        level 6,                            compress simple,                    4617089
+silesia.tar,                        level 7,                            compress simple,                    4576951
+silesia.tar,                        level 9,                            compress simple,                    4552638
+silesia.tar,                        level 13,                           compress simple,                    4491768
+silesia.tar,                        level 16,                           compress simple,                    4356834
+silesia.tar,                        level 19,                           compress simple,                    4264388
+silesia.tar,                        uncompressed literals,              compress simple,                    4861423
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264388
+silesia.tar,                        huffman literals,                   compress simple,                    6186042
+github.tar,                         level -5,                           compress simple,                    46856
+github.tar,                         level -3,                           compress simple,                    43754
+github.tar,                         level -1,                           compress simple,                    42490
 github.tar,                         level 0,                            compress simple,                    38441
-github.tar,                         level 1,                            compress simple,                    39200
+github.tar,                         level 1,                            compress simple,                    39265
 github.tar,                         level 3,                            compress simple,                    38441
 github.tar,                         level 4,                            compress simple,                    38467
-github.tar,                         level 5,                            compress simple,                    38376
-github.tar,                         level 6,                            compress simple,                    38610
-github.tar,                         level 7,                            compress simple,                    38073
-github.tar,                         level 9,                            compress simple,                    36767
-github.tar,                         level 13,                           compress simple,                    35501
-github.tar,                         level 16,                           compress simple,                    40471
-github.tar,                         level 19,                           compress simple,                    32134
+github.tar,                         level 5,                            compress simple,                    38394
+github.tar,                         level 6,                            compress simple,                    38669
+github.tar,                         level 7,                            compress simple,                    38153
+github.tar,                         level 9,                            compress simple,                    36768
+github.tar,                         level 13,                           compress simple,                    35621
+github.tar,                         level 16,                           compress simple,                    40255
+github.tar,                         level 19,                           compress simple,                    32837
 github.tar,                         uncompressed literals,              compress simple,                    38441
-github.tar,                         uncompressed literals optimal,      compress simple,                    32134
-github.tar,                         huffman literals,                   compress simple,                    42560
-silesia,                            level -5,                           compress cctx,                      7354675
-silesia,                            level -3,                           compress cctx,                      6902374
-silesia,                            level -1,                           compress cctx,                      6177565
-silesia,                            level 0,                            compress cctx,                      4849553
-silesia,                            level 1,                            compress cctx,                      5309098
-silesia,                            level 3,                            compress cctx,                      4849553
-silesia,                            level 4,                            compress cctx,                      4786968
-silesia,                            level 5,                            compress cctx,                      4638961
-silesia,                            level 6,                            compress cctx,                      4605369
-silesia,                            level 7,                            compress cctx,                      4567204
-silesia,                            level 9,                            compress cctx,                      4543310
-silesia,                            level 13,                           compress cctx,                      4493990
-silesia,                            level 16,                           compress cctx,                      4359864
-silesia,                            level 19,                           compress cctx,                      4296880
-silesia,                            long distance mode,                 compress cctx,                      4849553
-silesia,                            multithreaded,                      compress cctx,                      4849553
-silesia,                            multithreaded long distance mode,   compress cctx,                      4849553
+github.tar,                         uncompressed literals optimal,      compress simple,                    32837
+github.tar,                         huffman literals,                   compress simple,                    42490
+silesia,                            level -5,                           compress cctx,                      6737607
+silesia,                            level -3,                           compress cctx,                      6444677
+silesia,                            level -1,                           compress cctx,                      6178460
+silesia,                            level 0,                            compress cctx,                      4849551
+silesia,                            level 1,                            compress cctx,                      5313202
+silesia,                            level 3,                            compress cctx,                      4849551
+silesia,                            level 4,                            compress cctx,                      4786969
+silesia,                            level 5,                            compress cctx,                      4639132
+silesia,                            level 6,                            compress cctx,                      4605629
+silesia,                            level 7,                            compress cctx,                      4567307
+silesia,                            level 9,                            compress cctx,                      4543330
+silesia,                            level 13,                           compress cctx,                      4482131
+silesia,                            level 16,                           compress cctx,                      4360251
+silesia,                            level 19,                           compress cctx,                      4283236
+silesia,                            long distance mode,                 compress cctx,                      4849551
+silesia,                            multithreaded,                      compress cctx,                      4849551
+silesia,                            multithreaded long distance mode,   compress cctx,                      4849551
 silesia,                            small window log,                   compress cctx,                      7084179
 silesia,                            small hash log,                     compress cctx,                      6526141
-silesia,                            small chain log,                    compress cctx,                      4912197
-silesia,                            explicit params,                    compress cctx,                      4794481
-silesia,                            uncompressed literals,              compress cctx,                      4849553
-silesia,                            uncompressed literals optimal,      compress cctx,                      4296880
-silesia,                            huffman literals,                   compress cctx,                      6177565
-silesia,                            multithreaded with advanced params, compress cctx,                      4849553
-github,                             level -5,                           compress cctx,                      232315
+silesia,                            small chain log,                    compress cctx,                      4912199
+silesia,                            explicit params,                    compress cctx,                      4794917
+silesia,                            uncompressed literals,              compress cctx,                      4849551
+silesia,                            uncompressed literals optimal,      compress cctx,                      4283236
+silesia,                            huffman literals,                   compress cctx,                      6178460
+silesia,                            multithreaded with advanced params, compress cctx,                      4849551
+github,                             level -5,                           compress cctx,                      205285
 github,                             level -5 with dict,                 compress cctx,                      47294
-github,                             level -3,                           compress cctx,                      220760
+github,                             level -3,                           compress cctx,                      190643
 github,                             level -3 with dict,                 compress cctx,                      48047
-github,                             level -1,                           compress cctx,                      175468
+github,                             level -1,                           compress cctx,                      175568
 github,                             level -1 with dict,                 compress cctx,                      43527
 github,                             level 0,                            compress cctx,                      136335
 github,                             level 0 with dict,                  compress cctx,                      41534
-github,                             level 1,                            compress cctx,                      142365
+github,                             level 1,                            compress cctx,                      142465
 github,                             level 1 with dict,                  compress cctx,                      42157
 github,                             level 3,                            compress cctx,                      136335
 github,                             level 3 with dict,                  compress cctx,                      41534
@@ -95,68 +95,68 @@ github,                             small chain log,                    compress
 github,                             explicit params,                    compress cctx,                      140932
 github,                             uncompressed literals,              compress cctx,                      136335
 github,                             uncompressed literals optimal,      compress cctx,                      134064
-github,                             huffman literals,                   compress cctx,                      175468
+github,                             huffman literals,                   compress cctx,                      175568
 github,                             multithreaded with advanced params, compress cctx,                      141102
-silesia,                            level -5,                           zstdcli,                            7354723
-silesia,                            level -3,                           zstdcli,                            6902422
-silesia,                            level -1,                           zstdcli,                            6177613
-silesia,                            level 0,                            zstdcli,                            4849601
-silesia,                            level 1,                            zstdcli,                            5309146
-silesia,                            level 3,                            zstdcli,                            4849601
-silesia,                            level 4,                            zstdcli,                            4787016
-silesia,                            level 5,                            zstdcli,                            4639009
-silesia,                            level 6,                            zstdcli,                            4605417
-silesia,                            level 7,                            zstdcli,                            4567252
-silesia,                            level 9,                            zstdcli,                            4543358
-silesia,                            level 13,                           zstdcli,                            4494038
-silesia,                            level 16,                           zstdcli,                            4359912
-silesia,                            level 19,                           zstdcli,                            4296928
+silesia,                            level -5,                           zstdcli,                            6737655
+silesia,                            level -3,                           zstdcli,                            6444725
+silesia,                            level -1,                           zstdcli,                            6178508
+silesia,                            level 0,                            zstdcli,                            4849599
+silesia,                            level 1,                            zstdcli,                            5313250
+silesia,                            level 3,                            zstdcli,                            4849599
+silesia,                            level 4,                            zstdcli,                            4787017
+silesia,                            level 5,                            zstdcli,                            4639180
+silesia,                            level 6,                            zstdcli,                            4605677
+silesia,                            level 7,                            zstdcli,                            4567355
+silesia,                            level 9,                            zstdcli,                            4543378
+silesia,                            level 13,                           zstdcli,                            4482179
+silesia,                            level 16,                           zstdcli,                            4360299
+silesia,                            level 19,                           zstdcli,                            4283284
 silesia,                            long distance mode,                 zstdcli,                            4840807
-silesia,                            multithreaded,                      zstdcli,                            4849601
+silesia,                            multithreaded,                      zstdcli,                            4849599
 silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
 silesia,                            small window log,                   zstdcli,                            7095967
 silesia,                            small hash log,                     zstdcli,                            6526189
-silesia,                            small chain log,                    zstdcli,                            4912245
-silesia,                            explicit params,                    zstdcli,                            4795856
+silesia,                            small chain log,                    zstdcli,                            4912247
+silesia,                            explicit params,                    zstdcli,                            4796282
 silesia,                            uncompressed literals,              zstdcli,                            5128030
-silesia,                            uncompressed literals optimal,      zstdcli,                            4319566
-silesia,                            huffman literals,                   zstdcli,                            5326394
+silesia,                            uncompressed literals optimal,      zstdcli,                            4317944
+silesia,                            huffman literals,                   zstdcli,                            5326317
 silesia,                            multithreaded with advanced params, zstdcli,                            5128030
-silesia.tar,                        level -5,                           zstdcli,                            7363866
-silesia.tar,                        level -3,                           zstdcli,                            6902158
-silesia.tar,                        level -1,                           zstdcli,                            6182939
-silesia.tar,                        level 0,                            zstdcli,                            4861512
-silesia.tar,                        level 1,                            zstdcli,                            5333183
-silesia.tar,                        level 3,                            zstdcli,                            4861512
-silesia.tar,                        level 4,                            zstdcli,                            4800528
-silesia.tar,                        level 5,                            zstdcli,                            4651160
-silesia.tar,                        level 6,                            zstdcli,                            4618402
-silesia.tar,                        level 7,                            zstdcli,                            4578884
-silesia.tar,                        level 9,                            zstdcli,                            4553499
-silesia.tar,                        level 13,                           zstdcli,                            4502960
-silesia.tar,                        level 16,                           zstdcli,                            4360531
-silesia.tar,                        level 19,                           zstdcli,                            4267270
-silesia.tar,                        no source size,                     zstdcli,                            4861508
+silesia.tar,                        level -5,                           zstdcli,                            6738934
+silesia.tar,                        level -3,                           zstdcli,                            6448419
+silesia.tar,                        level -1,                           zstdcli,                            6186912
+silesia.tar,                        level 0,                            zstdcli,                            4861511
+silesia.tar,                        level 1,                            zstdcli,                            5336318
+silesia.tar,                        level 3,                            zstdcli,                            4861511
+silesia.tar,                        level 4,                            zstdcli,                            4800529
+silesia.tar,                        level 5,                            zstdcli,                            4651342
+silesia.tar,                        level 6,                            zstdcli,                            4618674
+silesia.tar,                        level 7,                            zstdcli,                            4579009
+silesia.tar,                        level 9,                            zstdcli,                            4553551
+silesia.tar,                        level 13,                           zstdcli,                            4491772
+silesia.tar,                        level 16,                           zstdcli,                            4356838
+silesia.tar,                        level 19,                           zstdcli,                            4264392
+silesia.tar,                        no source size,                     zstdcli,                            4861507
 silesia.tar,                        long distance mode,                 zstdcli,                            4853225
-silesia.tar,                        multithreaded,                      zstdcli,                            4861512
+silesia.tar,                        multithreaded,                      zstdcli,                            4861511
 silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4853225
 silesia.tar,                        small window log,                   zstdcli,                            7101576
-silesia.tar,                        small hash log,                     zstdcli,                            6529289
-silesia.tar,                        small chain log,                    zstdcli,                            4917022
-silesia.tar,                        explicit params,                    zstdcli,                            4821274
+silesia.tar,                        small hash log,                     zstdcli,                            6529286
+silesia.tar,                        small chain log,                    zstdcli,                            4917020
+silesia.tar,                        explicit params,                    zstdcli,                            4821593
 silesia.tar,                        uncompressed literals,              zstdcli,                            5129559
-silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4310145
-silesia.tar,                        huffman literals,                   zstdcli,                            5344915
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4307404
+silesia.tar,                        huffman literals,                   zstdcli,                            5347610
 silesia.tar,                        multithreaded with advanced params, zstdcli,                            5129559
-github,                             level -5,                           zstdcli,                            234315
+github,                             level -5,                           zstdcli,                            207285
 github,                             level -5 with dict,                 zstdcli,                            48718
-github,                             level -3,                           zstdcli,                            222760
+github,                             level -3,                           zstdcli,                            192643
 github,                             level -3 with dict,                 zstdcli,                            47395
-github,                             level -1,                           zstdcli,                            177468
+github,                             level -1,                           zstdcli,                            177568
 github,                             level -1 with dict,                 zstdcli,                            45170
 github,                             level 0,                            zstdcli,                            138335
 github,                             level 0 with dict,                  zstdcli,                            43148
-github,                             level 1,                            zstdcli,                            144365
+github,                             level 1,                            zstdcli,                            144465
 github,                             level 1 with dict,                  zstdcli,                            43682
 github,                             level 3,                            zstdcli,                            138335
 github,                             level 3 with dict,                  zstdcli,                            43148
@@ -185,36 +185,36 @@ github,                             small chain log,                    zstdcli,
 github,                             explicit params,                    zstdcli,                            136197
 github,                             uncompressed literals,              zstdcli,                            167915
 github,                             uncompressed literals optimal,      zstdcli,                            159227
-github,                             huffman literals,                   zstdcli,                            144365
+github,                             huffman literals,                   zstdcli,                            144465
 github,                             multithreaded with advanced params, zstdcli,                            167915
-github.tar,                         level -5,                           zstdcli,                            66918
-github.tar,                         level -5 with dict,                 zstdcli,                            51529
-github.tar,                         level -3,                           zstdcli,                            52131
-github.tar,                         level -3 with dict,                 zstdcli,                            44246
-github.tar,                         level -1,                           zstdcli,                            42564
-github.tar,                         level -1 with dict,                 zstdcli,                            41140
+github.tar,                         level -5,                           zstdcli,                            46860
+github.tar,                         level -5 with dict,                 zstdcli,                            44575
+github.tar,                         level -3,                           zstdcli,                            43758
+github.tar,                         level -3 with dict,                 zstdcli,                            41451
+github.tar,                         level -1,                           zstdcli,                            42494
+github.tar,                         level -1 with dict,                 zstdcli,                            41135
 github.tar,                         level 0,                            zstdcli,                            38445
 github.tar,                         level 0 with dict,                  zstdcli,                            37999
-github.tar,                         level 1,                            zstdcli,                            39204
-github.tar,                         level 1 with dict,                  zstdcli,                            38288
+github.tar,                         level 1,                            zstdcli,                            39269
+github.tar,                         level 1 with dict,                  zstdcli,                            38284
 github.tar,                         level 3,                            zstdcli,                            38445
 github.tar,                         level 3 with dict,                  zstdcli,                            37999
 github.tar,                         level 4,                            zstdcli,                            38471
 github.tar,                         level 4 with dict,                  zstdcli,                            37952
-github.tar,                         level 5,                            zstdcli,                            38380
-github.tar,                         level 5 with dict,                  zstdcli,                            39032
-github.tar,                         level 6,                            zstdcli,                            38614
-github.tar,                         level 6 with dict,                  zstdcli,                            38614
-github.tar,                         level 7,                            zstdcli,                            38077
-github.tar,                         level 7 with dict,                  zstdcli,                            37873
-github.tar,                         level 9,                            zstdcli,                            36771
-github.tar,                         level 9 with dict,                  zstdcli,                            36623
-github.tar,                         level 13,                           zstdcli,                            35505
-github.tar,                         level 13 with dict,                 zstdcli,                            37134
-github.tar,                         level 16,                           zstdcli,                            40475
-github.tar,                         level 16 with dict,                 zstdcli,                            33382
-github.tar,                         level 19,                           zstdcli,                            32138
-github.tar,                         level 19 with dict,                 zstdcli,                            32713
+github.tar,                         level 5,                            zstdcli,                            38398
+github.tar,                         level 5 with dict,                  zstdcli,                            39048
+github.tar,                         level 6,                            zstdcli,                            38673
+github.tar,                         level 6 with dict,                  zstdcli,                            38660
+github.tar,                         level 7,                            zstdcli,                            38157
+github.tar,                         level 7 with dict,                  zstdcli,                            37914
+github.tar,                         level 9,                            zstdcli,                            36772
+github.tar,                         level 9 with dict,                  zstdcli,                            36650
+github.tar,                         level 13,                           zstdcli,                            35625
+github.tar,                         level 13 with dict,                 zstdcli,                            38730
+github.tar,                         level 16,                           zstdcli,                            40259
+github.tar,                         level 16 with dict,                 zstdcli,                            33643
+github.tar,                         level 19,                           zstdcli,                            32841
+github.tar,                         level 19 with dict,                 zstdcli,                            32899
 github.tar,                         no source size,                     zstdcli,                            38442
 github.tar,                         no source size with dict,           zstdcli,                            38004
 github.tar,                         long distance mode,                 zstdcli,                            39730
@@ -223,84 +223,84 @@ github.tar,                         multithreaded long distance mode,   zstdcli,
 github.tar,                         small window log,                   zstdcli,                            198544
 github.tar,                         small hash log,                     zstdcli,                            129874
 github.tar,                         small chain log,                    zstdcli,                            41673
-github.tar,                         explicit params,                    zstdcli,                            41227
+github.tar,                         explicit params,                    zstdcli,                            41350
 github.tar,                         uncompressed literals,              zstdcli,                            41126
-github.tar,                         uncompressed literals optimal,      zstdcli,                            35401
-github.tar,                         huffman literals,                   zstdcli,                            38857
+github.tar,                         uncompressed literals optimal,      zstdcli,                            35392
+github.tar,                         huffman literals,                   zstdcli,                            38781
 github.tar,                         multithreaded with advanced params, zstdcli,                            41126
-silesia,                            level -5,                           advanced one pass,                  7354675
-silesia,                            level -3,                           advanced one pass,                  6902374
-silesia,                            level -1,                           advanced one pass,                  6177565
-silesia,                            level 0,                            advanced one pass,                  4849553
-silesia,                            level 1,                            advanced one pass,                  5309098
-silesia,                            level 3,                            advanced one pass,                  4849553
-silesia,                            level 4,                            advanced one pass,                  4786968
-silesia,                            level 5 row 1,                      advanced one pass,                  4638961
-silesia,                            level 5 row 2,                      advanced one pass,                  4640752
-silesia,                            level 5,                            advanced one pass,                  4638961
-silesia,                            level 6,                            advanced one pass,                  4605369
-silesia,                            level 7 row 1,                      advanced one pass,                  4567204
-silesia,                            level 7 row 2,                      advanced one pass,                  4564868
-silesia,                            level 7,                            advanced one pass,                  4567204
-silesia,                            level 9,                            advanced one pass,                  4543310
-silesia,                            level 11 row 1,                     advanced one pass,                  4521399
-silesia,                            level 11 row 2,                     advanced one pass,                  4519288
-silesia,                            level 12 row 1,                     advanced one pass,                  4505153
-silesia,                            level 12 row 2,                     advanced one pass,                  4503116
-silesia,                            level 13,                           advanced one pass,                  4493990
-silesia,                            level 16,                           advanced one pass,                  4359864
-silesia,                            level 19,                           advanced one pass,                  4296880
-silesia,                            no source size,                     advanced one pass,                  4849553
-silesia,                            long distance mode,                 advanced one pass,                  4840737
-silesia,                            multithreaded,                      advanced one pass,                  4849553
+silesia,                            level -5,                           advanced one pass,                  6737607
+silesia,                            level -3,                           advanced one pass,                  6444677
+silesia,                            level -1,                           advanced one pass,                  6178460
+silesia,                            level 0,                            advanced one pass,                  4849551
+silesia,                            level 1,                            advanced one pass,                  5313202
+silesia,                            level 3,                            advanced one pass,                  4849551
+silesia,                            level 4,                            advanced one pass,                  4786969
+silesia,                            level 5 row 1,                      advanced one pass,                  4640753
+silesia,                            level 5 row 2,                      advanced one pass,                  4639132
+silesia,                            level 5,                            advanced one pass,                  4639132
+silesia,                            level 6,                            advanced one pass,                  4605629
+silesia,                            level 7 row 1,                      advanced one pass,                  4564870
+silesia,                            level 7 row 2,                      advanced one pass,                  4567307
+silesia,                            level 7,                            advanced one pass,                  4567307
+silesia,                            level 9,                            advanced one pass,                  4543330
+silesia,                            level 11 row 1,                     advanced one pass,                  4519288
+silesia,                            level 11 row 2,                     advanced one pass,                  4521524
+silesia,                            level 12 row 1,                     advanced one pass,                  4503117
+silesia,                            level 12 row 2,                     advanced one pass,                  4505093
+silesia,                            level 13,                           advanced one pass,                  4482131
+silesia,                            level 16,                           advanced one pass,                  4360251
+silesia,                            level 19,                           advanced one pass,                  4283236
+silesia,                            no source size,                     advanced one pass,                  4849551
+silesia,                            long distance mode,                 advanced one pass,                  4840738
+silesia,                            multithreaded,                      advanced one pass,                  4849551
 silesia,                            multithreaded long distance mode,   advanced one pass,                  4840759
 silesia,                            small window log,                   advanced one pass,                  7095919
 silesia,                            small hash log,                     advanced one pass,                  6526141
-silesia,                            small chain log,                    advanced one pass,                  4912197
-silesia,                            explicit params,                    advanced one pass,                  4795856
+silesia,                            small chain log,                    advanced one pass,                  4912199
+silesia,                            explicit params,                    advanced one pass,                  4796282
 silesia,                            uncompressed literals,              advanced one pass,                  5127982
-silesia,                            uncompressed literals optimal,      advanced one pass,                  4319518
-silesia,                            huffman literals,                   advanced one pass,                  5326346
+silesia,                            uncompressed literals optimal,      advanced one pass,                  4317896
+silesia,                            huffman literals,                   advanced one pass,                  5326269
 silesia,                            multithreaded with advanced params, advanced one pass,                  5127982
-silesia.tar,                        level -5,                           advanced one pass,                  7359401
-silesia.tar,                        level -3,                           advanced one pass,                  6901672
-silesia.tar,                        level -1,                           advanced one pass,                  6182241
-silesia.tar,                        level 0,                            advanced one pass,                  4861424
-silesia.tar,                        level 1,                            advanced one pass,                  5331946
-silesia.tar,                        level 3,                            advanced one pass,                  4861424
+silesia.tar,                        level -5,                           advanced one pass,                  6738593
+silesia.tar,                        level -3,                           advanced one pass,                  6446372
+silesia.tar,                        level -1,                           advanced one pass,                  6186042
+silesia.tar,                        level 0,                            advanced one pass,                  4861423
+silesia.tar,                        level 1,                            advanced one pass,                  5334885
+silesia.tar,                        level 3,                            advanced one pass,                  4861423
 silesia.tar,                        level 4,                            advanced one pass,                  4799632
-silesia.tar,                        level 5 row 1,                      advanced one pass,                  4650202
-silesia.tar,                        level 5 row 2,                      advanced one pass,                  4652862
-silesia.tar,                        level 5,                            advanced one pass,                  4650202
-silesia.tar,                        level 6,                            advanced one pass,                  4616811
-silesia.tar,                        level 7 row 1,                      advanced one pass,                  4576829
-silesia.tar,                        level 7 row 2,                      advanced one pass,                  4575393
-silesia.tar,                        level 7,                            advanced one pass,                  4576829
-silesia.tar,                        level 9,                            advanced one pass,                  4552584
-silesia.tar,                        level 11 row 1,                     advanced one pass,                  4530256
-silesia.tar,                        level 11 row 2,                     advanced one pass,                  4529461
-silesia.tar,                        level 12 row 1,                     advanced one pass,                  4514568
-silesia.tar,                        level 12 row 2,                     advanced one pass,                  4513604
-silesia.tar,                        level 13,                           advanced one pass,                  4502956
-silesia.tar,                        level 16,                           advanced one pass,                  4360527
-silesia.tar,                        level 19,                           advanced one pass,                  4267266
-silesia.tar,                        no source size,                     advanced one pass,                  4861424
-silesia.tar,                        long distance mode,                 advanced one pass,                  4847752
-silesia.tar,                        multithreaded,                      advanced one pass,                  4861508
+silesia.tar,                        level 5 row 1,                      advanced one pass,                  4652862
+silesia.tar,                        level 5 row 2,                      advanced one pass,                  4650387
+silesia.tar,                        level 5,                            advanced one pass,                  4650387
+silesia.tar,                        level 6,                            advanced one pass,                  4617089
+silesia.tar,                        level 7 row 1,                      advanced one pass,                  4575392
+silesia.tar,                        level 7 row 2,                      advanced one pass,                  4576951
+silesia.tar,                        level 7,                            advanced one pass,                  4576951
+silesia.tar,                        level 9,                            advanced one pass,                  4552638
+silesia.tar,                        level 11 row 1,                     advanced one pass,                  4529458
+silesia.tar,                        level 11 row 2,                     advanced one pass,                  4530416
+silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513603
+silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514499
+silesia.tar,                        level 13,                           advanced one pass,                  4491768
+silesia.tar,                        level 16,                           advanced one pass,                  4356834
+silesia.tar,                        level 19,                           advanced one pass,                  4264388
+silesia.tar,                        no source size,                     advanced one pass,                  4861423
+silesia.tar,                        long distance mode,                 advanced one pass,                  4847753
+silesia.tar,                        multithreaded,                      advanced one pass,                  4861507
 silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4853221
 silesia.tar,                        small window log,                   advanced one pass,                  7101530
-silesia.tar,                        small hash log,                     advanced one pass,                  6529231
-silesia.tar,                        small chain log,                    advanced one pass,                  4917041
-silesia.tar,                        explicit params,                    advanced one pass,                  4807381
+silesia.tar,                        small hash log,                     advanced one pass,                  6529228
+silesia.tar,                        small chain log,                    advanced one pass,                  4917039
+silesia.tar,                        explicit params,                    advanced one pass,                  4807675
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4310141
-silesia.tar,                        huffman literals,                   advanced one pass,                  5344545
+silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4307400
+silesia.tar,                        huffman literals,                   advanced one pass,                  5347335
 silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5129555
-github,                             level -5,                           advanced one pass,                  232315
+github,                             level -5,                           advanced one pass,                  205285
 github,                             level -5 with dict,                 advanced one pass,                  46718
-github,                             level -3,                           advanced one pass,                  220760
+github,                             level -3,                           advanced one pass,                  190643
 github,                             level -3 with dict,                 advanced one pass,                  45395
-github,                             level -1,                           advanced one pass,                  175468
+github,                             level -1,                           advanced one pass,                  175568
 github,                             level -1 with dict,                 advanced one pass,                  43170
 github,                             level 0,                            advanced one pass,                  136335
 github,                             level 0 with dict,                  advanced one pass,                  41148
@@ -308,7 +308,7 @@ github,                             level 0 with dict dms,              advanced
 github,                             level 0 with dict dds,              advanced one pass,                  41148
 github,                             level 0 with dict copy,             advanced one pass,                  41124
 github,                             level 0 with dict load,             advanced one pass,                  42252
-github,                             level 1,                            advanced one pass,                  142365
+github,                             level 1,                            advanced one pass,                  142465
 github,                             level 1 with dict,                  advanced one pass,                  41682
 github,                             level 1 with dict dms,              advanced one pass,                  41682
 github,                             level 1 with dict dds,              advanced one pass,                  41682
@@ -326,16 +326,16 @@ github,                             level 4 with dict dms,              advanced
 github,                             level 4 with dict dds,              advanced one pass,                  41251
 github,                             level 4 with dict copy,             advanced one pass,                  41216
 github,                             level 4 with dict load,             advanced one pass,                  41159
-github,                             level 5 row 1,                      advanced one pass,                  134584
-github,                             level 5 row 1 with dict dms,        advanced one pass,                  38758
-github,                             level 5 row 1 with dict dds,        advanced one pass,                  38728
-github,                             level 5 row 1 with dict copy,       advanced one pass,                  38759
-github,                             level 5 row 1 with dict load,       advanced one pass,                  41518
-github,                             level 5 row 2,                      advanced one pass,                  135121
-github,                             level 5 row 2 with dict dms,        advanced one pass,                  38938
-github,                             level 5 row 2 with dict dds,        advanced one pass,                  38732
-github,                             level 5 row 2 with dict copy,       advanced one pass,                  38934
-github,                             level 5 row 2 with dict load,       advanced one pass,                  40725
+github,                             level 5 row 1,                      advanced one pass,                  135121
+github,                             level 5 row 1 with dict dms,        advanced one pass,                  38938
+github,                             level 5 row 1 with dict dds,        advanced one pass,                  38732
+github,                             level 5 row 1 with dict copy,       advanced one pass,                  38934
+github,                             level 5 row 1 with dict load,       advanced one pass,                  40725
+github,                             level 5 row 2,                      advanced one pass,                  134584
+github,                             level 5 row 2 with dict dms,        advanced one pass,                  38758
+github,                             level 5 row 2 with dict dds,        advanced one pass,                  38728
+github,                             level 5 row 2 with dict copy,       advanced one pass,                  38759
+github,                             level 5 row 2 with dict load,       advanced one pass,                  41518
 github,                             level 5,                            advanced one pass,                  135121
 github,                             level 5 with dict,                  advanced one pass,                  38758
 github,                             level 5 with dict dms,              advanced one pass,                  38758
@@ -348,16 +348,16 @@ github,                             level 6 with dict dms,              advanced
 github,                             level 6 with dict dds,              advanced one pass,                  38636
 github,                             level 6 with dict copy,             advanced one pass,                  38669
 github,                             level 6 with dict load,             advanced one pass,                  40695
-github,                             level 7 row 1,                      advanced one pass,                  134584
-github,                             level 7 row 1 with dict dms,        advanced one pass,                  38758
-github,                             level 7 row 1 with dict dds,        advanced one pass,                  38745
-github,                             level 7 row 1 with dict copy,       advanced one pass,                  38755
-github,                             level 7 row 1 with dict load,       advanced one pass,                  43154
-github,                             level 7 row 2,                      advanced one pass,                  135122
-github,                             level 7 row 2 with dict dms,        advanced one pass,                  38860
-github,                             level 7 row 2 with dict dds,        advanced one pass,                  38766
-github,                             level 7 row 2 with dict copy,       advanced one pass,                  38834
-github,                             level 7 row 2 with dict load,       advanced one pass,                  40695
+github,                             level 7 row 1,                      advanced one pass,                  135122
+github,                             level 7 row 1 with dict dms,        advanced one pass,                  38860
+github,                             level 7 row 1 with dict dds,        advanced one pass,                  38766
+github,                             level 7 row 1 with dict copy,       advanced one pass,                  38834
+github,                             level 7 row 1 with dict load,       advanced one pass,                  40695
+github,                             level 7 row 2,                      advanced one pass,                  134584
+github,                             level 7 row 2 with dict dms,        advanced one pass,                  38758
+github,                             level 7 row 2 with dict dds,        advanced one pass,                  38745
+github,                             level 7 row 2 with dict copy,       advanced one pass,                  38755
+github,                             level 7 row 2 with dict load,       advanced one pass,                  43154
 github,                             level 7,                            advanced one pass,                  135122
 github,                             level 7 with dict,                  advanced one pass,                  38758
 github,                             level 7 with dict dms,              advanced one pass,                  38758
@@ -419,26 +419,26 @@ github,                             small chain log,                    advanced
 github,                             explicit params,                    advanced one pass,                  137727
 github,                             uncompressed literals,              advanced one pass,                  165915
 github,                             uncompressed literals optimal,      advanced one pass,                  157227
-github,                             huffman literals,                   advanced one pass,                  142365
+github,                             huffman literals,                   advanced one pass,                  142465
 github,                             multithreaded with advanced params, advanced one pass,                  165915
-github.tar,                         level -5,                           advanced one pass,                  66914
-github.tar,                         level -5 with dict,                 advanced one pass,                  51525
-github.tar,                         level -3,                           advanced one pass,                  52127
-github.tar,                         level -3 with dict,                 advanced one pass,                  44242
-github.tar,                         level -1,                           advanced one pass,                  42560
-github.tar,                         level -1 with dict,                 advanced one pass,                  41136
+github.tar,                         level -5,                           advanced one pass,                  46856
+github.tar,                         level -5 with dict,                 advanced one pass,                  44571
+github.tar,                         level -3,                           advanced one pass,                  43754
+github.tar,                         level -3 with dict,                 advanced one pass,                  41447
+github.tar,                         level -1,                           advanced one pass,                  42490
+github.tar,                         level -1 with dict,                 advanced one pass,                  41131
 github.tar,                         level 0,                            advanced one pass,                  38441
 github.tar,                         level 0 with dict,                  advanced one pass,                  37995
 github.tar,                         level 0 with dict dms,              advanced one pass,                  38003
 github.tar,                         level 0 with dict dds,              advanced one pass,                  38003
 github.tar,                         level 0 with dict copy,             advanced one pass,                  37995
 github.tar,                         level 0 with dict load,             advanced one pass,                  37956
-github.tar,                         level 1,                            advanced one pass,                  39200
-github.tar,                         level 1 with dict,                  advanced one pass,                  38284
-github.tar,                         level 1 with dict dms,              advanced one pass,                  38294
-github.tar,                         level 1 with dict dds,              advanced one pass,                  38294
-github.tar,                         level 1 with dict copy,             advanced one pass,                  38284
-github.tar,                         level 1 with dict load,             advanced one pass,                  38724
+github.tar,                         level 1,                            advanced one pass,                  39265
+github.tar,                         level 1 with dict,                  advanced one pass,                  38280
+github.tar,                         level 1 with dict dms,              advanced one pass,                  38290
+github.tar,                         level 1 with dict dds,              advanced one pass,                  38290
+github.tar,                         level 1 with dict copy,             advanced one pass,                  38280
+github.tar,                         level 1 with dict load,             advanced one pass,                  38729
 github.tar,                         level 3,                            advanced one pass,                  38441
 github.tar,                         level 3 with dict,                  advanced one pass,                  37995
 github.tar,                         level 3 with dict dms,              advanced one pass,                  38003
@@ -451,88 +451,88 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass,                  37954
 github.tar,                         level 4 with dict copy,             advanced one pass,                  37948
 github.tar,                         level 4 with dict load,             advanced one pass,                  37927
-github.tar,                         level 5 row 1,                      advanced one pass,                  38376
-github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39024
-github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39028
-github.tar,                         level 5 row 1 with dict copy,       advanced one pass,                  39040
-github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  37600
-github.tar,                         level 5 row 2,                      advanced one pass,                  38534
-github.tar,                         level 5 row 2 with dict dms,        advanced one pass,                  39365
-github.tar,                         level 5 row 2 with dict dds,        advanced one pass,                  39233
-github.tar,                         level 5 row 2 with dict copy,       advanced one pass,                  39715
-github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  38019
-github.tar,                         level 5,                            advanced one pass,                  38376
-github.tar,                         level 5 with dict,                  advanced one pass,                  39040
-github.tar,                         level 5 with dict dms,              advanced one pass,                  39024
-github.tar,                         level 5 with dict dds,              advanced one pass,                  39028
-github.tar,                         level 5 with dict copy,             advanced one pass,                  39040
-github.tar,                         level 5 with dict load,             advanced one pass,                  37600
-github.tar,                         level 6,                            advanced one pass,                  38610
-github.tar,                         level 6 with dict,                  advanced one pass,                  38622
-github.tar,                         level 6 with dict dms,              advanced one pass,                  38608
-github.tar,                         level 6 with dict dds,              advanced one pass,                  38610
-github.tar,                         level 6 with dict copy,             advanced one pass,                  38622
-github.tar,                         level 6 with dict load,             advanced one pass,                  37829
-github.tar,                         level 7 row 1,                      advanced one pass,                  38073
-github.tar,                         level 7 row 1 with dict dms,        advanced one pass,                  37848
-github.tar,                         level 7 row 1 with dict dds,        advanced one pass,                  37869
-github.tar,                         level 7 row 1 with dict copy,       advanced one pass,                  37848
-github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  37371
-github.tar,                         level 7 row 2,                      advanced one pass,                  38077
-github.tar,                         level 7 row 2 with dict dms,        advanced one pass,                  38012
-github.tar,                         level 7 row 2 with dict dds,        advanced one pass,                  38014
-github.tar,                         level 7 row 2 with dict copy,       advanced one pass,                  38101
-github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  37402
-github.tar,                         level 7,                            advanced one pass,                  38073
-github.tar,                         level 7 with dict,                  advanced one pass,                  37848
-github.tar,                         level 7 with dict dms,              advanced one pass,                  37848
-github.tar,                         level 7 with dict dds,              advanced one pass,                  37869
-github.tar,                         level 7 with dict copy,             advanced one pass,                  37848
-github.tar,                         level 7 with dict load,             advanced one pass,                  37371
-github.tar,                         level 9,                            advanced one pass,                  36767
-github.tar,                         level 9 with dict,                  advanced one pass,                  36457
-github.tar,                         level 9 with dict dms,              advanced one pass,                  36549
-github.tar,                         level 9 with dict dds,              advanced one pass,                  36619
-github.tar,                         level 9 with dict copy,             advanced one pass,                  36457
-github.tar,                         level 9 with dict load,             advanced one pass,                  36352
+github.tar,                         level 5 row 1,                      advanced one pass,                  38534
+github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39365
+github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39233
+github.tar,                         level 5 row 1 with dict copy,       advanced one pass,                  39715
+github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  38019
+github.tar,                         level 5 row 2,                      advanced one pass,                  38394
+github.tar,                         level 5 row 2 with dict dms,        advanced one pass,                  39048
+github.tar,                         level 5 row 2 with dict dds,        advanced one pass,                  39044
+github.tar,                         level 5 row 2 with dict copy,       advanced one pass,                  39074
+github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  37665
+github.tar,                         level 5,                            advanced one pass,                  38394
+github.tar,                         level 5 with dict,                  advanced one pass,                  39074
+github.tar,                         level 5 with dict dms,              advanced one pass,                  39048
+github.tar,                         level 5 with dict dds,              advanced one pass,                  39044
+github.tar,                         level 5 with dict copy,             advanced one pass,                  39074
+github.tar,                         level 5 with dict load,             advanced one pass,                  37665
+github.tar,                         level 6,                            advanced one pass,                  38669
+github.tar,                         level 6 with dict,                  advanced one pass,                  38660
+github.tar,                         level 6 with dict dms,              advanced one pass,                  38654
+github.tar,                         level 6 with dict dds,              advanced one pass,                  38656
+github.tar,                         level 6 with dict copy,             advanced one pass,                  38660
+github.tar,                         level 6 with dict load,             advanced one pass,                  37889
+github.tar,                         level 7 row 1,                      advanced one pass,                  38077
+github.tar,                         level 7 row 1 with dict dms,        advanced one pass,                  38012
+github.tar,                         level 7 row 1 with dict dds,        advanced one pass,                  38014
+github.tar,                         level 7 row 1 with dict copy,       advanced one pass,                  38101
+github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  37402
+github.tar,                         level 7 row 2,                      advanced one pass,                  38153
+github.tar,                         level 7 row 2 with dict dms,        advanced one pass,                  37888
+github.tar,                         level 7 row 2 with dict dds,        advanced one pass,                  37910
+github.tar,                         level 7 row 2 with dict copy,       advanced one pass,                  37892
+github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  37457
+github.tar,                         level 7,                            advanced one pass,                  38153
+github.tar,                         level 7 with dict,                  advanced one pass,                  37892
+github.tar,                         level 7 with dict dms,              advanced one pass,                  37888
+github.tar,                         level 7 with dict dds,              advanced one pass,                  37910
+github.tar,                         level 7 with dict copy,             advanced one pass,                  37892
+github.tar,                         level 7 with dict load,             advanced one pass,                  37457
+github.tar,                         level 9,                            advanced one pass,                  36768
+github.tar,                         level 9 with dict,                  advanced one pass,                  36510
+github.tar,                         level 9 with dict dms,              advanced one pass,                  36584
+github.tar,                         level 9 with dict dds,              advanced one pass,                  36646
+github.tar,                         level 9 with dict copy,             advanced one pass,                  36510
+github.tar,                         level 9 with dict load,             advanced one pass,                  36383
 github.tar,                         level 11 row 1,                     advanced one pass,                  36435
 github.tar,                         level 11 row 1 with dict dms,       advanced one pass,                  36963
 github.tar,                         level 11 row 1 with dict dds,       advanced one pass,                  36963
 github.tar,                         level 11 row 1 with dict copy,      advanced one pass,                  36557
-github.tar,                         level 11 row 1 with dict load,      advanced one pass,                  36424
-github.tar,                         level 11 row 2,                     advanced one pass,                  36435
+github.tar,                         level 11 row 1 with dict load,      advanced one pass,                  36419
+github.tar,                         level 11 row 2,                     advanced one pass,                  36412
 github.tar,                         level 11 row 2 with dict dms,       advanced one pass,                  36963
 github.tar,                         level 11 row 2 with dict dds,       advanced one pass,                  36963
 github.tar,                         level 11 row 2 with dict copy,      advanced one pass,                  36557
-github.tar,                         level 11 row 2 with dict load,      advanced one pass,                  36419
-github.tar,                         level 12 row 1,                     advanced one pass,                  36105
+github.tar,                         level 11 row 2 with dict load,      advanced one pass,                  36439
+github.tar,                         level 12 row 1,                     advanced one pass,                  36110
 github.tar,                         level 12 row 1 with dict dms,       advanced one pass,                  36986
 github.tar,                         level 12 row 1 with dict dds,       advanced one pass,                  36986
 github.tar,                         level 12 row 1 with dict copy,      advanced one pass,                  36609
-github.tar,                         level 12 row 1 with dict load,      advanced one pass,                  36460
-github.tar,                         level 12 row 2,                     advanced one pass,                  36110
+github.tar,                         level 12 row 1 with dict load,      advanced one pass,                  36459
+github.tar,                         level 12 row 2,                     advanced one pass,                  36062
 github.tar,                         level 12 row 2 with dict dms,       advanced one pass,                  36986
 github.tar,                         level 12 row 2 with dict dds,       advanced one pass,                  36986
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass,                  36609
-github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36459
-github.tar,                         level 13,                           advanced one pass,                  35501
-github.tar,                         level 13 with dict,                 advanced one pass,                  37130
-github.tar,                         level 13 with dict dms,             advanced one pass,                  37267
-github.tar,                         level 13 with dict dds,             advanced one pass,                  37267
-github.tar,                         level 13 with dict copy,            advanced one pass,                  37130
-github.tar,                         level 13 with dict load,            advanced one pass,                  36010
-github.tar,                         level 16,                           advanced one pass,                  40471
-github.tar,                         level 16 with dict,                 advanced one pass,                  33378
-github.tar,                         level 16 with dict dms,             advanced one pass,                  33213
-github.tar,                         level 16 with dict dds,             advanced one pass,                  33213
-github.tar,                         level 16 with dict copy,            advanced one pass,                  33378
-github.tar,                         level 16 with dict load,            advanced one pass,                  39081
-github.tar,                         level 19,                           advanced one pass,                  32134
-github.tar,                         level 19 with dict,                 advanced one pass,                  32709
-github.tar,                         level 19 with dict dms,             advanced one pass,                  32553
-github.tar,                         level 19 with dict dds,             advanced one pass,                  32553
-github.tar,                         level 19 with dict copy,            advanced one pass,                  32709
-github.tar,                         level 19 with dict load,            advanced one pass,                  32474
+github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36392
+github.tar,                         level 13,                           advanced one pass,                  35621
+github.tar,                         level 13 with dict,                 advanced one pass,                  38726
+github.tar,                         level 13 with dict dms,             advanced one pass,                  38903
+github.tar,                         level 13 with dict dds,             advanced one pass,                  38903
+github.tar,                         level 13 with dict copy,            advanced one pass,                  38726
+github.tar,                         level 13 with dict load,            advanced one pass,                  36372
+github.tar,                         level 16,                           advanced one pass,                  40255
+github.tar,                         level 16 with dict,                 advanced one pass,                  33639
+github.tar,                         level 16 with dict dms,             advanced one pass,                  33544
+github.tar,                         level 16 with dict dds,             advanced one pass,                  33544
+github.tar,                         level 16 with dict copy,            advanced one pass,                  33639
+github.tar,                         level 16 with dict load,            advanced one pass,                  39353
+github.tar,                         level 19,                           advanced one pass,                  32837
+github.tar,                         level 19 with dict,                 advanced one pass,                  32895
+github.tar,                         level 19 with dict dms,             advanced one pass,                  32672
+github.tar,                         level 19 with dict dds,             advanced one pass,                  32672
+github.tar,                         level 19 with dict copy,            advanced one pass,                  32895
+github.tar,                         level 19 with dict load,            advanced one pass,                  32676
 github.tar,                         no source size,                     advanced one pass,                  38441
 github.tar,                         no source size with dict,           advanced one pass,                  37995
 github.tar,                         long distance mode,                 advanced one pass,                  39757
@@ -541,84 +541,84 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced one pass,                  198540
 github.tar,                         small hash log,                     advanced one pass,                  129870
 github.tar,                         small chain log,                    advanced one pass,                  41669
-github.tar,                         explicit params,                    advanced one pass,                  41227
+github.tar,                         explicit params,                    advanced one pass,                  41350
 github.tar,                         uncompressed literals,              advanced one pass,                  41122
-github.tar,                         uncompressed literals optimal,      advanced one pass,                  35397
-github.tar,                         huffman literals,                   advanced one pass,                  38853
+github.tar,                         uncompressed literals optimal,      advanced one pass,                  35388
+github.tar,                         huffman literals,                   advanced one pass,                  38777
 github.tar,                         multithreaded with advanced params, advanced one pass,                  41122
-silesia,                            level -5,                           advanced one pass small out,        7354675
-silesia,                            level -3,                           advanced one pass small out,        6902374
-silesia,                            level -1,                           advanced one pass small out,        6177565
-silesia,                            level 0,                            advanced one pass small out,        4849553
-silesia,                            level 1,                            advanced one pass small out,        5309098
-silesia,                            level 3,                            advanced one pass small out,        4849553
-silesia,                            level 4,                            advanced one pass small out,        4786968
-silesia,                            level 5 row 1,                      advanced one pass small out,        4638961
-silesia,                            level 5 row 2,                      advanced one pass small out,        4640752
-silesia,                            level 5,                            advanced one pass small out,        4638961
-silesia,                            level 6,                            advanced one pass small out,        4605369
-silesia,                            level 7 row 1,                      advanced one pass small out,        4567204
-silesia,                            level 7 row 2,                      advanced one pass small out,        4564868
-silesia,                            level 7,                            advanced one pass small out,        4567204
-silesia,                            level 9,                            advanced one pass small out,        4543310
-silesia,                            level 11 row 1,                     advanced one pass small out,        4521399
-silesia,                            level 11 row 2,                     advanced one pass small out,        4519288
-silesia,                            level 12 row 1,                     advanced one pass small out,        4505153
-silesia,                            level 12 row 2,                     advanced one pass small out,        4503116
-silesia,                            level 13,                           advanced one pass small out,        4493990
-silesia,                            level 16,                           advanced one pass small out,        4359864
-silesia,                            level 19,                           advanced one pass small out,        4296880
-silesia,                            no source size,                     advanced one pass small out,        4849553
-silesia,                            long distance mode,                 advanced one pass small out,        4840737
-silesia,                            multithreaded,                      advanced one pass small out,        4849553
+silesia,                            level -5,                           advanced one pass small out,        6737607
+silesia,                            level -3,                           advanced one pass small out,        6444677
+silesia,                            level -1,                           advanced one pass small out,        6178460
+silesia,                            level 0,                            advanced one pass small out,        4849551
+silesia,                            level 1,                            advanced one pass small out,        5313202
+silesia,                            level 3,                            advanced one pass small out,        4849551
+silesia,                            level 4,                            advanced one pass small out,        4786969
+silesia,                            level 5 row 1,                      advanced one pass small out,        4640753
+silesia,                            level 5 row 2,                      advanced one pass small out,        4639132
+silesia,                            level 5,                            advanced one pass small out,        4639132
+silesia,                            level 6,                            advanced one pass small out,        4605629
+silesia,                            level 7 row 1,                      advanced one pass small out,        4564870
+silesia,                            level 7 row 2,                      advanced one pass small out,        4567307
+silesia,                            level 7,                            advanced one pass small out,        4567307
+silesia,                            level 9,                            advanced one pass small out,        4543330
+silesia,                            level 11 row 1,                     advanced one pass small out,        4519288
+silesia,                            level 11 row 2,                     advanced one pass small out,        4521524
+silesia,                            level 12 row 1,                     advanced one pass small out,        4503117
+silesia,                            level 12 row 2,                     advanced one pass small out,        4505093
+silesia,                            level 13,                           advanced one pass small out,        4482131
+silesia,                            level 16,                           advanced one pass small out,        4360251
+silesia,                            level 19,                           advanced one pass small out,        4283236
+silesia,                            no source size,                     advanced one pass small out,        4849551
+silesia,                            long distance mode,                 advanced one pass small out,        4840738
+silesia,                            multithreaded,                      advanced one pass small out,        4849551
 silesia,                            multithreaded long distance mode,   advanced one pass small out,        4840759
 silesia,                            small window log,                   advanced one pass small out,        7095919
 silesia,                            small hash log,                     advanced one pass small out,        6526141
-silesia,                            small chain log,                    advanced one pass small out,        4912197
-silesia,                            explicit params,                    advanced one pass small out,        4795856
+silesia,                            small chain log,                    advanced one pass small out,        4912199
+silesia,                            explicit params,                    advanced one pass small out,        4796282
 silesia,                            uncompressed literals,              advanced one pass small out,        5127982
-silesia,                            uncompressed literals optimal,      advanced one pass small out,        4319518
-silesia,                            huffman literals,                   advanced one pass small out,        5326346
+silesia,                            uncompressed literals optimal,      advanced one pass small out,        4317896
+silesia,                            huffman literals,                   advanced one pass small out,        5326269
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5127982
-silesia.tar,                        level -5,                           advanced one pass small out,        7359401
-silesia.tar,                        level -3,                           advanced one pass small out,        6901672
-silesia.tar,                        level -1,                           advanced one pass small out,        6182241
-silesia.tar,                        level 0,                            advanced one pass small out,        4861424
-silesia.tar,                        level 1,                            advanced one pass small out,        5331946
-silesia.tar,                        level 3,                            advanced one pass small out,        4861424
+silesia.tar,                        level -5,                           advanced one pass small out,        6738593
+silesia.tar,                        level -3,                           advanced one pass small out,        6446372
+silesia.tar,                        level -1,                           advanced one pass small out,        6186042
+silesia.tar,                        level 0,                            advanced one pass small out,        4861423
+silesia.tar,                        level 1,                            advanced one pass small out,        5334885
+silesia.tar,                        level 3,                            advanced one pass small out,        4861423
 silesia.tar,                        level 4,                            advanced one pass small out,        4799632
-silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4650202
-silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4652862
-silesia.tar,                        level 5,                            advanced one pass small out,        4650202
-silesia.tar,                        level 6,                            advanced one pass small out,        4616811
-silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4576829
-silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4575393
-silesia.tar,                        level 7,                            advanced one pass small out,        4576829
-silesia.tar,                        level 9,                            advanced one pass small out,        4552584
-silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4530256
-silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4529461
-silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4514568
-silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4513604
-silesia.tar,                        level 13,                           advanced one pass small out,        4502956
-silesia.tar,                        level 16,                           advanced one pass small out,        4360527
-silesia.tar,                        level 19,                           advanced one pass small out,        4267266
-silesia.tar,                        no source size,                     advanced one pass small out,        4861424
-silesia.tar,                        long distance mode,                 advanced one pass small out,        4847752
-silesia.tar,                        multithreaded,                      advanced one pass small out,        4861508
+silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4652862
+silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4650387
+silesia.tar,                        level 5,                            advanced one pass small out,        4650387
+silesia.tar,                        level 6,                            advanced one pass small out,        4617089
+silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4575392
+silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4576951
+silesia.tar,                        level 7,                            advanced one pass small out,        4576951
+silesia.tar,                        level 9,                            advanced one pass small out,        4552638
+silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4529458
+silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4530416
+silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513603
+silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514499
+silesia.tar,                        level 13,                           advanced one pass small out,        4491768
+silesia.tar,                        level 16,                           advanced one pass small out,        4356834
+silesia.tar,                        level 19,                           advanced one pass small out,        4264388
+silesia.tar,                        no source size,                     advanced one pass small out,        4861423
+silesia.tar,                        long distance mode,                 advanced one pass small out,        4847753
+silesia.tar,                        multithreaded,                      advanced one pass small out,        4861507
 silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4853221
 silesia.tar,                        small window log,                   advanced one pass small out,        7101530
-silesia.tar,                        small hash log,                     advanced one pass small out,        6529231
-silesia.tar,                        small chain log,                    advanced one pass small out,        4917041
-silesia.tar,                        explicit params,                    advanced one pass small out,        4807381
+silesia.tar,                        small hash log,                     advanced one pass small out,        6529228
+silesia.tar,                        small chain log,                    advanced one pass small out,        4917039
+silesia.tar,                        explicit params,                    advanced one pass small out,        4807675
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4310141
-silesia.tar,                        huffman literals,                   advanced one pass small out,        5344545
+silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4307400
+silesia.tar,                        huffman literals,                   advanced one pass small out,        5347335
 silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5129555
-github,                             level -5,                           advanced one pass small out,        232315
+github,                             level -5,                           advanced one pass small out,        205285
 github,                             level -5 with dict,                 advanced one pass small out,        46718
-github,                             level -3,                           advanced one pass small out,        220760
+github,                             level -3,                           advanced one pass small out,        190643
 github,                             level -3 with dict,                 advanced one pass small out,        45395
-github,                             level -1,                           advanced one pass small out,        175468
+github,                             level -1,                           advanced one pass small out,        175568
 github,                             level -1 with dict,                 advanced one pass small out,        43170
 github,                             level 0,                            advanced one pass small out,        136335
 github,                             level 0 with dict,                  advanced one pass small out,        41148
@@ -626,7 +626,7 @@ github,                             level 0 with dict dms,              advanced
 github,                             level 0 with dict dds,              advanced one pass small out,        41148
 github,                             level 0 with dict copy,             advanced one pass small out,        41124
 github,                             level 0 with dict load,             advanced one pass small out,        42252
-github,                             level 1,                            advanced one pass small out,        142365
+github,                             level 1,                            advanced one pass small out,        142465
 github,                             level 1 with dict,                  advanced one pass small out,        41682
 github,                             level 1 with dict dms,              advanced one pass small out,        41682
 github,                             level 1 with dict dds,              advanced one pass small out,        41682
@@ -644,16 +644,16 @@ github,                             level 4 with dict dms,              advanced
 github,                             level 4 with dict dds,              advanced one pass small out,        41251
 github,                             level 4 with dict copy,             advanced one pass small out,        41216
 github,                             level 4 with dict load,             advanced one pass small out,        41159
-github,                             level 5 row 1,                      advanced one pass small out,        134584
-github,                             level 5 row 1 with dict dms,        advanced one pass small out,        38758
-github,                             level 5 row 1 with dict dds,        advanced one pass small out,        38728
-github,                             level 5 row 1 with dict copy,       advanced one pass small out,        38759
-github,                             level 5 row 1 with dict load,       advanced one pass small out,        41518
-github,                             level 5 row 2,                      advanced one pass small out,        135121
-github,                             level 5 row 2 with dict dms,        advanced one pass small out,        38938
-github,                             level 5 row 2 with dict dds,        advanced one pass small out,        38732
-github,                             level 5 row 2 with dict copy,       advanced one pass small out,        38934
-github,                             level 5 row 2 with dict load,       advanced one pass small out,        40725
+github,                             level 5 row 1,                      advanced one pass small out,        135121
+github,                             level 5 row 1 with dict dms,        advanced one pass small out,        38938
+github,                             level 5 row 1 with dict dds,        advanced one pass small out,        38732
+github,                             level 5 row 1 with dict copy,       advanced one pass small out,        38934
+github,                             level 5 row 1 with dict load,       advanced one pass small out,        40725
+github,                             level 5 row 2,                      advanced one pass small out,        134584
+github,                             level 5 row 2 with dict dms,        advanced one pass small out,        38758
+github,                             level 5 row 2 with dict dds,        advanced one pass small out,        38728
+github,                             level 5 row 2 with dict copy,       advanced one pass small out,        38759
+github,                             level 5 row 2 with dict load,       advanced one pass small out,        41518
 github,                             level 5,                            advanced one pass small out,        135121
 github,                             level 5 with dict,                  advanced one pass small out,        38758
 github,                             level 5 with dict dms,              advanced one pass small out,        38758
@@ -666,16 +666,16 @@ github,                             level 6 with dict dms,              advanced
 github,                             level 6 with dict dds,              advanced one pass small out,        38636
 github,                             level 6 with dict copy,             advanced one pass small out,        38669
 github,                             level 6 with dict load,             advanced one pass small out,        40695
-github,                             level 7 row 1,                      advanced one pass small out,        134584
-github,                             level 7 row 1 with dict dms,        advanced one pass small out,        38758
-github,                             level 7 row 1 with dict dds,        advanced one pass small out,        38745
-github,                             level 7 row 1 with dict copy,       advanced one pass small out,        38755
-github,                             level 7 row 1 with dict load,       advanced one pass small out,        43154
-github,                             level 7 row 2,                      advanced one pass small out,        135122
-github,                             level 7 row 2 with dict dms,        advanced one pass small out,        38860
-github,                             level 7 row 2 with dict dds,        advanced one pass small out,        38766
-github,                             level 7 row 2 with dict copy,       advanced one pass small out,        38834
-github,                             level 7 row 2 with dict load,       advanced one pass small out,        40695
+github,                             level 7 row 1,                      advanced one pass small out,        135122
+github,                             level 7 row 1 with dict dms,        advanced one pass small out,        38860
+github,                             level 7 row 1 with dict dds,        advanced one pass small out,        38766
+github,                             level 7 row 1 with dict copy,       advanced one pass small out,        38834
+github,                             level 7 row 1 with dict load,       advanced one pass small out,        40695
+github,                             level 7 row 2,                      advanced one pass small out,        134584
+github,                             level 7 row 2 with dict dms,        advanced one pass small out,        38758
+github,                             level 7 row 2 with dict dds,        advanced one pass small out,        38745
+github,                             level 7 row 2 with dict copy,       advanced one pass small out,        38755
+github,                             level 7 row 2 with dict load,       advanced one pass small out,        43154
 github,                             level 7,                            advanced one pass small out,        135122
 github,                             level 7 with dict,                  advanced one pass small out,        38758
 github,                             level 7 with dict dms,              advanced one pass small out,        38758
@@ -737,26 +737,26 @@ github,                             small chain log,                    advanced
 github,                             explicit params,                    advanced one pass small out,        137727
 github,                             uncompressed literals,              advanced one pass small out,        165915
 github,                             uncompressed literals optimal,      advanced one pass small out,        157227
-github,                             huffman literals,                   advanced one pass small out,        142365
+github,                             huffman literals,                   advanced one pass small out,        142465
 github,                             multithreaded with advanced params, advanced one pass small out,        165915
-github.tar,                         level -5,                           advanced one pass small out,        66914
-github.tar,                         level -5 with dict,                 advanced one pass small out,        51525
-github.tar,                         level -3,                           advanced one pass small out,        52127
-github.tar,                         level -3 with dict,                 advanced one pass small out,        44242
-github.tar,                         level -1,                           advanced one pass small out,        42560
-github.tar,                         level -1 with dict,                 advanced one pass small out,        41136
+github.tar,                         level -5,                           advanced one pass small out,        46856
+github.tar,                         level -5 with dict,                 advanced one pass small out,        44571
+github.tar,                         level -3,                           advanced one pass small out,        43754
+github.tar,                         level -3 with dict,                 advanced one pass small out,        41447
+github.tar,                         level -1,                           advanced one pass small out,        42490
+github.tar,                         level -1 with dict,                 advanced one pass small out,        41131
 github.tar,                         level 0,                            advanced one pass small out,        38441
 github.tar,                         level 0 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 0 with dict dms,              advanced one pass small out,        38003
 github.tar,                         level 0 with dict dds,              advanced one pass small out,        38003
 github.tar,                         level 0 with dict copy,             advanced one pass small out,        37995
 github.tar,                         level 0 with dict load,             advanced one pass small out,        37956
-github.tar,                         level 1,                            advanced one pass small out,        39200
-github.tar,                         level 1 with dict,                  advanced one pass small out,        38284
-github.tar,                         level 1 with dict dms,              advanced one pass small out,        38294
-github.tar,                         level 1 with dict dds,              advanced one pass small out,        38294
-github.tar,                         level 1 with dict copy,             advanced one pass small out,        38284
-github.tar,                         level 1 with dict load,             advanced one pass small out,        38724
+github.tar,                         level 1,                            advanced one pass small out,        39265
+github.tar,                         level 1 with dict,                  advanced one pass small out,        38280
+github.tar,                         level 1 with dict dms,              advanced one pass small out,        38290
+github.tar,                         level 1 with dict dds,              advanced one pass small out,        38290
+github.tar,                         level 1 with dict copy,             advanced one pass small out,        38280
+github.tar,                         level 1 with dict load,             advanced one pass small out,        38729
 github.tar,                         level 3,                            advanced one pass small out,        38441
 github.tar,                         level 3 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 3 with dict dms,              advanced one pass small out,        38003
@@ -769,88 +769,88 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass small out,        37954
 github.tar,                         level 4 with dict copy,             advanced one pass small out,        37948
 github.tar,                         level 4 with dict load,             advanced one pass small out,        37927
-github.tar,                         level 5 row 1,                      advanced one pass small out,        38376
-github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39024
-github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39028
-github.tar,                         level 5 row 1 with dict copy,       advanced one pass small out,        39040
-github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        37600
-github.tar,                         level 5 row 2,                      advanced one pass small out,        38534
-github.tar,                         level 5 row 2 with dict dms,        advanced one pass small out,        39365
-github.tar,                         level 5 row 2 with dict dds,        advanced one pass small out,        39233
-github.tar,                         level 5 row 2 with dict copy,       advanced one pass small out,        39715
-github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        38019
-github.tar,                         level 5,                            advanced one pass small out,        38376
-github.tar,                         level 5 with dict,                  advanced one pass small out,        39040
-github.tar,                         level 5 with dict dms,              advanced one pass small out,        39024
-github.tar,                         level 5 with dict dds,              advanced one pass small out,        39028
-github.tar,                         level 5 with dict copy,             advanced one pass small out,        39040
-github.tar,                         level 5 with dict load,             advanced one pass small out,        37600
-github.tar,                         level 6,                            advanced one pass small out,        38610
-github.tar,                         level 6 with dict,                  advanced one pass small out,        38622
-github.tar,                         level 6 with dict dms,              advanced one pass small out,        38608
-github.tar,                         level 6 with dict dds,              advanced one pass small out,        38610
-github.tar,                         level 6 with dict copy,             advanced one pass small out,        38622
-github.tar,                         level 6 with dict load,             advanced one pass small out,        37829
-github.tar,                         level 7 row 1,                      advanced one pass small out,        38073
-github.tar,                         level 7 row 1 with dict dms,        advanced one pass small out,        37848
-github.tar,                         level 7 row 1 with dict dds,        advanced one pass small out,        37869
-github.tar,                         level 7 row 1 with dict copy,       advanced one pass small out,        37848
-github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        37371
-github.tar,                         level 7 row 2,                      advanced one pass small out,        38077
-github.tar,                         level 7 row 2 with dict dms,        advanced one pass small out,        38012
-github.tar,                         level 7 row 2 with dict dds,        advanced one pass small out,        38014
-github.tar,                         level 7 row 2 with dict copy,       advanced one pass small out,        38101
-github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        37402
-github.tar,                         level 7,                            advanced one pass small out,        38073
-github.tar,                         level 7 with dict,                  advanced one pass small out,        37848
-github.tar,                         level 7 with dict dms,              advanced one pass small out,        37848
-github.tar,                         level 7 with dict dds,              advanced one pass small out,        37869
-github.tar,                         level 7 with dict copy,             advanced one pass small out,        37848
-github.tar,                         level 7 with dict load,             advanced one pass small out,        37371
-github.tar,                         level 9,                            advanced one pass small out,        36767
-github.tar,                         level 9 with dict,                  advanced one pass small out,        36457
-github.tar,                         level 9 with dict dms,              advanced one pass small out,        36549
-github.tar,                         level 9 with dict dds,              advanced one pass small out,        36619
-github.tar,                         level 9 with dict copy,             advanced one pass small out,        36457
-github.tar,                         level 9 with dict load,             advanced one pass small out,        36352
+github.tar,                         level 5 row 1,                      advanced one pass small out,        38534
+github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39365
+github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39233
+github.tar,                         level 5 row 1 with dict copy,       advanced one pass small out,        39715
+github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        38019
+github.tar,                         level 5 row 2,                      advanced one pass small out,        38394
+github.tar,                         level 5 row 2 with dict dms,        advanced one pass small out,        39048
+github.tar,                         level 5 row 2 with dict dds,        advanced one pass small out,        39044
+github.tar,                         level 5 row 2 with dict copy,       advanced one pass small out,        39074
+github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        37665
+github.tar,                         level 5,                            advanced one pass small out,        38394
+github.tar,                         level 5 with dict,                  advanced one pass small out,        39074
+github.tar,                         level 5 with dict dms,              advanced one pass small out,        39048
+github.tar,                         level 5 with dict dds,              advanced one pass small out,        39044
+github.tar,                         level 5 with dict copy,             advanced one pass small out,        39074
+github.tar,                         level 5 with dict load,             advanced one pass small out,        37665
+github.tar,                         level 6,                            advanced one pass small out,        38669
+github.tar,                         level 6 with dict,                  advanced one pass small out,        38660
+github.tar,                         level 6 with dict dms,              advanced one pass small out,        38654
+github.tar,                         level 6 with dict dds,              advanced one pass small out,        38656
+github.tar,                         level 6 with dict copy,             advanced one pass small out,        38660
+github.tar,                         level 6 with dict load,             advanced one pass small out,        37889
+github.tar,                         level 7 row 1,                      advanced one pass small out,        38077
+github.tar,                         level 7 row 1 with dict dms,        advanced one pass small out,        38012
+github.tar,                         level 7 row 1 with dict dds,        advanced one pass small out,        38014
+github.tar,                         level 7 row 1 with dict copy,       advanced one pass small out,        38101
+github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        37402
+github.tar,                         level 7 row 2,                      advanced one pass small out,        38153
+github.tar,                         level 7 row 2 with dict dms,        advanced one pass small out,        37888
+github.tar,                         level 7 row 2 with dict dds,        advanced one pass small out,        37910
+github.tar,                         level 7 row 2 with dict copy,       advanced one pass small out,        37892
+github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        37457
+github.tar,                         level 7,                            advanced one pass small out,        38153
+github.tar,                         level 7 with dict,                  advanced one pass small out,        37892
+github.tar,                         level 7 with dict dms,              advanced one pass small out,        37888
+github.tar,                         level 7 with dict dds,              advanced one pass small out,        37910
+github.tar,                         level 7 with dict copy,             advanced one pass small out,        37892
+github.tar,                         level 7 with dict load,             advanced one pass small out,        37457
+github.tar,                         level 9,                            advanced one pass small out,        36768
+github.tar,                         level 9 with dict,                  advanced one pass small out,        36510
+github.tar,                         level 9 with dict dms,              advanced one pass small out,        36584
+github.tar,                         level 9 with dict dds,              advanced one pass small out,        36646
+github.tar,                         level 9 with dict copy,             advanced one pass small out,        36510
+github.tar,                         level 9 with dict load,             advanced one pass small out,        36383
 github.tar,                         level 11 row 1,                     advanced one pass small out,        36435
 github.tar,                         level 11 row 1 with dict dms,       advanced one pass small out,        36963
 github.tar,                         level 11 row 1 with dict dds,       advanced one pass small out,        36963
 github.tar,                         level 11 row 1 with dict copy,      advanced one pass small out,        36557
-github.tar,                         level 11 row 1 with dict load,      advanced one pass small out,        36424
-github.tar,                         level 11 row 2,                     advanced one pass small out,        36435
+github.tar,                         level 11 row 1 with dict load,      advanced one pass small out,        36419
+github.tar,                         level 11 row 2,                     advanced one pass small out,        36412
 github.tar,                         level 11 row 2 with dict dms,       advanced one pass small out,        36963
 github.tar,                         level 11 row 2 with dict dds,       advanced one pass small out,        36963
 github.tar,                         level 11 row 2 with dict copy,      advanced one pass small out,        36557
-github.tar,                         level 11 row 2 with dict load,      advanced one pass small out,        36419
-github.tar,                         level 12 row 1,                     advanced one pass small out,        36105
+github.tar,                         level 11 row 2 with dict load,      advanced one pass small out,        36439
+github.tar,                         level 12 row 1,                     advanced one pass small out,        36110
 github.tar,                         level 12 row 1 with dict dms,       advanced one pass small out,        36986
 github.tar,                         level 12 row 1 with dict dds,       advanced one pass small out,        36986
 github.tar,                         level 12 row 1 with dict copy,      advanced one pass small out,        36609
-github.tar,                         level 12 row 1 with dict load,      advanced one pass small out,        36460
-github.tar,                         level 12 row 2,                     advanced one pass small out,        36110
+github.tar,                         level 12 row 1 with dict load,      advanced one pass small out,        36459
+github.tar,                         level 12 row 2,                     advanced one pass small out,        36062
 github.tar,                         level 12 row 2 with dict dms,       advanced one pass small out,        36986
 github.tar,                         level 12 row 2 with dict dds,       advanced one pass small out,        36986
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass small out,        36609
-github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36459
-github.tar,                         level 13,                           advanced one pass small out,        35501
-github.tar,                         level 13 with dict,                 advanced one pass small out,        37130
-github.tar,                         level 13 with dict dms,             advanced one pass small out,        37267
-github.tar,                         level 13 with dict dds,             advanced one pass small out,        37267
-github.tar,                         level 13 with dict copy,            advanced one pass small out,        37130
-github.tar,                         level 13 with dict load,            advanced one pass small out,        36010
-github.tar,                         level 16,                           advanced one pass small out,        40471
-github.tar,                         level 16 with dict,                 advanced one pass small out,        33378
-github.tar,                         level 16 with dict dms,             advanced one pass small out,        33213
-github.tar,                         level 16 with dict dds,             advanced one pass small out,        33213
-github.tar,                         level 16 with dict copy,            advanced one pass small out,        33378
-github.tar,                         level 16 with dict load,            advanced one pass small out,        39081
-github.tar,                         level 19,                           advanced one pass small out,        32134
-github.tar,                         level 19 with dict,                 advanced one pass small out,        32709
-github.tar,                         level 19 with dict dms,             advanced one pass small out,        32553
-github.tar,                         level 19 with dict dds,             advanced one pass small out,        32553
-github.tar,                         level 19 with dict copy,            advanced one pass small out,        32709
-github.tar,                         level 19 with dict load,            advanced one pass small out,        32474
+github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36392
+github.tar,                         level 13,                           advanced one pass small out,        35621
+github.tar,                         level 13 with dict,                 advanced one pass small out,        38726
+github.tar,                         level 13 with dict dms,             advanced one pass small out,        38903
+github.tar,                         level 13 with dict dds,             advanced one pass small out,        38903
+github.tar,                         level 13 with dict copy,            advanced one pass small out,        38726
+github.tar,                         level 13 with dict load,            advanced one pass small out,        36372
+github.tar,                         level 16,                           advanced one pass small out,        40255
+github.tar,                         level 16 with dict,                 advanced one pass small out,        33639
+github.tar,                         level 16 with dict dms,             advanced one pass small out,        33544
+github.tar,                         level 16 with dict dds,             advanced one pass small out,        33544
+github.tar,                         level 16 with dict copy,            advanced one pass small out,        33639
+github.tar,                         level 16 with dict load,            advanced one pass small out,        39353
+github.tar,                         level 19,                           advanced one pass small out,        32837
+github.tar,                         level 19 with dict,                 advanced one pass small out,        32895
+github.tar,                         level 19 with dict dms,             advanced one pass small out,        32672
+github.tar,                         level 19 with dict dds,             advanced one pass small out,        32672
+github.tar,                         level 19 with dict copy,            advanced one pass small out,        32895
+github.tar,                         level 19 with dict load,            advanced one pass small out,        32676
 github.tar,                         no source size,                     advanced one pass small out,        38441
 github.tar,                         no source size with dict,           advanced one pass small out,        37995
 github.tar,                         long distance mode,                 advanced one pass small out,        39757
@@ -859,84 +859,84 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced one pass small out,        198540
 github.tar,                         small hash log,                     advanced one pass small out,        129870
 github.tar,                         small chain log,                    advanced one pass small out,        41669
-github.tar,                         explicit params,                    advanced one pass small out,        41227
+github.tar,                         explicit params,                    advanced one pass small out,        41350
 github.tar,                         uncompressed literals,              advanced one pass small out,        41122
-github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35397
-github.tar,                         huffman literals,                   advanced one pass small out,        38853
+github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35388
+github.tar,                         huffman literals,                   advanced one pass small out,        38777
 github.tar,                         multithreaded with advanced params, advanced one pass small out,        41122
-silesia,                            level -5,                           advanced streaming,                 7292053
-silesia,                            level -3,                           advanced streaming,                 6867875
-silesia,                            level -1,                           advanced streaming,                 6183923
-silesia,                            level 0,                            advanced streaming,                 4849553
-silesia,                            level 1,                            advanced streaming,                 5312694
-silesia,                            level 3,                            advanced streaming,                 4849553
-silesia,                            level 4,                            advanced streaming,                 4786968
-silesia,                            level 5 row 1,                      advanced streaming,                 4638961
-silesia,                            level 5 row 2,                      advanced streaming,                 4640752
-silesia,                            level 5,                            advanced streaming,                 4638961
-silesia,                            level 6,                            advanced streaming,                 4605369
-silesia,                            level 7 row 1,                      advanced streaming,                 4567204
-silesia,                            level 7 row 2,                      advanced streaming,                 4564868
-silesia,                            level 7,                            advanced streaming,                 4567204
-silesia,                            level 9,                            advanced streaming,                 4543310
-silesia,                            level 11 row 1,                     advanced streaming,                 4521399
-silesia,                            level 11 row 2,                     advanced streaming,                 4519288
-silesia,                            level 12 row 1,                     advanced streaming,                 4505153
-silesia,                            level 12 row 2,                     advanced streaming,                 4503116
-silesia,                            level 13,                           advanced streaming,                 4493990
-silesia,                            level 16,                           advanced streaming,                 4359864
-silesia,                            level 19,                           advanced streaming,                 4296880
-silesia,                            no source size,                     advanced streaming,                 4849517
-silesia,                            long distance mode,                 advanced streaming,                 4840737
-silesia,                            multithreaded,                      advanced streaming,                 4849553
+silesia,                            level -5,                           advanced streaming,                 6882505
+silesia,                            level -3,                           advanced streaming,                 6568376
+silesia,                            level -1,                           advanced streaming,                 6183403
+silesia,                            level 0,                            advanced streaming,                 4849551
+silesia,                            level 1,                            advanced streaming,                 5314161
+silesia,                            level 3,                            advanced streaming,                 4849551
+silesia,                            level 4,                            advanced streaming,                 4786969
+silesia,                            level 5 row 1,                      advanced streaming,                 4640753
+silesia,                            level 5 row 2,                      advanced streaming,                 4639132
+silesia,                            level 5,                            advanced streaming,                 4639132
+silesia,                            level 6,                            advanced streaming,                 4605629
+silesia,                            level 7 row 1,                      advanced streaming,                 4564870
+silesia,                            level 7 row 2,                      advanced streaming,                 4567307
+silesia,                            level 7,                            advanced streaming,                 4567307
+silesia,                            level 9,                            advanced streaming,                 4543330
+silesia,                            level 11 row 1,                     advanced streaming,                 4519288
+silesia,                            level 11 row 2,                     advanced streaming,                 4521524
+silesia,                            level 12 row 1,                     advanced streaming,                 4503117
+silesia,                            level 12 row 2,                     advanced streaming,                 4505093
+silesia,                            level 13,                           advanced streaming,                 4482131
+silesia,                            level 16,                           advanced streaming,                 4360251
+silesia,                            level 19,                           advanced streaming,                 4283236
+silesia,                            no source size,                     advanced streaming,                 4849515
+silesia,                            long distance mode,                 advanced streaming,                 4840738
+silesia,                            multithreaded,                      advanced streaming,                 4849551
 silesia,                            multithreaded long distance mode,   advanced streaming,                 4840759
 silesia,                            small window log,                   advanced streaming,                 7112062
 silesia,                            small hash log,                     advanced streaming,                 6526141
-silesia,                            small chain log,                    advanced streaming,                 4912197
-silesia,                            explicit params,                    advanced streaming,                 4795883
+silesia,                            small chain log,                    advanced streaming,                 4912199
+silesia,                            explicit params,                    advanced streaming,                 4796309
 silesia,                            uncompressed literals,              advanced streaming,                 5127982
-silesia,                            uncompressed literals optimal,      advanced streaming,                 4319518
-silesia,                            huffman literals,                   advanced streaming,                 5332234
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4317896
+silesia,                            huffman literals,                   advanced streaming,                 5331171
 silesia,                            multithreaded with advanced params, advanced streaming,                 5127982
-silesia.tar,                        level -5,                           advanced streaming,                 7260007
-silesia.tar,                        level -3,                           advanced streaming,                 6845151
-silesia.tar,                        level -1,                           advanced streaming,                 6187938
-silesia.tar,                        level 0,                            advanced streaming,                 4861426
-silesia.tar,                        level 1,                            advanced streaming,                 5334890
-silesia.tar,                        level 3,                            advanced streaming,                 4861426
+silesia.tar,                        level -5,                           advanced streaming,                 6982759
+silesia.tar,                        level -3,                           advanced streaming,                 6641283
+silesia.tar,                        level -1,                           advanced streaming,                 6190795
+silesia.tar,                        level 0,                            advanced streaming,                 4861425
+silesia.tar,                        level 1,                            advanced streaming,                 5336941
+silesia.tar,                        level 3,                            advanced streaming,                 4861425
 silesia.tar,                        level 4,                            advanced streaming,                 4799632
-silesia.tar,                        level 5 row 1,                      advanced streaming,                 4650207
-silesia.tar,                        level 5 row 2,                      advanced streaming,                 4652866
-silesia.tar,                        level 5,                            advanced streaming,                 4650207
-silesia.tar,                        level 6,                            advanced streaming,                 4616816
-silesia.tar,                        level 7 row 1,                      advanced streaming,                 4576831
-silesia.tar,                        level 7 row 2,                      advanced streaming,                 4575394
-silesia.tar,                        level 7,                            advanced streaming,                 4576831
-silesia.tar,                        level 9,                            advanced streaming,                 4552590
-silesia.tar,                        level 11 row 1,                     advanced streaming,                 4530258
-silesia.tar,                        level 11 row 2,                     advanced streaming,                 4529461
-silesia.tar,                        level 12 row 1,                     advanced streaming,                 4514569
-silesia.tar,                        level 12 row 2,                     advanced streaming,                 4513604
-silesia.tar,                        level 13,                           advanced streaming,                 4502956
-silesia.tar,                        level 16,                           advanced streaming,                 4360527
-silesia.tar,                        level 19,                           advanced streaming,                 4267266
-silesia.tar,                        no source size,                     advanced streaming,                 4861422
-silesia.tar,                        long distance mode,                 advanced streaming,                 4847752
-silesia.tar,                        multithreaded,                      advanced streaming,                 4861508
+silesia.tar,                        level 5 row 1,                      advanced streaming,                 4652866
+silesia.tar,                        level 5 row 2,                      advanced streaming,                 4650392
+silesia.tar,                        level 5,                            advanced streaming,                 4650392
+silesia.tar,                        level 6,                            advanced streaming,                 4617097
+silesia.tar,                        level 7 row 1,                      advanced streaming,                 4575393
+silesia.tar,                        level 7 row 2,                      advanced streaming,                 4576953
+silesia.tar,                        level 7,                            advanced streaming,                 4576953
+silesia.tar,                        level 9,                            advanced streaming,                 4552646
+silesia.tar,                        level 11 row 1,                     advanced streaming,                 4529458
+silesia.tar,                        level 11 row 2,                     advanced streaming,                 4530417
+silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513603
+silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514500
+silesia.tar,                        level 13,                           advanced streaming,                 4491769
+silesia.tar,                        level 16,                           advanced streaming,                 4356834
+silesia.tar,                        level 19,                           advanced streaming,                 4264388
+silesia.tar,                        no source size,                     advanced streaming,                 4861421
+silesia.tar,                        long distance mode,                 advanced streaming,                 4847753
+silesia.tar,                        multithreaded,                      advanced streaming,                 4861507
 silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4853221
 silesia.tar,                        small window log,                   advanced streaming,                 7118769
-silesia.tar,                        small hash log,                     advanced streaming,                 6529234
-silesia.tar,                        small chain log,                    advanced streaming,                 4917021
-silesia.tar,                        explicit params,                    advanced streaming,                 4807401
+silesia.tar,                        small hash log,                     advanced streaming,                 6529231
+silesia.tar,                        small chain log,                    advanced streaming,                 4917019
+silesia.tar,                        explicit params,                    advanced streaming,                 4807688
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5129461
-silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4310141
-silesia.tar,                        huffman literals,                   advanced streaming,                 5350519
+silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4307400
+silesia.tar,                        huffman literals,                   advanced streaming,                 5352360
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5129555
-github,                             level -5,                           advanced streaming,                 232315
+github,                             level -5,                           advanced streaming,                 205285
 github,                             level -5 with dict,                 advanced streaming,                 46718
-github,                             level -3,                           advanced streaming,                 220760
+github,                             level -3,                           advanced streaming,                 190643
 github,                             level -3 with dict,                 advanced streaming,                 45395
-github,                             level -1,                           advanced streaming,                 175468
+github,                             level -1,                           advanced streaming,                 175568
 github,                             level -1 with dict,                 advanced streaming,                 43170
 github,                             level 0,                            advanced streaming,                 136335
 github,                             level 0 with dict,                  advanced streaming,                 41148
@@ -944,7 +944,7 @@ github,                             level 0 with dict dms,              advanced
 github,                             level 0 with dict dds,              advanced streaming,                 41148
 github,                             level 0 with dict copy,             advanced streaming,                 41124
 github,                             level 0 with dict load,             advanced streaming,                 42252
-github,                             level 1,                            advanced streaming,                 142365
+github,                             level 1,                            advanced streaming,                 142465
 github,                             level 1 with dict,                  advanced streaming,                 41682
 github,                             level 1 with dict dms,              advanced streaming,                 41682
 github,                             level 1 with dict dds,              advanced streaming,                 41682
@@ -962,16 +962,16 @@ github,                             level 4 with dict dms,              advanced
 github,                             level 4 with dict dds,              advanced streaming,                 41251
 github,                             level 4 with dict copy,             advanced streaming,                 41216
 github,                             level 4 with dict load,             advanced streaming,                 41159
-github,                             level 5 row 1,                      advanced streaming,                 134584
-github,                             level 5 row 1 with dict dms,        advanced streaming,                 38758
-github,                             level 5 row 1 with dict dds,        advanced streaming,                 38728
-github,                             level 5 row 1 with dict copy,       advanced streaming,                 38759
-github,                             level 5 row 1 with dict load,       advanced streaming,                 41518
-github,                             level 5 row 2,                      advanced streaming,                 135121
-github,                             level 5 row 2 with dict dms,        advanced streaming,                 38938
-github,                             level 5 row 2 with dict dds,        advanced streaming,                 38732
-github,                             level 5 row 2 with dict copy,       advanced streaming,                 38934
-github,                             level 5 row 2 with dict load,       advanced streaming,                 40725
+github,                             level 5 row 1,                      advanced streaming,                 135121
+github,                             level 5 row 1 with dict dms,        advanced streaming,                 38938
+github,                             level 5 row 1 with dict dds,        advanced streaming,                 38732
+github,                             level 5 row 1 with dict copy,       advanced streaming,                 38934
+github,                             level 5 row 1 with dict load,       advanced streaming,                 40725
+github,                             level 5 row 2,                      advanced streaming,                 134584
+github,                             level 5 row 2 with dict dms,        advanced streaming,                 38758
+github,                             level 5 row 2 with dict dds,        advanced streaming,                 38728
+github,                             level 5 row 2 with dict copy,       advanced streaming,                 38759
+github,                             level 5 row 2 with dict load,       advanced streaming,                 41518
 github,                             level 5,                            advanced streaming,                 135121
 github,                             level 5 with dict,                  advanced streaming,                 38758
 github,                             level 5 with dict dms,              advanced streaming,                 38758
@@ -984,16 +984,16 @@ github,                             level 6 with dict dms,              advanced
 github,                             level 6 with dict dds,              advanced streaming,                 38636
 github,                             level 6 with dict copy,             advanced streaming,                 38669
 github,                             level 6 with dict load,             advanced streaming,                 40695
-github,                             level 7 row 1,                      advanced streaming,                 134584
-github,                             level 7 row 1 with dict dms,        advanced streaming,                 38758
-github,                             level 7 row 1 with dict dds,        advanced streaming,                 38745
-github,                             level 7 row 1 with dict copy,       advanced streaming,                 38755
-github,                             level 7 row 1 with dict load,       advanced streaming,                 43154
-github,                             level 7 row 2,                      advanced streaming,                 135122
-github,                             level 7 row 2 with dict dms,        advanced streaming,                 38860
-github,                             level 7 row 2 with dict dds,        advanced streaming,                 38766
-github,                             level 7 row 2 with dict copy,       advanced streaming,                 38834
-github,                             level 7 row 2 with dict load,       advanced streaming,                 40695
+github,                             level 7 row 1,                      advanced streaming,                 135122
+github,                             level 7 row 1 with dict dms,        advanced streaming,                 38860
+github,                             level 7 row 1 with dict dds,        advanced streaming,                 38766
+github,                             level 7 row 1 with dict copy,       advanced streaming,                 38834
+github,                             level 7 row 1 with dict load,       advanced streaming,                 40695
+github,                             level 7 row 2,                      advanced streaming,                 134584
+github,                             level 7 row 2 with dict dms,        advanced streaming,                 38758
+github,                             level 7 row 2 with dict dds,        advanced streaming,                 38745
+github,                             level 7 row 2 with dict copy,       advanced streaming,                 38755
+github,                             level 7 row 2 with dict load,       advanced streaming,                 43154
 github,                             level 7,                            advanced streaming,                 135122
 github,                             level 7 with dict,                  advanced streaming,                 38758
 github,                             level 7 with dict dms,              advanced streaming,                 38758
@@ -1055,26 +1055,26 @@ github,                             small chain log,                    advanced
 github,                             explicit params,                    advanced streaming,                 137727
 github,                             uncompressed literals,              advanced streaming,                 165915
 github,                             uncompressed literals optimal,      advanced streaming,                 157227
-github,                             huffman literals,                   advanced streaming,                 142365
+github,                             huffman literals,                   advanced streaming,                 142465
 github,                             multithreaded with advanced params, advanced streaming,                 165915
-github.tar,                         level -5,                           advanced streaming,                 64132
-github.tar,                         level -5 with dict,                 advanced streaming,                 48642
-github.tar,                         level -3,                           advanced streaming,                 50964
-github.tar,                         level -3 with dict,                 advanced streaming,                 42750
-github.tar,                         level -1,                           advanced streaming,                 42536
-github.tar,                         level -1 with dict,                 advanced streaming,                 41198
+github.tar,                         level -5,                           advanced streaming,                 46747
+github.tar,                         level -5 with dict,                 advanced streaming,                 44440
+github.tar,                         level -3,                           advanced streaming,                 43537
+github.tar,                         level -3 with dict,                 advanced streaming,                 41112
+github.tar,                         level -1,                           advanced streaming,                 42465
+github.tar,                         level -1 with dict,                 advanced streaming,                 41196
 github.tar,                         level 0,                            advanced streaming,                 38441
 github.tar,                         level 0 with dict,                  advanced streaming,                 37995
 github.tar,                         level 0 with dict dms,              advanced streaming,                 38003
 github.tar,                         level 0 with dict dds,              advanced streaming,                 38003
 github.tar,                         level 0 with dict copy,             advanced streaming,                 37995
 github.tar,                         level 0 with dict load,             advanced streaming,                 37956
-github.tar,                         level 1,                            advanced streaming,                 39270
-github.tar,                         level 1 with dict,                  advanced streaming,                 38316
-github.tar,                         level 1 with dict dms,              advanced streaming,                 38326
-github.tar,                         level 1 with dict dds,              advanced streaming,                 38326
-github.tar,                         level 1 with dict copy,             advanced streaming,                 38316
-github.tar,                         level 1 with dict load,             advanced streaming,                 38761
+github.tar,                         level 1,                            advanced streaming,                 39342
+github.tar,                         level 1 with dict,                  advanced streaming,                 38293
+github.tar,                         level 1 with dict dms,              advanced streaming,                 38303
+github.tar,                         level 1 with dict dds,              advanced streaming,                 38303
+github.tar,                         level 1 with dict copy,             advanced streaming,                 38293
+github.tar,                         level 1 with dict load,             advanced streaming,                 38766
 github.tar,                         level 3,                            advanced streaming,                 38441
 github.tar,                         level 3 with dict,                  advanced streaming,                 37995
 github.tar,                         level 3 with dict dms,              advanced streaming,                 38003
@@ -1087,88 +1087,88 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced streaming,                 37954
 github.tar,                         level 4 with dict copy,             advanced streaming,                 37948
 github.tar,                         level 4 with dict load,             advanced streaming,                 37927
-github.tar,                         level 5 row 1,                      advanced streaming,                 38376
-github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39024
-github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39028
-github.tar,                         level 5 row 1 with dict copy,       advanced streaming,                 39040
-github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 37600
-github.tar,                         level 5 row 2,                      advanced streaming,                 38534
-github.tar,                         level 5 row 2 with dict dms,        advanced streaming,                 39365
-github.tar,                         level 5 row 2 with dict dds,        advanced streaming,                 39233
-github.tar,                         level 5 row 2 with dict copy,       advanced streaming,                 39715
-github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 38019
-github.tar,                         level 5,                            advanced streaming,                 38376
-github.tar,                         level 5 with dict,                  advanced streaming,                 39040
-github.tar,                         level 5 with dict dms,              advanced streaming,                 39024
-github.tar,                         level 5 with dict dds,              advanced streaming,                 39028
-github.tar,                         level 5 with dict copy,             advanced streaming,                 39040
-github.tar,                         level 5 with dict load,             advanced streaming,                 37600
-github.tar,                         level 6,                            advanced streaming,                 38610
-github.tar,                         level 6 with dict,                  advanced streaming,                 38622
-github.tar,                         level 6 with dict dms,              advanced streaming,                 38608
-github.tar,                         level 6 with dict dds,              advanced streaming,                 38610
-github.tar,                         level 6 with dict copy,             advanced streaming,                 38622
-github.tar,                         level 6 with dict load,             advanced streaming,                 37829
-github.tar,                         level 7 row 1,                      advanced streaming,                 38073
-github.tar,                         level 7 row 1 with dict dms,        advanced streaming,                 37848
-github.tar,                         level 7 row 1 with dict dds,        advanced streaming,                 37869
-github.tar,                         level 7 row 1 with dict copy,       advanced streaming,                 37848
-github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 37371
-github.tar,                         level 7 row 2,                      advanced streaming,                 38077
-github.tar,                         level 7 row 2 with dict dms,        advanced streaming,                 38012
-github.tar,                         level 7 row 2 with dict dds,        advanced streaming,                 38014
-github.tar,                         level 7 row 2 with dict copy,       advanced streaming,                 38101
-github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 37402
-github.tar,                         level 7,                            advanced streaming,                 38073
-github.tar,                         level 7 with dict,                  advanced streaming,                 37848
-github.tar,                         level 7 with dict dms,              advanced streaming,                 37848
-github.tar,                         level 7 with dict dds,              advanced streaming,                 37869
-github.tar,                         level 7 with dict copy,             advanced streaming,                 37848
-github.tar,                         level 7 with dict load,             advanced streaming,                 37371
-github.tar,                         level 9,                            advanced streaming,                 36767
-github.tar,                         level 9 with dict,                  advanced streaming,                 36457
-github.tar,                         level 9 with dict dms,              advanced streaming,                 36549
-github.tar,                         level 9 with dict dds,              advanced streaming,                 36619
-github.tar,                         level 9 with dict copy,             advanced streaming,                 36457
-github.tar,                         level 9 with dict load,             advanced streaming,                 36352
+github.tar,                         level 5 row 1,                      advanced streaming,                 38534
+github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39365
+github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39233
+github.tar,                         level 5 row 1 with dict copy,       advanced streaming,                 39715
+github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 38019
+github.tar,                         level 5 row 2,                      advanced streaming,                 38394
+github.tar,                         level 5 row 2 with dict dms,        advanced streaming,                 39048
+github.tar,                         level 5 row 2 with dict dds,        advanced streaming,                 39044
+github.tar,                         level 5 row 2 with dict copy,       advanced streaming,                 39074
+github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 37665
+github.tar,                         level 5,                            advanced streaming,                 38394
+github.tar,                         level 5 with dict,                  advanced streaming,                 39074
+github.tar,                         level 5 with dict dms,              advanced streaming,                 39048
+github.tar,                         level 5 with dict dds,              advanced streaming,                 39044
+github.tar,                         level 5 with dict copy,             advanced streaming,                 39074
+github.tar,                         level 5 with dict load,             advanced streaming,                 37665
+github.tar,                         level 6,                            advanced streaming,                 38669
+github.tar,                         level 6 with dict,                  advanced streaming,                 38660
+github.tar,                         level 6 with dict dms,              advanced streaming,                 38654
+github.tar,                         level 6 with dict dds,              advanced streaming,                 38656
+github.tar,                         level 6 with dict copy,             advanced streaming,                 38660
+github.tar,                         level 6 with dict load,             advanced streaming,                 37889
+github.tar,                         level 7 row 1,                      advanced streaming,                 38077
+github.tar,                         level 7 row 1 with dict dms,        advanced streaming,                 38012
+github.tar,                         level 7 row 1 with dict dds,        advanced streaming,                 38014
+github.tar,                         level 7 row 1 with dict copy,       advanced streaming,                 38101
+github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 37402
+github.tar,                         level 7 row 2,                      advanced streaming,                 38153
+github.tar,                         level 7 row 2 with dict dms,        advanced streaming,                 37888
+github.tar,                         level 7 row 2 with dict dds,        advanced streaming,                 37910
+github.tar,                         level 7 row 2 with dict copy,       advanced streaming,                 37892
+github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 37457
+github.tar,                         level 7,                            advanced streaming,                 38153
+github.tar,                         level 7 with dict,                  advanced streaming,                 37892
+github.tar,                         level 7 with dict dms,              advanced streaming,                 37888
+github.tar,                         level 7 with dict dds,              advanced streaming,                 37910
+github.tar,                         level 7 with dict copy,             advanced streaming,                 37892
+github.tar,                         level 7 with dict load,             advanced streaming,                 37457
+github.tar,                         level 9,                            advanced streaming,                 36768
+github.tar,                         level 9 with dict,                  advanced streaming,                 36510
+github.tar,                         level 9 with dict dms,              advanced streaming,                 36584
+github.tar,                         level 9 with dict dds,              advanced streaming,                 36646
+github.tar,                         level 9 with dict copy,             advanced streaming,                 36510
+github.tar,                         level 9 with dict load,             advanced streaming,                 36383
 github.tar,                         level 11 row 1,                     advanced streaming,                 36435
 github.tar,                         level 11 row 1 with dict dms,       advanced streaming,                 36963
 github.tar,                         level 11 row 1 with dict dds,       advanced streaming,                 36963
 github.tar,                         level 11 row 1 with dict copy,      advanced streaming,                 36557
-github.tar,                         level 11 row 1 with dict load,      advanced streaming,                 36424
-github.tar,                         level 11 row 2,                     advanced streaming,                 36435
+github.tar,                         level 11 row 1 with dict load,      advanced streaming,                 36419
+github.tar,                         level 11 row 2,                     advanced streaming,                 36412
 github.tar,                         level 11 row 2 with dict dms,       advanced streaming,                 36963
 github.tar,                         level 11 row 2 with dict dds,       advanced streaming,                 36963
 github.tar,                         level 11 row 2 with dict copy,      advanced streaming,                 36557
-github.tar,                         level 11 row 2 with dict load,      advanced streaming,                 36419
-github.tar,                         level 12 row 1,                     advanced streaming,                 36105
+github.tar,                         level 11 row 2 with dict load,      advanced streaming,                 36439
+github.tar,                         level 12 row 1,                     advanced streaming,                 36110
 github.tar,                         level 12 row 1 with dict dms,       advanced streaming,                 36986
 github.tar,                         level 12 row 1 with dict dds,       advanced streaming,                 36986
 github.tar,                         level 12 row 1 with dict copy,      advanced streaming,                 36609
-github.tar,                         level 12 row 1 with dict load,      advanced streaming,                 36460
-github.tar,                         level 12 row 2,                     advanced streaming,                 36110
+github.tar,                         level 12 row 1 with dict load,      advanced streaming,                 36459
+github.tar,                         level 12 row 2,                     advanced streaming,                 36062
 github.tar,                         level 12 row 2 with dict dms,       advanced streaming,                 36986
 github.tar,                         level 12 row 2 with dict dds,       advanced streaming,                 36986
 github.tar,                         level 12 row 2 with dict copy,      advanced streaming,                 36609
-github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36459
-github.tar,                         level 13,                           advanced streaming,                 35501
-github.tar,                         level 13 with dict,                 advanced streaming,                 37130
-github.tar,                         level 13 with dict dms,             advanced streaming,                 37267
-github.tar,                         level 13 with dict dds,             advanced streaming,                 37267
-github.tar,                         level 13 with dict copy,            advanced streaming,                 37130
-github.tar,                         level 13 with dict load,            advanced streaming,                 36010
-github.tar,                         level 16,                           advanced streaming,                 40471
-github.tar,                         level 16 with dict,                 advanced streaming,                 33378
-github.tar,                         level 16 with dict dms,             advanced streaming,                 33213
-github.tar,                         level 16 with dict dds,             advanced streaming,                 33213
-github.tar,                         level 16 with dict copy,            advanced streaming,                 33378
-github.tar,                         level 16 with dict load,            advanced streaming,                 39081
-github.tar,                         level 19,                           advanced streaming,                 32134
-github.tar,                         level 19 with dict,                 advanced streaming,                 32709
-github.tar,                         level 19 with dict dms,             advanced streaming,                 32553
-github.tar,                         level 19 with dict dds,             advanced streaming,                 32553
-github.tar,                         level 19 with dict copy,            advanced streaming,                 32709
-github.tar,                         level 19 with dict load,            advanced streaming,                 32474
+github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36392
+github.tar,                         level 13,                           advanced streaming,                 35621
+github.tar,                         level 13 with dict,                 advanced streaming,                 38726
+github.tar,                         level 13 with dict dms,             advanced streaming,                 38903
+github.tar,                         level 13 with dict dds,             advanced streaming,                 38903
+github.tar,                         level 13 with dict copy,            advanced streaming,                 38726
+github.tar,                         level 13 with dict load,            advanced streaming,                 36372
+github.tar,                         level 16,                           advanced streaming,                 40255
+github.tar,                         level 16 with dict,                 advanced streaming,                 33639
+github.tar,                         level 16 with dict dms,             advanced streaming,                 33544
+github.tar,                         level 16 with dict dds,             advanced streaming,                 33544
+github.tar,                         level 16 with dict copy,            advanced streaming,                 33639
+github.tar,                         level 16 with dict load,            advanced streaming,                 39353
+github.tar,                         level 19,                           advanced streaming,                 32837
+github.tar,                         level 19 with dict,                 advanced streaming,                 32895
+github.tar,                         level 19 with dict dms,             advanced streaming,                 32672
+github.tar,                         level 19 with dict dds,             advanced streaming,                 32672
+github.tar,                         level 19 with dict copy,            advanced streaming,                 32895
+github.tar,                         level 19 with dict load,            advanced streaming,                 32676
 github.tar,                         no source size,                     advanced streaming,                 38438
 github.tar,                         no source size with dict,           advanced streaming,                 38000
 github.tar,                         long distance mode,                 advanced streaming,                 39757
@@ -1177,56 +1177,56 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced streaming,                 199558
 github.tar,                         small hash log,                     advanced streaming,                 129870
 github.tar,                         small chain log,                    advanced streaming,                 41669
-github.tar,                         explicit params,                    advanced streaming,                 41227
+github.tar,                         explicit params,                    advanced streaming,                 41351
 github.tar,                         uncompressed literals,              advanced streaming,                 41122
-github.tar,                         uncompressed literals optimal,      advanced streaming,                 35397
-github.tar,                         huffman literals,                   advanced streaming,                 38874
+github.tar,                         uncompressed literals optimal,      advanced streaming,                 35388
+github.tar,                         huffman literals,                   advanced streaming,                 38800
 github.tar,                         multithreaded with advanced params, advanced streaming,                 41122
-silesia,                            level -5,                           old streaming,                      7292053
-silesia,                            level -3,                           old streaming,                      6867875
-silesia,                            level -1,                           old streaming,                      6183923
-silesia,                            level 0,                            old streaming,                      4849553
-silesia,                            level 1,                            old streaming,                      5312694
-silesia,                            level 3,                            old streaming,                      4849553
-silesia,                            level 4,                            old streaming,                      4786968
-silesia,                            level 5,                            old streaming,                      4638961
-silesia,                            level 6,                            old streaming,                      4605369
-silesia,                            level 7,                            old streaming,                      4567204
-silesia,                            level 9,                            old streaming,                      4543310
-silesia,                            level 13,                           old streaming,                      4493990
-silesia,                            level 16,                           old streaming,                      4359864
-silesia,                            level 19,                           old streaming,                      4296880
-silesia,                            no source size,                     old streaming,                      4849517
-silesia,                            uncompressed literals,              old streaming,                      4849553
-silesia,                            uncompressed literals optimal,      old streaming,                      4296880
-silesia,                            huffman literals,                   old streaming,                      6183923
-silesia.tar,                        level -5,                           old streaming,                      7260007
-silesia.tar,                        level -3,                           old streaming,                      6845151
-silesia.tar,                        level -1,                           old streaming,                      6187938
-silesia.tar,                        level 0,                            old streaming,                      4861426
-silesia.tar,                        level 1,                            old streaming,                      5334890
-silesia.tar,                        level 3,                            old streaming,                      4861426
+silesia,                            level -5,                           old streaming,                      6882505
+silesia,                            level -3,                           old streaming,                      6568376
+silesia,                            level -1,                           old streaming,                      6183403
+silesia,                            level 0,                            old streaming,                      4849551
+silesia,                            level 1,                            old streaming,                      5314161
+silesia,                            level 3,                            old streaming,                      4849551
+silesia,                            level 4,                            old streaming,                      4786969
+silesia,                            level 5,                            old streaming,                      4639132
+silesia,                            level 6,                            old streaming,                      4605629
+silesia,                            level 7,                            old streaming,                      4567307
+silesia,                            level 9,                            old streaming,                      4543330
+silesia,                            level 13,                           old streaming,                      4482131
+silesia,                            level 16,                           old streaming,                      4360251
+silesia,                            level 19,                           old streaming,                      4283236
+silesia,                            no source size,                     old streaming,                      4849515
+silesia,                            uncompressed literals,              old streaming,                      4849551
+silesia,                            uncompressed literals optimal,      old streaming,                      4283236
+silesia,                            huffman literals,                   old streaming,                      6183403
+silesia.tar,                        level -5,                           old streaming,                      6982759
+silesia.tar,                        level -3,                           old streaming,                      6641283
+silesia.tar,                        level -1,                           old streaming,                      6190795
+silesia.tar,                        level 0,                            old streaming,                      4861425
+silesia.tar,                        level 1,                            old streaming,                      5336941
+silesia.tar,                        level 3,                            old streaming,                      4861425
 silesia.tar,                        level 4,                            old streaming,                      4799632
-silesia.tar,                        level 5,                            old streaming,                      4650207
-silesia.tar,                        level 6,                            old streaming,                      4616816
-silesia.tar,                        level 7,                            old streaming,                      4576831
-silesia.tar,                        level 9,                            old streaming,                      4552590
-silesia.tar,                        level 13,                           old streaming,                      4502956
-silesia.tar,                        level 16,                           old streaming,                      4360527
-silesia.tar,                        level 19,                           old streaming,                      4267266
-silesia.tar,                        no source size,                     old streaming,                      4861422
-silesia.tar,                        uncompressed literals,              old streaming,                      4861426
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4267266
-silesia.tar,                        huffman literals,                   old streaming,                      6187938
-github,                             level -5,                           old streaming,                      232315
+silesia.tar,                        level 5,                            old streaming,                      4650392
+silesia.tar,                        level 6,                            old streaming,                      4617097
+silesia.tar,                        level 7,                            old streaming,                      4576953
+silesia.tar,                        level 9,                            old streaming,                      4552646
+silesia.tar,                        level 13,                           old streaming,                      4491769
+silesia.tar,                        level 16,                           old streaming,                      4356834
+silesia.tar,                        level 19,                           old streaming,                      4264388
+silesia.tar,                        no source size,                     old streaming,                      4861421
+silesia.tar,                        uncompressed literals,              old streaming,                      4861425
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4264388
+silesia.tar,                        huffman literals,                   old streaming,                      6190795
+github,                             level -5,                           old streaming,                      205285
 github,                             level -5 with dict,                 old streaming,                      46718
-github,                             level -3,                           old streaming,                      220760
+github,                             level -3,                           old streaming,                      190643
 github,                             level -3 with dict,                 old streaming,                      45395
-github,                             level -1,                           old streaming,                      175468
+github,                             level -1,                           old streaming,                      175568
 github,                             level -1 with dict,                 old streaming,                      43170
 github,                             level 0,                            old streaming,                      136335
 github,                             level 0 with dict,                  old streaming,                      41148
-github,                             level 1,                            old streaming,                      142365
+github,                             level 1,                            old streaming,                      142465
 github,                             level 1 with dict,                  old streaming,                      41682
 github,                             level 3,                            old streaming,                      136335
 github,                             level 3 with dict,                  old streaming,                      41148
@@ -1250,101 +1250,101 @@ github,                             no source size,                     old stre
 github,                             no source size with dict,           old streaming,                      40654
 github,                             uncompressed literals,              old streaming,                      136335
 github,                             uncompressed literals optimal,      old streaming,                      134064
-github,                             huffman literals,                   old streaming,                      175468
-github.tar,                         level -5,                           old streaming,                      64132
-github.tar,                         level -5 with dict,                 old streaming,                      48642
-github.tar,                         level -3,                           old streaming,                      50964
-github.tar,                         level -3 with dict,                 old streaming,                      42750
-github.tar,                         level -1,                           old streaming,                      42536
-github.tar,                         level -1 with dict,                 old streaming,                      41198
+github,                             huffman literals,                   old streaming,                      175568
+github.tar,                         level -5,                           old streaming,                      46747
+github.tar,                         level -5 with dict,                 old streaming,                      44440
+github.tar,                         level -3,                           old streaming,                      43537
+github.tar,                         level -3 with dict,                 old streaming,                      41112
+github.tar,                         level -1,                           old streaming,                      42465
+github.tar,                         level -1 with dict,                 old streaming,                      41196
 github.tar,                         level 0,                            old streaming,                      38441
 github.tar,                         level 0 with dict,                  old streaming,                      37995
-github.tar,                         level 1,                            old streaming,                      39270
-github.tar,                         level 1 with dict,                  old streaming,                      38316
+github.tar,                         level 1,                            old streaming,                      39342
+github.tar,                         level 1 with dict,                  old streaming,                      38293
 github.tar,                         level 3,                            old streaming,                      38441
 github.tar,                         level 3 with dict,                  old streaming,                      37995
 github.tar,                         level 4,                            old streaming,                      38467
 github.tar,                         level 4 with dict,                  old streaming,                      37948
-github.tar,                         level 5,                            old streaming,                      38376
-github.tar,                         level 5 with dict,                  old streaming,                      39040
-github.tar,                         level 6,                            old streaming,                      38610
-github.tar,                         level 6 with dict,                  old streaming,                      38622
-github.tar,                         level 7,                            old streaming,                      38073
-github.tar,                         level 7 with dict,                  old streaming,                      37848
-github.tar,                         level 9,                            old streaming,                      36767
-github.tar,                         level 9 with dict,                  old streaming,                      36457
-github.tar,                         level 13,                           old streaming,                      35501
-github.tar,                         level 13 with dict,                 old streaming,                      37130
-github.tar,                         level 16,                           old streaming,                      40471
-github.tar,                         level 16 with dict,                 old streaming,                      33378
-github.tar,                         level 19,                           old streaming,                      32134
-github.tar,                         level 19 with dict,                 old streaming,                      32709
+github.tar,                         level 5,                            old streaming,                      38394
+github.tar,                         level 5 with dict,                  old streaming,                      39074
+github.tar,                         level 6,                            old streaming,                      38669
+github.tar,                         level 6 with dict,                  old streaming,                      38660
+github.tar,                         level 7,                            old streaming,                      38153
+github.tar,                         level 7 with dict,                  old streaming,                      37892
+github.tar,                         level 9,                            old streaming,                      36768
+github.tar,                         level 9 with dict,                  old streaming,                      36510
+github.tar,                         level 13,                           old streaming,                      35621
+github.tar,                         level 13 with dict,                 old streaming,                      38726
+github.tar,                         level 16,                           old streaming,                      40255
+github.tar,                         level 16 with dict,                 old streaming,                      33639
+github.tar,                         level 19,                           old streaming,                      32837
+github.tar,                         level 19 with dict,                 old streaming,                      32895
 github.tar,                         no source size,                     old streaming,                      38438
 github.tar,                         no source size with dict,           old streaming,                      38000
 github.tar,                         uncompressed literals,              old streaming,                      38441
-github.tar,                         uncompressed literals optimal,      old streaming,                      32134
-github.tar,                         huffman literals,                   old streaming,                      42536
-silesia,                            level -5,                           old streaming advanced,             7292053
-silesia,                            level -3,                           old streaming advanced,             6867875
-silesia,                            level -1,                           old streaming advanced,             6183923
-silesia,                            level 0,                            old streaming advanced,             4849553
-silesia,                            level 1,                            old streaming advanced,             5312694
-silesia,                            level 3,                            old streaming advanced,             4849553
-silesia,                            level 4,                            old streaming advanced,             4786968
-silesia,                            level 5,                            old streaming advanced,             4638961
-silesia,                            level 6,                            old streaming advanced,             4605369
-silesia,                            level 7,                            old streaming advanced,             4567204
-silesia,                            level 9,                            old streaming advanced,             4543310
-silesia,                            level 13,                           old streaming advanced,             4493990
-silesia,                            level 16,                           old streaming advanced,             4359864
-silesia,                            level 19,                           old streaming advanced,             4296880
-silesia,                            no source size,                     old streaming advanced,             4849517
-silesia,                            long distance mode,                 old streaming advanced,             4849553
-silesia,                            multithreaded,                      old streaming advanced,             4849553
-silesia,                            multithreaded long distance mode,   old streaming advanced,             4849553
+github.tar,                         uncompressed literals optimal,      old streaming,                      32837
+github.tar,                         huffman literals,                   old streaming,                      42465
+silesia,                            level -5,                           old streaming advanced,             6882505
+silesia,                            level -3,                           old streaming advanced,             6568376
+silesia,                            level -1,                           old streaming advanced,             6183403
+silesia,                            level 0,                            old streaming advanced,             4849551
+silesia,                            level 1,                            old streaming advanced,             5314161
+silesia,                            level 3,                            old streaming advanced,             4849551
+silesia,                            level 4,                            old streaming advanced,             4786969
+silesia,                            level 5,                            old streaming advanced,             4639132
+silesia,                            level 6,                            old streaming advanced,             4605629
+silesia,                            level 7,                            old streaming advanced,             4567307
+silesia,                            level 9,                            old streaming advanced,             4543330
+silesia,                            level 13,                           old streaming advanced,             4482131
+silesia,                            level 16,                           old streaming advanced,             4360251
+silesia,                            level 19,                           old streaming advanced,             4283236
+silesia,                            no source size,                     old streaming advanced,             4849515
+silesia,                            long distance mode,                 old streaming advanced,             4849551
+silesia,                            multithreaded,                      old streaming advanced,             4849551
+silesia,                            multithreaded long distance mode,   old streaming advanced,             4849551
 silesia,                            small window log,                   old streaming advanced,             7112062
 silesia,                            small hash log,                     old streaming advanced,             6526141
-silesia,                            small chain log,                    old streaming advanced,             4912197
-silesia,                            explicit params,                    old streaming advanced,             4795883
-silesia,                            uncompressed literals,              old streaming advanced,             4849553
-silesia,                            uncompressed literals optimal,      old streaming advanced,             4296880
-silesia,                            huffman literals,                   old streaming advanced,             6183923
-silesia,                            multithreaded with advanced params, old streaming advanced,             4849553
-silesia.tar,                        level -5,                           old streaming advanced,             7260007
-silesia.tar,                        level -3,                           old streaming advanced,             6845151
-silesia.tar,                        level -1,                           old streaming advanced,             6187938
-silesia.tar,                        level 0,                            old streaming advanced,             4861426
-silesia.tar,                        level 1,                            old streaming advanced,             5334890
-silesia.tar,                        level 3,                            old streaming advanced,             4861426
+silesia,                            small chain log,                    old streaming advanced,             4912199
+silesia,                            explicit params,                    old streaming advanced,             4796309
+silesia,                            uncompressed literals,              old streaming advanced,             4849551
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4283236
+silesia,                            huffman literals,                   old streaming advanced,             6183403
+silesia,                            multithreaded with advanced params, old streaming advanced,             4849551
+silesia.tar,                        level -5,                           old streaming advanced,             6982759
+silesia.tar,                        level -3,                           old streaming advanced,             6641283
+silesia.tar,                        level -1,                           old streaming advanced,             6190795
+silesia.tar,                        level 0,                            old streaming advanced,             4861425
+silesia.tar,                        level 1,                            old streaming advanced,             5336941
+silesia.tar,                        level 3,                            old streaming advanced,             4861425
 silesia.tar,                        level 4,                            old streaming advanced,             4799632
-silesia.tar,                        level 5,                            old streaming advanced,             4650207
-silesia.tar,                        level 6,                            old streaming advanced,             4616816
-silesia.tar,                        level 7,                            old streaming advanced,             4576831
-silesia.tar,                        level 9,                            old streaming advanced,             4552590
-silesia.tar,                        level 13,                           old streaming advanced,             4502956
-silesia.tar,                        level 16,                           old streaming advanced,             4360527
-silesia.tar,                        level 19,                           old streaming advanced,             4267266
-silesia.tar,                        no source size,                     old streaming advanced,             4861422
-silesia.tar,                        long distance mode,                 old streaming advanced,             4861426
-silesia.tar,                        multithreaded,                      old streaming advanced,             4861426
-silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861426
+silesia.tar,                        level 5,                            old streaming advanced,             4650392
+silesia.tar,                        level 6,                            old streaming advanced,             4617097
+silesia.tar,                        level 7,                            old streaming advanced,             4576953
+silesia.tar,                        level 9,                            old streaming advanced,             4552646
+silesia.tar,                        level 13,                           old streaming advanced,             4491769
+silesia.tar,                        level 16,                           old streaming advanced,             4356834
+silesia.tar,                        level 19,                           old streaming advanced,             4264388
+silesia.tar,                        no source size,                     old streaming advanced,             4861421
+silesia.tar,                        long distance mode,                 old streaming advanced,             4861425
+silesia.tar,                        multithreaded,                      old streaming advanced,             4861425
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861425
 silesia.tar,                        small window log,                   old streaming advanced,             7118772
-silesia.tar,                        small hash log,                     old streaming advanced,             6529234
-silesia.tar,                        small chain log,                    old streaming advanced,             4917021
-silesia.tar,                        explicit params,                    old streaming advanced,             4807401
-silesia.tar,                        uncompressed literals,              old streaming advanced,             4861426
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4267266
-silesia.tar,                        huffman literals,                   old streaming advanced,             6187938
-silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861426
-github,                             level -5,                           old streaming advanced,             241214
+silesia.tar,                        small hash log,                     old streaming advanced,             6529231
+silesia.tar,                        small chain log,                    old streaming advanced,             4917019
+silesia.tar,                        explicit params,                    old streaming advanced,             4807688
+silesia.tar,                        uncompressed literals,              old streaming advanced,             4861425
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4264388
+silesia.tar,                        huffman literals,                   old streaming advanced,             6190795
+silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861425
+github,                             level -5,                           old streaming advanced,             216734
 github,                             level -5 with dict,                 old streaming advanced,             49562
-github,                             level -3,                           old streaming advanced,             222937
+github,                             level -3,                           old streaming advanced,             192160
 github,                             level -3 with dict,                 old streaming advanced,             44956
-github,                             level -1,                           old streaming advanced,             181107
+github,                             level -1,                           old streaming advanced,             181108
 github,                             level -1 with dict,                 old streaming advanced,             42383
 github,                             level 0,                            old streaming advanced,             141104
 github,                             level 0 with dict,                  old streaming advanced,             41113
-github,                             level 1,                            old streaming advanced,             143693
+github,                             level 1,                            old streaming advanced,             143692
 github,                             level 1 with dict,                  old streaming advanced,             42430
 github,                             level 3,                            old streaming advanced,             141104
 github,                             level 3 with dict,                  old streaming advanced,             41113
@@ -1359,7 +1359,7 @@ github,                             level 7 with dict,                  old stre
 github,                             level 9,                            old streaming advanced,             138676
 github,                             level 9 with dict,                  old streaming advanced,             38981
 github,                             level 13,                           old streaming advanced,             138676
-github,                             level 13 with dict,                 old streaming advanced,             39721
+github,                             level 13 with dict,                 old streaming advanced,             39731
 github,                             level 16,                           old streaming advanced,             138676
 github,                             level 16 with dict,                 old streaming advanced,             40789
 github,                             level 19,                           old streaming advanced,             134064
@@ -1375,36 +1375,36 @@ github,                             small chain log,                    old stre
 github,                             explicit params,                    old streaming advanced,             140937
 github,                             uncompressed literals,              old streaming advanced,             141104
 github,                             uncompressed literals optimal,      old streaming advanced,             134064
-github,                             huffman literals,                   old streaming advanced,             181107
+github,                             huffman literals,                   old streaming advanced,             181108
 github,                             multithreaded with advanced params, old streaming advanced,             141104
-github.tar,                         level -5,                           old streaming advanced,             64132
-github.tar,                         level -5 with dict,                 old streaming advanced,             48982
-github.tar,                         level -3,                           old streaming advanced,             50964
-github.tar,                         level -3 with dict,                 old streaming advanced,             43357
-github.tar,                         level -1,                           old streaming advanced,             42536
-github.tar,                         level -1 with dict,                 old streaming advanced,             41494
+github.tar,                         level -5,                           old streaming advanced,             46747
+github.tar,                         level -5 with dict,                 old streaming advanced,             44824
+github.tar,                         level -3,                           old streaming advanced,             43537
+github.tar,                         level -3 with dict,                 old streaming advanced,             41800
+github.tar,                         level -1,                           old streaming advanced,             42465
+github.tar,                         level -1 with dict,                 old streaming advanced,             41471
 github.tar,                         level 0,                            old streaming advanced,             38441
 github.tar,                         level 0 with dict,                  old streaming advanced,             38013
-github.tar,                         level 1,                            old streaming advanced,             39270
-github.tar,                         level 1 with dict,                  old streaming advanced,             38934
+github.tar,                         level 1,                            old streaming advanced,             39342
+github.tar,                         level 1 with dict,                  old streaming advanced,             38940
 github.tar,                         level 3,                            old streaming advanced,             38441
 github.tar,                         level 3 with dict,                  old streaming advanced,             38013
 github.tar,                         level 4,                            old streaming advanced,             38467
 github.tar,                         level 4 with dict,                  old streaming advanced,             38063
-github.tar,                         level 5,                            old streaming advanced,             38376
-github.tar,                         level 5 with dict,                  old streaming advanced,             37677
-github.tar,                         level 6,                            old streaming advanced,             38610
-github.tar,                         level 6 with dict,                  old streaming advanced,             37786
-github.tar,                         level 7,                            old streaming advanced,             38073
-github.tar,                         level 7 with dict,                  old streaming advanced,             37322
-github.tar,                         level 9,                            old streaming advanced,             36767
-github.tar,                         level 9 with dict,                  old streaming advanced,             36233
-github.tar,                         level 13,                           old streaming advanced,             35501
-github.tar,                         level 13 with dict,                 old streaming advanced,             35807
-github.tar,                         level 16,                           old streaming advanced,             40471
-github.tar,                         level 16 with dict,                 old streaming advanced,             38578
-github.tar,                         level 19,                           old streaming advanced,             32134
-github.tar,                         level 19 with dict,                 old streaming advanced,             32702
+github.tar,                         level 5,                            old streaming advanced,             38394
+github.tar,                         level 5 with dict,                  old streaming advanced,             37763
+github.tar,                         level 6,                            old streaming advanced,             38669
+github.tar,                         level 6 with dict,                  old streaming advanced,             37851
+github.tar,                         level 7,                            old streaming advanced,             38153
+github.tar,                         level 7 with dict,                  old streaming advanced,             37406
+github.tar,                         level 9,                            old streaming advanced,             36768
+github.tar,                         level 9 with dict,                  old streaming advanced,             36304
+github.tar,                         level 13,                           old streaming advanced,             35621
+github.tar,                         level 13 with dict,                 old streaming advanced,             36035
+github.tar,                         level 16,                           old streaming advanced,             40255
+github.tar,                         level 16 with dict,                 old streaming advanced,             38736
+github.tar,                         level 19,                           old streaming advanced,             32837
+github.tar,                         level 19 with dict,                 old streaming advanced,             32876
 github.tar,                         no source size,                     old streaming advanced,             38438
 github.tar,                         no source size with dict,           old streaming advanced,             38015
 github.tar,                         long distance mode,                 old streaming advanced,             38441
@@ -1413,10 +1413,10 @@ github.tar,                         multithreaded long distance mode,   old stre
 github.tar,                         small window log,                   old streaming advanced,             199561
 github.tar,                         small hash log,                     old streaming advanced,             129870
 github.tar,                         small chain log,                    old streaming advanced,             41669
-github.tar,                         explicit params,                    old streaming advanced,             41227
+github.tar,                         explicit params,                    old streaming advanced,             41351
 github.tar,                         uncompressed literals,              old streaming advanced,             38441
-github.tar,                         uncompressed literals optimal,      old streaming advanced,             32134
-github.tar,                         huffman literals,                   old streaming advanced,             42536
+github.tar,                         uncompressed literals optimal,      old streaming advanced,             32837
+github.tar,                         huffman literals,                   old streaming advanced,             42465
 github.tar,                         multithreaded with advanced params, old streaming advanced,             38441
 github,                             level -5 with dict,                 old streaming cdict,                46718
 github,                             level -3 with dict,                 old streaming cdict,                45395
@@ -1433,20 +1433,20 @@ github,                             level 13 with dict,                 old stre
 github,                             level 16 with dict,                 old streaming cdict,                37577
 github,                             level 19 with dict,                 old streaming cdict,                37576
 github,                             no source size with dict,           old streaming cdict,                40654
-github.tar,                         level -5 with dict,                 old streaming cdict,                49146
-github.tar,                         level -3 with dict,                 old streaming cdict,                43468
-github.tar,                         level -1 with dict,                 old streaming cdict,                41662
+github.tar,                         level -5 with dict,                 old streaming cdict,                45018
+github.tar,                         level -3 with dict,                 old streaming cdict,                41886
+github.tar,                         level -1 with dict,                 old streaming cdict,                41636
 github.tar,                         level 0 with dict,                  old streaming cdict,                37956
-github.tar,                         level 1 with dict,                  old streaming cdict,                38761
+github.tar,                         level 1 with dict,                  old streaming cdict,                38766
 github.tar,                         level 3 with dict,                  old streaming cdict,                37956
 github.tar,                         level 4 with dict,                  old streaming cdict,                37927
-github.tar,                         level 5 with dict,                  old streaming cdict,                37600
-github.tar,                         level 6 with dict,                  old streaming cdict,                37829
-github.tar,                         level 7 with dict,                  old streaming cdict,                37371
-github.tar,                         level 9 with dict,                  old streaming cdict,                36352
-github.tar,                         level 13 with dict,                 old streaming cdict,                36010
-github.tar,                         level 16 with dict,                 old streaming cdict,                39081
-github.tar,                         level 19 with dict,                 old streaming cdict,                32474
+github.tar,                         level 5 with dict,                  old streaming cdict,                37665
+github.tar,                         level 6 with dict,                  old streaming cdict,                37889
+github.tar,                         level 7 with dict,                  old streaming cdict,                37457
+github.tar,                         level 9 with dict,                  old streaming cdict,                36383
+github.tar,                         level 13 with dict,                 old streaming cdict,                36372
+github.tar,                         level 16 with dict,                 old streaming cdict,                39353
+github.tar,                         level 19 with dict,                 old streaming cdict,                32676
 github.tar,                         no source size with dict,           old streaming cdict,                38000
 github,                             level -5 with dict,                 old streaming advanced cdict,       49562
 github,                             level -3 with dict,                 old streaming advanced cdict,       44956
@@ -1459,7 +1459,7 @@ github,                             level 5 with dict,                  old stre
 github,                             level 6 with dict,                  old streaming advanced cdict,       39363
 github,                             level 7 with dict,                  old streaming advanced cdict,       38924
 github,                             level 9 with dict,                  old streaming advanced cdict,       38981
-github,                             level 13 with dict,                 old streaming advanced cdict,       39721
+github,                             level 13 with dict,                 old streaming advanced cdict,       39731
 github,                             level 16 with dict,                 old streaming advanced cdict,       40789
 github,                             level 19 with dict,                 old streaming advanced cdict,       37576
 github,                             no source size with dict,           old streaming advanced cdict,       40608
@@ -1470,11 +1470,11 @@ github.tar,                         level 0 with dict,                  old stre
 github.tar,                         level 1 with dict,                  old streaming advanced cdict,       39002
 github.tar,                         level 3 with dict,                  old streaming advanced cdict,       38013
 github.tar,                         level 4 with dict,                  old streaming advanced cdict,       38063
-github.tar,                         level 5 with dict,                  old streaming advanced cdict,       37677
-github.tar,                         level 6 with dict,                  old streaming advanced cdict,       37786
-github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37322
-github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36233
-github.tar,                         level 13 with dict,                 old streaming advanced cdict,       35807
-github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38578
-github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32702
+github.tar,                         level 5 with dict,                  old streaming advanced cdict,       37763
+github.tar,                         level 6 with dict,                  old streaming advanced cdict,       37851
+github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37406
+github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36304
+github.tar,                         level 13 with dict,                 old streaming advanced cdict,       36035
+github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38736
+github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32876
 github.tar,                         no source size with dict,           old streaming advanced cdict,       38015


### PR DESCRIPTION
**Origin:**
Brought up in #2662. Fix suggested here by @terrelln, https://github.com/facebook/zstd/issues/2662#issuecomment-842727489.

**Overview:**
With this change, for the lazy matchfinder, we only ever update up to 256 positions in the hash table, which improves performance on long matches. When this happens, we need to stop and overwrite everything in the hash cache. 

**Current status:**
I've been playing around with different settings for the threshold to skip, and 256 seems reasonable. It seems like random changes to the code can cause noticeable and consistent shifts in the performance. It's hard to say if this is generally positive or negative for the average case. We care most about level 6 since that's what the warehouse-type use cases should be using starting with 1.5.1.

Most importantly, I think it's important to understand why the performance is changing in the various ways, since I don't really have a good explanation for that yet. For example, the `UNLIKELY` annotation I don't think is actually that helpful, yet on level 5 it dramatically increases speed.

```
skip_long_matches_lazy:
 5#silesia.tar       : 202 MiB -> 59.6 MiB (3.392),  115.2 MB/s, 1007.7 MB/s 
 6#silesia.tar       : 202 MiB -> 58.6 MiB (3.448),   93.0 MB/s, 1001.1 MB/s 
 7#silesia.tar       : 202 MiB -> 57.7 MiB (3.505),   71.8 MB/s, 1061.9 MB/s

 5#enwik7            : 9.54 MiB -> 3.21 MiB (2.973),   89.1 MB/s,  845.7 MB/s 
 6#enwik7            : 9.54 MiB -> 3.15 MiB (3.031),   68.8 MB/s,  845.8 MB/s 
 7#enwik7            : 9.54 MiB -> 3.07 MiB (3.107),   53.9 MB/s,  886.0 MB/s 

// out.txt is the edge case mentioned in issue #2662
 5#out.txt           : 256 KiB -> 4.46 KiB (57.46),  790.3 MB/s, 7064.6 MB/s 
 6#out.txt           : 256 KiB -> 4.89 KiB (52.40),  606.9 MB/s, 3075.7 MB/s 
 7#out.txt           : 256 KiB -> 3.54 KiB (72.36),  582.4 MB/s, 7072.2 MB/s


dev:
 5#silesia.tar       : 202 MiB -> 59.6 MiB (3.393),  113.8 MB/s, 1011.5 MB/s 
 6#silesia.tar       : 202 MiB -> 58.6 MiB (3.449),   94.6 MB/s, 1003.0 MB/s 
 7#silesia.tar       : 202 MiB -> 57.7 MiB (3.506),   70.4 MB/s, 1063.9 MB/s

 5#enwik7            : 9.54 MiB -> 3.21 MiB (2.973),   88.0 MB/s,  834.6 MB/s 
 6#enwik7            : 9.54 MiB -> 3.15 MiB (3.032),   70.5 MB/s,  838.3 MB/s 
 7#enwik7            : 9.54 MiB -> 3.07 MiB (3.107),   52.8 MB/s,  866.1 MB/s

 5#out.txt           : 256 KiB -> 4.74 KiB (53.96),  360.7 MB/s, 7084.3 MB/s 
 6#out.txt           : 256 KiB -> 5.05 KiB (50.68),  336.8 MB/s, 3051.4 MB/s 
 7#out.txt           : 256 KiB -> 3.85 KiB (66.53),  344.7 MB/s, 7045.6 MB/s
```

Some variations:

```
skip, without UNLIKELY annotation:
 5#silesia.tar       : 202 MiB -> 59.6 MiB (3.392),  111.7 MB/s, 1010.8 MB/s 
 6#silesia.tar       : 202 MiB -> 58.6 MiB (3.448),   94.4 MB/s, 1002.7 MB/s 
 7#silesia.tar       : 202 MiB -> 57.7 MiB (3.505),   71.7 MB/s, 1063.4 MB/s

 5#enwik7            : 9.54 MiB -> 3.21 MiB (2.973),   85.4 MB/s,  848.2 MB/s 
 6#enwik7            : 9.54 MiB -> 3.15 MiB (3.031),   70.0 MB/s,  846.2 MB/s 
 7#enwik7            : 9.54 MiB -> 3.07 MiB (3.107),   54.0 MB/s,  890.2 MB/s

skip, without UNLIKELY annotation, with "p2align 5" before the update loop:
 5#silesia.tar       : 202 MiB -> 59.6 MiB (3.392),  112.1 MB/s, 1010.7 MB/s 
 6#silesia.tar       : 202 MiB -> 58.6 MiB (3.448),   93.1 MB/s, 1002.8 MB/s 
 7#silesia.tar       : 202 MiB -> 57.7 MiB (3.505),   72.5 MB/s, 1063.4 MB/s

 5#enwik7            : 9.54 MiB -> 3.21 MiB (2.973),   86.6 MB/s,  848.1 MB/s 
 6#enwik7            : 9.54 MiB -> 3.15 MiB (3.031),   69.3 MB/s,  848.9 MB/s 
 7#enwik7            : 9.54 MiB -> 3.07 MiB (3.107),   54.3 MB/s,  894.8 MB/s

// Disabling prefetching in ZSTD_row_fillHashCache() seems to be neutral/negative
```