### PR TITLE
Improve optimal parser performance on small data

### DIFF
--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -204,7 +204,7 @@ ZSTD_rescaleFreqs(optState_t* const optPtr,
                     1, 1, 1, 1, 1, 1, 1, 1,
                     1, 1, 1, 1
                 };
-                memcpy(optPtr->litLengthFreq, baseLLfreqs, sizeof(baseLLfreqs)); optPtr->litLengthSum = sum_u32(baseLLfreqs, MaxLL+1);
+                ZSTD_memcpy(optPtr->litLengthFreq, baseLLfreqs, sizeof(baseLLfreqs)); optPtr->litLengthSum = sum_u32(baseLLfreqs, MaxLL+1);
             }
 
             {   unsigned ml;
@@ -219,7 +219,7 @@ ZSTD_rescaleFreqs(optState_t* const optPtr,
                     1, 1, 1, 1, 1, 1, 1, 1,
                     1, 1, 1, 1, 1, 1, 1, 1
                 };
-                memcpy(optPtr->offCodeFreq, baseOFCfreqs, sizeof(baseOFCfreqs)); optPtr->offCodeSum = sum_u32(baseOFCfreqs, MaxOff+1);
+                ZSTD_memcpy(optPtr->offCodeFreq, baseOFCfreqs, sizeof(baseOFCfreqs)); optPtr->offCodeSum = sum_u32(baseOFCfreqs, MaxOff+1);
             }
 
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -987,7 +987,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
              * in every price. We include the literal length to avoid negative
              * prices when we subtract the previous literal length.
              */
-            opt[0].price = ZSTD_litLengthPrice(litlen, optStatePtr, optLevel);
+            opt[0].price = (int)ZSTD_litLengthPrice(litlen, optStatePtr, optLevel);
 
             /* large match -> immediate encoding */
             {   U32 const maxML = matches[nbMatches-1].len;
@@ -1007,6 +1007,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
             }   }
 
             /* set prices for first matches starting position == 0 */
+            assert(opt[0].price >= 0);
             {   U32 const literalsPrice = opt[0].price + ZSTD_litLengthPrice(0, optStatePtr, optLevel);
                 U32 pos;
                 U32 matchNb;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -196,7 +196,6 @@ ZSTD_rescaleFreqs(optState_t* const optPtr,
                     1, 1, 1, 1
                 };
                 memcpy(optPtr->litLengthFreq, baseLLfreqs, sizeof(baseLLfreqs)); optPtr->litLengthSum = sum_u32(baseLLfreqs, MaxLL+1);
-                //unsigned ll; for (ll=0; ll<=MaxLL; ll++) optPtr->litLengthFreq[ll] = 1; optPtr->litLengthSum = MaxLL+1;
             }
 
             {   unsigned ml;
@@ -206,13 +205,12 @@ ZSTD_rescaleFreqs(optState_t* const optPtr,
             optPtr->matchLengthSum = MaxML+1;
 
             {   unsigned const baseOFCfreqs[MaxOff+1] = {
-                        8, 4, 3, 3, 3, 4, 4, 4,
-                        4, 4, 3, 3, 3, 2, 2, 2,
-                        1, 1, 1, 1, 1, 1, 1, 1,
-                        1, 1, 1, 1, 1, 1, 1, 1,
-                    };
-                //memcpy(optPtr->offCodeFreq, baseOFCfreqs, sizeof(baseOFCfreqs)); optPtr->offCodeSum = sum_u32(baseOFCfreqs, MaxOff+1);
-                unsigned of; for (of=0; of<=MaxOff; of++) optPtr->offCodeFreq[of] = 1; optPtr->offCodeSum = MaxOff+1;
+                    6, 2, 1, 1, 2, 3, 4, 4,
+                    4, 3, 2, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1
+                };
+                memcpy(optPtr->offCodeFreq, baseOFCfreqs, sizeof(baseOFCfreqs)); optPtr->offCodeSum = sum_u32(baseOFCfreqs, MaxOff+1);
             }
 
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -228,10 +228,10 @@ ZSTD_rescaleFreqs(optState_t* const optPtr,
     } else {   /* new block : re-use previous statistics, scaled down */
 
         if (compressedLiterals)
-            optPtr->litSum = ZSTD_scaleStats(optPtr->litFreq, MaxLit, 11);
-        optPtr->litLengthSum = ZSTD_scaleStats(optPtr->litLengthFreq, MaxLL, 10);
-        optPtr->matchLengthSum = ZSTD_scaleStats(optPtr->matchLengthFreq, MaxML, 10);
-        optPtr->offCodeSum = ZSTD_scaleStats(optPtr->offCodeFreq, MaxOff, 10);
+            optPtr->litSum = ZSTD_scaleStats(optPtr->litFreq, MaxLit, 12);
+        optPtr->litLengthSum = ZSTD_scaleStats(optPtr->litLengthFreq, MaxLL, 11);
+        optPtr->matchLengthSum = ZSTD_scaleStats(optPtr->matchLengthFreq, MaxML, 11);
+        optPtr->offCodeSum = ZSTD_scaleStats(optPtr->offCodeFreq, MaxOff, 11);
     }
 
     ZSTD_setBasePrices(optPtr, optLevel);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -1008,7 +1008,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
 
             /* set prices for first matches starting position == 0 */
             assert(opt[0].price >= 0);
-            {   U32 const literalsPrice = opt[0].price + ZSTD_litLengthPrice(0, optStatePtr, optLevel);
+            {   U32 const literalsPrice = (U32)opt[0].price + ZSTD_litLengthPrice(0, optStatePtr, optLevel);
                 U32 pos;
                 U32 matchNb;
                 for (pos = 1; pos < minMatch; pos++) {
@@ -1025,7 +1025,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                         opt[pos].mlen = pos;
                         opt[pos].off = offset;
                         opt[pos].litlen = litlen;
-                        opt[pos].price = sequencePrice;
+                        opt[pos].price = (int)sequencePrice;
                 }   }
                 last_pos = pos-1;
             }
@@ -1040,9 +1040,9 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
             /* Fix current position with one literal if cheaper */
             {   U32 const litlen = (opt[cur-1].mlen == 0) ? opt[cur-1].litlen + 1 : 1;
                 int const price = opt[cur-1].price
-                                + ZSTD_rawLiteralsCost(ip+cur-1, 1, optStatePtr, optLevel)
-                                + ZSTD_litLengthPrice(litlen, optStatePtr, optLevel)
-                                - ZSTD_litLengthPrice(litlen-1, optStatePtr, optLevel);
+                                + (int)ZSTD_rawLiteralsCost(ip+cur-1, 1, optStatePtr, optLevel)
+                                + (int)ZSTD_litLengthPrice(litlen, optStatePtr, optLevel)
+                                - (int)ZSTD_litLengthPrice(litlen-1, optStatePtr, optLevel);
                 assert(price < 1000000000); /* overflow check */
                 if (price <= opt[cur].price) {
                     DEBUGLOG(7, "cPos:%zi==rPos:%u : better price (%.2f<=%.2f) using literal (ll==%u) (hist:%u,%u,%u)",
@@ -1085,9 +1085,10 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                 continue;  /* skip unpromising positions; about ~+6% speed, -0.01 ratio */
             }
 
+            assert(opt[cur].price >= 0);
             {   U32 const ll0 = (opt[cur].mlen != 0);
                 U32 const litlen = (opt[cur].mlen == 0) ? opt[cur].litlen : 0;
-                U32 const previousPrice = opt[cur].price;
+                U32 const previousPrice = (U32)opt[cur].price;
                 U32 const basePrice = previousPrice + ZSTD_litLengthPrice(0, optStatePtr, optLevel);
                 U32 nbMatches = ZSTD_BtGetAllMatches(matches, ms, &nextToUpdate3, inr, iend, dictMode, opt[cur].rep, ll0, minMatch);
                 U32 matchNb;
@@ -1127,7 +1128,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
 
                     for (mlen = lastML; mlen >= startML; mlen--) {  /* scan downward */
                         U32 const pos = cur + mlen;
-                        int const price = basePrice + ZSTD_getMatchPrice(offset, mlen, optStatePtr, optLevel);
+                        int const price = (int)basePrice + (int)ZSTD_getMatchPrice(offset, mlen, optStatePtr, optLevel);
 
                         if ((pos > last_pos) || (price < opt[pos].price)) {
                             DEBUGLOG(7, "rPos:%u (ml=%2u) => new better price (%.2f<%.2f)",

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -228,10 +228,10 @@ ZSTD_rescaleFreqs(optState_t* const optPtr,
     } else {   /* new block : re-use previous statistics, scaled down */
 
         if (compressedLiterals)
-            optPtr->litSum = ZSTD_scaleStats(optPtr->litFreq, MaxLit, 10);
-        optPtr->litLengthSum = ZSTD_scaleStats(optPtr->litLengthFreq, MaxLL, 9);
-        optPtr->matchLengthSum = ZSTD_scaleStats(optPtr->matchLengthFreq, MaxML, 9);
-        optPtr->offCodeSum = ZSTD_scaleStats(optPtr->offCodeFreq, MaxOff, 9);
+            optPtr->litSum = ZSTD_scaleStats(optPtr->litFreq, MaxLit, 11);
+        optPtr->litLengthSum = ZSTD_scaleStats(optPtr->litLengthFreq, MaxLL, 10);
+        optPtr->matchLengthSum = ZSTD_scaleStats(optPtr->matchLengthFreq, MaxML, 10);
+        optPtr->offCodeSum = ZSTD_scaleStats(optPtr->offCodeFreq, MaxOff, 10);
     }
 
     ZSTD_setBasePrices(optPtr, optLevel);

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -47,7 +47,7 @@
 *  Console display
 ***************************************/
 #ifndef LOCALDISPLAYLEVEL
-static int g_displayLevel = 2;
+static int g_displayLevel = 0;
 #endif
 #undef  DISPLAY
 #define DISPLAY(...)                                                           \
@@ -735,7 +735,7 @@ ZDICTLIB_API size_t ZDICT_trainFromBuffer_cover(
   COVER_map_t activeDmers;
   parameters.splitPoint = 1.0;
   /* Initialize global data */
-  g_displayLevel = parameters.zParams.notificationLevel;
+  g_displayLevel = (int)parameters.zParams.notificationLevel;
   /* Checks */
   if (!COVER_checkParameters(parameters, dictBufferCapacity)) {
     DISPLAYLEVEL(1, "Cover parameters incorrect\n");

--- a/lib/dictBuilder/fastcover.c
+++ b/lib/dictBuilder/fastcover.c
@@ -44,7 +44,7 @@
 *  Console display
 ***************************************/
 #ifndef LOCALDISPLAYLEVEL
-static int g_displayLevel = 2;
+static int g_displayLevel = 0;
 #endif
 #undef  DISPLAY
 #define DISPLAY(...)                                                           \
@@ -549,7 +549,7 @@ ZDICT_trainFromBuffer_fastCover(void* dictBuffer, size_t dictBufferCapacity,
     ZDICT_cover_params_t coverParams;
     FASTCOVER_accel_t accelParams;
     /* Initialize global data */
-    g_displayLevel = parameters.zParams.notificationLevel;
+    g_displayLevel = (int)parameters.zParams.notificationLevel;
     /* Assign splitPoint and f if not provided */
     parameters.splitPoint = 1.0;
     parameters.f = parameters.f == 0 ? DEFAULT_F : parameters.f;
@@ -632,7 +632,7 @@ ZDICT_optimizeTrainFromBuffer_fastCover(
     const unsigned accel = parameters->accel == 0 ? DEFAULT_ACCEL : parameters->accel;
     const unsigned shrinkDict = 0;
     /* Local variables */
-    const int displayLevel = parameters->zParams.notificationLevel;
+    const int displayLevel = (int)parameters->zParams.notificationLevel;
     unsigned iteration = 1;
     unsigned d;
     unsigned k;
@@ -716,7 +716,7 @@ ZDICT_optimizeTrainFromBuffer_fastCover(
         data->parameters.splitPoint = splitPoint;
         data->parameters.steps = kSteps;
         data->parameters.shrinkDict = shrinkDict;
-        data->parameters.zParams.notificationLevel = g_displayLevel;
+        data->parameters.zParams.notificationLevel = (unsigned)g_displayLevel;
         /* Check the parameters */
         if (!FASTCOVER_checkParameters(data->parameters, dictBufferCapacity,
                                        data->ctx->f, accel)) {

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -70,6 +70,8 @@ static const size_t maxMemory = (sizeof(size_t)==4)  ?
 #define DISPLAY(...)         { fprintf(stderr, __VA_ARGS__); fflush(NULL); }
 #define DISPLAYLEVEL(l, ...) if (displayLevel>=l) { DISPLAY(__VA_ARGS__); }
 /* 0 : no display;   1: errors;   2 : + result + interaction + warnings;   3 : + progression;   4 : + information */
+#define OUTPUT(...)          { fprintf(stdout, __VA_ARGS__); fflush(NULL); }
+#define OUTPUTLEVEL(l, ...)  if (displayLevel>=l) { OUTPUT(__VA_ARGS__); }
 
 
 /* *************************************
@@ -429,9 +431,9 @@ BMK_benchMemAdvancedNoAlloc(
         dctxprep.dictBuffer = dictBuffer;
         dctxprep.dictBufferSize = dictBufferSize;
 
-        DISPLAYLEVEL(2, "\r%70s\r", "");   /* blank line */
+        OUTPUTLEVEL(2, "\r%70s\r", "");   /* blank line */
         assert(srcSize < UINT_MAX);
-        DISPLAYLEVEL(2, "%2s-%-17.17s :%10u -> \r", marks[markNb], displayName, (unsigned)srcSize);
+        OUTPUTLEVEL(2, "%2s-%-17.17s :%10u -> \r", marks[markNb], displayName, (unsigned)srcSize);
 
         while (!(compressionCompleted && decompressionCompleted)) {
             if (!compressionCompleted) {
@@ -453,7 +455,7 @@ BMK_benchMemAdvancedNoAlloc(
 
                 {   int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
                     assert(cSize < UINT_MAX);
-                    DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f), %6.*f MB/s\r",
+                    OUTPUTLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f), %6.*f MB/s\r",
                             marks[markNb], displayName,
                             (unsigned)srcSize, (unsigned)cSize,
                             ratioAccuracy, ratio,
@@ -476,7 +478,7 @@ BMK_benchMemAdvancedNoAlloc(
                 }
 
                 {   int const ratioAccuracy = (ratio < 10.) ? 3 : 2;
-                    DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f), %6.*f MB/s, %6.1f MB/s \r",
+                    OUTPUTLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.*f), %6.*f MB/s, %6.1f MB/s \r",
                             marks[markNb], displayName,
                             (unsigned)srcSize, (unsigned)cSize,
                             ratioAccuracy, ratio,
@@ -537,13 +539,13 @@ BMK_benchMemAdvancedNoAlloc(
             double const cSpeed = (double)benchResult.cSpeed / MB_UNIT;
             double const dSpeed = (double)benchResult.dSpeed / MB_UNIT;
             if (adv->additionalParam) {
-                DISPLAY("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s (param=%d)\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName, adv->additionalParam);
+                OUTPUT("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s (param=%d)\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName, adv->additionalParam);
             } else {
-                DISPLAY("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName);
+                OUTPUT("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName);
             }
         }
 
-        DISPLAYLEVEL(2, "%2i#\n", cLevel);
+        OUTPUTLEVEL(2, "%2i#\n", cLevel);
     }   /* Bench */
 
     benchResult.cMem = (1ULL << (comprParams->windowLog)) + ZSTD_sizeof_CCtx(cctx);
@@ -672,7 +674,7 @@ static BMK_benchOutcome_t BMK_benchCLevel(const void* srcBuffer, size_t benchedS
     }
 
     if (displayLevel == 1 && !adv->additionalParam)   /* --quiet mode */
-        DISPLAY("bench %s %s: input %u bytes, %u seconds, %u KB blocks\n",
+        OUTPUT("bench %s %s: input %u bytes, %u seconds, %u KB blocks\n",
                 ZSTD_VERSION_STRING, ZSTD_GIT_COMMIT_STRING,
                 (unsigned)benchedSize, adv->nbSeconds, (unsigned)(adv->blockSize>>10));
 
@@ -762,7 +764,7 @@ static int BMK_loadFiles(void* buffer, size_t bufferSize,
         }
         {   FILE* const f = fopen(fileNamesTable[n], "rb");
             if (f==NULL) RETURN_ERROR_INT(10, "impossible to open file %s", fileNamesTable[n]);
-            DISPLAYLEVEL(2, "Loading %s...       \r", fileNamesTable[n]);
+            OUTPUTLEVEL(2, "Loading %s...       \r", fileNamesTable[n]);
             if (fileSize > bufferSize-pos) fileSize = bufferSize-pos, nbFiles=n;   /* buffer too small - stop after this file */
             {   size_t const readSize = fread(((char*)buffer)+pos, 1, (size_t)fileSize, f);
                 if (readSize != (size_t)fileSize) RETURN_ERROR_INT(11, "could not read %s", fileNamesTable[n]);

--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -373,10 +373,7 @@ BMK_benchMemAdvancedNoAlloc(
                 if (adv->mode == BMK_decodeOnly) {
                     cSizes[nbBlocks] = thisBlockSize;
                     benchResult.cSize = thisBlockSize;
-                }
-            }
-        }
-    }
+    }   }   }   }
 
     /* warming up `compressedBuffer` */
     if (adv->mode == BMK_decodeOnly) {

--- a/programs/util.c
+++ b/programs/util.c
@@ -308,7 +308,8 @@ U64 UTIL_getFileSizeStat(const stat_t* statbuf)
     return (U64)statbuf->st_size;
 }
 
-UTIL_HumanReadableSize_t UTIL_makeHumanReadableSize(U64 size) {
+UTIL_HumanReadableSize_t UTIL_makeHumanReadableSize(U64 size)
+{
     UTIL_HumanReadableSize_t hrs;
 
     if (g_utilDisplayLevel > 3) {
@@ -1121,9 +1122,9 @@ DWORD CountSetBits(ULONG_PTR bitMask)
 {
     DWORD LSHIFT = sizeof(ULONG_PTR)*8 - 1;
     DWORD bitSetCount = 0;
-    ULONG_PTR bitTest = (ULONG_PTR)1 << LSHIFT;    
+    ULONG_PTR bitTest = (ULONG_PTR)1 << LSHIFT;
     DWORD i;
-    
+
     for (i = 0; i <= LSHIFT; ++i)
     {
         bitSetCount += ((bitMask & bitTest)?1:0);

--- a/programs/util.h
+++ b/programs/util.h
@@ -180,9 +180,13 @@ U64 UTIL_getFileSize(const char* infilename);
 U64 UTIL_getTotalFileSize(const char* const * fileNamesTable, unsigned nbFiles);
 
 /**
- * Take a size in bytes and prepare the components to pretty-print it in a
- * scaled way. The components in the returned struct should be passed in
+ * Take @size in bytes,
+ * prepare the components to pretty-print it in a scaled way.
+ * The components in the returned struct should be passed in
  * precision, value, suffix order to a "%.*f%s" format string.
+ * Output policy is sensible to @g_utilDisplayLevel,
+ * for verbose mode (@g_utilDisplayLevel >= 4),
+ * does not scale down.
  */
 typedef struct {
   double value;

--- a/tests/automated_benchmarking.py
+++ b/tests/automated_benchmarking.py
@@ -112,9 +112,9 @@ def parse_benchmark_output(output):
 def benchmark_single(executable, level, filename):
     return parse_benchmark_output((
         subprocess.run(
-            [executable, "-qb{}".format(level), filename], stderr=subprocess.PIPE
+            [executable, "-qb{}".format(level), filename], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         )
-        .stderr.decode("utf-8")
+        .stdout.decode("utf-8")
         .split(" ")
     ))
 
@@ -145,7 +145,7 @@ def benchmark(build, filenames, levels, iterations):
 def benchmark_dictionary_single(executable, filenames_directory, dictionary_filename, level, iterations):
     cspeeds, dspeeds = [], []
     for _ in range(iterations):
-        output = subprocess.run([executable, "-qb{}".format(level), "-D", dictionary_filename, "-r", filenames_directory], stderr=subprocess.PIPE).stderr.decode("utf-8").split(" ")
+        output = subprocess.run([executable, "-qb{}".format(level), "-D", dictionary_filename, "-r", filenames_directory], stdout=subprocess.PIPE).stdout.decode("utf-8").split(" ")
         cspeed, dspeed = parse_benchmark_output(output)
         cspeeds.append(cspeed)
         dspeeds.append(dspeed)

--- a/tests/automated_benchmarking.py
+++ b/tests/automated_benchmarking.py
@@ -87,7 +87,7 @@ def clone_and_build(build):
             git clone {github_url} zstd-{user}-{sha} &&
             cd zstd-{user}-{sha} &&
             {checkout_command}
-            make &&
+            make -j &&
             cd ../
         """.format(
                 user=build["user"],
@@ -100,7 +100,7 @@ def clone_and_build(build):
         )
         return "zstd-{user}-{sha}/zstd".format(user=build["user"], sha=build["hash"])
     else:
-        os.system("cd ../ && make && cd tests")
+        os.system("cd ../ && make -j && cd tests")
         return "../zstd"
 
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -42,7 +42,7 @@
 #include "util.h"
 #include "timefn.h"       /* SEC_TO_MICRO, UTIL_time_t, UTIL_TIME_INITIALIZER, UTIL_clockSpanMicro, UTIL_getTime */
 /* must be included after util.h, due to ERROR macro redefinition issue on Visual Studio */
-#include "zstd_internal.h"  /* ZSTD_WORKSPACETOOLARGE_MAXDURATION, ZSTD_WORKSPACETOOLARGE_FACTOR, KB, MB */
+#include "zstd_internal.h" /* ZSTD_WORKSPACETOOLARGE_MAXDURATION, ZSTD_WORKSPACETOOLARGE_FACTOR, KB, MB */
 #include "threading.h"    /* ZSTD_pthread_create, ZSTD_pthread_join */
 
 
@@ -128,7 +128,7 @@ static U32 FUZ_highbit32(U32 v32)
 
 #define CHECK_VAR(var, fn)  var = fn; if (ZSTD_isError(var)) { DISPLAYLEVEL(1, "%s : fails : %s \n", #fn, ZSTD_getErrorName(var)); goto _output_error; }
 #define CHECK_NEWV(var, fn)  size_t const CHECK_VAR(var, fn)
-#define CHECK(fn)  { CHECK_NEWV(err, fn); }
+#define CHECK(fn)  { CHECK_NEWV(__err, fn); }
 #define CHECKPLUS(var, fn, more)  { CHECK_NEWV(var, fn); more; }
 
 #define CHECK_OP(op, lhs, rhs) {                                  \
@@ -1956,6 +1956,9 @@ static int basicUnitTests(U32 const seed, double compressibility)
         }   }
         DISPLAYLEVEL(3, "OK \n");
 
+        /* Note : these tests should be replaced by proper regression tests,
+         *         but existing ones do not focus on small data + dictionary + all levels.
+         */
         if ((int)(compressibility * 100 + 0.1) == FUZ_compressibility_default) { /* test only valid with known input */
             size_t const flatdictSize = 22 KB;
             size_t const contentSize = 9 KB;
@@ -1964,14 +1967,14 @@ static int basicUnitTests(U32 const seed, double compressibility)
             /* These upper bounds are generally within a few bytes of the compressed size */
             size_t target_nodict_cSize[22+1] = { 3840, 3770, 3870, 3830, 3770,
                                                  3770, 3770, 3770, 3750, 3750,
-                                                 3742, 3670, 3670, 3660, 3660,
-                                                 3660, 3660, 3660, 3660, 3660,
+                                                 3742, 3675, 3674, 3665, 3664,
+                                                 3663, 3662, 3661, 3660, 3660,
                                                  3660, 3660, 3660 };
             size_t const target_wdict_cSize[22+1] =  { 2830, 2890, 2890, 2820, 2940,
                                                        2950, 2950, 2925, 2900, 2891,
-                                                       2910, 2910, 2910, 2770, 2760,
-                                                       2750, 2750, 2750, 2750, 2750,
-                                                       2750, 2750, 2750 };
+                                                       2910, 2910, 2910, 2780, 2775,
+                                                       2765, 2760, 2755, 2754, 2753,
+                                                       2753, 2753, 2753 };
             int l = 1;
             int const maxLevel = ZSTD_maxCLevel();
             /* clevels with strategies that support rowhash on small inputs */
@@ -3472,11 +3475,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
                         DISPLAYLEVEL(3, "error! l: %d dict: %zu srcSize: %zu cctx size cpar: %zu, cctx size level: %zu\n",
                                      level, dictSize, srcSize, cctxSizeUsingCParams, cctxSizeUsingLevel);
                         goto _output_error;
-                    }
-                }
-            }
-        }
-    }
+    }   }   }   }   }
     DISPLAYLEVEL(3, "OK \n");
 
     DISPLAYLEVEL(3, "test%3i : thread pool API tests : \n", testNb++)
@@ -3592,8 +3591,7 @@ static int longUnitTests(U32 const seed, double compressibility)
     DISPLAYLEVEL(3, "OK \n");
 
     DISPLAYLEVEL(3, "longtest%3i : testing ldm no regressions in size for opt parser : ", testNb++);
-    {
-        size_t cSizeLdm;
+    {   size_t cSizeLdm;
         size_t cSizeNoLdm;
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1832,8 +1832,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
     /* Simple API skippable frame test */
     DISPLAYLEVEL(3, "test%3i : read/write a skippable frame : ", testNb++);
-    {
-        U32 i;
+    {   U32 i;
         unsigned readMagic;
         unsigned long long receivedSize;
         size_t skippableSize;
@@ -1841,9 +1840,10 @@ static int basicUnitTests(U32 const seed, double compressibility)
         char* const skipBuff = (char*)malloc(skipLen);
         assert(skipBuff != NULL);
         for (i = 0; i < skipLen; i++)
-            skipBuff[i] = (BYTE) ((seed + i) % 256);
-        skippableSize = ZSTD_writeSkippableFrame((BYTE*)compressedBuffer, compressedBufferSize,
-                                        skipBuff, skipLen, seed % 15);
+            skipBuff[i] = (char) ((seed + i) % 256);
+        skippableSize = ZSTD_writeSkippableFrame(
+                                compressedBuffer, compressedBufferSize,
+                                skipBuff, skipLen, seed % 15);
         CHECK_Z(skippableSize);
         CHECK_EQ(1, ZSTD_isSkippableFrame(compressedBuffer, skippableSize));
         receivedSize = ZSTD_readSkippableFrame(decodedBuffer, CNBuffSize, &readMagic, compressedBuffer, skippableSize);
@@ -1860,8 +1860,9 @@ static int basicUnitTests(U32 const seed, double compressibility)
         unsigned readMagic;
         unsigned long long receivedSize;
         size_t skippableSize;
-        skippableSize = ZSTD_writeSkippableFrame((BYTE*)compressedBuffer, compressedBufferSize,
-                                        CNBuffer, 0, seed % 15);
+        skippableSize = ZSTD_writeSkippableFrame(
+                                compressedBuffer, compressedBufferSize,
+                                CNBuffer, 0, seed % 15);
         CHECK_EQ(ZSTD_SKIPPABLEHEADERSIZE, skippableSize);
         CHECK_EQ(1, ZSTD_isSkippableFrame(compressedBuffer, skippableSize));
         receivedSize = ZSTD_readSkippableFrame(NULL, 0, &readMagic, compressedBuffer, skippableSize);
@@ -3670,7 +3671,7 @@ static int longUnitTests(U32 const seed, double compressibility)
                     CHECK(cdict != NULL);
 
                     CHECK_Z(ZSTD_CCtx_refCDict(cctx, cdict));
-                    CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_forceAttachDict, attachPref));
+                    CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_forceAttachDict, (int)attachPref));
 
                     cSize = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, CNBuffer, CNBuffSize);
                     CHECK_Z(cSize);

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -11,10 +11,10 @@ silesia.tar,                        level 6,                            compress
 silesia.tar,                        level 7,                            compress simple,                    4576828
 silesia.tar,                        level 9,                            compress simple,                    4552584
 silesia.tar,                        level 13,                           compress simple,                    4502955
-silesia.tar,                        level 16,                           compress simple,                    4356834
-silesia.tar,                        level 19,                           compress simple,                    4264388
+silesia.tar,                        level 16,                           compress simple,                    4356970
+silesia.tar,                        level 19,                           compress simple,                    4264314
 silesia.tar,                        uncompressed literals,              compress simple,                    4861423
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264388
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264314
 silesia.tar,                        huffman literals,                   compress simple,                    6186042
 github.tar,                         level -5,                           compress simple,                    46856
 github.tar,                         level -3,                           compress simple,                    43754
@@ -29,9 +29,9 @@ github.tar,                         level 7,                            compress
 github.tar,                         level 9,                            compress simple,                    36767
 github.tar,                         level 13,                           compress simple,                    35501
 github.tar,                         level 16,                           compress simple,                    40255
-github.tar,                         level 19,                           compress simple,                    32837
+github.tar,                         level 19,                           compress simple,                    32820
 github.tar,                         uncompressed literals,              compress simple,                    38441
-github.tar,                         uncompressed literals optimal,      compress simple,                    32837
+github.tar,                         uncompressed literals optimal,      compress simple,                    32820
 github.tar,                         huffman literals,                   compress simple,                    42490
 silesia,                            level -5,                           compress cctx,                      6737607
 silesia,                            level -3,                           compress cctx,                      6444677
@@ -45,8 +45,8 @@ silesia,                            level 6,                            compress
 silesia,                            level 7,                            compress cctx,                      4567203
 silesia,                            level 9,                            compress cctx,                      4543311
 silesia,                            level 13,                           compress cctx,                      4493990
-silesia,                            level 16,                           compress cctx,                      4360251
-silesia,                            level 19,                           compress cctx,                      4283236
+silesia,                            level 16,                           compress cctx,                      4360072
+silesia,                            level 19,                           compress cctx,                      4282792
 silesia,                            long distance mode,                 compress cctx,                      4849551
 silesia,                            multithreaded,                      compress cctx,                      4849551
 silesia,                            multithreaded long distance mode,   compress cctx,                      4849551
@@ -55,7 +55,7 @@ silesia,                            small hash log,                     compress
 silesia,                            small chain log,                    compress cctx,                      4912199
 silesia,                            explicit params,                    compress cctx,                      4794480
 silesia,                            uncompressed literals,              compress cctx,                      4849551
-silesia,                            uncompressed literals optimal,      compress cctx,                      4283236
+silesia,                            uncompressed literals optimal,      compress cctx,                      4282792
 silesia,                            huffman literals,                   compress cctx,                      6178460
 silesia,                            multithreaded with advanced params, compress cctx,                      4849551
 github,                             level -5,                           compress cctx,                      205285
@@ -109,8 +109,8 @@ silesia,                            level 6,                            zstdcli,
 silesia,                            level 7,                            zstdcli,                            4567251
 silesia,                            level 9,                            zstdcli,                            4543359
 silesia,                            level 13,                           zstdcli,                            4494038
-silesia,                            level 16,                           zstdcli,                            4360299
-silesia,                            level 19,                           zstdcli,                            4283284
+silesia,                            level 16,                           zstdcli,                            4360120
+silesia,                            level 19,                           zstdcli,                            4282840
 silesia,                            long distance mode,                 zstdcli,                            4840807
 silesia,                            multithreaded,                      zstdcli,                            4849599
 silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
@@ -119,7 +119,7 @@ silesia,                            small hash log,                     zstdcli,
 silesia,                            small chain log,                    zstdcli,                            4912247
 silesia,                            explicit params,                    zstdcli,                            4795856
 silesia,                            uncompressed literals,              zstdcli,                            5128030
-silesia,                            uncompressed literals optimal,      zstdcli,                            4317944
+silesia,                            uncompressed literals optimal,      zstdcli,                            4318048
 silesia,                            huffman literals,                   zstdcli,                            5326317
 silesia,                            multithreaded with advanced params, zstdcli,                            5128030
 silesia.tar,                        level -5,                           zstdcli,                            6738934
@@ -134,8 +134,8 @@ silesia.tar,                        level 6,                            zstdcli,
 silesia.tar,                        level 7,                            zstdcli,                            4578883
 silesia.tar,                        level 9,                            zstdcli,                            4553498
 silesia.tar,                        level 13,                           zstdcli,                            4502959
-silesia.tar,                        level 16,                           zstdcli,                            4356838
-silesia.tar,                        level 19,                           zstdcli,                            4264392
+silesia.tar,                        level 16,                           zstdcli,                            4356974
+silesia.tar,                        level 19,                           zstdcli,                            4264318
 silesia.tar,                        no source size,                     zstdcli,                            4861507
 silesia.tar,                        long distance mode,                 zstdcli,                            4853225
 silesia.tar,                        multithreaded,                      zstdcli,                            4861511
@@ -213,7 +213,7 @@ github.tar,                         level 13,                           zstdcli,
 github.tar,                         level 13 with dict,                 zstdcli,                            38730
 github.tar,                         level 16,                           zstdcli,                            40259
 github.tar,                         level 16 with dict,                 zstdcli,                            33643
-github.tar,                         level 19,                           zstdcli,                            32841
+github.tar,                         level 19,                           zstdcli,                            32824
 github.tar,                         level 19 with dict,                 zstdcli,                            32899
 github.tar,                         no source size,                     zstdcli,                            38442
 github.tar,                         no source size with dict,           zstdcli,                            38004
@@ -225,7 +225,7 @@ github.tar,                         small hash log,                     zstdcli,
 github.tar,                         small chain log,                    zstdcli,                            41673
 github.tar,                         explicit params,                    zstdcli,                            41227
 github.tar,                         uncompressed literals,              zstdcli,                            41126
-github.tar,                         uncompressed literals optimal,      zstdcli,                            35392
+github.tar,                         uncompressed literals optimal,      zstdcli,                            35498
 github.tar,                         huffman literals,                   zstdcli,                            38781
 github.tar,                         multithreaded with advanced params, zstdcli,                            41126
 silesia,                            level -5,                           advanced one pass,                  6737607
@@ -248,8 +248,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced one pass,                  4503117
 silesia,                            level 12 row 2,                     advanced one pass,                  4505152
 silesia,                            level 13,                           advanced one pass,                  4493990
-silesia,                            level 16,                           advanced one pass,                  4360251
-silesia,                            level 19,                           advanced one pass,                  4283236
+silesia,                            level 16,                           advanced one pass,                  4360072
+silesia,                            level 19,                           advanced one pass,                  4282792
 silesia,                            no source size,                     advanced one pass,                  4849551
 silesia,                            long distance mode,                 advanced one pass,                  4840738
 silesia,                            multithreaded,                      advanced one pass,                  4849551
@@ -259,7 +259,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass,                  4912199
 silesia,                            explicit params,                    advanced one pass,                  4795856
 silesia,                            uncompressed literals,              advanced one pass,                  5127982
-silesia,                            uncompressed literals optimal,      advanced one pass,                  4317896
+silesia,                            uncompressed literals optimal,      advanced one pass,                  4318000
 silesia,                            huffman literals,                   advanced one pass,                  5326269
 silesia,                            multithreaded with advanced params, advanced one pass,                  5127982
 silesia.tar,                        level -5,                           advanced one pass,                  6738593
@@ -282,8 +282,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513603
 silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514568
 silesia.tar,                        level 13,                           advanced one pass,                  4502955
-silesia.tar,                        level 16,                           advanced one pass,                  4356834
-silesia.tar,                        level 19,                           advanced one pass,                  4264388
+silesia.tar,                        level 16,                           advanced one pass,                  4356970
+silesia.tar,                        level 19,                           advanced one pass,                  4264314
 silesia.tar,                        no source size,                     advanced one pass,                  4861423
 silesia.tar,                        long distance mode,                 advanced one pass,                  4847753
 silesia.tar,                        multithreaded,                      advanced one pass,                  4861507
@@ -527,7 +527,7 @@ github.tar,                         level 16 with dict dms,             advanced
 github.tar,                         level 16 with dict dds,             advanced one pass,                  33544
 github.tar,                         level 16 with dict copy,            advanced one pass,                  33639
 github.tar,                         level 16 with dict load,            advanced one pass,                  39353
-github.tar,                         level 19,                           advanced one pass,                  32837
+github.tar,                         level 19,                           advanced one pass,                  32820
 github.tar,                         level 19 with dict,                 advanced one pass,                  32895
 github.tar,                         level 19 with dict dms,             advanced one pass,                  32672
 github.tar,                         level 19 with dict dds,             advanced one pass,                  32672
@@ -543,7 +543,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced one pass,                  41669
 github.tar,                         explicit params,                    advanced one pass,                  41227
 github.tar,                         uncompressed literals,              advanced one pass,                  41122
-github.tar,                         uncompressed literals optimal,      advanced one pass,                  35388
+github.tar,                         uncompressed literals optimal,      advanced one pass,                  35494
 github.tar,                         huffman literals,                   advanced one pass,                  38777
 github.tar,                         multithreaded with advanced params, advanced one pass,                  41122
 silesia,                            level -5,                           advanced one pass small out,        6737607
@@ -566,8 +566,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced one pass small out,        4503117
 silesia,                            level 12 row 2,                     advanced one pass small out,        4505152
 silesia,                            level 13,                           advanced one pass small out,        4493990
-silesia,                            level 16,                           advanced one pass small out,        4360251
-silesia,                            level 19,                           advanced one pass small out,        4283236
+silesia,                            level 16,                           advanced one pass small out,        4360072
+silesia,                            level 19,                           advanced one pass small out,        4282792
 silesia,                            no source size,                     advanced one pass small out,        4849551
 silesia,                            long distance mode,                 advanced one pass small out,        4840738
 silesia,                            multithreaded,                      advanced one pass small out,        4849551
@@ -577,7 +577,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass small out,        4912199
 silesia,                            explicit params,                    advanced one pass small out,        4795856
 silesia,                            uncompressed literals,              advanced one pass small out,        5127982
-silesia,                            uncompressed literals optimal,      advanced one pass small out,        4317896
+silesia,                            uncompressed literals optimal,      advanced one pass small out,        4318000
 silesia,                            huffman literals,                   advanced one pass small out,        5326269
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5127982
 silesia.tar,                        level -5,                           advanced one pass small out,        6738593
@@ -600,8 +600,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513603
 silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514568
 silesia.tar,                        level 13,                           advanced one pass small out,        4502955
-silesia.tar,                        level 16,                           advanced one pass small out,        4356834
-silesia.tar,                        level 19,                           advanced one pass small out,        4264388
+silesia.tar,                        level 16,                           advanced one pass small out,        4356970
+silesia.tar,                        level 19,                           advanced one pass small out,        4264314
 silesia.tar,                        no source size,                     advanced one pass small out,        4861423
 silesia.tar,                        long distance mode,                 advanced one pass small out,        4847753
 silesia.tar,                        multithreaded,                      advanced one pass small out,        4861507
@@ -845,7 +845,7 @@ github.tar,                         level 16 with dict dms,             advanced
 github.tar,                         level 16 with dict dds,             advanced one pass small out,        33544
 github.tar,                         level 16 with dict copy,            advanced one pass small out,        33639
 github.tar,                         level 16 with dict load,            advanced one pass small out,        39353
-github.tar,                         level 19,                           advanced one pass small out,        32837
+github.tar,                         level 19,                           advanced one pass small out,        32820
 github.tar,                         level 19 with dict,                 advanced one pass small out,        32895
 github.tar,                         level 19 with dict dms,             advanced one pass small out,        32672
 github.tar,                         level 19 with dict dds,             advanced one pass small out,        32672
@@ -861,7 +861,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced one pass small out,        41669
 github.tar,                         explicit params,                    advanced one pass small out,        41227
 github.tar,                         uncompressed literals,              advanced one pass small out,        41122
-github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35388
+github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35494
 github.tar,                         huffman literals,                   advanced one pass small out,        38777
 github.tar,                         multithreaded with advanced params, advanced one pass small out,        41122
 silesia,                            level -5,                           advanced streaming,                 6882505
@@ -884,8 +884,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced streaming,                 4503117
 silesia,                            level 12 row 2,                     advanced streaming,                 4505152
 silesia,                            level 13,                           advanced streaming,                 4493990
-silesia,                            level 16,                           advanced streaming,                 4360251
-silesia,                            level 19,                           advanced streaming,                 4283236
+silesia,                            level 16,                           advanced streaming,                 4360072
+silesia,                            level 19,                           advanced streaming,                 4282792
 silesia,                            no source size,                     advanced streaming,                 4849515
 silesia,                            long distance mode,                 advanced streaming,                 4840738
 silesia,                            multithreaded,                      advanced streaming,                 4849551
@@ -895,7 +895,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced streaming,                 4912199
 silesia,                            explicit params,                    advanced streaming,                 4795884
 silesia,                            uncompressed literals,              advanced streaming,                 5127982
-silesia,                            uncompressed literals optimal,      advanced streaming,                 4317896
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4318000
 silesia,                            huffman literals,                   advanced streaming,                 5331171
 silesia,                            multithreaded with advanced params, advanced streaming,                 5127982
 silesia.tar,                        level -5,                           advanced streaming,                 6982759
@@ -918,8 +918,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513603
 silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514569
 silesia.tar,                        level 13,                           advanced streaming,                 4502955
-silesia.tar,                        level 16,                           advanced streaming,                 4356834
-silesia.tar,                        level 19,                           advanced streaming,                 4264388
+silesia.tar,                        level 16,                           advanced streaming,                 4356970
+silesia.tar,                        level 19,                           advanced streaming,                 4264314
 silesia.tar,                        no source size,                     advanced streaming,                 4861421
 silesia.tar,                        long distance mode,                 advanced streaming,                 4847753
 silesia.tar,                        multithreaded,                      advanced streaming,                 4861507
@@ -1163,7 +1163,7 @@ github.tar,                         level 16 with dict dms,             advanced
 github.tar,                         level 16 with dict dds,             advanced streaming,                 33544
 github.tar,                         level 16 with dict copy,            advanced streaming,                 33639
 github.tar,                         level 16 with dict load,            advanced streaming,                 39353
-github.tar,                         level 19,                           advanced streaming,                 32837
+github.tar,                         level 19,                           advanced streaming,                 32820
 github.tar,                         level 19 with dict,                 advanced streaming,                 32895
 github.tar,                         level 19 with dict dms,             advanced streaming,                 32672
 github.tar,                         level 19 with dict dds,             advanced streaming,                 32672
@@ -1179,7 +1179,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced streaming,                 41669
 github.tar,                         explicit params,                    advanced streaming,                 41227
 github.tar,                         uncompressed literals,              advanced streaming,                 41122
-github.tar,                         uncompressed literals optimal,      advanced streaming,                 35388
+github.tar,                         uncompressed literals optimal,      advanced streaming,                 35494
 github.tar,                         huffman literals,                   advanced streaming,                 38800
 github.tar,                         multithreaded with advanced params, advanced streaming,                 41122
 silesia,                            level -5,                           old streaming,                      6882505
@@ -1194,11 +1194,11 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming,                      4567203
 silesia,                            level 9,                            old streaming,                      4543311
 silesia,                            level 13,                           old streaming,                      4493990
-silesia,                            level 16,                           old streaming,                      4360251
-silesia,                            level 19,                           old streaming,                      4283236
+silesia,                            level 16,                           old streaming,                      4360072
+silesia,                            level 19,                           old streaming,                      4282792
 silesia,                            no source size,                     old streaming,                      4849515
 silesia,                            uncompressed literals,              old streaming,                      4849551
-silesia,                            uncompressed literals optimal,      old streaming,                      4283236
+silesia,                            uncompressed literals optimal,      old streaming,                      4282792
 silesia,                            huffman literals,                   old streaming,                      6183403
 silesia.tar,                        level -5,                           old streaming,                      6982759
 silesia.tar,                        level -3,                           old streaming,                      6641283
@@ -1212,11 +1212,11 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming,                      4576830
 silesia.tar,                        level 9,                            old streaming,                      4552590
 silesia.tar,                        level 13,                           old streaming,                      4502955
-silesia.tar,                        level 16,                           old streaming,                      4356834
-silesia.tar,                        level 19,                           old streaming,                      4264388
+silesia.tar,                        level 16,                           old streaming,                      4356970
+silesia.tar,                        level 19,                           old streaming,                      4264314
 silesia.tar,                        no source size,                     old streaming,                      4861421
 silesia.tar,                        uncompressed literals,              old streaming,                      4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4264388
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4264314
 silesia.tar,                        huffman literals,                   old streaming,                      6190795
 github,                             level -5,                           old streaming,                      205285
 github,                             level -5 with dict,                 old streaming,                      46718
@@ -1277,12 +1277,12 @@ github.tar,                         level 13,                           old stre
 github.tar,                         level 13 with dict,                 old streaming,                      38726
 github.tar,                         level 16,                           old streaming,                      40255
 github.tar,                         level 16 with dict,                 old streaming,                      33639
-github.tar,                         level 19,                           old streaming,                      32837
+github.tar,                         level 19,                           old streaming,                      32820
 github.tar,                         level 19 with dict,                 old streaming,                      32895
 github.tar,                         no source size,                     old streaming,                      38438
 github.tar,                         no source size with dict,           old streaming,                      38000
 github.tar,                         uncompressed literals,              old streaming,                      38441
-github.tar,                         uncompressed literals optimal,      old streaming,                      32837
+github.tar,                         uncompressed literals optimal,      old streaming,                      32820
 github.tar,                         huffman literals,                   old streaming,                      42465
 silesia,                            level -5,                           old streaming advanced,             6882505
 silesia,                            level -3,                           old streaming advanced,             6568376
@@ -1296,8 +1296,8 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming advanced,             4567203
 silesia,                            level 9,                            old streaming advanced,             4543311
 silesia,                            level 13,                           old streaming advanced,             4493990
-silesia,                            level 16,                           old streaming advanced,             4360251
-silesia,                            level 19,                           old streaming advanced,             4283236
+silesia,                            level 16,                           old streaming advanced,             4360072
+silesia,                            level 19,                           old streaming advanced,             4282792
 silesia,                            no source size,                     old streaming advanced,             4849515
 silesia,                            long distance mode,                 old streaming advanced,             4849551
 silesia,                            multithreaded,                      old streaming advanced,             4849551
@@ -1307,7 +1307,7 @@ silesia,                            small hash log,                     old stre
 silesia,                            small chain log,                    old streaming advanced,             4912199
 silesia,                            explicit params,                    old streaming advanced,             4795884
 silesia,                            uncompressed literals,              old streaming advanced,             4849551
-silesia,                            uncompressed literals optimal,      old streaming advanced,             4283236
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4282792
 silesia,                            huffman literals,                   old streaming advanced,             6183403
 silesia,                            multithreaded with advanced params, old streaming advanced,             4849551
 silesia.tar,                        level -5,                           old streaming advanced,             6982759
@@ -1322,8 +1322,8 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming advanced,             4576830
 silesia.tar,                        level 9,                            old streaming advanced,             4552590
 silesia.tar,                        level 13,                           old streaming advanced,             4502955
-silesia.tar,                        level 16,                           old streaming advanced,             4356834
-silesia.tar,                        level 19,                           old streaming advanced,             4264388
+silesia.tar,                        level 16,                           old streaming advanced,             4356970
+silesia.tar,                        level 19,                           old streaming advanced,             4264314
 silesia.tar,                        no source size,                     old streaming advanced,             4861421
 silesia.tar,                        long distance mode,                 old streaming advanced,             4861425
 silesia.tar,                        multithreaded,                      old streaming advanced,             4861425
@@ -1333,7 +1333,7 @@ silesia.tar,                        small hash log,                     old stre
 silesia.tar,                        small chain log,                    old streaming advanced,             4917019
 silesia.tar,                        explicit params,                    old streaming advanced,             4807403
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4264388
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4264314
 silesia.tar,                        huffman literals,                   old streaming advanced,             6190795
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861425
 github,                             level -5,                           old streaming advanced,             216734
@@ -1403,7 +1403,7 @@ github.tar,                         level 13,                           old stre
 github.tar,                         level 13 with dict,                 old streaming advanced,             35807
 github.tar,                         level 16,                           old streaming advanced,             40255
 github.tar,                         level 16 with dict,                 old streaming advanced,             38736
-github.tar,                         level 19,                           old streaming advanced,             32837
+github.tar,                         level 19,                           old streaming advanced,             32820
 github.tar,                         level 19 with dict,                 old streaming advanced,             32876
 github.tar,                         no source size,                     old streaming advanced,             38438
 github.tar,                         no source size with dict,           old streaming advanced,             38015
@@ -1415,7 +1415,7 @@ github.tar,                         small hash log,                     old stre
 github.tar,                         small chain log,                    old streaming advanced,             41669
 github.tar,                         explicit params,                    old streaming advanced,             41227
 github.tar,                         uncompressed literals,              old streaming advanced,             38441
-github.tar,                         uncompressed literals optimal,      old streaming advanced,             32837
+github.tar,                         uncompressed literals optimal,      old streaming advanced,             32820
 github.tar,                         huffman literals,                   old streaming advanced,             42465
 github.tar,                         multithreaded with advanced params, old streaming advanced,             38441
 github,                             level -5 with dict,                 old streaming cdict,                46718

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -97,137 +97,137 @@ github,                             uncompressed literals,              compress
 github,                             uncompressed literals optimal,      compress cctx,                      134064
 github,                             huffman literals,                   compress cctx,                      175468
 github,                             multithreaded with advanced params, compress cctx,                      141102
-silesia,                            level -5,                           zstdcli,                            compression error
-silesia,                            level -3,                           zstdcli,                            compression error
-silesia,                            level -1,                           zstdcli,                            compression error
-silesia,                            level 0,                            zstdcli,                            compression error
-silesia,                            level 1,                            zstdcli,                            compression error
-silesia,                            level 3,                            zstdcli,                            compression error
-silesia,                            level 4,                            zstdcli,                            compression error
-silesia,                            level 5,                            zstdcli,                            compression error
-silesia,                            level 6,                            zstdcli,                            compression error
-silesia,                            level 7,                            zstdcli,                            compression error
-silesia,                            level 9,                            zstdcli,                            compression error
-silesia,                            level 13,                           zstdcli,                            compression error
-silesia,                            level 16,                           zstdcli,                            compression error
-silesia,                            level 19,                           zstdcli,                            compression error
-silesia,                            long distance mode,                 zstdcli,                            compression error
-silesia,                            multithreaded,                      zstdcli,                            compression error
-silesia,                            multithreaded long distance mode,   zstdcli,                            compression error
-silesia,                            small window log,                   zstdcli,                            compression error
-silesia,                            small hash log,                     zstdcli,                            compression error
-silesia,                            small chain log,                    zstdcli,                            compression error
-silesia,                            explicit params,                    zstdcli,                            compression error
-silesia,                            uncompressed literals,              zstdcli,                            compression error
-silesia,                            uncompressed literals optimal,      zstdcli,                            compression error
-silesia,                            huffman literals,                   zstdcli,                            compression error
-silesia,                            multithreaded with advanced params, zstdcli,                            compression error
-silesia.tar,                        level -5,                           zstdcli,                            compression error
-silesia.tar,                        level -3,                           zstdcli,                            compression error
-silesia.tar,                        level -1,                           zstdcli,                            compression error
-silesia.tar,                        level 0,                            zstdcli,                            compression error
-silesia.tar,                        level 1,                            zstdcli,                            compression error
-silesia.tar,                        level 3,                            zstdcli,                            compression error
-silesia.tar,                        level 4,                            zstdcli,                            compression error
-silesia.tar,                        level 5,                            zstdcli,                            compression error
-silesia.tar,                        level 6,                            zstdcli,                            compression error
-silesia.tar,                        level 7,                            zstdcli,                            compression error
-silesia.tar,                        level 9,                            zstdcli,                            compression error
-silesia.tar,                        level 13,                           zstdcli,                            compression error
-silesia.tar,                        level 16,                           zstdcli,                            compression error
-silesia.tar,                        level 19,                           zstdcli,                            compression error
-silesia.tar,                        no source size,                     zstdcli,                            compression error
-silesia.tar,                        long distance mode,                 zstdcli,                            compression error
-silesia.tar,                        multithreaded,                      zstdcli,                            compression error
-silesia.tar,                        multithreaded long distance mode,   zstdcli,                            compression error
-silesia.tar,                        small window log,                   zstdcli,                            compression error
-silesia.tar,                        small hash log,                     zstdcli,                            compression error
-silesia.tar,                        small chain log,                    zstdcli,                            compression error
-silesia.tar,                        explicit params,                    zstdcli,                            compression error
-silesia.tar,                        uncompressed literals,              zstdcli,                            compression error
-silesia.tar,                        uncompressed literals optimal,      zstdcli,                            compression error
-silesia.tar,                        huffman literals,                   zstdcli,                            compression error
-silesia.tar,                        multithreaded with advanced params, zstdcli,                            compression error
-github,                             level -5,                           zstdcli,                            compression error
-github,                             level -5 with dict,                 zstdcli,                            compression error
-github,                             level -3,                           zstdcli,                            compression error
-github,                             level -3 with dict,                 zstdcli,                            compression error
-github,                             level -1,                           zstdcli,                            compression error
-github,                             level -1 with dict,                 zstdcli,                            compression error
-github,                             level 0,                            zstdcli,                            compression error
-github,                             level 0 with dict,                  zstdcli,                            compression error
-github,                             level 1,                            zstdcli,                            compression error
-github,                             level 1 with dict,                  zstdcli,                            compression error
-github,                             level 3,                            zstdcli,                            compression error
-github,                             level 3 with dict,                  zstdcli,                            compression error
-github,                             level 4,                            zstdcli,                            compression error
-github,                             level 4 with dict,                  zstdcli,                            compression error
-github,                             level 5,                            zstdcli,                            compression error
-github,                             level 5 with dict,                  zstdcli,                            compression error
-github,                             level 6,                            zstdcli,                            compression error
-github,                             level 6 with dict,                  zstdcli,                            compression error
-github,                             level 7,                            zstdcli,                            compression error
-github,                             level 7 with dict,                  zstdcli,                            compression error
-github,                             level 9,                            zstdcli,                            compression error
-github,                             level 9 with dict,                  zstdcli,                            compression error
-github,                             level 13,                           zstdcli,                            compression error
-github,                             level 13 with dict,                 zstdcli,                            compression error
-github,                             level 16,                           zstdcli,                            compression error
-github,                             level 16 with dict,                 zstdcli,                            compression error
-github,                             level 19,                           zstdcli,                            compression error
-github,                             level 19 with dict,                 zstdcli,                            compression error
-github,                             long distance mode,                 zstdcli,                            compression error
-github,                             multithreaded,                      zstdcli,                            compression error
-github,                             multithreaded long distance mode,   zstdcli,                            compression error
-github,                             small window log,                   zstdcli,                            compression error
-github,                             small hash log,                     zstdcli,                            compression error
-github,                             small chain log,                    zstdcli,                            compression error
-github,                             explicit params,                    zstdcli,                            compression error
-github,                             uncompressed literals,              zstdcli,                            compression error
-github,                             uncompressed literals optimal,      zstdcli,                            compression error
-github,                             huffman literals,                   zstdcli,                            compression error
-github,                             multithreaded with advanced params, zstdcli,                            compression error
-github.tar,                         level -5,                           zstdcli,                            compression error
-github.tar,                         level -5 with dict,                 zstdcli,                            compression error
-github.tar,                         level -3,                           zstdcli,                            compression error
-github.tar,                         level -3 with dict,                 zstdcli,                            compression error
-github.tar,                         level -1,                           zstdcli,                            compression error
-github.tar,                         level -1 with dict,                 zstdcli,                            compression error
-github.tar,                         level 0,                            zstdcli,                            compression error
-github.tar,                         level 0 with dict,                  zstdcli,                            compression error
-github.tar,                         level 1,                            zstdcli,                            compression error
-github.tar,                         level 1 with dict,                  zstdcli,                            compression error
-github.tar,                         level 3,                            zstdcli,                            compression error
-github.tar,                         level 3 with dict,                  zstdcli,                            compression error
-github.tar,                         level 4,                            zstdcli,                            compression error
-github.tar,                         level 4 with dict,                  zstdcli,                            compression error
-github.tar,                         level 5,                            zstdcli,                            compression error
-github.tar,                         level 5 with dict,                  zstdcli,                            compression error
-github.tar,                         level 6,                            zstdcli,                            compression error
-github.tar,                         level 6 with dict,                  zstdcli,                            compression error
-github.tar,                         level 7,                            zstdcli,                            compression error
-github.tar,                         level 7 with dict,                  zstdcli,                            compression error
-github.tar,                         level 9,                            zstdcli,                            compression error
-github.tar,                         level 9 with dict,                  zstdcli,                            compression error
-github.tar,                         level 13,                           zstdcli,                            compression error
-github.tar,                         level 13 with dict,                 zstdcli,                            compression error
-github.tar,                         level 16,                           zstdcli,                            compression error
-github.tar,                         level 16 with dict,                 zstdcli,                            compression error
-github.tar,                         level 19,                           zstdcli,                            compression error
-github.tar,                         level 19 with dict,                 zstdcli,                            compression error
-github.tar,                         no source size,                     zstdcli,                            compression error
-github.tar,                         no source size with dict,           zstdcli,                            compression error
-github.tar,                         long distance mode,                 zstdcli,                            compression error
-github.tar,                         multithreaded,                      zstdcli,                            compression error
-github.tar,                         multithreaded long distance mode,   zstdcli,                            compression error
-github.tar,                         small window log,                   zstdcli,                            compression error
-github.tar,                         small hash log,                     zstdcli,                            compression error
-github.tar,                         small chain log,                    zstdcli,                            compression error
-github.tar,                         explicit params,                    zstdcli,                            compression error
-github.tar,                         uncompressed literals,              zstdcli,                            compression error
-github.tar,                         uncompressed literals optimal,      zstdcli,                            compression error
-github.tar,                         huffman literals,                   zstdcli,                            compression error
-github.tar,                         multithreaded with advanced params, zstdcli,                            compression error
+silesia,                            level -5,                           zstdcli,                            7354723
+silesia,                            level -3,                           zstdcli,                            6902422
+silesia,                            level -1,                           zstdcli,                            6177613
+silesia,                            level 0,                            zstdcli,                            4849599
+silesia,                            level 1,                            zstdcli,                            5309145
+silesia,                            level 3,                            zstdcli,                            4849599
+silesia,                            level 4,                            zstdcli,                            4787017
+silesia,                            level 5,                            zstdcli,                            4639008
+silesia,                            level 6,                            zstdcli,                            4605417
+silesia,                            level 7,                            zstdcli,                            4567251
+silesia,                            level 9,                            zstdcli,                            4543359
+silesia,                            level 13,                           zstdcli,                            4494038
+silesia,                            level 16,                           zstdcli,                            4359912
+silesia,                            level 19,                           zstdcli,                            4296928
+silesia,                            long distance mode,                 zstdcli,                            4840807
+silesia,                            multithreaded,                      zstdcli,                            4849599
+silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
+silesia,                            small window log,                   zstdcli,                            7095967
+silesia,                            small hash log,                     zstdcli,                            6526189
+silesia,                            small chain log,                    zstdcli,                            4912247
+silesia,                            explicit params,                    zstdcli,                            4795856
+silesia,                            uncompressed literals,              zstdcli,                            5128030
+silesia,                            uncompressed literals optimal,      zstdcli,                            4319566
+silesia,                            huffman literals,                   zstdcli,                            5326394
+silesia,                            multithreaded with advanced params, zstdcli,                            5128030
+silesia.tar,                        level -5,                           zstdcli,                            7363866
+silesia.tar,                        level -3,                           zstdcli,                            6902158
+silesia.tar,                        level -1,                           zstdcli,                            6182939
+silesia.tar,                        level 0,                            zstdcli,                            4861511
+silesia.tar,                        level 1,                            zstdcli,                            5333184
+silesia.tar,                        level 3,                            zstdcli,                            4861511
+silesia.tar,                        level 4,                            zstdcli,                            4800529
+silesia.tar,                        level 5,                            zstdcli,                            4651159
+silesia.tar,                        level 6,                            zstdcli,                            4618402
+silesia.tar,                        level 7,                            zstdcli,                            4578883
+silesia.tar,                        level 9,                            zstdcli,                            4553498
+silesia.tar,                        level 13,                           zstdcli,                            4502959
+silesia.tar,                        level 16,                           zstdcli,                            4360530
+silesia.tar,                        level 19,                           zstdcli,                            4267270
+silesia.tar,                        no source size,                     zstdcli,                            4861507
+silesia.tar,                        long distance mode,                 zstdcli,                            4853225
+silesia.tar,                        multithreaded,                      zstdcli,                            4861511
+silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4853225
+silesia.tar,                        small window log,                   zstdcli,                            7101576
+silesia.tar,                        small hash log,                     zstdcli,                            6529286
+silesia.tar,                        small chain log,                    zstdcli,                            4917020
+silesia.tar,                        explicit params,                    zstdcli,                            4821277
+silesia.tar,                        uncompressed literals,              zstdcli,                            5129559
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4310145
+silesia.tar,                        huffman literals,                   zstdcli,                            5344915
+silesia.tar,                        multithreaded with advanced params, zstdcli,                            5129559
+github,                             level -5,                           zstdcli,                            234315
+github,                             level -5 with dict,                 zstdcli,                            48718
+github,                             level -3,                           zstdcli,                            222760
+github,                             level -3 with dict,                 zstdcli,                            47395
+github,                             level -1,                           zstdcli,                            177468
+github,                             level -1 with dict,                 zstdcli,                            45170
+github,                             level 0,                            zstdcli,                            138335
+github,                             level 0 with dict,                  zstdcli,                            43148
+github,                             level 1,                            zstdcli,                            144365
+github,                             level 1 with dict,                  zstdcli,                            43682
+github,                             level 3,                            zstdcli,                            138335
+github,                             level 3 with dict,                  zstdcli,                            43148
+github,                             level 4,                            zstdcli,                            138199
+github,                             level 4 with dict,                  zstdcli,                            43251
+github,                             level 5,                            zstdcli,                            137121
+github,                             level 5 with dict,                  zstdcli,                            40728
+github,                             level 6,                            zstdcli,                            137122
+github,                             level 6 with dict,                  zstdcli,                            40636
+github,                             level 7,                            zstdcli,                            137122
+github,                             level 7 with dict,                  zstdcli,                            40745
+github,                             level 9,                            zstdcli,                            137122
+github,                             level 9 with dict,                  zstdcli,                            41393
+github,                             level 13,                           zstdcli,                            136064
+github,                             level 13 with dict,                 zstdcli,                            41743
+github,                             level 16,                           zstdcli,                            136064
+github,                             level 16 with dict,                 zstdcli,                            39577
+github,                             level 19,                           zstdcli,                            136064
+github,                             level 19 with dict,                 zstdcli,                            39576
+github,                             long distance mode,                 zstdcli,                            138335
+github,                             multithreaded,                      zstdcli,                            138335
+github,                             multithreaded long distance mode,   zstdcli,                            138335
+github,                             small window log,                   zstdcli,                            138335
+github,                             small hash log,                     zstdcli,                            137590
+github,                             small chain log,                    zstdcli,                            138341
+github,                             explicit params,                    zstdcli,                            136197
+github,                             uncompressed literals,              zstdcli,                            167915
+github,                             uncompressed literals optimal,      zstdcli,                            159227
+github,                             huffman literals,                   zstdcli,                            144365
+github,                             multithreaded with advanced params, zstdcli,                            167915
+github.tar,                         level -5,                           zstdcli,                            66918
+github.tar,                         level -5 with dict,                 zstdcli,                            51529
+github.tar,                         level -3,                           zstdcli,                            52131
+github.tar,                         level -3 with dict,                 zstdcli,                            44246
+github.tar,                         level -1,                           zstdcli,                            42564
+github.tar,                         level -1 with dict,                 zstdcli,                            41140
+github.tar,                         level 0,                            zstdcli,                            38445
+github.tar,                         level 0 with dict,                  zstdcli,                            37999
+github.tar,                         level 1,                            zstdcli,                            39204
+github.tar,                         level 1 with dict,                  zstdcli,                            38288
+github.tar,                         level 3,                            zstdcli,                            38445
+github.tar,                         level 3 with dict,                  zstdcli,                            37999
+github.tar,                         level 4,                            zstdcli,                            38471
+github.tar,                         level 4 with dict,                  zstdcli,                            37952
+github.tar,                         level 5,                            zstdcli,                            38380
+github.tar,                         level 5 with dict,                  zstdcli,                            39032
+github.tar,                         level 6,                            zstdcli,                            38614
+github.tar,                         level 6 with dict,                  zstdcli,                            38614
+github.tar,                         level 7,                            zstdcli,                            38077
+github.tar,                         level 7 with dict,                  zstdcli,                            37873
+github.tar,                         level 9,                            zstdcli,                            36771
+github.tar,                         level 9 with dict,                  zstdcli,                            36623
+github.tar,                         level 13,                           zstdcli,                            35505
+github.tar,                         level 13 with dict,                 zstdcli,                            37134
+github.tar,                         level 16,                           zstdcli,                            40475
+github.tar,                         level 16 with dict,                 zstdcli,                            33382
+github.tar,                         level 19,                           zstdcli,                            32138
+github.tar,                         level 19 with dict,                 zstdcli,                            32713
+github.tar,                         no source size,                     zstdcli,                            38442
+github.tar,                         no source size with dict,           zstdcli,                            38004
+github.tar,                         long distance mode,                 zstdcli,                            39730
+github.tar,                         multithreaded,                      zstdcli,                            38445
+github.tar,                         multithreaded long distance mode,   zstdcli,                            39730
+github.tar,                         small window log,                   zstdcli,                            198544
+github.tar,                         small hash log,                     zstdcli,                            129874
+github.tar,                         small chain log,                    zstdcli,                            41673
+github.tar,                         explicit params,                    zstdcli,                            41227
+github.tar,                         uncompressed literals,              zstdcli,                            41126
+github.tar,                         uncompressed literals optimal,      zstdcli,                            35401
+github.tar,                         huffman literals,                   zstdcli,                            38857
+github.tar,                         multithreaded with advanced params, zstdcli,                            41126
 silesia,                            level -5,                           advanced one pass,                  7354675
 silesia,                            level -3,                           advanced one pass,                  6902374
 silesia,                            level -1,                           advanced one pass,                  6177565

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -11,10 +11,10 @@ silesia.tar,                        level 6,                            compress
 silesia.tar,                        level 7,                            compress simple,                    4576828
 silesia.tar,                        level 9,                            compress simple,                    4552584
 silesia.tar,                        level 13,                           compress simple,                    4502955
-silesia.tar,                        level 16,                           compress simple,                    4358753
-silesia.tar,                        level 19,                           compress simple,                    4263936
+silesia.tar,                        level 16,                           compress simple,                    4360526
+silesia.tar,                        level 19,                           compress simple,                    4267266
 silesia.tar,                        uncompressed literals,              compress simple,                    4861423
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4263936
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4267266
 silesia.tar,                        huffman literals,                   compress simple,                    6186042
 github.tar,                         level -5,                           compress simple,                    46856
 github.tar,                         level -3,                           compress simple,                    43754
@@ -28,10 +28,10 @@ github.tar,                         level 6,                            compress
 github.tar,                         level 7,                            compress simple,                    38073
 github.tar,                         level 9,                            compress simple,                    36767
 github.tar,                         level 13,                           compress simple,                    35501
-github.tar,                         level 16,                           compress simple,                    40357
-github.tar,                         level 19,                           compress simple,                    32506
+github.tar,                         level 16,                           compress simple,                    40471
+github.tar,                         level 19,                           compress simple,                    32134
 github.tar,                         uncompressed literals,              compress simple,                    38441
-github.tar,                         uncompressed literals optimal,      compress simple,                    32506
+github.tar,                         uncompressed literals optimal,      compress simple,                    32134
 github.tar,                         huffman literals,                   compress simple,                    42490
 silesia,                            level -5,                           compress cctx,                      6737607
 silesia,                            level -3,                           compress cctx,                      6444677
@@ -45,8 +45,8 @@ silesia,                            level 6,                            compress
 silesia,                            level 7,                            compress cctx,                      4567203
 silesia,                            level 9,                            compress cctx,                      4543311
 silesia,                            level 13,                           compress cctx,                      4493990
-silesia,                            level 16,                           compress cctx,                      4358530
-silesia,                            level 19,                           compress cctx,                      4288570
+silesia,                            level 16,                           compress cctx,                      4359864
+silesia,                            level 19,                           compress cctx,                      4296880
 silesia,                            long distance mode,                 compress cctx,                      4849551
 silesia,                            multithreaded,                      compress cctx,                      4849551
 silesia,                            multithreaded long distance mode,   compress cctx,                      4849551
@@ -55,7 +55,7 @@ silesia,                            small hash log,                     compress
 silesia,                            small chain log,                    compress cctx,                      4912199
 silesia,                            explicit params,                    compress cctx,                      4794480
 silesia,                            uncompressed literals,              compress cctx,                      4849551
-silesia,                            uncompressed literals optimal,      compress cctx,                      4288570
+silesia,                            uncompressed literals optimal,      compress cctx,                      4296880
 silesia,                            huffman literals,                   compress cctx,                      6178460
 silesia,                            multithreaded with advanced params, compress cctx,                      4849551
 github,                             level -5,                           compress cctx,                      205285
@@ -109,8 +109,8 @@ silesia,                            level 6,                            zstdcli,
 silesia,                            level 7,                            zstdcli,                            4567251
 silesia,                            level 9,                            zstdcli,                            4543359
 silesia,                            level 13,                           zstdcli,                            4494038
-silesia,                            level 16,                           zstdcli,                            4358578
-silesia,                            level 19,                           zstdcli,                            4288618
+silesia,                            level 16,                           zstdcli,                            4359912
+silesia,                            level 19,                           zstdcli,                            4296928
 silesia,                            long distance mode,                 zstdcli,                            4840807
 silesia,                            multithreaded,                      zstdcli,                            4849599
 silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
@@ -119,7 +119,7 @@ silesia,                            small hash log,                     zstdcli,
 silesia,                            small chain log,                    zstdcli,                            4912247
 silesia,                            explicit params,                    zstdcli,                            4795856
 silesia,                            uncompressed literals,              zstdcli,                            5128030
-silesia,                            uncompressed literals optimal,      zstdcli,                            4318014
+silesia,                            uncompressed literals optimal,      zstdcli,                            4319566
 silesia,                            huffman literals,                   zstdcli,                            5326317
 silesia,                            multithreaded with advanced params, zstdcli,                            5128030
 silesia.tar,                        level -5,                           zstdcli,                            6738934
@@ -134,8 +134,8 @@ silesia.tar,                        level 6,                            zstdcli,
 silesia.tar,                        level 7,                            zstdcli,                            4578883
 silesia.tar,                        level 9,                            zstdcli,                            4553498
 silesia.tar,                        level 13,                           zstdcli,                            4502959
-silesia.tar,                        level 16,                           zstdcli,                            4358757
-silesia.tar,                        level 19,                           zstdcli,                            4263940
+silesia.tar,                        level 16,                           zstdcli,                            4360530
+silesia.tar,                        level 19,                           zstdcli,                            4267270
 silesia.tar,                        no source size,                     zstdcli,                            4861507
 silesia.tar,                        long distance mode,                 zstdcli,                            4853225
 silesia.tar,                        multithreaded,                      zstdcli,                            4861511
@@ -145,7 +145,7 @@ silesia.tar,                        small hash log,                     zstdcli,
 silesia.tar,                        small chain log,                    zstdcli,                            4917020
 silesia.tar,                        explicit params,                    zstdcli,                            4821277
 silesia.tar,                        uncompressed literals,              zstdcli,                            5129559
-silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4307883
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4310145
 silesia.tar,                        huffman literals,                   zstdcli,                            5347610
 silesia.tar,                        multithreaded with advanced params, zstdcli,                            5129559
 github,                             level -5,                           zstdcli,                            207285
@@ -210,11 +210,11 @@ github.tar,                         level 7 with dict,                  zstdcli,
 github.tar,                         level 9,                            zstdcli,                            36771
 github.tar,                         level 9 with dict,                  zstdcli,                            36623
 github.tar,                         level 13,                           zstdcli,                            35505
-github.tar,                         level 13 with dict,                 zstdcli,                            37009
-github.tar,                         level 16,                           zstdcli,                            40361
-github.tar,                         level 16 with dict,                 zstdcli,                            33479
-github.tar,                         level 19,                           zstdcli,                            32510
-github.tar,                         level 19 with dict,                 zstdcli,                            32973
+github.tar,                         level 13 with dict,                 zstdcli,                            37134
+github.tar,                         level 16,                           zstdcli,                            40475
+github.tar,                         level 16 with dict,                 zstdcli,                            33382
+github.tar,                         level 19,                           zstdcli,                            32138
+github.tar,                         level 19 with dict,                 zstdcli,                            32713
 github.tar,                         no source size,                     zstdcli,                            38442
 github.tar,                         no source size with dict,           zstdcli,                            38004
 github.tar,                         long distance mode,                 zstdcli,                            39730
@@ -225,7 +225,7 @@ github.tar,                         small hash log,                     zstdcli,
 github.tar,                         small chain log,                    zstdcli,                            41673
 github.tar,                         explicit params,                    zstdcli,                            41227
 github.tar,                         uncompressed literals,              zstdcli,                            41126
-github.tar,                         uncompressed literals optimal,      zstdcli,                            35284
+github.tar,                         uncompressed literals optimal,      zstdcli,                            35401
 github.tar,                         huffman literals,                   zstdcli,                            38781
 github.tar,                         multithreaded with advanced params, zstdcli,                            41126
 silesia,                            level -5,                           advanced one pass,                  6737607
@@ -248,8 +248,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced one pass,                  4503117
 silesia,                            level 12 row 2,                     advanced one pass,                  4505152
 silesia,                            level 13,                           advanced one pass,                  4493990
-silesia,                            level 16,                           advanced one pass,                  4358530
-silesia,                            level 19,                           advanced one pass,                  4288570
+silesia,                            level 16,                           advanced one pass,                  4359864
+silesia,                            level 19,                           advanced one pass,                  4296880
 silesia,                            no source size,                     advanced one pass,                  4849551
 silesia,                            long distance mode,                 advanced one pass,                  4840738
 silesia,                            multithreaded,                      advanced one pass,                  4849551
@@ -259,7 +259,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass,                  4912199
 silesia,                            explicit params,                    advanced one pass,                  4795856
 silesia,                            uncompressed literals,              advanced one pass,                  5127982
-silesia,                            uncompressed literals optimal,      advanced one pass,                  4317966
+silesia,                            uncompressed literals optimal,      advanced one pass,                  4319518
 silesia,                            huffman literals,                   advanced one pass,                  5326269
 silesia,                            multithreaded with advanced params, advanced one pass,                  5127982
 silesia.tar,                        level -5,                           advanced one pass,                  6738593
@@ -282,8 +282,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513603
 silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514568
 silesia.tar,                        level 13,                           advanced one pass,                  4502955
-silesia.tar,                        level 16,                           advanced one pass,                  4358753
-silesia.tar,                        level 19,                           advanced one pass,                  4263936
+silesia.tar,                        level 16,                           advanced one pass,                  4360526
+silesia.tar,                        level 19,                           advanced one pass,                  4267266
 silesia.tar,                        no source size,                     advanced one pass,                  4861423
 silesia.tar,                        long distance mode,                 advanced one pass,                  4847753
 silesia.tar,                        multithreaded,                      advanced one pass,                  4861507
@@ -293,7 +293,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced one pass,                  4917039
 silesia.tar,                        explicit params,                    advanced one pass,                  4807383
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4307879
+silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4310141
 silesia.tar,                        huffman literals,                   advanced one pass,                  5347335
 silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5129555
 github,                             level -5,                           advanced one pass,                  205285
@@ -516,23 +516,23 @@ github.tar,                         level 12 row 2 with dict dds,       advanced
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass,                  36609
 github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36460
 github.tar,                         level 13,                           advanced one pass,                  35501
-github.tar,                         level 13 with dict,                 advanced one pass,                  37005
-github.tar,                         level 13 with dict dms,             advanced one pass,                  37180
-github.tar,                         level 13 with dict dds,             advanced one pass,                  37180
-github.tar,                         level 13 with dict copy,            advanced one pass,                  37005
+github.tar,                         level 13 with dict,                 advanced one pass,                  37130
+github.tar,                         level 13 with dict dms,             advanced one pass,                  37267
+github.tar,                         level 13 with dict dds,             advanced one pass,                  37267
+github.tar,                         level 13 with dict copy,            advanced one pass,                  37130
 github.tar,                         level 13 with dict load,            advanced one pass,                  36010
-github.tar,                         level 16,                           advanced one pass,                  40357
-github.tar,                         level 16 with dict,                 advanced one pass,                  33475
-github.tar,                         level 16 with dict dms,             advanced one pass,                  33357
-github.tar,                         level 16 with dict dds,             advanced one pass,                  33357
-github.tar,                         level 16 with dict copy,            advanced one pass,                  33475
-github.tar,                         level 16 with dict load,            advanced one pass,                  39064
-github.tar,                         level 19,                           advanced one pass,                  32506
-github.tar,                         level 19 with dict,                 advanced one pass,                  32969
-github.tar,                         level 19 with dict dms,             advanced one pass,                  32624
-github.tar,                         level 19 with dict dds,             advanced one pass,                  32624
-github.tar,                         level 19 with dict copy,            advanced one pass,                  32969
-github.tar,                         level 19 with dict load,            advanced one pass,                  32570
+github.tar,                         level 16,                           advanced one pass,                  40471
+github.tar,                         level 16 with dict,                 advanced one pass,                  33378
+github.tar,                         level 16 with dict dms,             advanced one pass,                  33213
+github.tar,                         level 16 with dict dds,             advanced one pass,                  33213
+github.tar,                         level 16 with dict copy,            advanced one pass,                  33378
+github.tar,                         level 16 with dict load,            advanced one pass,                  39081
+github.tar,                         level 19,                           advanced one pass,                  32134
+github.tar,                         level 19 with dict,                 advanced one pass,                  32709
+github.tar,                         level 19 with dict dms,             advanced one pass,                  32553
+github.tar,                         level 19 with dict dds,             advanced one pass,                  32553
+github.tar,                         level 19 with dict copy,            advanced one pass,                  32709
+github.tar,                         level 19 with dict load,            advanced one pass,                  32474
 github.tar,                         no source size,                     advanced one pass,                  38441
 github.tar,                         no source size with dict,           advanced one pass,                  37995
 github.tar,                         long distance mode,                 advanced one pass,                  39757
@@ -543,7 +543,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced one pass,                  41669
 github.tar,                         explicit params,                    advanced one pass,                  41227
 github.tar,                         uncompressed literals,              advanced one pass,                  41122
-github.tar,                         uncompressed literals optimal,      advanced one pass,                  35280
+github.tar,                         uncompressed literals optimal,      advanced one pass,                  35397
 github.tar,                         huffman literals,                   advanced one pass,                  38777
 github.tar,                         multithreaded with advanced params, advanced one pass,                  41122
 silesia,                            level -5,                           advanced one pass small out,        6737607
@@ -566,8 +566,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced one pass small out,        4503117
 silesia,                            level 12 row 2,                     advanced one pass small out,        4505152
 silesia,                            level 13,                           advanced one pass small out,        4493990
-silesia,                            level 16,                           advanced one pass small out,        4358530
-silesia,                            level 19,                           advanced one pass small out,        4288570
+silesia,                            level 16,                           advanced one pass small out,        4359864
+silesia,                            level 19,                           advanced one pass small out,        4296880
 silesia,                            no source size,                     advanced one pass small out,        4849551
 silesia,                            long distance mode,                 advanced one pass small out,        4840738
 silesia,                            multithreaded,                      advanced one pass small out,        4849551
@@ -577,7 +577,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass small out,        4912199
 silesia,                            explicit params,                    advanced one pass small out,        4795856
 silesia,                            uncompressed literals,              advanced one pass small out,        5127982
-silesia,                            uncompressed literals optimal,      advanced one pass small out,        4317966
+silesia,                            uncompressed literals optimal,      advanced one pass small out,        4319518
 silesia,                            huffman literals,                   advanced one pass small out,        5326269
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5127982
 silesia.tar,                        level -5,                           advanced one pass small out,        6738593
@@ -600,8 +600,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513603
 silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514568
 silesia.tar,                        level 13,                           advanced one pass small out,        4502955
-silesia.tar,                        level 16,                           advanced one pass small out,        4358753
-silesia.tar,                        level 19,                           advanced one pass small out,        4263936
+silesia.tar,                        level 16,                           advanced one pass small out,        4360526
+silesia.tar,                        level 19,                           advanced one pass small out,        4267266
 silesia.tar,                        no source size,                     advanced one pass small out,        4861423
 silesia.tar,                        long distance mode,                 advanced one pass small out,        4847753
 silesia.tar,                        multithreaded,                      advanced one pass small out,        4861507
@@ -611,7 +611,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced one pass small out,        4917039
 silesia.tar,                        explicit params,                    advanced one pass small out,        4807383
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4307879
+silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4310141
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5347335
 silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5129555
 github,                             level -5,                           advanced one pass small out,        205285
@@ -834,23 +834,23 @@ github.tar,                         level 12 row 2 with dict dds,       advanced
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass small out,        36609
 github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36460
 github.tar,                         level 13,                           advanced one pass small out,        35501
-github.tar,                         level 13 with dict,                 advanced one pass small out,        37005
-github.tar,                         level 13 with dict dms,             advanced one pass small out,        37180
-github.tar,                         level 13 with dict dds,             advanced one pass small out,        37180
-github.tar,                         level 13 with dict copy,            advanced one pass small out,        37005
+github.tar,                         level 13 with dict,                 advanced one pass small out,        37130
+github.tar,                         level 13 with dict dms,             advanced one pass small out,        37267
+github.tar,                         level 13 with dict dds,             advanced one pass small out,        37267
+github.tar,                         level 13 with dict copy,            advanced one pass small out,        37130
 github.tar,                         level 13 with dict load,            advanced one pass small out,        36010
-github.tar,                         level 16,                           advanced one pass small out,        40357
-github.tar,                         level 16 with dict,                 advanced one pass small out,        33475
-github.tar,                         level 16 with dict dms,             advanced one pass small out,        33357
-github.tar,                         level 16 with dict dds,             advanced one pass small out,        33357
-github.tar,                         level 16 with dict copy,            advanced one pass small out,        33475
-github.tar,                         level 16 with dict load,            advanced one pass small out,        39064
-github.tar,                         level 19,                           advanced one pass small out,        32506
-github.tar,                         level 19 with dict,                 advanced one pass small out,        32969
-github.tar,                         level 19 with dict dms,             advanced one pass small out,        32624
-github.tar,                         level 19 with dict dds,             advanced one pass small out,        32624
-github.tar,                         level 19 with dict copy,            advanced one pass small out,        32969
-github.tar,                         level 19 with dict load,            advanced one pass small out,        32570
+github.tar,                         level 16,                           advanced one pass small out,        40471
+github.tar,                         level 16 with dict,                 advanced one pass small out,        33378
+github.tar,                         level 16 with dict dms,             advanced one pass small out,        33213
+github.tar,                         level 16 with dict dds,             advanced one pass small out,        33213
+github.tar,                         level 16 with dict copy,            advanced one pass small out,        33378
+github.tar,                         level 16 with dict load,            advanced one pass small out,        39081
+github.tar,                         level 19,                           advanced one pass small out,        32134
+github.tar,                         level 19 with dict,                 advanced one pass small out,        32709
+github.tar,                         level 19 with dict dms,             advanced one pass small out,        32553
+github.tar,                         level 19 with dict dds,             advanced one pass small out,        32553
+github.tar,                         level 19 with dict copy,            advanced one pass small out,        32709
+github.tar,                         level 19 with dict load,            advanced one pass small out,        32474
 github.tar,                         no source size,                     advanced one pass small out,        38441
 github.tar,                         no source size with dict,           advanced one pass small out,        37995
 github.tar,                         long distance mode,                 advanced one pass small out,        39757
@@ -861,7 +861,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced one pass small out,        41669
 github.tar,                         explicit params,                    advanced one pass small out,        41227
 github.tar,                         uncompressed literals,              advanced one pass small out,        41122
-github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35280
+github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35397
 github.tar,                         huffman literals,                   advanced one pass small out,        38777
 github.tar,                         multithreaded with advanced params, advanced one pass small out,        41122
 silesia,                            level -5,                           advanced streaming,                 6882505
@@ -884,8 +884,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced streaming,                 4503117
 silesia,                            level 12 row 2,                     advanced streaming,                 4505152
 silesia,                            level 13,                           advanced streaming,                 4493990
-silesia,                            level 16,                           advanced streaming,                 4358530
-silesia,                            level 19,                           advanced streaming,                 4288570
+silesia,                            level 16,                           advanced streaming,                 4359864
+silesia,                            level 19,                           advanced streaming,                 4296880
 silesia,                            no source size,                     advanced streaming,                 4849515
 silesia,                            long distance mode,                 advanced streaming,                 4840738
 silesia,                            multithreaded,                      advanced streaming,                 4849551
@@ -895,7 +895,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced streaming,                 4912199
 silesia,                            explicit params,                    advanced streaming,                 4795884
 silesia,                            uncompressed literals,              advanced streaming,                 5127982
-silesia,                            uncompressed literals optimal,      advanced streaming,                 4317966
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4319518
 silesia,                            huffman literals,                   advanced streaming,                 5331171
 silesia,                            multithreaded with advanced params, advanced streaming,                 5127982
 silesia.tar,                        level -5,                           advanced streaming,                 6982759
@@ -918,8 +918,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513603
 silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514569
 silesia.tar,                        level 13,                           advanced streaming,                 4502955
-silesia.tar,                        level 16,                           advanced streaming,                 4358753
-silesia.tar,                        level 19,                           advanced streaming,                 4263936
+silesia.tar,                        level 16,                           advanced streaming,                 4360526
+silesia.tar,                        level 19,                           advanced streaming,                 4267266
 silesia.tar,                        no source size,                     advanced streaming,                 4861421
 silesia.tar,                        long distance mode,                 advanced streaming,                 4847753
 silesia.tar,                        multithreaded,                      advanced streaming,                 4861507
@@ -929,7 +929,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced streaming,                 4917019
 silesia.tar,                        explicit params,                    advanced streaming,                 4807403
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5129461
-silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4307879
+silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4310141
 silesia.tar,                        huffman literals,                   advanced streaming,                 5352360
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5129555
 github,                             level -5,                           advanced streaming,                 205285
@@ -1152,23 +1152,23 @@ github.tar,                         level 12 row 2 with dict dds,       advanced
 github.tar,                         level 12 row 2 with dict copy,      advanced streaming,                 36609
 github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36460
 github.tar,                         level 13,                           advanced streaming,                 35501
-github.tar,                         level 13 with dict,                 advanced streaming,                 37005
-github.tar,                         level 13 with dict dms,             advanced streaming,                 37180
-github.tar,                         level 13 with dict dds,             advanced streaming,                 37180
-github.tar,                         level 13 with dict copy,            advanced streaming,                 37005
+github.tar,                         level 13 with dict,                 advanced streaming,                 37130
+github.tar,                         level 13 with dict dms,             advanced streaming,                 37267
+github.tar,                         level 13 with dict dds,             advanced streaming,                 37267
+github.tar,                         level 13 with dict copy,            advanced streaming,                 37130
 github.tar,                         level 13 with dict load,            advanced streaming,                 36010
-github.tar,                         level 16,                           advanced streaming,                 40357
-github.tar,                         level 16 with dict,                 advanced streaming,                 33475
-github.tar,                         level 16 with dict dms,             advanced streaming,                 33357
-github.tar,                         level 16 with dict dds,             advanced streaming,                 33357
-github.tar,                         level 16 with dict copy,            advanced streaming,                 33475
-github.tar,                         level 16 with dict load,            advanced streaming,                 39064
-github.tar,                         level 19,                           advanced streaming,                 32506
-github.tar,                         level 19 with dict,                 advanced streaming,                 32969
-github.tar,                         level 19 with dict dms,             advanced streaming,                 32624
-github.tar,                         level 19 with dict dds,             advanced streaming,                 32624
-github.tar,                         level 19 with dict copy,            advanced streaming,                 32969
-github.tar,                         level 19 with dict load,            advanced streaming,                 32570
+github.tar,                         level 16,                           advanced streaming,                 40471
+github.tar,                         level 16 with dict,                 advanced streaming,                 33378
+github.tar,                         level 16 with dict dms,             advanced streaming,                 33213
+github.tar,                         level 16 with dict dds,             advanced streaming,                 33213
+github.tar,                         level 16 with dict copy,            advanced streaming,                 33378
+github.tar,                         level 16 with dict load,            advanced streaming,                 39081
+github.tar,                         level 19,                           advanced streaming,                 32134
+github.tar,                         level 19 with dict,                 advanced streaming,                 32709
+github.tar,                         level 19 with dict dms,             advanced streaming,                 32553
+github.tar,                         level 19 with dict dds,             advanced streaming,                 32553
+github.tar,                         level 19 with dict copy,            advanced streaming,                 32709
+github.tar,                         level 19 with dict load,            advanced streaming,                 32474
 github.tar,                         no source size,                     advanced streaming,                 38438
 github.tar,                         no source size with dict,           advanced streaming,                 38000
 github.tar,                         long distance mode,                 advanced streaming,                 39757
@@ -1179,7 +1179,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced streaming,                 41669
 github.tar,                         explicit params,                    advanced streaming,                 41227
 github.tar,                         uncompressed literals,              advanced streaming,                 41122
-github.tar,                         uncompressed literals optimal,      advanced streaming,                 35280
+github.tar,                         uncompressed literals optimal,      advanced streaming,                 35397
 github.tar,                         huffman literals,                   advanced streaming,                 38800
 github.tar,                         multithreaded with advanced params, advanced streaming,                 41122
 silesia,                            level -5,                           old streaming,                      6882505
@@ -1194,11 +1194,11 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming,                      4567203
 silesia,                            level 9,                            old streaming,                      4543311
 silesia,                            level 13,                           old streaming,                      4493990
-silesia,                            level 16,                           old streaming,                      4358530
-silesia,                            level 19,                           old streaming,                      4288570
+silesia,                            level 16,                           old streaming,                      4359864
+silesia,                            level 19,                           old streaming,                      4296880
 silesia,                            no source size,                     old streaming,                      4849515
 silesia,                            uncompressed literals,              old streaming,                      4849551
-silesia,                            uncompressed literals optimal,      old streaming,                      4288570
+silesia,                            uncompressed literals optimal,      old streaming,                      4296880
 silesia,                            huffman literals,                   old streaming,                      6183403
 silesia.tar,                        level -5,                           old streaming,                      6982759
 silesia.tar,                        level -3,                           old streaming,                      6641283
@@ -1212,11 +1212,11 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming,                      4576830
 silesia.tar,                        level 9,                            old streaming,                      4552590
 silesia.tar,                        level 13,                           old streaming,                      4502955
-silesia.tar,                        level 16,                           old streaming,                      4358753
-silesia.tar,                        level 19,                           old streaming,                      4263936
+silesia.tar,                        level 16,                           old streaming,                      4360526
+silesia.tar,                        level 19,                           old streaming,                      4267266
 silesia.tar,                        no source size,                     old streaming,                      4861421
 silesia.tar,                        uncompressed literals,              old streaming,                      4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4263936
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4267266
 silesia.tar,                        huffman literals,                   old streaming,                      6190795
 github,                             level -5,                           old streaming,                      205285
 github,                             level -5 with dict,                 old streaming,                      46718
@@ -1274,15 +1274,15 @@ github.tar,                         level 7 with dict,                  old stre
 github.tar,                         level 9,                            old streaming,                      36767
 github.tar,                         level 9 with dict,                  old streaming,                      36457
 github.tar,                         level 13,                           old streaming,                      35501
-github.tar,                         level 13 with dict,                 old streaming,                      37005
-github.tar,                         level 16,                           old streaming,                      40357
-github.tar,                         level 16 with dict,                 old streaming,                      33475
-github.tar,                         level 19,                           old streaming,                      32506
-github.tar,                         level 19 with dict,                 old streaming,                      32969
+github.tar,                         level 13 with dict,                 old streaming,                      37130
+github.tar,                         level 16,                           old streaming,                      40471
+github.tar,                         level 16 with dict,                 old streaming,                      33378
+github.tar,                         level 19,                           old streaming,                      32134
+github.tar,                         level 19 with dict,                 old streaming,                      32709
 github.tar,                         no source size,                     old streaming,                      38438
 github.tar,                         no source size with dict,           old streaming,                      38000
 github.tar,                         uncompressed literals,              old streaming,                      38441
-github.tar,                         uncompressed literals optimal,      old streaming,                      32506
+github.tar,                         uncompressed literals optimal,      old streaming,                      32134
 github.tar,                         huffman literals,                   old streaming,                      42465
 silesia,                            level -5,                           old streaming advanced,             6882505
 silesia,                            level -3,                           old streaming advanced,             6568376
@@ -1296,8 +1296,8 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming advanced,             4567203
 silesia,                            level 9,                            old streaming advanced,             4543311
 silesia,                            level 13,                           old streaming advanced,             4493990
-silesia,                            level 16,                           old streaming advanced,             4358530
-silesia,                            level 19,                           old streaming advanced,             4288570
+silesia,                            level 16,                           old streaming advanced,             4359864
+silesia,                            level 19,                           old streaming advanced,             4296880
 silesia,                            no source size,                     old streaming advanced,             4849515
 silesia,                            long distance mode,                 old streaming advanced,             4849551
 silesia,                            multithreaded,                      old streaming advanced,             4849551
@@ -1307,7 +1307,7 @@ silesia,                            small hash log,                     old stre
 silesia,                            small chain log,                    old streaming advanced,             4912199
 silesia,                            explicit params,                    old streaming advanced,             4795884
 silesia,                            uncompressed literals,              old streaming advanced,             4849551
-silesia,                            uncompressed literals optimal,      old streaming advanced,             4288570
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4296880
 silesia,                            huffman literals,                   old streaming advanced,             6183403
 silesia,                            multithreaded with advanced params, old streaming advanced,             4849551
 silesia.tar,                        level -5,                           old streaming advanced,             6982759
@@ -1322,8 +1322,8 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming advanced,             4576830
 silesia.tar,                        level 9,                            old streaming advanced,             4552590
 silesia.tar,                        level 13,                           old streaming advanced,             4502955
-silesia.tar,                        level 16,                           old streaming advanced,             4358753
-silesia.tar,                        level 19,                           old streaming advanced,             4263936
+silesia.tar,                        level 16,                           old streaming advanced,             4360526
+silesia.tar,                        level 19,                           old streaming advanced,             4267266
 silesia.tar,                        no source size,                     old streaming advanced,             4861421
 silesia.tar,                        long distance mode,                 old streaming advanced,             4861425
 silesia.tar,                        multithreaded,                      old streaming advanced,             4861425
@@ -1333,7 +1333,7 @@ silesia.tar,                        small hash log,                     old stre
 silesia.tar,                        small chain log,                    old streaming advanced,             4917019
 silesia.tar,                        explicit params,                    old streaming advanced,             4807403
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4263936
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4267266
 silesia.tar,                        huffman literals,                   old streaming advanced,             6190795
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861425
 github,                             level -5,                           old streaming advanced,             216734
@@ -1401,10 +1401,10 @@ github.tar,                         level 9,                            old stre
 github.tar,                         level 9 with dict,                  old streaming advanced,             36233
 github.tar,                         level 13,                           old streaming advanced,             35501
 github.tar,                         level 13 with dict,                 old streaming advanced,             35807
-github.tar,                         level 16,                           old streaming advanced,             40357
-github.tar,                         level 16 with dict,                 old streaming advanced,             38730
-github.tar,                         level 19,                           old streaming advanced,             32506
-github.tar,                         level 19 with dict,                 old streaming advanced,             32900
+github.tar,                         level 16,                           old streaming advanced,             40471
+github.tar,                         level 16 with dict,                 old streaming advanced,             38578
+github.tar,                         level 19,                           old streaming advanced,             32134
+github.tar,                         level 19 with dict,                 old streaming advanced,             32702
 github.tar,                         no source size,                     old streaming advanced,             38438
 github.tar,                         no source size with dict,           old streaming advanced,             38015
 github.tar,                         long distance mode,                 old streaming advanced,             38441
@@ -1415,7 +1415,7 @@ github.tar,                         small hash log,                     old stre
 github.tar,                         small chain log,                    old streaming advanced,             41669
 github.tar,                         explicit params,                    old streaming advanced,             41227
 github.tar,                         uncompressed literals,              old streaming advanced,             38441
-github.tar,                         uncompressed literals optimal,      old streaming advanced,             32506
+github.tar,                         uncompressed literals optimal,      old streaming advanced,             32134
 github.tar,                         huffman literals,                   old streaming advanced,             42465
 github.tar,                         multithreaded with advanced params, old streaming advanced,             38441
 github,                             level -5 with dict,                 old streaming cdict,                46718
@@ -1445,8 +1445,8 @@ github.tar,                         level 6 with dict,                  old stre
 github.tar,                         level 7 with dict,                  old streaming cdict,                37371
 github.tar,                         level 9 with dict,                  old streaming cdict,                36352
 github.tar,                         level 13 with dict,                 old streaming cdict,                36010
-github.tar,                         level 16 with dict,                 old streaming cdict,                39064
-github.tar,                         level 19 with dict,                 old streaming cdict,                32570
+github.tar,                         level 16 with dict,                 old streaming cdict,                39081
+github.tar,                         level 19 with dict,                 old streaming cdict,                32474
 github.tar,                         no source size with dict,           old streaming cdict,                38000
 github,                             level -5 with dict,                 old streaming advanced cdict,       49562
 github,                             level -3 with dict,                 old streaming advanced cdict,       44956
@@ -1475,6 +1475,6 @@ github.tar,                         level 6 with dict,                  old stre
 github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37322
 github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36233
 github.tar,                         level 13 with dict,                 old streaming advanced cdict,       35807
-github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38730
-github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32900
+github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38578
+github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32702
 github.tar,                         no source size with dict,           old streaming advanced cdict,       38015

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -11,10 +11,10 @@ silesia.tar,                        level 6,                            compress
 silesia.tar,                        level 7,                            compress simple,                    4576828
 silesia.tar,                        level 9,                            compress simple,                    4552584
 silesia.tar,                        level 13,                           compress simple,                    4502955
-silesia.tar,                        level 16,                           compress simple,                    4356970
-silesia.tar,                        level 19,                           compress simple,                    4264314
+silesia.tar,                        level 16,                           compress simple,                    4358753
+silesia.tar,                        level 19,                           compress simple,                    4263936
 silesia.tar,                        uncompressed literals,              compress simple,                    4861423
-silesia.tar,                        uncompressed literals optimal,      compress simple,                    4264314
+silesia.tar,                        uncompressed literals optimal,      compress simple,                    4263936
 silesia.tar,                        huffman literals,                   compress simple,                    6186042
 github.tar,                         level -5,                           compress simple,                    46856
 github.tar,                         level -3,                           compress simple,                    43754
@@ -28,10 +28,10 @@ github.tar,                         level 6,                            compress
 github.tar,                         level 7,                            compress simple,                    38073
 github.tar,                         level 9,                            compress simple,                    36767
 github.tar,                         level 13,                           compress simple,                    35501
-github.tar,                         level 16,                           compress simple,                    40255
-github.tar,                         level 19,                           compress simple,                    32820
+github.tar,                         level 16,                           compress simple,                    40357
+github.tar,                         level 19,                           compress simple,                    32506
 github.tar,                         uncompressed literals,              compress simple,                    38441
-github.tar,                         uncompressed literals optimal,      compress simple,                    32820
+github.tar,                         uncompressed literals optimal,      compress simple,                    32506
 github.tar,                         huffman literals,                   compress simple,                    42490
 silesia,                            level -5,                           compress cctx,                      6737607
 silesia,                            level -3,                           compress cctx,                      6444677
@@ -45,8 +45,8 @@ silesia,                            level 6,                            compress
 silesia,                            level 7,                            compress cctx,                      4567203
 silesia,                            level 9,                            compress cctx,                      4543311
 silesia,                            level 13,                           compress cctx,                      4493990
-silesia,                            level 16,                           compress cctx,                      4360072
-silesia,                            level 19,                           compress cctx,                      4282792
+silesia,                            level 16,                           compress cctx,                      4358530
+silesia,                            level 19,                           compress cctx,                      4288570
 silesia,                            long distance mode,                 compress cctx,                      4849551
 silesia,                            multithreaded,                      compress cctx,                      4849551
 silesia,                            multithreaded long distance mode,   compress cctx,                      4849551
@@ -55,7 +55,7 @@ silesia,                            small hash log,                     compress
 silesia,                            small chain log,                    compress cctx,                      4912199
 silesia,                            explicit params,                    compress cctx,                      4794480
 silesia,                            uncompressed literals,              compress cctx,                      4849551
-silesia,                            uncompressed literals optimal,      compress cctx,                      4282792
+silesia,                            uncompressed literals optimal,      compress cctx,                      4288570
 silesia,                            huffman literals,                   compress cctx,                      6178460
 silesia,                            multithreaded with advanced params, compress cctx,                      4849551
 github,                             level -5,                           compress cctx,                      205285
@@ -109,8 +109,8 @@ silesia,                            level 6,                            zstdcli,
 silesia,                            level 7,                            zstdcli,                            4567251
 silesia,                            level 9,                            zstdcli,                            4543359
 silesia,                            level 13,                           zstdcli,                            4494038
-silesia,                            level 16,                           zstdcli,                            4360120
-silesia,                            level 19,                           zstdcli,                            4282840
+silesia,                            level 16,                           zstdcli,                            4358578
+silesia,                            level 19,                           zstdcli,                            4288618
 silesia,                            long distance mode,                 zstdcli,                            4840807
 silesia,                            multithreaded,                      zstdcli,                            4849599
 silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
@@ -119,7 +119,7 @@ silesia,                            small hash log,                     zstdcli,
 silesia,                            small chain log,                    zstdcli,                            4912247
 silesia,                            explicit params,                    zstdcli,                            4795856
 silesia,                            uncompressed literals,              zstdcli,                            5128030
-silesia,                            uncompressed literals optimal,      zstdcli,                            4318048
+silesia,                            uncompressed literals optimal,      zstdcli,                            4318014
 silesia,                            huffman literals,                   zstdcli,                            5326317
 silesia,                            multithreaded with advanced params, zstdcli,                            5128030
 silesia.tar,                        level -5,                           zstdcli,                            6738934
@@ -134,8 +134,8 @@ silesia.tar,                        level 6,                            zstdcli,
 silesia.tar,                        level 7,                            zstdcli,                            4578883
 silesia.tar,                        level 9,                            zstdcli,                            4553498
 silesia.tar,                        level 13,                           zstdcli,                            4502959
-silesia.tar,                        level 16,                           zstdcli,                            4356974
-silesia.tar,                        level 19,                           zstdcli,                            4264318
+silesia.tar,                        level 16,                           zstdcli,                            4358757
+silesia.tar,                        level 19,                           zstdcli,                            4263940
 silesia.tar,                        no source size,                     zstdcli,                            4861507
 silesia.tar,                        long distance mode,                 zstdcli,                            4853225
 silesia.tar,                        multithreaded,                      zstdcli,                            4861511
@@ -145,7 +145,7 @@ silesia.tar,                        small hash log,                     zstdcli,
 silesia.tar,                        small chain log,                    zstdcli,                            4917020
 silesia.tar,                        explicit params,                    zstdcli,                            4821277
 silesia.tar,                        uncompressed literals,              zstdcli,                            5129559
-silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4307404
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4307883
 silesia.tar,                        huffman literals,                   zstdcli,                            5347610
 silesia.tar,                        multithreaded with advanced params, zstdcli,                            5129559
 github,                             level -5,                           zstdcli,                            207285
@@ -210,11 +210,11 @@ github.tar,                         level 7 with dict,                  zstdcli,
 github.tar,                         level 9,                            zstdcli,                            36771
 github.tar,                         level 9 with dict,                  zstdcli,                            36623
 github.tar,                         level 13,                           zstdcli,                            35505
-github.tar,                         level 13 with dict,                 zstdcli,                            38730
-github.tar,                         level 16,                           zstdcli,                            40259
-github.tar,                         level 16 with dict,                 zstdcli,                            33643
-github.tar,                         level 19,                           zstdcli,                            32824
-github.tar,                         level 19 with dict,                 zstdcli,                            32899
+github.tar,                         level 13 with dict,                 zstdcli,                            37009
+github.tar,                         level 16,                           zstdcli,                            40361
+github.tar,                         level 16 with dict,                 zstdcli,                            33479
+github.tar,                         level 19,                           zstdcli,                            32510
+github.tar,                         level 19 with dict,                 zstdcli,                            32973
 github.tar,                         no source size,                     zstdcli,                            38442
 github.tar,                         no source size with dict,           zstdcli,                            38004
 github.tar,                         long distance mode,                 zstdcli,                            39730
@@ -225,7 +225,7 @@ github.tar,                         small hash log,                     zstdcli,
 github.tar,                         small chain log,                    zstdcli,                            41673
 github.tar,                         explicit params,                    zstdcli,                            41227
 github.tar,                         uncompressed literals,              zstdcli,                            41126
-github.tar,                         uncompressed literals optimal,      zstdcli,                            35498
+github.tar,                         uncompressed literals optimal,      zstdcli,                            35284
 github.tar,                         huffman literals,                   zstdcli,                            38781
 github.tar,                         multithreaded with advanced params, zstdcli,                            41126
 silesia,                            level -5,                           advanced one pass,                  6737607
@@ -248,8 +248,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced one pass,                  4503117
 silesia,                            level 12 row 2,                     advanced one pass,                  4505152
 silesia,                            level 13,                           advanced one pass,                  4493990
-silesia,                            level 16,                           advanced one pass,                  4360072
-silesia,                            level 19,                           advanced one pass,                  4282792
+silesia,                            level 16,                           advanced one pass,                  4358530
+silesia,                            level 19,                           advanced one pass,                  4288570
 silesia,                            no source size,                     advanced one pass,                  4849551
 silesia,                            long distance mode,                 advanced one pass,                  4840738
 silesia,                            multithreaded,                      advanced one pass,                  4849551
@@ -259,7 +259,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass,                  4912199
 silesia,                            explicit params,                    advanced one pass,                  4795856
 silesia,                            uncompressed literals,              advanced one pass,                  5127982
-silesia,                            uncompressed literals optimal,      advanced one pass,                  4318000
+silesia,                            uncompressed literals optimal,      advanced one pass,                  4317966
 silesia,                            huffman literals,                   advanced one pass,                  5326269
 silesia,                            multithreaded with advanced params, advanced one pass,                  5127982
 silesia.tar,                        level -5,                           advanced one pass,                  6738593
@@ -282,8 +282,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass,                  4513603
 silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514568
 silesia.tar,                        level 13,                           advanced one pass,                  4502955
-silesia.tar,                        level 16,                           advanced one pass,                  4356970
-silesia.tar,                        level 19,                           advanced one pass,                  4264314
+silesia.tar,                        level 16,                           advanced one pass,                  4358753
+silesia.tar,                        level 19,                           advanced one pass,                  4263936
 silesia.tar,                        no source size,                     advanced one pass,                  4861423
 silesia.tar,                        long distance mode,                 advanced one pass,                  4847753
 silesia.tar,                        multithreaded,                      advanced one pass,                  4861507
@@ -293,7 +293,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced one pass,                  4917039
 silesia.tar,                        explicit params,                    advanced one pass,                  4807383
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4307400
+silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4307879
 silesia.tar,                        huffman literals,                   advanced one pass,                  5347335
 silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5129555
 github,                             level -5,                           advanced one pass,                  205285
@@ -516,23 +516,23 @@ github.tar,                         level 12 row 2 with dict dds,       advanced
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass,                  36609
 github.tar,                         level 12 row 2 with dict load,      advanced one pass,                  36460
 github.tar,                         level 13,                           advanced one pass,                  35501
-github.tar,                         level 13 with dict,                 advanced one pass,                  38726
-github.tar,                         level 13 with dict dms,             advanced one pass,                  38903
-github.tar,                         level 13 with dict dds,             advanced one pass,                  38903
-github.tar,                         level 13 with dict copy,            advanced one pass,                  38726
+github.tar,                         level 13 with dict,                 advanced one pass,                  37005
+github.tar,                         level 13 with dict dms,             advanced one pass,                  37180
+github.tar,                         level 13 with dict dds,             advanced one pass,                  37180
+github.tar,                         level 13 with dict copy,            advanced one pass,                  37005
 github.tar,                         level 13 with dict load,            advanced one pass,                  36010
-github.tar,                         level 16,                           advanced one pass,                  40255
-github.tar,                         level 16 with dict,                 advanced one pass,                  33639
-github.tar,                         level 16 with dict dms,             advanced one pass,                  33544
-github.tar,                         level 16 with dict dds,             advanced one pass,                  33544
-github.tar,                         level 16 with dict copy,            advanced one pass,                  33639
-github.tar,                         level 16 with dict load,            advanced one pass,                  39353
-github.tar,                         level 19,                           advanced one pass,                  32820
-github.tar,                         level 19 with dict,                 advanced one pass,                  32895
-github.tar,                         level 19 with dict dms,             advanced one pass,                  32672
-github.tar,                         level 19 with dict dds,             advanced one pass,                  32672
-github.tar,                         level 19 with dict copy,            advanced one pass,                  32895
-github.tar,                         level 19 with dict load,            advanced one pass,                  32676
+github.tar,                         level 16,                           advanced one pass,                  40357
+github.tar,                         level 16 with dict,                 advanced one pass,                  33475
+github.tar,                         level 16 with dict dms,             advanced one pass,                  33357
+github.tar,                         level 16 with dict dds,             advanced one pass,                  33357
+github.tar,                         level 16 with dict copy,            advanced one pass,                  33475
+github.tar,                         level 16 with dict load,            advanced one pass,                  39064
+github.tar,                         level 19,                           advanced one pass,                  32506
+github.tar,                         level 19 with dict,                 advanced one pass,                  32969
+github.tar,                         level 19 with dict dms,             advanced one pass,                  32624
+github.tar,                         level 19 with dict dds,             advanced one pass,                  32624
+github.tar,                         level 19 with dict copy,            advanced one pass,                  32969
+github.tar,                         level 19 with dict load,            advanced one pass,                  32570
 github.tar,                         no source size,                     advanced one pass,                  38441
 github.tar,                         no source size with dict,           advanced one pass,                  37995
 github.tar,                         long distance mode,                 advanced one pass,                  39757
@@ -543,7 +543,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced one pass,                  41669
 github.tar,                         explicit params,                    advanced one pass,                  41227
 github.tar,                         uncompressed literals,              advanced one pass,                  41122
-github.tar,                         uncompressed literals optimal,      advanced one pass,                  35494
+github.tar,                         uncompressed literals optimal,      advanced one pass,                  35280
 github.tar,                         huffman literals,                   advanced one pass,                  38777
 github.tar,                         multithreaded with advanced params, advanced one pass,                  41122
 silesia,                            level -5,                           advanced one pass small out,        6737607
@@ -566,8 +566,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced one pass small out,        4503117
 silesia,                            level 12 row 2,                     advanced one pass small out,        4505152
 silesia,                            level 13,                           advanced one pass small out,        4493990
-silesia,                            level 16,                           advanced one pass small out,        4360072
-silesia,                            level 19,                           advanced one pass small out,        4282792
+silesia,                            level 16,                           advanced one pass small out,        4358530
+silesia,                            level 19,                           advanced one pass small out,        4288570
 silesia,                            no source size,                     advanced one pass small out,        4849551
 silesia,                            long distance mode,                 advanced one pass small out,        4840738
 silesia,                            multithreaded,                      advanced one pass small out,        4849551
@@ -577,7 +577,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced one pass small out,        4912199
 silesia,                            explicit params,                    advanced one pass small out,        4795856
 silesia,                            uncompressed literals,              advanced one pass small out,        5127982
-silesia,                            uncompressed literals optimal,      advanced one pass small out,        4318000
+silesia,                            uncompressed literals optimal,      advanced one pass small out,        4317966
 silesia,                            huffman literals,                   advanced one pass small out,        5326269
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5127982
 silesia.tar,                        level -5,                           advanced one pass small out,        6738593
@@ -600,8 +600,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4513603
 silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514568
 silesia.tar,                        level 13,                           advanced one pass small out,        4502955
-silesia.tar,                        level 16,                           advanced one pass small out,        4356970
-silesia.tar,                        level 19,                           advanced one pass small out,        4264314
+silesia.tar,                        level 16,                           advanced one pass small out,        4358753
+silesia.tar,                        level 19,                           advanced one pass small out,        4263936
 silesia.tar,                        no source size,                     advanced one pass small out,        4861423
 silesia.tar,                        long distance mode,                 advanced one pass small out,        4847753
 silesia.tar,                        multithreaded,                      advanced one pass small out,        4861507
@@ -611,7 +611,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced one pass small out,        4917039
 silesia.tar,                        explicit params,                    advanced one pass small out,        4807383
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5129458
-silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4307400
+silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4307879
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5347335
 silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5129555
 github,                             level -5,                           advanced one pass small out,        205285
@@ -834,23 +834,23 @@ github.tar,                         level 12 row 2 with dict dds,       advanced
 github.tar,                         level 12 row 2 with dict copy,      advanced one pass small out,        36609
 github.tar,                         level 12 row 2 with dict load,      advanced one pass small out,        36460
 github.tar,                         level 13,                           advanced one pass small out,        35501
-github.tar,                         level 13 with dict,                 advanced one pass small out,        38726
-github.tar,                         level 13 with dict dms,             advanced one pass small out,        38903
-github.tar,                         level 13 with dict dds,             advanced one pass small out,        38903
-github.tar,                         level 13 with dict copy,            advanced one pass small out,        38726
+github.tar,                         level 13 with dict,                 advanced one pass small out,        37005
+github.tar,                         level 13 with dict dms,             advanced one pass small out,        37180
+github.tar,                         level 13 with dict dds,             advanced one pass small out,        37180
+github.tar,                         level 13 with dict copy,            advanced one pass small out,        37005
 github.tar,                         level 13 with dict load,            advanced one pass small out,        36010
-github.tar,                         level 16,                           advanced one pass small out,        40255
-github.tar,                         level 16 with dict,                 advanced one pass small out,        33639
-github.tar,                         level 16 with dict dms,             advanced one pass small out,        33544
-github.tar,                         level 16 with dict dds,             advanced one pass small out,        33544
-github.tar,                         level 16 with dict copy,            advanced one pass small out,        33639
-github.tar,                         level 16 with dict load,            advanced one pass small out,        39353
-github.tar,                         level 19,                           advanced one pass small out,        32820
-github.tar,                         level 19 with dict,                 advanced one pass small out,        32895
-github.tar,                         level 19 with dict dms,             advanced one pass small out,        32672
-github.tar,                         level 19 with dict dds,             advanced one pass small out,        32672
-github.tar,                         level 19 with dict copy,            advanced one pass small out,        32895
-github.tar,                         level 19 with dict load,            advanced one pass small out,        32676
+github.tar,                         level 16,                           advanced one pass small out,        40357
+github.tar,                         level 16 with dict,                 advanced one pass small out,        33475
+github.tar,                         level 16 with dict dms,             advanced one pass small out,        33357
+github.tar,                         level 16 with dict dds,             advanced one pass small out,        33357
+github.tar,                         level 16 with dict copy,            advanced one pass small out,        33475
+github.tar,                         level 16 with dict load,            advanced one pass small out,        39064
+github.tar,                         level 19,                           advanced one pass small out,        32506
+github.tar,                         level 19 with dict,                 advanced one pass small out,        32969
+github.tar,                         level 19 with dict dms,             advanced one pass small out,        32624
+github.tar,                         level 19 with dict dds,             advanced one pass small out,        32624
+github.tar,                         level 19 with dict copy,            advanced one pass small out,        32969
+github.tar,                         level 19 with dict load,            advanced one pass small out,        32570
 github.tar,                         no source size,                     advanced one pass small out,        38441
 github.tar,                         no source size with dict,           advanced one pass small out,        37995
 github.tar,                         long distance mode,                 advanced one pass small out,        39757
@@ -861,7 +861,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced one pass small out,        41669
 github.tar,                         explicit params,                    advanced one pass small out,        41227
 github.tar,                         uncompressed literals,              advanced one pass small out,        41122
-github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35494
+github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35280
 github.tar,                         huffman literals,                   advanced one pass small out,        38777
 github.tar,                         multithreaded with advanced params, advanced one pass small out,        41122
 silesia,                            level -5,                           advanced streaming,                 6882505
@@ -884,8 +884,8 @@ silesia,                            level 11 row 2,                     advanced
 silesia,                            level 12 row 1,                     advanced streaming,                 4503117
 silesia,                            level 12 row 2,                     advanced streaming,                 4505152
 silesia,                            level 13,                           advanced streaming,                 4493990
-silesia,                            level 16,                           advanced streaming,                 4360072
-silesia,                            level 19,                           advanced streaming,                 4282792
+silesia,                            level 16,                           advanced streaming,                 4358530
+silesia,                            level 19,                           advanced streaming,                 4288570
 silesia,                            no source size,                     advanced streaming,                 4849515
 silesia,                            long distance mode,                 advanced streaming,                 4840738
 silesia,                            multithreaded,                      advanced streaming,                 4849551
@@ -895,7 +895,7 @@ silesia,                            small hash log,                     advanced
 silesia,                            small chain log,                    advanced streaming,                 4912199
 silesia,                            explicit params,                    advanced streaming,                 4795884
 silesia,                            uncompressed literals,              advanced streaming,                 5127982
-silesia,                            uncompressed literals optimal,      advanced streaming,                 4318000
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4317966
 silesia,                            huffman literals,                   advanced streaming,                 5331171
 silesia,                            multithreaded with advanced params, advanced streaming,                 5127982
 silesia.tar,                        level -5,                           advanced streaming,                 6982759
@@ -918,8 +918,8 @@ silesia.tar,                        level 11 row 2,                     advanced
 silesia.tar,                        level 12 row 1,                     advanced streaming,                 4513603
 silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514569
 silesia.tar,                        level 13,                           advanced streaming,                 4502955
-silesia.tar,                        level 16,                           advanced streaming,                 4356970
-silesia.tar,                        level 19,                           advanced streaming,                 4264314
+silesia.tar,                        level 16,                           advanced streaming,                 4358753
+silesia.tar,                        level 19,                           advanced streaming,                 4263936
 silesia.tar,                        no source size,                     advanced streaming,                 4861421
 silesia.tar,                        long distance mode,                 advanced streaming,                 4847753
 silesia.tar,                        multithreaded,                      advanced streaming,                 4861507
@@ -929,7 +929,7 @@ silesia.tar,                        small hash log,                     advanced
 silesia.tar,                        small chain log,                    advanced streaming,                 4917019
 silesia.tar,                        explicit params,                    advanced streaming,                 4807403
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5129461
-silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4307400
+silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4307879
 silesia.tar,                        huffman literals,                   advanced streaming,                 5352360
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5129555
 github,                             level -5,                           advanced streaming,                 205285
@@ -1152,23 +1152,23 @@ github.tar,                         level 12 row 2 with dict dds,       advanced
 github.tar,                         level 12 row 2 with dict copy,      advanced streaming,                 36609
 github.tar,                         level 12 row 2 with dict load,      advanced streaming,                 36460
 github.tar,                         level 13,                           advanced streaming,                 35501
-github.tar,                         level 13 with dict,                 advanced streaming,                 38726
-github.tar,                         level 13 with dict dms,             advanced streaming,                 38903
-github.tar,                         level 13 with dict dds,             advanced streaming,                 38903
-github.tar,                         level 13 with dict copy,            advanced streaming,                 38726
+github.tar,                         level 13 with dict,                 advanced streaming,                 37005
+github.tar,                         level 13 with dict dms,             advanced streaming,                 37180
+github.tar,                         level 13 with dict dds,             advanced streaming,                 37180
+github.tar,                         level 13 with dict copy,            advanced streaming,                 37005
 github.tar,                         level 13 with dict load,            advanced streaming,                 36010
-github.tar,                         level 16,                           advanced streaming,                 40255
-github.tar,                         level 16 with dict,                 advanced streaming,                 33639
-github.tar,                         level 16 with dict dms,             advanced streaming,                 33544
-github.tar,                         level 16 with dict dds,             advanced streaming,                 33544
-github.tar,                         level 16 with dict copy,            advanced streaming,                 33639
-github.tar,                         level 16 with dict load,            advanced streaming,                 39353
-github.tar,                         level 19,                           advanced streaming,                 32820
-github.tar,                         level 19 with dict,                 advanced streaming,                 32895
-github.tar,                         level 19 with dict dms,             advanced streaming,                 32672
-github.tar,                         level 19 with dict dds,             advanced streaming,                 32672
-github.tar,                         level 19 with dict copy,            advanced streaming,                 32895
-github.tar,                         level 19 with dict load,            advanced streaming,                 32676
+github.tar,                         level 16,                           advanced streaming,                 40357
+github.tar,                         level 16 with dict,                 advanced streaming,                 33475
+github.tar,                         level 16 with dict dms,             advanced streaming,                 33357
+github.tar,                         level 16 with dict dds,             advanced streaming,                 33357
+github.tar,                         level 16 with dict copy,            advanced streaming,                 33475
+github.tar,                         level 16 with dict load,            advanced streaming,                 39064
+github.tar,                         level 19,                           advanced streaming,                 32506
+github.tar,                         level 19 with dict,                 advanced streaming,                 32969
+github.tar,                         level 19 with dict dms,             advanced streaming,                 32624
+github.tar,                         level 19 with dict dds,             advanced streaming,                 32624
+github.tar,                         level 19 with dict copy,            advanced streaming,                 32969
+github.tar,                         level 19 with dict load,            advanced streaming,                 32570
 github.tar,                         no source size,                     advanced streaming,                 38438
 github.tar,                         no source size with dict,           advanced streaming,                 38000
 github.tar,                         long distance mode,                 advanced streaming,                 39757
@@ -1179,7 +1179,7 @@ github.tar,                         small hash log,                     advanced
 github.tar,                         small chain log,                    advanced streaming,                 41669
 github.tar,                         explicit params,                    advanced streaming,                 41227
 github.tar,                         uncompressed literals,              advanced streaming,                 41122
-github.tar,                         uncompressed literals optimal,      advanced streaming,                 35494
+github.tar,                         uncompressed literals optimal,      advanced streaming,                 35280
 github.tar,                         huffman literals,                   advanced streaming,                 38800
 github.tar,                         multithreaded with advanced params, advanced streaming,                 41122
 silesia,                            level -5,                           old streaming,                      6882505
@@ -1194,11 +1194,11 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming,                      4567203
 silesia,                            level 9,                            old streaming,                      4543311
 silesia,                            level 13,                           old streaming,                      4493990
-silesia,                            level 16,                           old streaming,                      4360072
-silesia,                            level 19,                           old streaming,                      4282792
+silesia,                            level 16,                           old streaming,                      4358530
+silesia,                            level 19,                           old streaming,                      4288570
 silesia,                            no source size,                     old streaming,                      4849515
 silesia,                            uncompressed literals,              old streaming,                      4849551
-silesia,                            uncompressed literals optimal,      old streaming,                      4282792
+silesia,                            uncompressed literals optimal,      old streaming,                      4288570
 silesia,                            huffman literals,                   old streaming,                      6183403
 silesia.tar,                        level -5,                           old streaming,                      6982759
 silesia.tar,                        level -3,                           old streaming,                      6641283
@@ -1212,11 +1212,11 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming,                      4576830
 silesia.tar,                        level 9,                            old streaming,                      4552590
 silesia.tar,                        level 13,                           old streaming,                      4502955
-silesia.tar,                        level 16,                           old streaming,                      4356970
-silesia.tar,                        level 19,                           old streaming,                      4264314
+silesia.tar,                        level 16,                           old streaming,                      4358753
+silesia.tar,                        level 19,                           old streaming,                      4263936
 silesia.tar,                        no source size,                     old streaming,                      4861421
 silesia.tar,                        uncompressed literals,              old streaming,                      4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4264314
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4263936
 silesia.tar,                        huffman literals,                   old streaming,                      6190795
 github,                             level -5,                           old streaming,                      205285
 github,                             level -5 with dict,                 old streaming,                      46718
@@ -1274,15 +1274,15 @@ github.tar,                         level 7 with dict,                  old stre
 github.tar,                         level 9,                            old streaming,                      36767
 github.tar,                         level 9 with dict,                  old streaming,                      36457
 github.tar,                         level 13,                           old streaming,                      35501
-github.tar,                         level 13 with dict,                 old streaming,                      38726
-github.tar,                         level 16,                           old streaming,                      40255
-github.tar,                         level 16 with dict,                 old streaming,                      33639
-github.tar,                         level 19,                           old streaming,                      32820
-github.tar,                         level 19 with dict,                 old streaming,                      32895
+github.tar,                         level 13 with dict,                 old streaming,                      37005
+github.tar,                         level 16,                           old streaming,                      40357
+github.tar,                         level 16 with dict,                 old streaming,                      33475
+github.tar,                         level 19,                           old streaming,                      32506
+github.tar,                         level 19 with dict,                 old streaming,                      32969
 github.tar,                         no source size,                     old streaming,                      38438
 github.tar,                         no source size with dict,           old streaming,                      38000
 github.tar,                         uncompressed literals,              old streaming,                      38441
-github.tar,                         uncompressed literals optimal,      old streaming,                      32820
+github.tar,                         uncompressed literals optimal,      old streaming,                      32506
 github.tar,                         huffman literals,                   old streaming,                      42465
 silesia,                            level -5,                           old streaming advanced,             6882505
 silesia,                            level -3,                           old streaming advanced,             6568376
@@ -1296,8 +1296,8 @@ silesia,                            level 6,                            old stre
 silesia,                            level 7,                            old streaming advanced,             4567203
 silesia,                            level 9,                            old streaming advanced,             4543311
 silesia,                            level 13,                           old streaming advanced,             4493990
-silesia,                            level 16,                           old streaming advanced,             4360072
-silesia,                            level 19,                           old streaming advanced,             4282792
+silesia,                            level 16,                           old streaming advanced,             4358530
+silesia,                            level 19,                           old streaming advanced,             4288570
 silesia,                            no source size,                     old streaming advanced,             4849515
 silesia,                            long distance mode,                 old streaming advanced,             4849551
 silesia,                            multithreaded,                      old streaming advanced,             4849551
@@ -1307,7 +1307,7 @@ silesia,                            small hash log,                     old stre
 silesia,                            small chain log,                    old streaming advanced,             4912199
 silesia,                            explicit params,                    old streaming advanced,             4795884
 silesia,                            uncompressed literals,              old streaming advanced,             4849551
-silesia,                            uncompressed literals optimal,      old streaming advanced,             4282792
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4288570
 silesia,                            huffman literals,                   old streaming advanced,             6183403
 silesia,                            multithreaded with advanced params, old streaming advanced,             4849551
 silesia.tar,                        level -5,                           old streaming advanced,             6982759
@@ -1322,8 +1322,8 @@ silesia.tar,                        level 6,                            old stre
 silesia.tar,                        level 7,                            old streaming advanced,             4576830
 silesia.tar,                        level 9,                            old streaming advanced,             4552590
 silesia.tar,                        level 13,                           old streaming advanced,             4502955
-silesia.tar,                        level 16,                           old streaming advanced,             4356970
-silesia.tar,                        level 19,                           old streaming advanced,             4264314
+silesia.tar,                        level 16,                           old streaming advanced,             4358753
+silesia.tar,                        level 19,                           old streaming advanced,             4263936
 silesia.tar,                        no source size,                     old streaming advanced,             4861421
 silesia.tar,                        long distance mode,                 old streaming advanced,             4861425
 silesia.tar,                        multithreaded,                      old streaming advanced,             4861425
@@ -1333,7 +1333,7 @@ silesia.tar,                        small hash log,                     old stre
 silesia.tar,                        small chain log,                    old streaming advanced,             4917019
 silesia.tar,                        explicit params,                    old streaming advanced,             4807403
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4861425
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4264314
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4263936
 silesia.tar,                        huffman literals,                   old streaming advanced,             6190795
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861425
 github,                             level -5,                           old streaming advanced,             216734
@@ -1401,10 +1401,10 @@ github.tar,                         level 9,                            old stre
 github.tar,                         level 9 with dict,                  old streaming advanced,             36233
 github.tar,                         level 13,                           old streaming advanced,             35501
 github.tar,                         level 13 with dict,                 old streaming advanced,             35807
-github.tar,                         level 16,                           old streaming advanced,             40255
-github.tar,                         level 16 with dict,                 old streaming advanced,             38736
-github.tar,                         level 19,                           old streaming advanced,             32820
-github.tar,                         level 19 with dict,                 old streaming advanced,             32876
+github.tar,                         level 16,                           old streaming advanced,             40357
+github.tar,                         level 16 with dict,                 old streaming advanced,             38730
+github.tar,                         level 19,                           old streaming advanced,             32506
+github.tar,                         level 19 with dict,                 old streaming advanced,             32900
 github.tar,                         no source size,                     old streaming advanced,             38438
 github.tar,                         no source size with dict,           old streaming advanced,             38015
 github.tar,                         long distance mode,                 old streaming advanced,             38441
@@ -1415,7 +1415,7 @@ github.tar,                         small hash log,                     old stre
 github.tar,                         small chain log,                    old streaming advanced,             41669
 github.tar,                         explicit params,                    old streaming advanced,             41227
 github.tar,                         uncompressed literals,              old streaming advanced,             38441
-github.tar,                         uncompressed literals optimal,      old streaming advanced,             32820
+github.tar,                         uncompressed literals optimal,      old streaming advanced,             32506
 github.tar,                         huffman literals,                   old streaming advanced,             42465
 github.tar,                         multithreaded with advanced params, old streaming advanced,             38441
 github,                             level -5 with dict,                 old streaming cdict,                46718
@@ -1445,8 +1445,8 @@ github.tar,                         level 6 with dict,                  old stre
 github.tar,                         level 7 with dict,                  old streaming cdict,                37371
 github.tar,                         level 9 with dict,                  old streaming cdict,                36352
 github.tar,                         level 13 with dict,                 old streaming cdict,                36010
-github.tar,                         level 16 with dict,                 old streaming cdict,                39353
-github.tar,                         level 19 with dict,                 old streaming cdict,                32676
+github.tar,                         level 16 with dict,                 old streaming cdict,                39064
+github.tar,                         level 19 with dict,                 old streaming cdict,                32570
 github.tar,                         no source size with dict,           old streaming cdict,                38000
 github,                             level -5 with dict,                 old streaming advanced cdict,       49562
 github,                             level -3 with dict,                 old streaming advanced cdict,       44956
@@ -1475,6 +1475,6 @@ github.tar,                         level 6 with dict,                  old stre
 github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37322
 github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36233
 github.tar,                         level 13 with dict,                 old streaming advanced cdict,       35807
-github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38736
-github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32876
+github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38730
+github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32900
 github.tar,                         no source size with dict,           old streaming advanced cdict,       38015


### PR DESCRIPTION
This investigation was driven by #2765 .

In essence, this user sample contains a file which, depending on early choices made by the optimal parser, end up compressing or not the data, resulting in large relative differences (+100%).

This is a case of self-reinforcing local optimal. In order to find the shortest path (i.e. which leads to better compression), the algorithm needs to evaluate the "cost" of its choices. For this sample to work, the algorithm must consider small matches as better than literals. If it does, its weight evaluation will favor future choices of the same kind. If not, it will keep considering them too expensive.

One of the known issues of the optimal parser is that it doesn't know which stats to start from. Over time, the process tends to self-regulate, but in the early stages, there is not enough statistics collected yet.
The initially selected approach was to start from a blank pages, with all choices essentially equivalent.
This is what this PR modifies.

Initial statistics are modified this way : 
- Nudge literal lengths slightly towards less or no literals : this small change to initial conditions has an outsized impact, featuring > 100 KB savings on `silesia.tar` cut into small blocks. It's not clear why, I suspect it merely corrects another side effect which tends to favor more literals than it should. This change, all by itself, fix #2765.
- Nudge offset codes towards short distances and repeat codes : this one has a small positive effect. I was expecting more impact. It only improves `silesia.tar` by a few dozens of KB. That might be because, due to the total cost including supplementary bits, the algorithm might already be biased enough ( in the general case ) in favor of small offsets and repeat code. Still, since the impact was consistently positive, this change was kept. It also fixes, all by itself, #2765, proving there is more than one way to fix that one.
- Revisit statistics update : this point is supposed to be mostly important for large files, since it impacts the transport of statistics between blocks. But it also impacts `btultra2`, which compress a small block twice, the first time merely to collect statistics for the second time. The issue is that the general update algorithm was presumed to be invoked once every 128 KB block. On small inputs, it's invoked twice in a much shorter timeframe, having no time to collect a "full block" of statistics. The issue is that the rescaling factor is static, and will squash down statistics the same way, no matter if they are numerous or not. In this new method, the rescaling is a bit more dynamic, trying to maintain a certain baseline budget between consecutive blocks, and adapting the squashing depending on actual runtime amounts. One issue is that there is no "one size fits all". Files with homogeneous entropy prefer slow adaptation, hence larger inter-block correlations, while files with heterogeneous sections prefer fast adaptation. I presume a more optimal solution should adapt the update rate depending on how likely statistics are to be representative of the following section. It's a topic for a full paper. For the time being, the simple heuristics selected in this PR will do (See benchmarks below).
- Revisit early literals estimation : when starting a new frame from scratch, the algorithm takes some clues from actual statistics in the samples. It seems it wasn't such a good idea after all. Potential reasons are : there is a large difference between left-over from LZ sequences, and raw bytes directly present in the file, the most recurrent bytes might be present too often and overwhelm statistics unfairly, and possibly the remaining nb of bytes is sometimes too small to be compressed. In all of these cases, literals will be considered cheaper than they actually will be in the final compressed block. Here also, this topic should deserve a full revisit. But for this PR, the simple heuristic selected improves compression ratio enough.

So what are the benefits ? Let's do some benchmark : 

<details>
<summary> `silesia.tar`, cut into 2 KB blocks : </summary>

Level | File | dev | PR | diff | diff % | comment |  
-- | -- | -- | -- | -- | -- | -- | --
11 | silesia.tar -B2K | 95169105 | 95000131 | -168974 | -0.18% | opt | mml=4
12 | silesia.tar -B2K | 93413153 | 93017601 | -395552 | -0.42% |   | mml=3
13 | silesia.tar -B2K | 93108397 | 92691659 | -416738 | -0.45% | ultra |  
14 | silesia.tar -B2K | 92972963 | 92569885 | -403078 | -0.43% |   |  
15 | silesia.tar -B2K | 92950860 | 92547104 | -403756 | -0.43% |   |  
16 | silesia.tar -B2K | 92628560 | 92401081 | -227479 | -0.25% | ultra2 |  
17 | silesia.tar -B2K | 92516103 | 92288346 | -227757 | -0.25% |   |  
18 | silesia.tar -B2K | 92513639 | 92285819 | -227820 | -0.25% |   |  
19 | silesia.tar -B2K | 92513546 | 92285727 | -227819 | -0.25% |   |  
20 | silesia.tar -B2K | 92511223 | 92284095 | -227128 | -0.25% |   |  
21 | silesia.tar -B2K | 92510965 | 92283782 | -227183 | -0.25% |   |  
22 | silesia.tar -B2K | 92510917 | 92283698 | -227219 | -0.25% |   |  
</details>

This round is consistently positive. It's even better when small matches of length 3 can be selected (levels 12+). The benefit is less pronounced on reaching `ultra2` levels. The generous interpretation is that `ultra2` was already designed to compensate for the "early statistics" problem, so it benefits less from this new round of improvement. Still, it benefits a little, which is almost surprising, and points at a self-reinforcing effect.

OK, but maybe 2 KB is a too favorable scenario, and the new statistics were designed for this one use case ? Let's try some bigger 16 KB blocks then.

<details>
<summary> `silesia.tar`, cut into 16 KB blocks : </summary>

Level | File | dev | PR | diff | diff % | comment |  
-- | -- | -- | -- | -- | -- | -- | --
11 | silesia.tar -B16K | 75619806 | 75488340 | -131466 | -0.17% | opt | mml=4
12 | silesia.tar -B16K | 73648745 | 73392013 | -256732 | -0.35% |   | mml=3
13 | silesia.tar -B16K | 73257726 | 72967672 | -290054 | -0.40% | ultra |  
14 | silesia.tar -B16K | 73032188 | 72730261 | -301927 | -0.41% |   |  
15 | silesia.tar -B16K | 72968198 | 72663133 | -305065 | -0.42% |   |  
16 | silesia.tar -B16K | 72800467 | 72641294 | -159173 | -0.22% | ultra2 |  
17 | silesia.tar -B16K | 72577872 | 72413473 | -164399 | -0.23% |   |  
18 | silesia.tar -B16K | 72572119 | 72407890 | -164229 | -0.23% |   |  
19 | silesia.tar -B16K | 72571968 | 72407720 | -164248 | -0.23% |   |  
20 | silesia.tar -B16K | 72572244 | 72409779 | -162465 | -0.22% |   |  
21 | silesia.tar -B16K | 72571829 | 72409500 | -162329 | -0.22% |   |  
22 | silesia.tar -B16K | 72571211 | 72408727 | -162484 | -0.22% |   |  

</details>

Well, with bigger blocks, the impact seems a little less pronounced, but it's still there, proving initial stats remain useful after 2 KB.

OK, fine for small blocks. What about large blocks ? Full 128 KB ?

<details>
<summary> `silesia.tar`, cut into 128 KB blocks : </summary>

Level | File | dev | PR | diff | diff % | comment |  
-- | -- | -- | -- | -- | -- | -- | --
13 | silesia.tar -B128K | 65656825 | 65611779 | -45046 | -0.07% | opt | mml=4
14 | silesia.tar -B128K | 63675123 | 63462802 | -212321 | -0.33% |   | mml=3
15 | silesia.tar -B128K | 63282894 | 63059738 | -223156 | -0.35% |   |  
16 | silesia.tar -B128K | 63023353 | 62799390 | -223963 | -0.36% | ultra |  
17 | silesia.tar -B128K | 63007738 | 62783036 | -224702 | -0.36% |   |  
18 | silesia.tar -B128K | 63003547 | 62780536 | -223011 | -0.35% |   |  
19 | silesia.tar -B128K | 62798322 | 62743773 | -54549 | -0.09% | ultra2 |  
20 | silesia.tar -B128K | 62789783 | 62736999 | -52784 | -0.08% |   |  
21 | silesia.tar -B128K | 62785135 | 62739262 | -45873 | -0.07% |   |  
22 | silesia.tar -B128K | 62783801 | 62736795 | -47006 | -0.07% |   |  

</details> 

Note that, for these sizes, `zstd_btopt` only starts at level 13.
Anyway, the benefit is now clearly reduced. But reassuringly, it's still globally positive, so it's still worth it.

Does this change impact full-length files, and if yes how ?

<details>
<summary> `silesia.tar` whole file : </summary>

Level | File | dev | PR | diff | diff % | comment |  
-- | -- | -- | -- | -- | -- | -- | --
16 | silesia.tar | 55351684 | 55321640 | -30044 | -0.05% | opt | mml=4
17 | silesia.tar | 54284712 | 54275326 | -9386 | -0.02% |   | mml=3
18 | silesia.tar | 53420100 | 53427159 | 7059 | 0.01% | ultra |  
19 | silesia.tar | 52986703 | 52991722 | 5019 | 0.01% | ultra2 |  
20 | silesia.tar | 52577641 | 52574471 | -3170 | -0.01% |   |  
21 | silesia.tar | 52481750 | 52480144 | -1606 | 0.00% |   |  
22 | silesia.tar | 52460817 | 52458096 | -2721 | -0.01% |   |  

</details>

Well, barely. This time, size differences are barely significant. And note that they are not always positive. But wether they are or not, it doesn't matter, as the compression ratio is essentially equivalent.

OK, but let's try some different file now. Maybe `calgary.tar`, which is a collection of small files of different types appended together, resulting in rapidly changing statistics. How does it behave with this new update policy ? 

<details>
<summary> `calgary.tar` whole file : </summary>

Level | File | dev | PR | diff | diff % | comment |  
-- | -- | -- | -- | -- | -- | -- | --
16 | calgary.tar | 881311 | 881780 | 469 | 0.05% | opt | mml=4
17 | calgary.tar | 873376 | 874742 | 1366 | 0.16% |  | mml=3
18 | calgary.tar | 861665 | 863272 | 1607 | 0.19% | ultra
19 | calgary.tar | 859732 | 860927 | 1195 | 0.14% | ultra2
20 | calgary.tar | 859732 | 860927 | 1195 | 0.14% |  
21 | calgary.tar | 859598 | 860842 | 1244 | 0.14% |  
22 | calgary.tar | 859587 | 860789 | 1202 | 0.14% |  

</details>

Well, this time, it's rather negative. But thankfully, by very little.
This is a case where statistics update would benefit from being more actively changed, since 2 consecutive internal files can be very different (text, image, db, etc.). It could be fixed with a faster update rate, but alas, other use cases (like `silesia.tar`) would then suffer. This is a situation where selecting a "good enough" middle ground heuristic is all we can do before moving on to some more complex algorithm.

Anyway, an important point : it's not _always_ a win. This change is more targeted at small blocks (~2 KB), for which it's _generally_ a win. For larger files, it's less clear, but the impact is also less pronounced.