### PR TITLE
Improve compile speed and binary size in `opt`

### DIFF
--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -253,11 +253,10 @@ static U32 ZSTD_litLengthPrice(U32 const litLength, const optState_t* const optP
  * Provides the cost of the match part (offset + matchLength) of a sequence
  * Must be combined with ZSTD_fullLiteralsCost() to get the full cost of a sequence.
  * optLevel: when <2, favors small offset for decompression speed (improved cache efficiency) */
-FORCE_INLINE_TEMPLATE U32
-ZSTD_getMatchPrice(U32 const offset,
-                   U32 const matchLength,
-             const optState_t* const optPtr,
-                   int const optLevel)
+static U32 ZSTD_getMatchPrice(U32 const offset,
+                              U32 const matchLength,
+                        const optState_t* const optPtr,
+                              int const optLevel)
 {
     U32 price;
     U32 const offCode = ZSTD_highbit32(offset+1);
@@ -485,11 +484,9 @@ static U32 ZSTD_insertBt1(
     }
 }
 
-FORCE_INLINE_TEMPLATE
-void ZSTD_updateTree_internal(
-                ZSTD_matchState_t* ms,
-                const BYTE* const ip, const BYTE* const iend,
-                const U32 mls, const ZSTD_dictMode_e dictMode)
+static void ZSTD_updateTree_internal(ZSTD_matchState_t* ms,
+                               const BYTE* const ip, const BYTE* const iend,
+                               const U32 mls, const ZSTD_dictMode_e dictMode)
 {
     const BYTE* const base = ms->window.base;
     U32 const target = (U32)(ip - base);
@@ -511,8 +508,7 @@ void ZSTD_updateTree(ZSTD_matchState_t* ms, const BYTE* ip, const BYTE* iend) {
     ZSTD_updateTree_internal(ms, ip, iend, ms->cParams.minMatch, ZSTD_noDict);
 }
 
-FORCE_INLINE_TEMPLATE
-U32 ZSTD_insertBtAndGetAllMatches (
+static U32 ZSTD_insertBtAndGetAllMatches (
                     ZSTD_match_t* matches,   /* store result (found matches) in this table (presumed large enough) */
                     ZSTD_matchState_t* ms,
                     U32* nextToUpdate3,
@@ -745,7 +741,7 @@ U32 ZSTD_insertBtAndGetAllMatches (
 }
 
 
-FORCE_INLINE_TEMPLATE U32 ZSTD_BtGetAllMatches (
+static U32 ZSTD_BtGetAllMatches (
                         ZSTD_match_t* matches,   /* store result (match found, increasing size) in this table */
                         ZSTD_matchState_t* ms,
                         U32* nextToUpdate3,
@@ -932,7 +928,7 @@ listStats(const U32* table, int lastEltID)
 
 #endif
 
-FORCE_INLINE_TEMPLATE size_t
+static size_t
 ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                                seqStore_t* seqStore,
                                U32 rep[ZSTD_REP_NUM],


### PR DESCRIPTION
Remove basically all inlining/templating in opt.
I measure no impact to end-to-end compression speed at all (levels 13-16, `silesia.tar`).

```
macOS with gcc

dev:
zstdcli binary size: 1703976
time to compile opt.o: ~8.5s

opt_compiletime:
zstdcli binary size: 1458352  (14.5% reduction)
time to compile opt.o: ~1.8s
```

The bigger bottleneck is still lazy, which will require a bit more work to reduce without speed regressions.
