### PR TITLE
Pipelined Implementation of ZSTD_dfast

### DIFF
--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -591,7 +591,7 @@ static size_t ZSTD_compressBlock_doubleFast_extDict_generic(
 
     /* if extDict is invalidated due to maxDistance, switch to "regular" variant */
     if (prefixStartIndex == dictStartIndex)
-        return ZSTD_compressBlock_doubleFast_generic(ms, seqStore, rep, src, srcSize, mls, ZSTD_noDict);
+        return ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, mls);
 
     /* Search Loop */
     while (ip < ilimit) {  /* < instead of <=, because (ip+1) */

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -184,26 +184,22 @@ _cleanup:
     return (size_t)(iend - anchor);
 
 _search_next_long:
-    {
 
-        /* check prefix long +1 match */
-        if (idxl1 > prefixLowestIndex) {
-            if (MEM_read64(matchl1) == MEM_read64(ip1)) {
-                ip = ip1;
-                mLength = ZSTD_count(ip+8, matchl1+8, iend) + 8;
-                offset = (U32)(ip-matchl1);
-                while (((ip>anchor) & (matchl1>prefixLowest)) && (ip[-1] == matchl1[-1])) { ip--; matchl1--; mLength++; } /* catch up */
-                goto _match_found;
-            }
+    /* check prefix long +1 match */
+    if (idxl1 > prefixLowestIndex) {
+        if (MEM_read64(matchl1) == MEM_read64(ip1)) {
+            ip = ip1;
+            mLength = ZSTD_count(ip+8, matchl1+8, iend) + 8;
+            offset = (U32)(ip-matchl1);
+            while (((ip>anchor) & (matchl1>prefixLowest)) && (ip[-1] == matchl1[-1])) { ip--; matchl1--; mLength++; } /* catch up */
+            goto _match_found;
         }
     }
 
     /* if no long +1 match, explore the short match we found */
-    {
-        mLength = ZSTD_count(ip+4, matchs0+4, iend) + 4;
-        offset = (U32)(ip - matchs0);
-        while (((ip>anchor) & (matchs0>prefixLowest)) && (ip[-1] == matchs0[-1])) { ip--; matchs0--; mLength++; } /* catch up */
-    }
+    mLength = ZSTD_count(ip+4, matchs0+4, iend) + 4;
+    offset = (U32)(ip - matchs0);
+    while (((ip>anchor) & (matchs0>prefixLowest)) && (ip[-1] == matchs0[-1])) { ip--; matchs0--; mLength++; } /* catch up */
 
     /* fall-through */
 

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -48,10 +48,9 @@ void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
 
 
 FORCE_INLINE_TEMPLATE
-size_t ZSTD_compressBlock_doubleFast_singleSegment_generic(
+size_t ZSTD_compressBlock_doubleFast_noDict_generic(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
-        void const* src, size_t srcSize,
-        U32 const mls /* template */)
+        void const* src, size_t srcSize, U32 const mls /* template */)
 {
     ZSTD_compressionParameters const* cParams = &ms->cParams;
     U32* const hashLong = ms->hashTable;
@@ -93,7 +92,7 @@ size_t ZSTD_compressBlock_doubleFast_singleSegment_generic(
     const BYTE* ip = istart;
     const BYTE* ip1;
 
-    DEBUGLOG(5, "ZSTD_compressBlock_doubleFast_singleSegment_generic");
+    DEBUGLOG(5, "ZSTD_compressBlock_doubleFast_noDict_generic");
 
     /* init */
     ip += ((ip - prefixLowest) == 0);
@@ -530,13 +529,13 @@ size_t ZSTD_compressBlock_doubleFast(
     {
     default: /* includes case 3 */
     case 4 :
-        return ZSTD_compressBlock_doubleFast_singleSegment_generic(ms, seqStore, rep, src, srcSize, 4);
+        return ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 4);
     case 5 :
-        return ZSTD_compressBlock_doubleFast_singleSegment_generic(ms, seqStore, rep, src, srcSize, 5);
+        return ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 5);
     case 6 :
-        return ZSTD_compressBlock_doubleFast_singleSegment_generic(ms, seqStore, rep, src, srcSize, 6);
+        return ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 6);
     case 7 :
-        return ZSTD_compressBlock_doubleFast_singleSegment_generic(ms, seqStore, rep, src, srcSize, 7);
+        return ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 7);
     }
 }
 

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -111,7 +111,7 @@ _start:
     nextStep = ip + kStepIncr;
     ip1 = ip + step;
 
-    if (ip1 >= ilimit) {
+    if (ip1 > ilimit) {
         goto _cleanup;
     }
 
@@ -173,7 +173,7 @@ _start:
 #if defined(__aarch64__)
         PREFETCH_L1(ip+256);
 #endif
-    } while (ip1 < ilimit);
+    } while (ip1 <= ilimit);
 
 _cleanup:
     /* save reps for next block */

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -73,24 +73,24 @@ size_t ZSTD_compressBlock_doubleFast_noDict_generic(
     U32 offset;
     U32 curr;
 
+    /* how many positions to search before increasing step size */
     const size_t kStepIncr = 1 << kSearchStrength;
+    /* the position at which to increment the step size if no match is found */
     const BYTE* nextStep;
-    size_t step;
+    size_t step; /* the current step size */
 
-    size_t hl0;
-    size_t hs0;
-    size_t hl1;
+    size_t hl0; /* the long hash at ip */
+    size_t hl1; /* the long hash at ip1 */
 
-    U32 idxl0;
-    U32 idxs0;
-    U32 idxl1;
+    U32 idxl0; /* the long match index for ip */
+    U32 idxl1; /* the long match index for ip1 */
 
-    const BYTE* matchl0;
-    const BYTE* matchs0;
-    const BYTE* matchl1;
+    const BYTE* matchl0; /* the long match for ip */
+    const BYTE* matchs0; /* the short match for ip */
+    const BYTE* matchl1; /* the long match for ip1 */
 
-    const BYTE* ip = istart;
-    const BYTE* ip1;
+    const BYTE* ip = istart; /* the current position */
+    const BYTE* ip1; /* the next position */
 
     DEBUGLOG(5, "ZSTD_compressBlock_doubleFast_noDict_generic");
 
@@ -120,9 +120,9 @@ _start:
 
     /* Main Search Loop */
     do {
+        const size_t hs0 = ZSTD_hashPtr(ip, hBitsS, mls);
+        const U32 idxs0 = hashSmall[hs0];
         curr = (U32)(ip-base);
-        hs0 = ZSTD_hashPtr(ip, hBitsS, mls);
-        idxs0 = hashSmall[hs0];
         matchs0 = base + idxs0;
 
         hashLong[hl0] = hashSmall[hs0] = curr;   /* update hash tables */

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -204,6 +204,12 @@ _search_next_long:
         while (((ip>anchor) & (matchs0>prefixLowest)) && (ip[-1] == matchs0[-1])) { ip--; matchs0--; mLength++; } /* catch up */
     }
 
+    /* fall-through */
+
+_match_found: /* requires ip, offset, mLength */
+    offset_2 = offset_1;
+    offset_1 = offset;
+
     if (step < 4) {
         /* It is unsafe to write this value back to the hashtable when ip1 is
          * greater than or equal to the new ip we will have after we're done
@@ -214,12 +220,6 @@ _search_next_long:
          * (initially) is less than 4, we know ip1 < new ip. */
         hashLong[hl1] = (U32)(ip1 - base);
     }
-
-    /* fall-through */
-
-_match_found: /* requires ip, offset, mLength */
-    offset_2 = offset_1;
-    offset_1 = offset;
 
     ZSTD_storeSeq(seqStore, (size_t)(ip-anchor), anchor, iend, offset + ZSTD_REP_MOVE, mLength-MINMATCH);
 

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -81,17 +81,14 @@ size_t ZSTD_compressBlock_doubleFast_singleSegment_generic(
     size_t hl0;
     size_t hs0;
     size_t hl1;
-    // size_t hs1;
 
     U32 idxl0;
     U32 idxs0;
     U32 idxl1;
-    // U32 idxs0;
 
     const BYTE* matchl0;
     const BYTE* matchs0;
     const BYTE* matchl1;
-    // const BYTE* matchs1;
 
     const BYTE* ip = istart;
     const BYTE* ip1;
@@ -119,14 +116,14 @@ _start:
     }
 
     hl0 = ZSTD_hashPtr(ip, hBitsL, 8);
+    idxl0 = hashLong[hl0];
+    matchl0 = base + idxl0;
 
     /* Main Search Loop */
     do {
         curr = (U32)(ip-base);
         hs0 = ZSTD_hashPtr(ip, hBitsS, mls);
-        idxl0 = hashLong[hl0];
         idxs0 = hashSmall[hs0];
-        matchl0 = base + idxl0;
         matchs0 = base + idxs0;
 
         hashLong[hl0] = hashSmall[hs0] = curr;   /* update hash tables */
@@ -151,6 +148,9 @@ _start:
             }
         }
 
+        idxl1 = hashLong[hl1];
+        matchl1 = base + idxl1;
+
         if (idxs0 > prefixLowestIndex) {
             /* check prefix short match */
             if (MEM_read32(matchs0) == MEM_read32(ip)) {
@@ -168,6 +168,8 @@ _start:
         ip1 += step;
 
         hl0 = hl1;
+        idxl0 = idxl1;
+        matchl0 = matchl1;
 #if defined(__aarch64__)
         PREFETCH_L1(ip+256);
 #endif
@@ -182,8 +184,7 @@ _cleanup:
     return (size_t)(iend - anchor);
 
 _search_next_long:
-    {   idxl1 = hashLong[hl1];
-        matchl1 = base + idxl1;
+    {
 
         /* check prefix long +1 match */
         if (idxl1 > prefixLowestIndex) {

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -2,10 +2,10 @@ Data,                               Config,                             Method, 
 silesia.tar,                        level -5,                           compress simple,                    7359401
 silesia.tar,                        level -3,                           compress simple,                    6901672
 silesia.tar,                        level -1,                           compress simple,                    6182241
-silesia.tar,                        level 0,                            compress simple,                    4861424
+silesia.tar,                        level 0,                            compress simple,                    4854086
 silesia.tar,                        level 1,                            compress simple,                    5331946
-silesia.tar,                        level 3,                            compress simple,                    4861424
-silesia.tar,                        level 4,                            compress simple,                    4799632
+silesia.tar,                        level 3,                            compress simple,                    4854086
+silesia.tar,                        level 4,                            compress simple,                    4791503
 silesia.tar,                        level 5,                            compress simple,                    4649987
 silesia.tar,                        level 6,                            compress simple,                    4616797
 silesia.tar,                        level 7,                            compress simple,                    4576661
@@ -13,16 +13,16 @@ silesia.tar,                        level 9,                            compress
 silesia.tar,                        level 13,                           compress simple,                    4502956
 silesia.tar,                        level 16,                           compress simple,                    4360527
 silesia.tar,                        level 19,                           compress simple,                    4267266
-silesia.tar,                        uncompressed literals,              compress simple,                    4861424
+silesia.tar,                        uncompressed literals,              compress simple,                    4854086
 silesia.tar,                        uncompressed literals optimal,      compress simple,                    4267266
 silesia.tar,                        huffman literals,                   compress simple,                    6182241
 github.tar,                         level -5,                           compress simple,                    66914
 github.tar,                         level -3,                           compress simple,                    52127
 github.tar,                         level -1,                           compress simple,                    42560
-github.tar,                         level 0,                            compress simple,                    38441
+github.tar,                         level 0,                            compress simple,                    38831
 github.tar,                         level 1,                            compress simple,                    39200
-github.tar,                         level 3,                            compress simple,                    38441
-github.tar,                         level 4,                            compress simple,                    38467
+github.tar,                         level 3,                            compress simple,                    38831
+github.tar,                         level 4,                            compress simple,                    38893
 github.tar,                         level 5,                            compress simple,                    38366
 github.tar,                         level 6,                            compress simple,                    38648
 github.tar,                         level 7,                            compress simple,                    38110
@@ -30,16 +30,16 @@ github.tar,                         level 9,                            compress
 github.tar,                         level 13,                           compress simple,                    35501
 github.tar,                         level 16,                           compress simple,                    40471
 github.tar,                         level 19,                           compress simple,                    32134
-github.tar,                         uncompressed literals,              compress simple,                    38441
+github.tar,                         uncompressed literals,              compress simple,                    38831
 github.tar,                         uncompressed literals optimal,      compress simple,                    32134
 github.tar,                         huffman literals,                   compress simple,                    42560
 silesia,                            level -5,                           compress cctx,                      7354675
 silesia,                            level -3,                           compress cctx,                      6902374
 silesia,                            level -1,                           compress cctx,                      6177565
-silesia,                            level 0,                            compress cctx,                      4849553
+silesia,                            level 0,                            compress cctx,                      4842075
 silesia,                            level 1,                            compress cctx,                      5309098
-silesia,                            level 3,                            compress cctx,                      4849553
-silesia,                            level 4,                            compress cctx,                      4786968
+silesia,                            level 3,                            compress cctx,                      4842075
+silesia,                            level 4,                            compress cctx,                      4779186
 silesia,                            level 5,                            compress cctx,                      4638691
 silesia,                            level 6,                            compress cctx,                      4605296
 silesia,                            level 7,                            compress cctx,                      4566984
@@ -47,28 +47,28 @@ silesia,                            level 9,                            compress
 silesia,                            level 13,                           compress cctx,                      4493990
 silesia,                            level 16,                           compress cctx,                      4359864
 silesia,                            level 19,                           compress cctx,                      4296880
-silesia,                            long distance mode,                 compress cctx,                      4849553
-silesia,                            multithreaded,                      compress cctx,                      4849553
-silesia,                            multithreaded long distance mode,   compress cctx,                      4849553
-silesia,                            small window log,                   compress cctx,                      7084179
+silesia,                            long distance mode,                 compress cctx,                      4842075
+silesia,                            multithreaded,                      compress cctx,                      4842075
+silesia,                            multithreaded long distance mode,   compress cctx,                      4842075
+silesia,                            small window log,                   compress cctx,                      7082951
 silesia,                            small hash log,                     compress cctx,                      6526141
 silesia,                            small chain log,                    compress cctx,                      4912197
 silesia,                            explicit params,                    compress cctx,                      4794052
-silesia,                            uncompressed literals,              compress cctx,                      4849553
+silesia,                            uncompressed literals,              compress cctx,                      4842075
 silesia,                            uncompressed literals optimal,      compress cctx,                      4296880
 silesia,                            huffman literals,                   compress cctx,                      6177565
-silesia,                            multithreaded with advanced params, compress cctx,                      4849553
+silesia,                            multithreaded with advanced params, compress cctx,                      4842075
 github,                             level -5,                           compress cctx,                      232315
 github,                             level -5 with dict,                 compress cctx,                      47294
 github,                             level -3,                           compress cctx,                      220760
 github,                             level -3 with dict,                 compress cctx,                      48047
 github,                             level -1,                           compress cctx,                      175468
 github,                             level -1 with dict,                 compress cctx,                      43527
-github,                             level 0,                            compress cctx,                      136335
+github,                             level 0,                            compress cctx,                      136332
 github,                             level 0 with dict,                  compress cctx,                      41534
 github,                             level 1,                            compress cctx,                      142365
 github,                             level 1 with dict,                  compress cctx,                      42157
-github,                             level 3,                            compress cctx,                      136335
+github,                             level 3,                            compress cctx,                      136332
 github,                             level 3 with dict,                  compress cctx,                      41534
 github,                             level 4,                            compress cctx,                      136199
 github,                             level 4 with dict,                  compress cctx,                      41725
@@ -86,24 +86,24 @@ github,                             level 16,                           compress
 github,                             level 16 with dict,                 compress cctx,                      37568
 github,                             level 19,                           compress cctx,                      134064
 github,                             level 19 with dict,                 compress cctx,                      37567
-github,                             long distance mode,                 compress cctx,                      141102
-github,                             multithreaded,                      compress cctx,                      141102
-github,                             multithreaded long distance mode,   compress cctx,                      141102
-github,                             small window log,                   compress cctx,                      141102
+github,                             long distance mode,                 compress cctx,                      141069
+github,                             multithreaded,                      compress cctx,                      141069
+github,                             multithreaded long distance mode,   compress cctx,                      141069
+github,                             small window log,                   compress cctx,                      141069
 github,                             small hash log,                     compress cctx,                      138949
 github,                             small chain log,                    compress cctx,                      139242
 github,                             explicit params,                    compress cctx,                      140932
-github,                             uncompressed literals,              compress cctx,                      136335
+github,                             uncompressed literals,              compress cctx,                      136332
 github,                             uncompressed literals optimal,      compress cctx,                      134064
 github,                             huffman literals,                   compress cctx,                      175468
-github,                             multithreaded with advanced params, compress cctx,                      141102
+github,                             multithreaded with advanced params, compress cctx,                      141069
 silesia,                            level -5,                           zstdcli,                            7354723
 silesia,                            level -3,                           zstdcli,                            6902422
 silesia,                            level -1,                           zstdcli,                            6177613
-silesia,                            level 0,                            zstdcli,                            4849601
+silesia,                            level 0,                            zstdcli,                            4842123
 silesia,                            level 1,                            zstdcli,                            5309146
-silesia,                            level 3,                            zstdcli,                            4849601
-silesia,                            level 4,                            zstdcli,                            4787016
+silesia,                            level 3,                            zstdcli,                            4842123
+silesia,                            level 4,                            zstdcli,                            4779234
 silesia,                            level 5,                            zstdcli,                            4638739
 silesia,                            level 6,                            zstdcli,                            4605344
 silesia,                            level 7,                            zstdcli,                            4567032
@@ -111,24 +111,24 @@ silesia,                            level 9,                            zstdcli,
 silesia,                            level 13,                           zstdcli,                            4494038
 silesia,                            level 16,                           zstdcli,                            4359912
 silesia,                            level 19,                           zstdcli,                            4296928
-silesia,                            long distance mode,                 zstdcli,                            4840807
-silesia,                            multithreaded,                      zstdcli,                            4849601
-silesia,                            multithreaded long distance mode,   zstdcli,                            4840807
-silesia,                            small window log,                   zstdcli,                            7095967
+silesia,                            long distance mode,                 zstdcli,                            4833785
+silesia,                            multithreaded,                      zstdcli,                            4842123
+silesia,                            multithreaded long distance mode,   zstdcli,                            4833785
+silesia,                            small window log,                   zstdcli,                            7095048
 silesia,                            small hash log,                     zstdcli,                            6526189
 silesia,                            small chain log,                    zstdcli,                            4912245
 silesia,                            explicit params,                    zstdcli,                            4795432
-silesia,                            uncompressed literals,              zstdcli,                            5128030
+silesia,                            uncompressed literals,              zstdcli,                            5120614
 silesia,                            uncompressed literals optimal,      zstdcli,                            4319566
 silesia,                            huffman literals,                   zstdcli,                            5326394
-silesia,                            multithreaded with advanced params, zstdcli,                            5128030
+silesia,                            multithreaded with advanced params, zstdcli,                            5120614
 silesia.tar,                        level -5,                           zstdcli,                            7363866
 silesia.tar,                        level -3,                           zstdcli,                            6902158
 silesia.tar,                        level -1,                           zstdcli,                            6182939
-silesia.tar,                        level 0,                            zstdcli,                            4861512
+silesia.tar,                        level 0,                            zstdcli,                            4854164
 silesia.tar,                        level 1,                            zstdcli,                            5333183
-silesia.tar,                        level 3,                            zstdcli,                            4861512
-silesia.tar,                        level 4,                            zstdcli,                            4800528
+silesia.tar,                        level 3,                            zstdcli,                            4854164
+silesia.tar,                        level 4,                            zstdcli,                            4792352
 silesia.tar,                        level 5,                            zstdcli,                            4650946
 silesia.tar,                        level 6,                            zstdcli,                            4618390
 silesia.tar,                        level 7,                            zstdcli,                            4578719
@@ -136,29 +136,29 @@ silesia.tar,                        level 9,                            zstdcli,
 silesia.tar,                        level 13,                           zstdcli,                            4502960
 silesia.tar,                        level 16,                           zstdcli,                            4360531
 silesia.tar,                        level 19,                           zstdcli,                            4267270
-silesia.tar,                        no source size,                     zstdcli,                            4861508
-silesia.tar,                        long distance mode,                 zstdcli,                            4853225
-silesia.tar,                        multithreaded,                      zstdcli,                            4861512
-silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4853225
-silesia.tar,                        small window log,                   zstdcli,                            7101576
+silesia.tar,                        no source size,                     zstdcli,                            4854160
+silesia.tar,                        long distance mode,                 zstdcli,                            4845745
+silesia.tar,                        multithreaded,                      zstdcli,                            4854164
+silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4845745
+silesia.tar,                        small window log,                   zstdcli,                            7100701
 silesia.tar,                        small hash log,                     zstdcli,                            6529289
 silesia.tar,                        small chain log,                    zstdcli,                            4917022
 silesia.tar,                        explicit params,                    zstdcli,                            4820713
-silesia.tar,                        uncompressed literals,              zstdcli,                            5129559
+silesia.tar,                        uncompressed literals,              zstdcli,                            5122571
 silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4310145
 silesia.tar,                        huffman literals,                   zstdcli,                            5344915
-silesia.tar,                        multithreaded with advanced params, zstdcli,                            5129559
+silesia.tar,                        multithreaded with advanced params, zstdcli,                            5122571
 github,                             level -5,                           zstdcli,                            234315
 github,                             level -5 with dict,                 zstdcli,                            48718
 github,                             level -3,                           zstdcli,                            222760
 github,                             level -3 with dict,                 zstdcli,                            47395
 github,                             level -1,                           zstdcli,                            177468
 github,                             level -1 with dict,                 zstdcli,                            45170
-github,                             level 0,                            zstdcli,                            138335
+github,                             level 0,                            zstdcli,                            138332
 github,                             level 0 with dict,                  zstdcli,                            43148
 github,                             level 1,                            zstdcli,                            144365
 github,                             level 1 with dict,                  zstdcli,                            43682
-github,                             level 3,                            zstdcli,                            138335
+github,                             level 3,                            zstdcli,                            138332
 github,                             level 3 with dict,                  zstdcli,                            43148
 github,                             level 4,                            zstdcli,                            138199
 github,                             level 4 with dict,                  zstdcli,                            43251
@@ -176,30 +176,30 @@ github,                             level 16,                           zstdcli,
 github,                             level 16 with dict,                 zstdcli,                            39577
 github,                             level 19,                           zstdcli,                            136064
 github,                             level 19 with dict,                 zstdcli,                            39576
-github,                             long distance mode,                 zstdcli,                            138335
-github,                             multithreaded,                      zstdcli,                            138335
-github,                             multithreaded long distance mode,   zstdcli,                            138335
-github,                             small window log,                   zstdcli,                            138335
+github,                             long distance mode,                 zstdcli,                            138332
+github,                             multithreaded,                      zstdcli,                            138332
+github,                             multithreaded long distance mode,   zstdcli,                            138332
+github,                             small window log,                   zstdcli,                            138332
 github,                             small hash log,                     zstdcli,                            137590
 github,                             small chain log,                    zstdcli,                            138341
 github,                             explicit params,                    zstdcli,                            136197
-github,                             uncompressed literals,              zstdcli,                            167915
+github,                             uncompressed literals,              zstdcli,                            167911
 github,                             uncompressed literals optimal,      zstdcli,                            159227
 github,                             huffman literals,                   zstdcli,                            144365
-github,                             multithreaded with advanced params, zstdcli,                            167915
+github,                             multithreaded with advanced params, zstdcli,                            167911
 github.tar,                         level -5,                           zstdcli,                            66918
 github.tar,                         level -5 with dict,                 zstdcli,                            51529
 github.tar,                         level -3,                           zstdcli,                            52131
 github.tar,                         level -3 with dict,                 zstdcli,                            44246
 github.tar,                         level -1,                           zstdcli,                            42564
 github.tar,                         level -1 with dict,                 zstdcli,                            41140
-github.tar,                         level 0,                            zstdcli,                            38445
+github.tar,                         level 0,                            zstdcli,                            38835
 github.tar,                         level 0 with dict,                  zstdcli,                            37999
 github.tar,                         level 1,                            zstdcli,                            39204
 github.tar,                         level 1 with dict,                  zstdcli,                            38288
-github.tar,                         level 3,                            zstdcli,                            38445
+github.tar,                         level 3,                            zstdcli,                            38835
 github.tar,                         level 3 with dict,                  zstdcli,                            37999
-github.tar,                         level 4,                            zstdcli,                            38471
+github.tar,                         level 4,                            zstdcli,                            38897
 github.tar,                         level 4 with dict,                  zstdcli,                            37952
 github.tar,                         level 5,                            zstdcli,                            38370
 github.tar,                         level 5 with dict,                  zstdcli,                            39071
@@ -215,26 +215,26 @@ github.tar,                         level 16,                           zstdcli,
 github.tar,                         level 16 with dict,                 zstdcli,                            33382
 github.tar,                         level 19,                           zstdcli,                            32138
 github.tar,                         level 19 with dict,                 zstdcli,                            32713
-github.tar,                         no source size,                     zstdcli,                            38442
+github.tar,                         no source size,                     zstdcli,                            38832
 github.tar,                         no source size with dict,           zstdcli,                            38004
-github.tar,                         long distance mode,                 zstdcli,                            39730
-github.tar,                         multithreaded,                      zstdcli,                            38445
-github.tar,                         multithreaded long distance mode,   zstdcli,                            39730
+github.tar,                         long distance mode,                 zstdcli,                            40236
+github.tar,                         multithreaded,                      zstdcli,                            38835
+github.tar,                         multithreaded long distance mode,   zstdcli,                            40236
 github.tar,                         small window log,                   zstdcli,                            198544
 github.tar,                         small hash log,                     zstdcli,                            129874
 github.tar,                         small chain log,                    zstdcli,                            41673
 github.tar,                         explicit params,                    zstdcli,                            41385
-github.tar,                         uncompressed literals,              zstdcli,                            41126
+github.tar,                         uncompressed literals,              zstdcli,                            41529
 github.tar,                         uncompressed literals optimal,      zstdcli,                            35401
 github.tar,                         huffman literals,                   zstdcli,                            38857
-github.tar,                         multithreaded with advanced params, zstdcli,                            41126
+github.tar,                         multithreaded with advanced params, zstdcli,                            41529
 silesia,                            level -5,                           advanced one pass,                  7354675
 silesia,                            level -3,                           advanced one pass,                  6902374
 silesia,                            level -1,                           advanced one pass,                  6177565
-silesia,                            level 0,                            advanced one pass,                  4849553
+silesia,                            level 0,                            advanced one pass,                  4842075
 silesia,                            level 1,                            advanced one pass,                  5309098
-silesia,                            level 3,                            advanced one pass,                  4849553
-silesia,                            level 4,                            advanced one pass,                  4786968
+silesia,                            level 3,                            advanced one pass,                  4842075
+silesia,                            level 4,                            advanced one pass,                  4779186
 silesia,                            level 5 row 1,                      advanced one pass,                  4638691
 silesia,                            level 5 row 2,                      advanced one pass,                  4640752
 silesia,                            level 5,                            advanced one pass,                  4638691
@@ -250,25 +250,25 @@ silesia,                            level 12 row 2,                     advanced
 silesia,                            level 13,                           advanced one pass,                  4493990
 silesia,                            level 16,                           advanced one pass,                  4359864
 silesia,                            level 19,                           advanced one pass,                  4296880
-silesia,                            no source size,                     advanced one pass,                  4849553
-silesia,                            long distance mode,                 advanced one pass,                  4840737
-silesia,                            multithreaded,                      advanced one pass,                  4849553
-silesia,                            multithreaded long distance mode,   advanced one pass,                  4840759
-silesia,                            small window log,                   advanced one pass,                  7095919
+silesia,                            no source size,                     advanced one pass,                  4842075
+silesia,                            long distance mode,                 advanced one pass,                  4833710
+silesia,                            multithreaded,                      advanced one pass,                  4842075
+silesia,                            multithreaded long distance mode,   advanced one pass,                  4833737
+silesia,                            small window log,                   advanced one pass,                  7095000
 silesia,                            small hash log,                     advanced one pass,                  6526141
 silesia,                            small chain log,                    advanced one pass,                  4912197
 silesia,                            explicit params,                    advanced one pass,                  4795432
-silesia,                            uncompressed literals,              advanced one pass,                  5127982
+silesia,                            uncompressed literals,              advanced one pass,                  5120566
 silesia,                            uncompressed literals optimal,      advanced one pass,                  4319518
 silesia,                            huffman literals,                   advanced one pass,                  5326346
-silesia,                            multithreaded with advanced params, advanced one pass,                  5127982
+silesia,                            multithreaded with advanced params, advanced one pass,                  5120566
 silesia.tar,                        level -5,                           advanced one pass,                  7359401
 silesia.tar,                        level -3,                           advanced one pass,                  6901672
 silesia.tar,                        level -1,                           advanced one pass,                  6182241
-silesia.tar,                        level 0,                            advanced one pass,                  4861424
+silesia.tar,                        level 0,                            advanced one pass,                  4854086
 silesia.tar,                        level 1,                            advanced one pass,                  5331946
-silesia.tar,                        level 3,                            advanced one pass,                  4861424
-silesia.tar,                        level 4,                            advanced one pass,                  4799632
+silesia.tar,                        level 3,                            advanced one pass,                  4854086
+silesia.tar,                        level 4,                            advanced one pass,                  4791503
 silesia.tar,                        level 5 row 1,                      advanced one pass,                  4649987
 silesia.tar,                        level 5 row 2,                      advanced one pass,                  4652862
 silesia.tar,                        level 5,                            advanced one pass,                  4649987
@@ -284,25 +284,25 @@ silesia.tar,                        level 12 row 2,                     advanced
 silesia.tar,                        level 13,                           advanced one pass,                  4502956
 silesia.tar,                        level 16,                           advanced one pass,                  4360527
 silesia.tar,                        level 19,                           advanced one pass,                  4267266
-silesia.tar,                        no source size,                     advanced one pass,                  4861424
-silesia.tar,                        long distance mode,                 advanced one pass,                  4847752
-silesia.tar,                        multithreaded,                      advanced one pass,                  4861508
-silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4853221
-silesia.tar,                        small window log,                   advanced one pass,                  7101530
+silesia.tar,                        no source size,                     advanced one pass,                  4854086
+silesia.tar,                        long distance mode,                 advanced one pass,                  4840452
+silesia.tar,                        multithreaded,                      advanced one pass,                  4854160
+silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4845741
+silesia.tar,                        small window log,                   advanced one pass,                  7100655
 silesia.tar,                        small hash log,                     advanced one pass,                  6529231
 silesia.tar,                        small chain log,                    advanced one pass,                  4917041
 silesia.tar,                        explicit params,                    advanced one pass,                  4806855
-silesia.tar,                        uncompressed literals,              advanced one pass,                  5129458
+silesia.tar,                        uncompressed literals,              advanced one pass,                  5122473
 silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4310141
 silesia.tar,                        huffman literals,                   advanced one pass,                  5344545
-silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5129555
+silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5122567
 github,                             level -5,                           advanced one pass,                  232315
 github,                             level -5 with dict,                 advanced one pass,                  46718
 github,                             level -3,                           advanced one pass,                  220760
 github,                             level -3 with dict,                 advanced one pass,                  45395
 github,                             level -1,                           advanced one pass,                  175468
 github,                             level -1 with dict,                 advanced one pass,                  43170
-github,                             level 0,                            advanced one pass,                  136335
+github,                             level 0,                            advanced one pass,                  136332
 github,                             level 0 with dict,                  advanced one pass,                  41148
 github,                             level 0 with dict dms,              advanced one pass,                  41148
 github,                             level 0 with dict dds,              advanced one pass,                  41148
@@ -314,7 +314,7 @@ github,                             level 1 with dict dms,              advanced
 github,                             level 1 with dict dds,              advanced one pass,                  41682
 github,                             level 1 with dict copy,             advanced one pass,                  41674
 github,                             level 1 with dict load,             advanced one pass,                  43755
-github,                             level 3,                            advanced one pass,                  136335
+github,                             level 3,                            advanced one pass,                  136332
 github,                             level 3 with dict,                  advanced one pass,                  41148
 github,                             level 3 with dict dms,              advanced one pass,                  41148
 github,                             level 3 with dict dds,              advanced one pass,                  41148
@@ -408,26 +408,26 @@ github,                             level 19 with dict dms,             advanced
 github,                             level 19 with dict dds,             advanced one pass,                  37576
 github,                             level 19 with dict copy,            advanced one pass,                  37567
 github,                             level 19 with dict load,            advanced one pass,                  39613
-github,                             no source size,                     advanced one pass,                  136335
+github,                             no source size,                     advanced one pass,                  136332
 github,                             no source size with dict,           advanced one pass,                  41148
-github,                             long distance mode,                 advanced one pass,                  136335
-github,                             multithreaded,                      advanced one pass,                  136335
-github,                             multithreaded long distance mode,   advanced one pass,                  136335
-github,                             small window log,                   advanced one pass,                  136335
+github,                             long distance mode,                 advanced one pass,                  136332
+github,                             multithreaded,                      advanced one pass,                  136332
+github,                             multithreaded long distance mode,   advanced one pass,                  136332
+github,                             small window log,                   advanced one pass,                  136332
 github,                             small hash log,                     advanced one pass,                  135590
 github,                             small chain log,                    advanced one pass,                  136341
 github,                             explicit params,                    advanced one pass,                  137727
-github,                             uncompressed literals,              advanced one pass,                  165915
+github,                             uncompressed literals,              advanced one pass,                  165911
 github,                             uncompressed literals optimal,      advanced one pass,                  157227
 github,                             huffman literals,                   advanced one pass,                  142365
-github,                             multithreaded with advanced params, advanced one pass,                  165915
+github,                             multithreaded with advanced params, advanced one pass,                  165911
 github.tar,                         level -5,                           advanced one pass,                  66914
 github.tar,                         level -5 with dict,                 advanced one pass,                  51525
 github.tar,                         level -3,                           advanced one pass,                  52127
 github.tar,                         level -3 with dict,                 advanced one pass,                  44242
 github.tar,                         level -1,                           advanced one pass,                  42560
 github.tar,                         level -1 with dict,                 advanced one pass,                  41136
-github.tar,                         level 0,                            advanced one pass,                  38441
+github.tar,                         level 0,                            advanced one pass,                  38831
 github.tar,                         level 0 with dict,                  advanced one pass,                  37995
 github.tar,                         level 0 with dict dms,              advanced one pass,                  38003
 github.tar,                         level 0 with dict dds,              advanced one pass,                  38003
@@ -439,13 +439,13 @@ github.tar,                         level 1 with dict dms,              advanced
 github.tar,                         level 1 with dict dds,              advanced one pass,                  38294
 github.tar,                         level 1 with dict copy,             advanced one pass,                  38284
 github.tar,                         level 1 with dict load,             advanced one pass,                  38724
-github.tar,                         level 3,                            advanced one pass,                  38441
+github.tar,                         level 3,                            advanced one pass,                  38831
 github.tar,                         level 3 with dict,                  advanced one pass,                  37995
 github.tar,                         level 3 with dict dms,              advanced one pass,                  38003
 github.tar,                         level 3 with dict dds,              advanced one pass,                  38003
 github.tar,                         level 3 with dict copy,             advanced one pass,                  37995
 github.tar,                         level 3 with dict load,             advanced one pass,                  37956
-github.tar,                         level 4,                            advanced one pass,                  38467
+github.tar,                         level 4,                            advanced one pass,                  38893
 github.tar,                         level 4 with dict,                  advanced one pass,                  37948
 github.tar,                         level 4 with dict dms,              advanced one pass,                  37954
 github.tar,                         level 4 with dict dds,              advanced one pass,                  37954
@@ -533,26 +533,26 @@ github.tar,                         level 19 with dict dms,             advanced
 github.tar,                         level 19 with dict dds,             advanced one pass,                  32553
 github.tar,                         level 19 with dict copy,            advanced one pass,                  32709
 github.tar,                         level 19 with dict load,            advanced one pass,                  32474
-github.tar,                         no source size,                     advanced one pass,                  38441
+github.tar,                         no source size,                     advanced one pass,                  38831
 github.tar,                         no source size with dict,           advanced one pass,                  37995
-github.tar,                         long distance mode,                 advanced one pass,                  39757
-github.tar,                         multithreaded,                      advanced one pass,                  38441
-github.tar,                         multithreaded long distance mode,   advanced one pass,                  39726
+github.tar,                         long distance mode,                 advanced one pass,                  40252
+github.tar,                         multithreaded,                      advanced one pass,                  38831
+github.tar,                         multithreaded long distance mode,   advanced one pass,                  40232
 github.tar,                         small window log,                   advanced one pass,                  198540
 github.tar,                         small hash log,                     advanced one pass,                  129870
 github.tar,                         small chain log,                    advanced one pass,                  41669
 github.tar,                         explicit params,                    advanced one pass,                  41385
-github.tar,                         uncompressed literals,              advanced one pass,                  41122
+github.tar,                         uncompressed literals,              advanced one pass,                  41525
 github.tar,                         uncompressed literals optimal,      advanced one pass,                  35397
 github.tar,                         huffman literals,                   advanced one pass,                  38853
-github.tar,                         multithreaded with advanced params, advanced one pass,                  41122
+github.tar,                         multithreaded with advanced params, advanced one pass,                  41525
 silesia,                            level -5,                           advanced one pass small out,        7354675
 silesia,                            level -3,                           advanced one pass small out,        6902374
 silesia,                            level -1,                           advanced one pass small out,        6177565
-silesia,                            level 0,                            advanced one pass small out,        4849553
+silesia,                            level 0,                            advanced one pass small out,        4842075
 silesia,                            level 1,                            advanced one pass small out,        5309098
-silesia,                            level 3,                            advanced one pass small out,        4849553
-silesia,                            level 4,                            advanced one pass small out,        4786968
+silesia,                            level 3,                            advanced one pass small out,        4842075
+silesia,                            level 4,                            advanced one pass small out,        4779186
 silesia,                            level 5 row 1,                      advanced one pass small out,        4638691
 silesia,                            level 5 row 2,                      advanced one pass small out,        4640752
 silesia,                            level 5,                            advanced one pass small out,        4638691
@@ -568,25 +568,25 @@ silesia,                            level 12 row 2,                     advanced
 silesia,                            level 13,                           advanced one pass small out,        4493990
 silesia,                            level 16,                           advanced one pass small out,        4359864
 silesia,                            level 19,                           advanced one pass small out,        4296880
-silesia,                            no source size,                     advanced one pass small out,        4849553
-silesia,                            long distance mode,                 advanced one pass small out,        4840737
-silesia,                            multithreaded,                      advanced one pass small out,        4849553
-silesia,                            multithreaded long distance mode,   advanced one pass small out,        4840759
-silesia,                            small window log,                   advanced one pass small out,        7095919
+silesia,                            no source size,                     advanced one pass small out,        4842075
+silesia,                            long distance mode,                 advanced one pass small out,        4833710
+silesia,                            multithreaded,                      advanced one pass small out,        4842075
+silesia,                            multithreaded long distance mode,   advanced one pass small out,        4833737
+silesia,                            small window log,                   advanced one pass small out,        7095000
 silesia,                            small hash log,                     advanced one pass small out,        6526141
 silesia,                            small chain log,                    advanced one pass small out,        4912197
 silesia,                            explicit params,                    advanced one pass small out,        4795432
-silesia,                            uncompressed literals,              advanced one pass small out,        5127982
+silesia,                            uncompressed literals,              advanced one pass small out,        5120566
 silesia,                            uncompressed literals optimal,      advanced one pass small out,        4319518
 silesia,                            huffman literals,                   advanced one pass small out,        5326346
-silesia,                            multithreaded with advanced params, advanced one pass small out,        5127982
+silesia,                            multithreaded with advanced params, advanced one pass small out,        5120566
 silesia.tar,                        level -5,                           advanced one pass small out,        7359401
 silesia.tar,                        level -3,                           advanced one pass small out,        6901672
 silesia.tar,                        level -1,                           advanced one pass small out,        6182241
-silesia.tar,                        level 0,                            advanced one pass small out,        4861424
+silesia.tar,                        level 0,                            advanced one pass small out,        4854086
 silesia.tar,                        level 1,                            advanced one pass small out,        5331946
-silesia.tar,                        level 3,                            advanced one pass small out,        4861424
-silesia.tar,                        level 4,                            advanced one pass small out,        4799632
+silesia.tar,                        level 3,                            advanced one pass small out,        4854086
+silesia.tar,                        level 4,                            advanced one pass small out,        4791503
 silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4649987
 silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4652862
 silesia.tar,                        level 5,                            advanced one pass small out,        4649987
@@ -602,25 +602,25 @@ silesia.tar,                        level 12 row 2,                     advanced
 silesia.tar,                        level 13,                           advanced one pass small out,        4502956
 silesia.tar,                        level 16,                           advanced one pass small out,        4360527
 silesia.tar,                        level 19,                           advanced one pass small out,        4267266
-silesia.tar,                        no source size,                     advanced one pass small out,        4861424
-silesia.tar,                        long distance mode,                 advanced one pass small out,        4847752
-silesia.tar,                        multithreaded,                      advanced one pass small out,        4861508
-silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4853221
-silesia.tar,                        small window log,                   advanced one pass small out,        7101530
+silesia.tar,                        no source size,                     advanced one pass small out,        4854086
+silesia.tar,                        long distance mode,                 advanced one pass small out,        4840452
+silesia.tar,                        multithreaded,                      advanced one pass small out,        4854160
+silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4845741
+silesia.tar,                        small window log,                   advanced one pass small out,        7100655
 silesia.tar,                        small hash log,                     advanced one pass small out,        6529231
 silesia.tar,                        small chain log,                    advanced one pass small out,        4917041
 silesia.tar,                        explicit params,                    advanced one pass small out,        4806855
-silesia.tar,                        uncompressed literals,              advanced one pass small out,        5129458
+silesia.tar,                        uncompressed literals,              advanced one pass small out,        5122473
 silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4310141
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5344545
-silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5129555
+silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5122567
 github,                             level -5,                           advanced one pass small out,        232315
 github,                             level -5 with dict,                 advanced one pass small out,        46718
 github,                             level -3,                           advanced one pass small out,        220760
 github,                             level -3 with dict,                 advanced one pass small out,        45395
 github,                             level -1,                           advanced one pass small out,        175468
 github,                             level -1 with dict,                 advanced one pass small out,        43170
-github,                             level 0,                            advanced one pass small out,        136335
+github,                             level 0,                            advanced one pass small out,        136332
 github,                             level 0 with dict,                  advanced one pass small out,        41148
 github,                             level 0 with dict dms,              advanced one pass small out,        41148
 github,                             level 0 with dict dds,              advanced one pass small out,        41148
@@ -632,7 +632,7 @@ github,                             level 1 with dict dms,              advanced
 github,                             level 1 with dict dds,              advanced one pass small out,        41682
 github,                             level 1 with dict copy,             advanced one pass small out,        41674
 github,                             level 1 with dict load,             advanced one pass small out,        43755
-github,                             level 3,                            advanced one pass small out,        136335
+github,                             level 3,                            advanced one pass small out,        136332
 github,                             level 3 with dict,                  advanced one pass small out,        41148
 github,                             level 3 with dict dms,              advanced one pass small out,        41148
 github,                             level 3 with dict dds,              advanced one pass small out,        41148
@@ -726,26 +726,26 @@ github,                             level 19 with dict dms,             advanced
 github,                             level 19 with dict dds,             advanced one pass small out,        37576
 github,                             level 19 with dict copy,            advanced one pass small out,        37567
 github,                             level 19 with dict load,            advanced one pass small out,        39613
-github,                             no source size,                     advanced one pass small out,        136335
+github,                             no source size,                     advanced one pass small out,        136332
 github,                             no source size with dict,           advanced one pass small out,        41148
-github,                             long distance mode,                 advanced one pass small out,        136335
-github,                             multithreaded,                      advanced one pass small out,        136335
-github,                             multithreaded long distance mode,   advanced one pass small out,        136335
-github,                             small window log,                   advanced one pass small out,        136335
+github,                             long distance mode,                 advanced one pass small out,        136332
+github,                             multithreaded,                      advanced one pass small out,        136332
+github,                             multithreaded long distance mode,   advanced one pass small out,        136332
+github,                             small window log,                   advanced one pass small out,        136332
 github,                             small hash log,                     advanced one pass small out,        135590
 github,                             small chain log,                    advanced one pass small out,        136341
 github,                             explicit params,                    advanced one pass small out,        137727
-github,                             uncompressed literals,              advanced one pass small out,        165915
+github,                             uncompressed literals,              advanced one pass small out,        165911
 github,                             uncompressed literals optimal,      advanced one pass small out,        157227
 github,                             huffman literals,                   advanced one pass small out,        142365
-github,                             multithreaded with advanced params, advanced one pass small out,        165915
+github,                             multithreaded with advanced params, advanced one pass small out,        165911
 github.tar,                         level -5,                           advanced one pass small out,        66914
 github.tar,                         level -5 with dict,                 advanced one pass small out,        51525
 github.tar,                         level -3,                           advanced one pass small out,        52127
 github.tar,                         level -3 with dict,                 advanced one pass small out,        44242
 github.tar,                         level -1,                           advanced one pass small out,        42560
 github.tar,                         level -1 with dict,                 advanced one pass small out,        41136
-github.tar,                         level 0,                            advanced one pass small out,        38441
+github.tar,                         level 0,                            advanced one pass small out,        38831
 github.tar,                         level 0 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 0 with dict dms,              advanced one pass small out,        38003
 github.tar,                         level 0 with dict dds,              advanced one pass small out,        38003
@@ -757,13 +757,13 @@ github.tar,                         level 1 with dict dms,              advanced
 github.tar,                         level 1 with dict dds,              advanced one pass small out,        38294
 github.tar,                         level 1 with dict copy,             advanced one pass small out,        38284
 github.tar,                         level 1 with dict load,             advanced one pass small out,        38724
-github.tar,                         level 3,                            advanced one pass small out,        38441
+github.tar,                         level 3,                            advanced one pass small out,        38831
 github.tar,                         level 3 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 3 with dict dms,              advanced one pass small out,        38003
 github.tar,                         level 3 with dict dds,              advanced one pass small out,        38003
 github.tar,                         level 3 with dict copy,             advanced one pass small out,        37995
 github.tar,                         level 3 with dict load,             advanced one pass small out,        37956
-github.tar,                         level 4,                            advanced one pass small out,        38467
+github.tar,                         level 4,                            advanced one pass small out,        38893
 github.tar,                         level 4 with dict,                  advanced one pass small out,        37948
 github.tar,                         level 4 with dict dms,              advanced one pass small out,        37954
 github.tar,                         level 4 with dict dds,              advanced one pass small out,        37954
@@ -851,26 +851,26 @@ github.tar,                         level 19 with dict dms,             advanced
 github.tar,                         level 19 with dict dds,             advanced one pass small out,        32553
 github.tar,                         level 19 with dict copy,            advanced one pass small out,        32709
 github.tar,                         level 19 with dict load,            advanced one pass small out,        32474
-github.tar,                         no source size,                     advanced one pass small out,        38441
+github.tar,                         no source size,                     advanced one pass small out,        38831
 github.tar,                         no source size with dict,           advanced one pass small out,        37995
-github.tar,                         long distance mode,                 advanced one pass small out,        39757
-github.tar,                         multithreaded,                      advanced one pass small out,        38441
-github.tar,                         multithreaded long distance mode,   advanced one pass small out,        39726
+github.tar,                         long distance mode,                 advanced one pass small out,        40252
+github.tar,                         multithreaded,                      advanced one pass small out,        38831
+github.tar,                         multithreaded long distance mode,   advanced one pass small out,        40232
 github.tar,                         small window log,                   advanced one pass small out,        198540
 github.tar,                         small hash log,                     advanced one pass small out,        129870
 github.tar,                         small chain log,                    advanced one pass small out,        41669
 github.tar,                         explicit params,                    advanced one pass small out,        41385
-github.tar,                         uncompressed literals,              advanced one pass small out,        41122
+github.tar,                         uncompressed literals,              advanced one pass small out,        41525
 github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35397
 github.tar,                         huffman literals,                   advanced one pass small out,        38853
-github.tar,                         multithreaded with advanced params, advanced one pass small out,        41122
+github.tar,                         multithreaded with advanced params, advanced one pass small out,        41525
 silesia,                            level -5,                           advanced streaming,                 7292053
 silesia,                            level -3,                           advanced streaming,                 6867875
 silesia,                            level -1,                           advanced streaming,                 6183923
-silesia,                            level 0,                            advanced streaming,                 4849553
+silesia,                            level 0,                            advanced streaming,                 4842075
 silesia,                            level 1,                            advanced streaming,                 5312694
-silesia,                            level 3,                            advanced streaming,                 4849553
-silesia,                            level 4,                            advanced streaming,                 4786968
+silesia,                            level 3,                            advanced streaming,                 4842075
+silesia,                            level 4,                            advanced streaming,                 4779186
 silesia,                            level 5 row 1,                      advanced streaming,                 4638691
 silesia,                            level 5 row 2,                      advanced streaming,                 4640752
 silesia,                            level 5,                            advanced streaming,                 4638691
@@ -886,25 +886,25 @@ silesia,                            level 12 row 2,                     advanced
 silesia,                            level 13,                           advanced streaming,                 4493990
 silesia,                            level 16,                           advanced streaming,                 4359864
 silesia,                            level 19,                           advanced streaming,                 4296880
-silesia,                            no source size,                     advanced streaming,                 4849517
-silesia,                            long distance mode,                 advanced streaming,                 4840737
-silesia,                            multithreaded,                      advanced streaming,                 4849553
-silesia,                            multithreaded long distance mode,   advanced streaming,                 4840759
-silesia,                            small window log,                   advanced streaming,                 7112062
+silesia,                            no source size,                     advanced streaming,                 4842039
+silesia,                            long distance mode,                 advanced streaming,                 4833710
+silesia,                            multithreaded,                      advanced streaming,                 4842075
+silesia,                            multithreaded long distance mode,   advanced streaming,                 4833737
+silesia,                            small window log,                   advanced streaming,                 7111103
 silesia,                            small hash log,                     advanced streaming,                 6526141
 silesia,                            small chain log,                    advanced streaming,                 4912197
 silesia,                            explicit params,                    advanced streaming,                 4795452
-silesia,                            uncompressed literals,              advanced streaming,                 5127982
+silesia,                            uncompressed literals,              advanced streaming,                 5120566
 silesia,                            uncompressed literals optimal,      advanced streaming,                 4319518
 silesia,                            huffman literals,                   advanced streaming,                 5332234
-silesia,                            multithreaded with advanced params, advanced streaming,                 5127982
+silesia,                            multithreaded with advanced params, advanced streaming,                 5120566
 silesia.tar,                        level -5,                           advanced streaming,                 7260007
 silesia.tar,                        level -3,                           advanced streaming,                 6845151
 silesia.tar,                        level -1,                           advanced streaming,                 6187938
-silesia.tar,                        level 0,                            advanced streaming,                 4861426
+silesia.tar,                        level 0,                            advanced streaming,                 4859271
 silesia.tar,                        level 1,                            advanced streaming,                 5334890
-silesia.tar,                        level 3,                            advanced streaming,                 4861426
-silesia.tar,                        level 4,                            advanced streaming,                 4799632
+silesia.tar,                        level 3,                            advanced streaming,                 4859271
+silesia.tar,                        level 4,                            advanced streaming,                 4797470
 silesia.tar,                        level 5 row 1,                      advanced streaming,                 4649992
 silesia.tar,                        level 5 row 2,                      advanced streaming,                 4652866
 silesia.tar,                        level 5,                            advanced streaming,                 4649992
@@ -920,25 +920,25 @@ silesia.tar,                        level 12 row 2,                     advanced
 silesia.tar,                        level 13,                           advanced streaming,                 4502956
 silesia.tar,                        level 16,                           advanced streaming,                 4360527
 silesia.tar,                        level 19,                           advanced streaming,                 4267266
-silesia.tar,                        no source size,                     advanced streaming,                 4861422
-silesia.tar,                        long distance mode,                 advanced streaming,                 4847752
-silesia.tar,                        multithreaded,                      advanced streaming,                 4861508
-silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4853221
-silesia.tar,                        small window log,                   advanced streaming,                 7118769
+silesia.tar,                        no source size,                     advanced streaming,                 4859267
+silesia.tar,                        long distance mode,                 advanced streaming,                 4840452
+silesia.tar,                        multithreaded,                      advanced streaming,                 4854160
+silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4845741
+silesia.tar,                        small window log,                   advanced streaming,                 7117559
 silesia.tar,                        small hash log,                     advanced streaming,                 6529234
 silesia.tar,                        small chain log,                    advanced streaming,                 4917021
 silesia.tar,                        explicit params,                    advanced streaming,                 4806873
-silesia.tar,                        uncompressed literals,              advanced streaming,                 5129461
+silesia.tar,                        uncompressed literals,              advanced streaming,                 5127423
 silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4310141
 silesia.tar,                        huffman literals,                   advanced streaming,                 5350519
-silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5129555
+silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5122567
 github,                             level -5,                           advanced streaming,                 232315
 github,                             level -5 with dict,                 advanced streaming,                 46718
 github,                             level -3,                           advanced streaming,                 220760
 github,                             level -3 with dict,                 advanced streaming,                 45395
 github,                             level -1,                           advanced streaming,                 175468
 github,                             level -1 with dict,                 advanced streaming,                 43170
-github,                             level 0,                            advanced streaming,                 136335
+github,                             level 0,                            advanced streaming,                 136332
 github,                             level 0 with dict,                  advanced streaming,                 41148
 github,                             level 0 with dict dms,              advanced streaming,                 41148
 github,                             level 0 with dict dds,              advanced streaming,                 41148
@@ -950,7 +950,7 @@ github,                             level 1 with dict dms,              advanced
 github,                             level 1 with dict dds,              advanced streaming,                 41682
 github,                             level 1 with dict copy,             advanced streaming,                 41674
 github,                             level 1 with dict load,             advanced streaming,                 43755
-github,                             level 3,                            advanced streaming,                 136335
+github,                             level 3,                            advanced streaming,                 136332
 github,                             level 3 with dict,                  advanced streaming,                 41148
 github,                             level 3 with dict dms,              advanced streaming,                 41148
 github,                             level 3 with dict dds,              advanced streaming,                 41148
@@ -1044,26 +1044,26 @@ github,                             level 19 with dict dms,             advanced
 github,                             level 19 with dict dds,             advanced streaming,                 37576
 github,                             level 19 with dict copy,            advanced streaming,                 37567
 github,                             level 19 with dict load,            advanced streaming,                 39613
-github,                             no source size,                     advanced streaming,                 136335
+github,                             no source size,                     advanced streaming,                 136332
 github,                             no source size with dict,           advanced streaming,                 41148
-github,                             long distance mode,                 advanced streaming,                 136335
-github,                             multithreaded,                      advanced streaming,                 136335
-github,                             multithreaded long distance mode,   advanced streaming,                 136335
-github,                             small window log,                   advanced streaming,                 136335
+github,                             long distance mode,                 advanced streaming,                 136332
+github,                             multithreaded,                      advanced streaming,                 136332
+github,                             multithreaded long distance mode,   advanced streaming,                 136332
+github,                             small window log,                   advanced streaming,                 136332
 github,                             small hash log,                     advanced streaming,                 135590
 github,                             small chain log,                    advanced streaming,                 136341
 github,                             explicit params,                    advanced streaming,                 137727
-github,                             uncompressed literals,              advanced streaming,                 165915
+github,                             uncompressed literals,              advanced streaming,                 165911
 github,                             uncompressed literals optimal,      advanced streaming,                 157227
 github,                             huffman literals,                   advanced streaming,                 142365
-github,                             multithreaded with advanced params, advanced streaming,                 165915
+github,                             multithreaded with advanced params, advanced streaming,                 165911
 github.tar,                         level -5,                           advanced streaming,                 64132
 github.tar,                         level -5 with dict,                 advanced streaming,                 48642
 github.tar,                         level -3,                           advanced streaming,                 50964
 github.tar,                         level -3 with dict,                 advanced streaming,                 42750
 github.tar,                         level -1,                           advanced streaming,                 42536
 github.tar,                         level -1 with dict,                 advanced streaming,                 41198
-github.tar,                         level 0,                            advanced streaming,                 38441
+github.tar,                         level 0,                            advanced streaming,                 38831
 github.tar,                         level 0 with dict,                  advanced streaming,                 37995
 github.tar,                         level 0 with dict dms,              advanced streaming,                 38003
 github.tar,                         level 0 with dict dds,              advanced streaming,                 38003
@@ -1075,13 +1075,13 @@ github.tar,                         level 1 with dict dms,              advanced
 github.tar,                         level 1 with dict dds,              advanced streaming,                 38326
 github.tar,                         level 1 with dict copy,             advanced streaming,                 38316
 github.tar,                         level 1 with dict load,             advanced streaming,                 38761
-github.tar,                         level 3,                            advanced streaming,                 38441
+github.tar,                         level 3,                            advanced streaming,                 38831
 github.tar,                         level 3 with dict,                  advanced streaming,                 37995
 github.tar,                         level 3 with dict dms,              advanced streaming,                 38003
 github.tar,                         level 3 with dict dds,              advanced streaming,                 38003
 github.tar,                         level 3 with dict copy,             advanced streaming,                 37995
 github.tar,                         level 3 with dict load,             advanced streaming,                 37956
-github.tar,                         level 4,                            advanced streaming,                 38467
+github.tar,                         level 4,                            advanced streaming,                 38893
 github.tar,                         level 4 with dict,                  advanced streaming,                 37948
 github.tar,                         level 4 with dict dms,              advanced streaming,                 37954
 github.tar,                         level 4 with dict dds,              advanced streaming,                 37954
@@ -1169,26 +1169,26 @@ github.tar,                         level 19 with dict dms,             advanced
 github.tar,                         level 19 with dict dds,             advanced streaming,                 32553
 github.tar,                         level 19 with dict copy,            advanced streaming,                 32709
 github.tar,                         level 19 with dict load,            advanced streaming,                 32474
-github.tar,                         no source size,                     advanced streaming,                 38438
+github.tar,                         no source size,                     advanced streaming,                 38828
 github.tar,                         no source size with dict,           advanced streaming,                 38000
-github.tar,                         long distance mode,                 advanced streaming,                 39757
-github.tar,                         multithreaded,                      advanced streaming,                 38441
-github.tar,                         multithreaded long distance mode,   advanced streaming,                 39726
+github.tar,                         long distance mode,                 advanced streaming,                 40252
+github.tar,                         multithreaded,                      advanced streaming,                 38831
+github.tar,                         multithreaded long distance mode,   advanced streaming,                 40232
 github.tar,                         small window log,                   advanced streaming,                 199558
 github.tar,                         small hash log,                     advanced streaming,                 129870
 github.tar,                         small chain log,                    advanced streaming,                 41669
 github.tar,                         explicit params,                    advanced streaming,                 41385
-github.tar,                         uncompressed literals,              advanced streaming,                 41122
+github.tar,                         uncompressed literals,              advanced streaming,                 41525
 github.tar,                         uncompressed literals optimal,      advanced streaming,                 35397
 github.tar,                         huffman literals,                   advanced streaming,                 38874
-github.tar,                         multithreaded with advanced params, advanced streaming,                 41122
+github.tar,                         multithreaded with advanced params, advanced streaming,                 41525
 silesia,                            level -5,                           old streaming,                      7292053
 silesia,                            level -3,                           old streaming,                      6867875
 silesia,                            level -1,                           old streaming,                      6183923
-silesia,                            level 0,                            old streaming,                      4849553
+silesia,                            level 0,                            old streaming,                      4842075
 silesia,                            level 1,                            old streaming,                      5312694
-silesia,                            level 3,                            old streaming,                      4849553
-silesia,                            level 4,                            old streaming,                      4786968
+silesia,                            level 3,                            old streaming,                      4842075
+silesia,                            level 4,                            old streaming,                      4779186
 silesia,                            level 5,                            old streaming,                      4638691
 silesia,                            level 6,                            old streaming,                      4605296
 silesia,                            level 7,                            old streaming,                      4566984
@@ -1196,17 +1196,17 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming,                      4493990
 silesia,                            level 16,                           old streaming,                      4359864
 silesia,                            level 19,                           old streaming,                      4296880
-silesia,                            no source size,                     old streaming,                      4849517
-silesia,                            uncompressed literals,              old streaming,                      4849553
+silesia,                            no source size,                     old streaming,                      4842039
+silesia,                            uncompressed literals,              old streaming,                      4842075
 silesia,                            uncompressed literals optimal,      old streaming,                      4296880
 silesia,                            huffman literals,                   old streaming,                      6183923
 silesia.tar,                        level -5,                           old streaming,                      7260007
 silesia.tar,                        level -3,                           old streaming,                      6845151
 silesia.tar,                        level -1,                           old streaming,                      6187938
-silesia.tar,                        level 0,                            old streaming,                      4861426
+silesia.tar,                        level 0,                            old streaming,                      4859271
 silesia.tar,                        level 1,                            old streaming,                      5334890
-silesia.tar,                        level 3,                            old streaming,                      4861426
-silesia.tar,                        level 4,                            old streaming,                      4799632
+silesia.tar,                        level 3,                            old streaming,                      4859271
+silesia.tar,                        level 4,                            old streaming,                      4797470
 silesia.tar,                        level 5,                            old streaming,                      4649992
 silesia.tar,                        level 6,                            old streaming,                      4616803
 silesia.tar,                        level 7,                            old streaming,                      4576664
@@ -1214,8 +1214,8 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming,                      4502956
 silesia.tar,                        level 16,                           old streaming,                      4360527
 silesia.tar,                        level 19,                           old streaming,                      4267266
-silesia.tar,                        no source size,                     old streaming,                      4861422
-silesia.tar,                        uncompressed literals,              old streaming,                      4861426
+silesia.tar,                        no source size,                     old streaming,                      4859267
+silesia.tar,                        uncompressed literals,              old streaming,                      4859271
 silesia.tar,                        uncompressed literals optimal,      old streaming,                      4267266
 silesia.tar,                        huffman literals,                   old streaming,                      6187938
 github,                             level -5,                           old streaming,                      232315
@@ -1224,11 +1224,11 @@ github,                             level -3,                           old stre
 github,                             level -3 with dict,                 old streaming,                      45395
 github,                             level -1,                           old streaming,                      175468
 github,                             level -1 with dict,                 old streaming,                      43170
-github,                             level 0,                            old streaming,                      136335
+github,                             level 0,                            old streaming,                      136332
 github,                             level 0 with dict,                  old streaming,                      41148
 github,                             level 1,                            old streaming,                      142365
 github,                             level 1 with dict,                  old streaming,                      41682
-github,                             level 3,                            old streaming,                      136335
+github,                             level 3,                            old streaming,                      136332
 github,                             level 3 with dict,                  old streaming,                      41148
 github,                             level 4,                            old streaming,                      136199
 github,                             level 4 with dict,                  old streaming,                      41251
@@ -1246,9 +1246,9 @@ github,                             level 16,                           old stre
 github,                             level 16 with dict,                 old streaming,                      37577
 github,                             level 19,                           old streaming,                      134064
 github,                             level 19 with dict,                 old streaming,                      37576
-github,                             no source size,                     old streaming,                      140632
+github,                             no source size,                     old streaming,                      140599
 github,                             no source size with dict,           old streaming,                      40654
-github,                             uncompressed literals,              old streaming,                      136335
+github,                             uncompressed literals,              old streaming,                      136332
 github,                             uncompressed literals optimal,      old streaming,                      134064
 github,                             huffman literals,                   old streaming,                      175468
 github.tar,                         level -5,                           old streaming,                      64132
@@ -1257,13 +1257,13 @@ github.tar,                         level -3,                           old stre
 github.tar,                         level -3 with dict,                 old streaming,                      42750
 github.tar,                         level -1,                           old streaming,                      42536
 github.tar,                         level -1 with dict,                 old streaming,                      41198
-github.tar,                         level 0,                            old streaming,                      38441
+github.tar,                         level 0,                            old streaming,                      38831
 github.tar,                         level 0 with dict,                  old streaming,                      37995
 github.tar,                         level 1,                            old streaming,                      39270
 github.tar,                         level 1 with dict,                  old streaming,                      38316
-github.tar,                         level 3,                            old streaming,                      38441
+github.tar,                         level 3,                            old streaming,                      38831
 github.tar,                         level 3 with dict,                  old streaming,                      37995
-github.tar,                         level 4,                            old streaming,                      38467
+github.tar,                         level 4,                            old streaming,                      38893
 github.tar,                         level 4 with dict,                  old streaming,                      37948
 github.tar,                         level 5,                            old streaming,                      38366
 github.tar,                         level 5 with dict,                  old streaming,                      39082
@@ -1279,18 +1279,18 @@ github.tar,                         level 16,                           old stre
 github.tar,                         level 16 with dict,                 old streaming,                      33378
 github.tar,                         level 19,                           old streaming,                      32134
 github.tar,                         level 19 with dict,                 old streaming,                      32709
-github.tar,                         no source size,                     old streaming,                      38438
+github.tar,                         no source size,                     old streaming,                      38828
 github.tar,                         no source size with dict,           old streaming,                      38000
-github.tar,                         uncompressed literals,              old streaming,                      38441
+github.tar,                         uncompressed literals,              old streaming,                      38831
 github.tar,                         uncompressed literals optimal,      old streaming,                      32134
 github.tar,                         huffman literals,                   old streaming,                      42536
 silesia,                            level -5,                           old streaming advanced,             7292053
 silesia,                            level -3,                           old streaming advanced,             6867875
 silesia,                            level -1,                           old streaming advanced,             6183923
-silesia,                            level 0,                            old streaming advanced,             4849553
+silesia,                            level 0,                            old streaming advanced,             4842075
 silesia,                            level 1,                            old streaming advanced,             5312694
-silesia,                            level 3,                            old streaming advanced,             4849553
-silesia,                            level 4,                            old streaming advanced,             4786968
+silesia,                            level 3,                            old streaming advanced,             4842075
+silesia,                            level 4,                            old streaming advanced,             4779186
 silesia,                            level 5,                            old streaming advanced,             4638691
 silesia,                            level 6,                            old streaming advanced,             4605296
 silesia,                            level 7,                            old streaming advanced,             4566984
@@ -1298,25 +1298,25 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming advanced,             4493990
 silesia,                            level 16,                           old streaming advanced,             4359864
 silesia,                            level 19,                           old streaming advanced,             4296880
-silesia,                            no source size,                     old streaming advanced,             4849517
-silesia,                            long distance mode,                 old streaming advanced,             4849553
-silesia,                            multithreaded,                      old streaming advanced,             4849553
-silesia,                            multithreaded long distance mode,   old streaming advanced,             4849553
-silesia,                            small window log,                   old streaming advanced,             7112062
+silesia,                            no source size,                     old streaming advanced,             4842039
+silesia,                            long distance mode,                 old streaming advanced,             4842075
+silesia,                            multithreaded,                      old streaming advanced,             4842075
+silesia,                            multithreaded long distance mode,   old streaming advanced,             4842075
+silesia,                            small window log,                   old streaming advanced,             7111103
 silesia,                            small hash log,                     old streaming advanced,             6526141
 silesia,                            small chain log,                    old streaming advanced,             4912197
 silesia,                            explicit params,                    old streaming advanced,             4795452
-silesia,                            uncompressed literals,              old streaming advanced,             4849553
+silesia,                            uncompressed literals,              old streaming advanced,             4842075
 silesia,                            uncompressed literals optimal,      old streaming advanced,             4296880
 silesia,                            huffman literals,                   old streaming advanced,             6183923
-silesia,                            multithreaded with advanced params, old streaming advanced,             4849553
+silesia,                            multithreaded with advanced params, old streaming advanced,             4842075
 silesia.tar,                        level -5,                           old streaming advanced,             7260007
 silesia.tar,                        level -3,                           old streaming advanced,             6845151
 silesia.tar,                        level -1,                           old streaming advanced,             6187938
-silesia.tar,                        level 0,                            old streaming advanced,             4861426
+silesia.tar,                        level 0,                            old streaming advanced,             4859271
 silesia.tar,                        level 1,                            old streaming advanced,             5334890
-silesia.tar,                        level 3,                            old streaming advanced,             4861426
-silesia.tar,                        level 4,                            old streaming advanced,             4799632
+silesia.tar,                        level 3,                            old streaming advanced,             4859271
+silesia.tar,                        level 4,                            old streaming advanced,             4797470
 silesia.tar,                        level 5,                            old streaming advanced,             4649992
 silesia.tar,                        level 6,                            old streaming advanced,             4616803
 silesia.tar,                        level 7,                            old streaming advanced,             4576664
@@ -1324,18 +1324,18 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming advanced,             4502956
 silesia.tar,                        level 16,                           old streaming advanced,             4360527
 silesia.tar,                        level 19,                           old streaming advanced,             4267266
-silesia.tar,                        no source size,                     old streaming advanced,             4861422
-silesia.tar,                        long distance mode,                 old streaming advanced,             4861426
-silesia.tar,                        multithreaded,                      old streaming advanced,             4861426
-silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4861426
-silesia.tar,                        small window log,                   old streaming advanced,             7118772
+silesia.tar,                        no source size,                     old streaming advanced,             4859267
+silesia.tar,                        long distance mode,                 old streaming advanced,             4859271
+silesia.tar,                        multithreaded,                      old streaming advanced,             4859271
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4859271
+silesia.tar,                        small window log,                   old streaming advanced,             7117562
 silesia.tar,                        small hash log,                     old streaming advanced,             6529234
 silesia.tar,                        small chain log,                    old streaming advanced,             4917021
 silesia.tar,                        explicit params,                    old streaming advanced,             4806873
-silesia.tar,                        uncompressed literals,              old streaming advanced,             4861426
+silesia.tar,                        uncompressed literals,              old streaming advanced,             4859271
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4267266
 silesia.tar,                        huffman literals,                   old streaming advanced,             6187938
-silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4861426
+silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4859271
 github,                             level -5,                           old streaming advanced,             241214
 github,                             level -5 with dict,                 old streaming advanced,             49562
 github,                             level -3,                           old streaming advanced,             222937
@@ -1364,7 +1364,7 @@ github,                             level 16,                           old stre
 github,                             level 16 with dict,                 old streaming advanced,             40789
 github,                             level 19,                           old streaming advanced,             134064
 github,                             level 19 with dict,                 old streaming advanced,             37576
-github,                             no source size,                     old streaming advanced,             140632
+github,                             no source size,                     old streaming advanced,             140599
 github,                             no source size with dict,           old streaming advanced,             40608
 github,                             long distance mode,                 old streaming advanced,             141104
 github,                             multithreaded,                      old streaming advanced,             141104
@@ -1383,13 +1383,13 @@ github.tar,                         level -3,                           old stre
 github.tar,                         level -3 with dict,                 old streaming advanced,             43357
 github.tar,                         level -1,                           old streaming advanced,             42536
 github.tar,                         level -1 with dict,                 old streaming advanced,             41494
-github.tar,                         level 0,                            old streaming advanced,             38441
+github.tar,                         level 0,                            old streaming advanced,             38831
 github.tar,                         level 0 with dict,                  old streaming advanced,             38013
 github.tar,                         level 1,                            old streaming advanced,             39270
 github.tar,                         level 1 with dict,                  old streaming advanced,             38934
-github.tar,                         level 3,                            old streaming advanced,             38441
+github.tar,                         level 3,                            old streaming advanced,             38831
 github.tar,                         level 3 with dict,                  old streaming advanced,             38013
-github.tar,                         level 4,                            old streaming advanced,             38467
+github.tar,                         level 4,                            old streaming advanced,             38893
 github.tar,                         level 4 with dict,                  old streaming advanced,             38063
 github.tar,                         level 5,                            old streaming advanced,             38366
 github.tar,                         level 5 with dict,                  old streaming advanced,             37728
@@ -1405,19 +1405,19 @@ github.tar,                         level 16,                           old stre
 github.tar,                         level 16 with dict,                 old streaming advanced,             38578
 github.tar,                         level 19,                           old streaming advanced,             32134
 github.tar,                         level 19 with dict,                 old streaming advanced,             32702
-github.tar,                         no source size,                     old streaming advanced,             38438
+github.tar,                         no source size,                     old streaming advanced,             38828
 github.tar,                         no source size with dict,           old streaming advanced,             38015
-github.tar,                         long distance mode,                 old streaming advanced,             38441
-github.tar,                         multithreaded,                      old streaming advanced,             38441
-github.tar,                         multithreaded long distance mode,   old streaming advanced,             38441
+github.tar,                         long distance mode,                 old streaming advanced,             38831
+github.tar,                         multithreaded,                      old streaming advanced,             38831
+github.tar,                         multithreaded long distance mode,   old streaming advanced,             38831
 github.tar,                         small window log,                   old streaming advanced,             199561
 github.tar,                         small hash log,                     old streaming advanced,             129870
 github.tar,                         small chain log,                    old streaming advanced,             41669
 github.tar,                         explicit params,                    old streaming advanced,             41385
-github.tar,                         uncompressed literals,              old streaming advanced,             38441
+github.tar,                         uncompressed literals,              old streaming advanced,             38831
 github.tar,                         uncompressed literals optimal,      old streaming advanced,             32134
 github.tar,                         huffman literals,                   old streaming advanced,             42536
-github.tar,                         multithreaded with advanced params, old streaming advanced,             38441
+github.tar,                         multithreaded with advanced params, old streaming advanced,             38831
 github,                             level -5 with dict,                 old streaming cdict,                46718
 github,                             level -3 with dict,                 old streaming cdict,                45395
 github,                             level -1 with dict,                 old streaming cdict,                43170

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -906,7 +906,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         in.pos = 0;
         in.size = CNBufferSize - in.size;
         CHECK(!(ZSTD_compressStream2(cctx, &out, &in, ZSTD_e_end) == 0), "Not finished");
-        CHECK_Z(ZSTD_decompress(decodedBuffer, CNBufferSize, compressedBuffer, cSize));
+        CHECK_Z(ZSTD_decompress(decodedBuffer, CNBufferSize, compressedBuffer, out.pos));
         DISPLAYLEVEL(3, "OK \n");
 
         DISPLAYLEVEL(3, "test%3i : ZSTD_compressStream2() ZSTD_c_stableOutBuffer modify buffer : ", testNb++);


### PR DESCRIPTION
This PR takes the ideas from #2749 and applies them to the double-fast implementation.

## Description

We start by pulling a single-segment copy out so that we can work on it separately from the DMS implementation.

This implementation makes two changes to how the input is parsed:

1. Instead of checking `ip + 1` when we find a short match, we check `ip + step`. This is a pretty minimal change to the parsing behavior, since `step` is almost always 1.
2. We write back `ip + 1` into the hash table even when we take a long match at `ip` (instead of only in the short match path). It costs us basically nothing to do this because we've already hashed it. This improves compression ratio.

Unlike the fast implementation, whose pipelining includes speculative work that we might throw away, this implementation doesn't do any additional work. It just moves some of it earlier. In particular, the crucial observation is that when we do not take a long match at the current position, we are guaranteed to inspect the next long position, either by taking a short match and checking the next one or by not taking the short match and moving on to the next position. So we can frontload that loading work some.

## Benchmarks

<details>
<summary>Silesia Results Table</summary>

```
dickens     gcc-4.8    3 |   99.9  100.3 ( +0.400%) |  2.769  2.779 ( +0.361%)
dickens     gcc-5      3 |   99.1   99.2 ( +0.101%) |  2.769  2.779 ( +0.361%)
dickens     gcc-6      3 |  101.5   99.0 ( -2.463%) |  2.769  2.779 ( +0.361%)
dickens     gcc-7      3 |  101.8   99.7 ( -2.063%) |  2.769  2.779 ( +0.361%)
dickens     gcc-8      3 |   96.5   97.9 ( +1.451%) |  2.769  2.779 ( +0.361%)
dickens     gcc-10     3 |  100.4   99.5 ( -0.896%) |  2.769  2.779 ( +0.361%)
dickens     clang-6.0  3 |  103.7  103.0 ( -0.675%) |  2.769  2.779 ( +0.361%)
dickens     clang-7    3 |  100.4   98.0 ( -2.390%) |  2.769  2.779 ( +0.361%)
dickens     clang-8    3 |  100.7   99.1 ( -1.589%) |  2.769  2.779 ( +0.361%)
dickens     clang-9    3 |  102.3   94.5 ( -7.625%) |  2.769  2.779 ( +0.361%)
dickens     clang-11   3 |  100.8  100.2 ( -0.595%) |  2.769  2.779 ( +0.361%)
dickens     clang-12   3 |  100.7   99.2 ( -1.490%) |  2.769  2.779 ( +0.361%)
dickens     gcc-4.8    4 |  101.9  101.8 ( -0.098%) |  2.827  2.841 ( +0.495%)
dickens     gcc-5      4 |   98.5   95.8 ( -2.741%) |  2.827  2.841 ( +0.495%)
dickens     gcc-6      4 |   98.9   96.9 ( -2.022%) |  2.827  2.841 ( +0.495%)
dickens     gcc-7      4 |   98.8   97.6 ( -1.215%) |  2.827  2.841 ( +0.495%)
dickens     gcc-8      4 |   98.6  101.7 ( +3.144%) |  2.827  2.841 ( +0.495%)
dickens     gcc-10     4 |   95.1  100.7 ( +5.889%) |  2.827  2.841 ( +0.495%)
dickens     clang-6.0  4 |  102.1  100.1 ( -1.959%) |  2.827  2.841 ( +0.495%)
dickens     clang-7    4 |   97.9   97.9 ( +0.000%) |  2.827  2.841 ( +0.495%)
dickens     clang-8    4 |  100.8   98.6 ( -2.183%) |  2.827  2.841 ( +0.495%)
dickens     clang-9    4 |   96.8   97.3 ( +0.517%) |  2.827  2.841 ( +0.495%)
dickens     clang-11   4 |  100.0   97.1 ( -2.900%) |  2.827  2.841 ( +0.495%)
dickens     clang-12   4 |   98.9   98.1 ( -0.809%) |  2.827  2.841 ( +0.495%)
enwik8      gcc-4.8    3 |  109.3  110.5 ( +1.098%) |  2.809  2.820 ( +0.392%)
enwik8      gcc-5      3 |  104.8  106.3 ( +1.431%) |  2.809  2.820 ( +0.392%)
enwik8      gcc-6      3 |  107.1  106.2 ( -0.840%) |  2.809  2.820 ( +0.392%)
enwik8      gcc-7      3 |  105.0  106.1 ( +1.048%) |  2.809  2.820 ( +0.392%)
enwik8      gcc-8      3 |  105.7  108.4 ( +2.554%) |  2.809  2.820 ( +0.392%)
enwik8      gcc-10     3 |  105.1  108.1 ( +2.854%) |  2.809  2.820 ( +0.392%)
enwik8      clang-6.0  3 |  111.7  111.1 ( -0.537%) |  2.809  2.820 ( +0.392%)
enwik8      clang-7    3 |  107.6  109.6 ( +1.859%) |  2.809  2.820 ( +0.392%)
enwik8      clang-8    3 |  109.2  110.2 ( +0.916%) |  2.809  2.820 ( +0.392%)
enwik8      clang-9    3 |  109.0  109.0 ( +0.000%) |  2.809  2.820 ( +0.392%)
enwik8      clang-11   3 |  112.5  111.8 ( -0.622%) |  2.809  2.820 ( +0.392%)
enwik8      clang-12   3 |  107.5  109.9 ( +2.233%) |  2.809  2.820 ( +0.392%)
enwik8      gcc-4.8    4 |  103.1  106.5 ( +3.298%) |  2.864  2.877 ( +0.454%)
enwik8      gcc-5      4 |  100.3   99.7 ( -0.598%) |  2.864  2.877 ( +0.454%)
enwik8      gcc-6      4 |  101.9  104.4 ( +2.453%) |  2.864  2.877 ( +0.454%)
enwik8      gcc-7      4 |  102.8  100.8 ( -1.946%) |  2.864  2.877 ( +0.454%)
enwik8      gcc-8      4 |   99.7  100.9 ( +1.204%) |  2.864  2.877 ( +0.454%)
enwik8      gcc-10     4 |   99.3  104.3 ( +5.035%) |  2.864  2.877 ( +0.454%)
enwik8      clang-6.0  4 |  106.5  105.7 ( -0.751%) |  2.864  2.877 ( +0.454%)
enwik8      clang-7    4 |  102.4  103.5 ( +1.074%) |  2.864  2.877 ( +0.454%)
enwik8      clang-8    4 |  104.2  104.6 ( +0.384%) |  2.864  2.877 ( +0.454%)
enwik8      clang-9    4 |  102.4  106.4 ( +3.906%) |  2.864  2.877 ( +0.454%)
enwik8      clang-11   4 |  106.8  103.6 ( -2.996%) |  2.864  2.877 ( +0.454%)
enwik8      clang-12   4 |  105.2  104.1 ( -1.046%) |  2.864  2.877 ( +0.454%)
enwik9      gcc-4.8    3 |  121.7  117.3 ( -3.615%) |  3.191  3.203 ( +0.376%)
enwik9      gcc-5      3 |  113.0  122.1 ( +8.053%) |  3.191  3.203 ( +0.376%)
enwik9      gcc-6      3 |  120.3  123.2 ( +2.411%) |  3.191  3.203 ( +0.376%)
enwik9      gcc-7      3 |  123.3  125.4 ( +1.703%) |  3.191  3.203 ( +0.376%)
enwik9      gcc-8      3 |  124.2  121.7 ( -2.013%) |  3.191  3.203 ( +0.376%)
enwik9      gcc-10     3 |  123.2  125.1 ( +1.542%) |  3.191  3.203 ( +0.376%)
enwik9      clang-6.0  3 |  124.8  125.1 ( +0.240%) |  3.191  3.203 ( +0.376%)
enwik9      clang-7    3 |  119.1  123.5 ( +3.694%) |  3.191  3.203 ( +0.376%)
enwik9      clang-8    3 |  119.5  119.2 ( -0.251%) |  3.191  3.203 ( +0.376%)
enwik9      clang-9    3 |  120.0  120.2 ( +0.167%) |  3.191  3.203 ( +0.376%)
enwik9      clang-11   3 |  123.0  124.6 ( +1.301%) |  3.191  3.203 ( +0.376%)
enwik9      clang-12   3 |  120.8  123.8 ( +2.483%) |  3.191  3.203 ( +0.376%)
enwik9      gcc-4.8    4 |  114.4  111.9 ( -2.185%) |  3.253  3.267 ( +0.430%)
enwik9      gcc-5      4 |  110.1  115.8 ( +5.177%) |  3.253  3.267 ( +0.430%)
enwik9      gcc-6      4 |  115.5  114.4 ( -0.952%) |  3.253  3.267 ( +0.430%)
enwik9      gcc-7      4 |  117.8  117.3 ( -0.424%) |  3.253  3.267 ( +0.430%)
enwik9      gcc-8      4 |  113.5  116.7 ( +2.819%) |  3.253  3.267 ( +0.430%)
enwik9      gcc-10     4 |  111.1  119.1 ( +7.201%) |  3.253  3.267 ( +0.430%)
enwik9      clang-6.0  4 |  117.7  120.0 ( +1.954%) |  3.253  3.267 ( +0.430%)
enwik9      clang-7    4 |  114.7  115.7 ( +0.872%) |  3.253  3.267 ( +0.430%)
enwik9      clang-8    4 |  113.8  118.9 ( +4.482%) |  3.253  3.267 ( +0.430%)
enwik9      clang-9    4 |  116.2  117.2 ( +0.861%) |  3.253  3.267 ( +0.430%)
enwik9      clang-11   4 |  117.1  118.4 ( +1.110%) |  3.253  3.267 ( +0.430%)
enwik9      clang-12   4 |  110.6  114.9 ( +3.888%) |  3.253  3.267 ( +0.430%)
mozilla     gcc-4.8    3 |  148.5  152.1 ( +2.424%) |  2.768  2.771 ( +0.108%)
mozilla     gcc-5      3 |  147.3  152.5 ( +3.530%) |  2.768  2.771 ( +0.108%)
mozilla     gcc-6      3 |  145.2  151.6 ( +4.408%) |  2.768  2.771 ( +0.108%)
mozilla     gcc-7      3 |  149.7  154.8 ( +3.407%) |  2.768  2.771 ( +0.108%)
mozilla     gcc-8      3 |  150.3  152.4 ( +1.397%) |  2.768  2.771 ( +0.108%)
mozilla     gcc-10     3 |  147.5  154.4 ( +4.678%) |  2.768  2.771 ( +0.108%)
mozilla     clang-6.0  3 |  156.4  150.0 ( -4.092%) |  2.768  2.771 ( +0.108%)
mozilla     clang-7    3 |  147.5  153.0 ( +3.729%) |  2.768  2.771 ( +0.108%)
mozilla     clang-8    3 |  145.8  153.8 ( +5.487%) |  2.768  2.771 ( +0.108%)
mozilla     clang-9    3 |  151.1  149.0 ( -1.390%) |  2.768  2.771 ( +0.108%)
mozilla     clang-11   3 |  146.5  152.5 ( +4.096%) |  2.768  2.771 ( +0.108%)
mozilla     clang-12   3 |  145.4  151.8 ( +4.402%) |  2.768  2.771 ( +0.108%)
mozilla     gcc-4.8    4 |  136.0  139.3 ( +2.426%) |  2.798  2.801 ( +0.107%)
mozilla     gcc-5      4 |  135.2  140.3 ( +3.772%) |  2.798  2.801 ( +0.107%)
mozilla     gcc-6      4 |  129.5  139.3 ( +7.568%) |  2.798  2.801 ( +0.107%)
mozilla     gcc-7      4 |  140.2  142.4 ( +1.569%) |  2.798  2.801 ( +0.107%)
mozilla     gcc-8      4 |  135.2  140.9 ( +4.216%) |  2.798  2.801 ( +0.107%)
mozilla     gcc-10     4 |  137.0  141.9 ( +3.577%) |  2.798  2.801 ( +0.107%)
mozilla     clang-6.0  4 |  140.9  137.1 ( -2.697%) |  2.798  2.801 ( +0.107%)
mozilla     clang-7    4 |  133.5  139.8 ( +4.719%) |  2.798  2.801 ( +0.107%)
mozilla     clang-8    4 |  136.9  139.5 ( +1.899%) |  2.798  2.801 ( +0.107%)
mozilla     clang-9    4 |  137.0  137.6 ( +0.438%) |  2.798  2.801 ( +0.107%)
mozilla     clang-11   4 |  138.7  139.5 ( +0.577%) |  2.798  2.801 ( +0.107%)
mozilla     clang-12   4 |  136.6  144.4 ( +5.710%) |  2.798  2.801 ( +0.107%)
mr          gcc-4.8    3 |  117.3  115.8 ( -1.279%) |  2.811  2.810 ( -0.036%)
mr          gcc-5      3 |  115.4  117.5 ( +1.820%) |  2.811  2.810 ( -0.036%)
mr          gcc-6      3 |  118.3  115.9 ( -2.029%) |  2.811  2.810 ( -0.036%)
mr          gcc-7      3 |  120.4  119.2 ( -0.997%) |  2.811  2.810 ( -0.036%)
mr          gcc-8      3 |  118.4  119.6 ( +1.014%) |  2.811  2.810 ( -0.036%)
mr          gcc-10     3 |  116.3  116.2 ( -0.086%) |  2.811  2.810 ( -0.036%)
mr          clang-6.0  3 |  119.6  115.1 ( -3.763%) |  2.811  2.810 ( -0.036%)
mr          clang-7    3 |  112.6  115.0 ( +2.131%) |  2.811  2.810 ( -0.036%)
mr          clang-8    3 |  114.0  117.1 ( +2.719%) |  2.811  2.810 ( -0.036%)
mr          clang-9    3 |  114.6  114.1 ( -0.436%) |  2.811  2.810 ( -0.036%)
mr          clang-11   3 |  109.2  114.2 ( +4.579%) |  2.811  2.810 ( -0.036%)
mr          clang-12   3 |  115.1  114.2 ( -0.782%) |  2.811  2.810 ( -0.036%)
mr          gcc-4.8    4 |  111.8  108.7 ( -2.773%) |  2.861  2.859 ( -0.070%)
mr          gcc-5      4 |  114.0  112.5 ( -1.316%) |  2.861  2.859 ( -0.070%)
mr          gcc-6      4 |  110.2  114.1 ( +3.539%) |  2.861  2.859 ( -0.070%)
mr          gcc-7      4 |  111.2  110.0 ( -1.079%) |  2.861  2.859 ( -0.070%)
mr          gcc-8      4 |  110.8  115.3 ( +4.061%) |  2.861  2.859 ( -0.070%)
mr          gcc-10     4 |  109.4  107.0 ( -2.194%) |  2.861  2.859 ( -0.070%)
mr          clang-6.0  4 |  115.7  109.3 ( -5.532%) |  2.861  2.859 ( -0.070%)
mr          clang-7    4 |  108.9  109.8 ( +0.826%) |  2.861  2.859 ( -0.070%)
mr          clang-8    4 |  110.1  108.4 ( -1.544%) |  2.861  2.859 ( -0.070%)
mr          clang-9    4 |  109.0  108.3 ( -0.642%) |  2.861  2.859 ( -0.070%)
mr          clang-11   4 |  115.2  107.4 ( -6.771%) |  2.861  2.859 ( -0.070%)
mr          clang-12   4 |  112.0  111.9 ( -0.089%) |  2.861  2.859 ( -0.070%)
nci         gcc-4.8    3 |  419.4  412.4 ( -1.669%) | 11.740 11.800 ( +0.511%)
nci         gcc-5      3 |  409.7  415.5 ( +1.416%) | 11.740 11.800 ( +0.511%)
nci         gcc-6      3 |  413.8  415.2 ( +0.338%) | 11.740 11.800 ( +0.511%)
nci         gcc-7      3 |  417.2  413.6 ( -0.863%) | 11.740 11.800 ( +0.511%)
nci         gcc-8      3 |  410.4  413.1 ( +0.658%) | 11.740 11.800 ( +0.511%)
nci         gcc-10     3 |  416.2  408.7 ( -1.802%) | 11.740 11.800 ( +0.511%)
nci         clang-6.0  3 |  424.2  399.5 ( -5.823%) | 11.740 11.800 ( +0.511%)
nci         clang-7    3 |  419.5  422.3 ( +0.667%) | 11.740 11.800 ( +0.511%)
nci         clang-8    3 |  433.3  413.4 ( -4.593%) | 11.740 11.800 ( +0.511%)
nci         clang-9    3 |  433.1  424.2 ( -2.055%) | 11.740 11.800 ( +0.511%)
nci         clang-11   3 |  438.4  412.1 ( -5.999%) | 11.740 11.800 ( +0.511%)
nci         clang-12   3 |  426.4  423.3 ( -0.727%) | 11.740 11.800 ( +0.511%)
nci         gcc-4.8    4 |  423.8  424.0 ( +0.047%) | 11.750 11.800 ( +0.426%)
nci         gcc-5      4 |  420.2  422.8 ( +0.619%) | 11.750 11.800 ( +0.426%)
nci         gcc-6      4 |  389.7  409.8 ( +5.158%) | 11.750 11.800 ( +0.426%)
nci         gcc-7      4 |  425.4  421.3 ( -0.964%) | 11.750 11.800 ( +0.426%)
nci         gcc-8      4 |  418.1  421.9 ( +0.909%) | 11.750 11.800 ( +0.426%)
nci         gcc-10     4 |  425.0  418.0 ( -1.647%) | 11.750 11.800 ( +0.426%)
nci         clang-6.0  4 |  435.3  394.6 ( -9.350%) | 11.750 11.800 ( +0.426%)
nci         clang-7    4 |  427.3  424.4 ( -0.679%) | 11.750 11.800 ( +0.426%)
nci         clang-8    4 |  444.6  417.7 ( -6.050%) | 11.750 11.800 ( +0.426%)
nci         clang-9    4 |  441.1  419.2 ( -4.965%) | 11.750 11.800 ( +0.426%)
nci         clang-11   4 |  437.2  419.2 ( -4.117%) | 11.750 11.800 ( +0.426%)
nci         clang-12   4 |  426.8  406.0 ( -4.873%) | 11.750 11.800 ( +0.426%)
ooffice     gcc-4.8    3 |   99.6  107.4 ( +7.831%) |  1.956  1.957 ( +0.051%)
ooffice     gcc-5      3 |   98.6  108.6 (+10.142%) |  1.956  1.957 ( +0.051%)
ooffice     gcc-6      3 |  101.1  103.9 ( +2.770%) |  1.956  1.957 ( +0.051%)
ooffice     gcc-7      3 |  101.9  108.6 ( +6.575%) |  1.956  1.957 ( +0.051%)
ooffice     gcc-8      3 |  100.3  107.8 ( +7.478%) |  1.956  1.957 ( +0.051%)
ooffice     gcc-10     3 |  101.0  109.6 ( +8.515%) |  1.956  1.957 ( +0.051%)
ooffice     clang-6.0  3 |  108.1  107.8 ( -0.278%) |  1.956  1.957 ( +0.051%)
ooffice     clang-7    3 |   93.5  105.5 (+12.834%) |  1.956  1.957 ( +0.051%)
ooffice     clang-8    3 |   92.6  104.3 (+12.635%) |  1.956  1.957 ( +0.051%)
ooffice     clang-9    3 |   97.0  107.5 (+10.825%) |  1.956  1.957 ( +0.051%)
ooffice     clang-11   3 |   96.0  108.0 (+12.500%) |  1.956  1.957 ( +0.051%)
ooffice     clang-12   3 |   98.3  104.4 ( +6.205%) |  1.956  1.957 ( +0.051%)
ooffice     gcc-4.8    4 |   94.2   98.5 ( +4.565%) |  2.003  2.004 ( +0.050%)
ooffice     gcc-5      4 |   94.2   98.6 ( +4.671%) |  2.003  2.004 ( +0.050%)
ooffice     gcc-6      4 |   93.1   96.2 ( +3.330%) |  2.003  2.004 ( +0.050%)
ooffice     gcc-7      4 |   92.8   99.7 ( +7.435%) |  2.003  2.004 ( +0.050%)
ooffice     gcc-8      4 |   90.9   98.5 ( +8.361%) |  2.003  2.004 ( +0.050%)
ooffice     gcc-10     4 |   94.1   99.6 ( +5.845%) |  2.003  2.004 ( +0.050%)
ooffice     clang-6.0  4 |   98.0   99.4 ( +1.429%) |  2.003  2.004 ( +0.050%)
ooffice     clang-7    4 |   89.1   97.7 ( +9.652%) |  2.003  2.004 ( +0.050%)
ooffice     clang-8    4 |   90.8   94.9 ( +4.515%) |  2.003  2.004 ( +0.050%)
ooffice     clang-9    4 |   90.2   97.4 ( +7.982%) |  2.003  2.004 ( +0.050%)
ooffice     clang-11   4 |   91.6   99.3 ( +8.406%) |  2.003  2.004 ( +0.050%)
ooffice     clang-12   4 |   91.0  101.3 (+11.319%) |  2.003  2.004 ( +0.050%)
osdb        gcc-4.8    3 |  142.6  145.0 ( +1.683%) |  2.867  2.876 ( +0.314%)
osdb        gcc-5      3 |  134.2  148.3 (+10.507%) |  2.867  2.876 ( +0.314%)
osdb        gcc-6      3 |  140.9  145.1 ( +2.981%) |  2.867  2.876 ( +0.314%)
osdb        gcc-7      3 |  138.7  142.1 ( +2.451%) |  2.867  2.876 ( +0.314%)
osdb        gcc-8      3 |  136.4  143.4 ( +5.132%) |  2.867  2.876 ( +0.314%)
osdb        gcc-10     3 |  136.8  145.7 ( +6.506%) |  2.867  2.876 ( +0.314%)
osdb        clang-6.0  3 |  141.3  145.4 ( +2.902%) |  2.867  2.876 ( +0.314%)
osdb        clang-7    3 |  137.9  150.4 ( +9.065%) |  2.867  2.876 ( +0.314%)
osdb        clang-8    3 |  132.5  147.7 (+11.472%) |  2.867  2.876 ( +0.314%)
osdb        clang-9    3 |  135.6  139.3 ( +2.729%) |  2.867  2.876 ( +0.314%)
osdb        clang-11   3 |  134.9  151.0 (+11.935%) |  2.867  2.876 ( +0.314%)
osdb        clang-12   3 |  129.2  141.1 ( +9.211%) |  2.867  2.876 ( +0.314%)
osdb        gcc-4.8    4 |  127.3  132.4 ( +4.006%) |  2.885  2.895 ( +0.347%)
osdb        gcc-5      4 |  123.3  135.7 (+10.057%) |  2.885  2.895 ( +0.347%)
osdb        gcc-6      4 |  124.5  133.6 ( +7.309%) |  2.885  2.895 ( +0.347%)
osdb        gcc-7      4 |  125.1  133.7 ( +6.875%) |  2.885  2.895 ( +0.347%)
osdb        gcc-8      4 |  121.4  136.8 (+12.685%) |  2.885  2.895 ( +0.347%)
osdb        gcc-10     4 |  124.8  142.6 (+14.263%) |  2.885  2.895 ( +0.347%)
osdb        clang-6.0  4 |  132.6  135.4 ( +2.112%) |  2.885  2.895 ( +0.347%)
osdb        clang-7    4 |  129.4  134.9 ( +4.250%) |  2.885  2.895 ( +0.347%)
osdb        clang-8    4 |  130.9  135.2 ( +3.285%) |  2.885  2.895 ( +0.347%)
osdb        clang-9    4 |  120.0  132.5 (+10.417%) |  2.885  2.895 ( +0.347%)
osdb        clang-11   4 |  129.3  138.6 ( +7.193%) |  2.885  2.895 ( +0.347%)
osdb        clang-12   4 |  122.2  131.8 ( +7.856%) |  2.885  2.895 ( +0.347%)
reymont     gcc-4.8    3 |  127.7  117.1 ( -8.301%) |  3.392  3.413 ( +0.619%)
reymont     gcc-5      3 |  123.5  124.1 ( +0.486%) |  3.392  3.413 ( +0.619%)
reymont     gcc-6      3 |  130.6  131.0 ( +0.306%) |  3.392  3.413 ( +0.619%)
reymont     gcc-7      3 |  127.5  129.9 ( +1.882%) |  3.392  3.413 ( +0.619%)
reymont     gcc-8      3 |  127.1  122.1 ( -3.934%) |  3.392  3.413 ( +0.619%)
reymont     gcc-10     3 |  124.3  126.0 ( +1.368%) |  3.392  3.413 ( +0.619%)
reymont     clang-6.0  3 |  127.6  127.6 ( +0.000%) |  3.392  3.413 ( +0.619%)
reymont     clang-7    3 |  125.3  126.8 ( +1.197%) |  3.392  3.413 ( +0.619%)
reymont     clang-8    3 |  127.1  126.7 ( -0.315%) |  3.392  3.413 ( +0.619%)
reymont     clang-9    3 |  126.1  124.5 ( -1.269%) |  3.392  3.413 ( +0.619%)
reymont     clang-11   3 |  124.5  125.5 ( +0.803%) |  3.392  3.413 ( +0.619%)
reymont     clang-12   3 |  122.8  125.9 ( +2.524%) |  3.392  3.413 ( +0.619%)
reymont     gcc-4.8    4 |  127.7  119.0 ( -6.813%) |  3.429  3.453 ( +0.700%)
reymont     gcc-5      4 |  123.6  125.6 ( +1.618%) |  3.429  3.453 ( +0.700%)
reymont     gcc-6      4 |  128.9  135.8 ( +5.353%) |  3.429  3.453 ( +0.700%)
reymont     gcc-7      4 |  128.7  130.0 ( +1.010%) |  3.429  3.453 ( +0.700%)
reymont     gcc-8      4 |  133.3  119.9 (-10.053%) |  3.429  3.453 ( +0.700%)
reymont     gcc-10     4 |  124.7  124.4 ( -0.241%) |  3.429  3.453 ( +0.700%)
reymont     clang-6.0  4 |  130.1  129.6 ( -0.384%) |  3.429  3.453 ( +0.700%)
reymont     clang-7    4 |  128.6  126.2 ( -1.866%) |  3.429  3.453 ( +0.700%)
reymont     clang-8    4 |  129.0  127.8 ( -0.930%) |  3.429  3.453 ( +0.700%)
reymont     clang-9    4 |  129.6  122.3 ( -5.633%) |  3.429  3.453 ( +0.700%)
reymont     clang-11   4 |  127.9  127.1 ( -0.625%) |  3.429  3.453 ( +0.700%)
reymont     clang-12   4 |  125.7  126.8 ( +0.875%) |  3.429  3.453 ( +0.700%)
samba       gcc-4.8    3 |  201.9  206.8 ( +2.427%) |  4.320  4.342 ( +0.509%)
samba       gcc-5      3 |  201.4  211.6 ( +5.065%) |  4.320  4.342 ( +0.509%)
samba       gcc-6      3 |  205.6  208.4 ( +1.362%) |  4.320  4.342 ( +0.509%)
samba       gcc-7      3 |  205.3  205.6 ( +0.146%) |  4.320  4.342 ( +0.509%)
samba       gcc-8      3 |  205.7  210.4 ( +2.285%) |  4.320  4.342 ( +0.509%)
samba       gcc-10     3 |  204.8  202.8 ( -0.977%) |  4.320  4.342 ( +0.509%)
samba       clang-6.0  3 |  209.9  201.9 ( -3.811%) |  4.320  4.342 ( +0.509%)
samba       clang-7    3 |  201.3  207.8 ( +3.229%) |  4.320  4.342 ( +0.509%)
samba       clang-8    3 |  196.2  200.8 ( +2.345%) |  4.320  4.342 ( +0.509%)
samba       clang-9    3 |  200.8  204.5 ( +1.843%) |  4.320  4.342 ( +0.509%)
samba       clang-11   3 |  202.7  207.8 ( +2.516%) |  4.320  4.342 ( +0.509%)
samba       clang-12   3 |  202.0  200.6 ( -0.693%) |  4.320  4.342 ( +0.509%)
samba       gcc-4.8    4 |  194.5  200.7 ( +3.188%) |  4.349  4.373 ( +0.552%)
samba       gcc-5      4 |  190.0  206.1 ( +8.474%) |  4.349  4.373 ( +0.552%)
samba       gcc-6      4 |  198.1  193.5 ( -2.322%) |  4.349  4.373 ( +0.552%)
samba       gcc-7      4 |  199.3  187.9 ( -5.720%) |  4.349  4.373 ( +0.552%)
samba       gcc-8      4 |  190.6  192.5 ( +0.997%) |  4.349  4.373 ( +0.552%)
samba       gcc-10     4 |  194.9  193.9 ( -0.513%) |  4.349  4.373 ( +0.552%)
samba       clang-6.0  4 |  196.0  188.5 ( -3.827%) |  4.349  4.373 ( +0.552%)
samba       clang-7    4 |  188.4  196.8 ( +4.459%) |  4.349  4.373 ( +0.552%)
samba       clang-8    4 |  180.4  192.2 ( +6.541%) |  4.349  4.373 ( +0.552%)
samba       clang-9    4 |  195.8  194.1 ( -0.868%) |  4.349  4.373 ( +0.552%)
samba       clang-11   4 |  196.2  195.2 ( -0.510%) |  4.349  4.373 ( +0.552%)
samba       clang-12   4 |  192.1  195.2 ( +1.614%) |  4.349  4.373 ( +0.552%)
sao         gcc-4.8    3 |   75.3   84.7 (+12.483%) |  1.306  1.306 ( +0.000%)
sao         gcc-5      3 |   76.7   86.6 (+12.907%) |  1.306  1.306 ( +0.000%)
sao         gcc-6      3 |   76.4   81.4 ( +6.545%) |  1.306  1.306 ( +0.000%)
sao         gcc-7      3 |   73.7   85.8 (+16.418%) |  1.306  1.306 ( +0.000%)
sao         gcc-8      3 |   74.8   81.2 ( +8.556%) |  1.306  1.306 ( +0.000%)
sao         gcc-10     3 |   73.8   78.6 ( +6.504%) |  1.306  1.306 ( +0.000%)
sao         clang-6.0  3 |   81.4   84.4 ( +3.686%) |  1.306  1.306 ( +0.000%)
sao         clang-7    3 |   71.7   84.7 (+18.131%) |  1.306  1.306 ( +0.000%)
sao         clang-8    3 |   71.3   83.1 (+16.550%) |  1.306  1.306 ( +0.000%)
sao         clang-9    3 |   72.5   84.0 (+15.862%) |  1.306  1.306 ( +0.000%)
sao         clang-11   3 |   73.4   86.9 (+18.392%) |  1.306  1.306 ( +0.000%)
sao         clang-12   3 |   72.9   85.9 (+17.833%) |  1.306  1.306 ( +0.000%)
sao         gcc-4.8    4 |   69.7   77.9 (+11.765%) |  1.337  1.337 ( +0.000%)
sao         gcc-5      4 |   69.6   77.4 (+11.207%) |  1.337  1.337 ( +0.000%)
sao         gcc-6      4 |   70.5   74.8 ( +6.099%) |  1.337  1.337 ( +0.000%)
sao         gcc-7      4 |   68.7   75.1 ( +9.316%) |  1.337  1.337 ( +0.000%)
sao         gcc-8      4 |   69.0   74.3 ( +7.681%) |  1.337  1.337 ( +0.000%)
sao         gcc-10     4 |   66.8   71.8 ( +7.485%) |  1.337  1.337 ( +0.000%)
sao         clang-6.0  4 |   73.8   74.7 ( +1.220%) |  1.337  1.337 ( +0.000%)
sao         clang-7    4 |   65.4   74.8 (+14.373%) |  1.337  1.337 ( +0.000%)
sao         clang-8    4 |   64.8   73.0 (+12.654%) |  1.337  1.337 ( +0.000%)
sao         clang-9    4 |   62.0   77.4 (+24.839%) |  1.337  1.337 ( +0.000%)
sao         clang-11   4 |   67.7   77.3 (+14.180%) |  1.337  1.337 ( +0.000%)
sao         clang-12   4 |   68.2   76.0 (+11.437%) |  1.337  1.337 ( +0.000%)
webster     gcc-4.8    3 |  126.6  126.8 ( +0.158%) |  3.403  3.420 ( +0.500%)
webster     gcc-5      3 |  117.1  124.2 ( +6.063%) |  3.403  3.420 ( +0.500%)
webster     gcc-6      3 |  122.9  124.0 ( +0.895%) |  3.403  3.420 ( +0.500%)
webster     gcc-7      3 |  126.3  125.5 ( -0.633%) |  3.403  3.420 ( +0.500%)
webster     gcc-8      3 |  127.6  124.4 ( -2.508%) |  3.403  3.420 ( +0.500%)
webster     gcc-10     3 |  123.5  124.7 ( +0.972%) |  3.403  3.420 ( +0.500%)
webster     clang-6.0  3 |  128.3  122.5 ( -4.521%) |  3.403  3.420 ( +0.500%)
webster     clang-7    3 |  124.3  125.2 ( +0.724%) |  3.403  3.420 ( +0.500%)
webster     clang-8    3 |  121.0  120.2 ( -0.661%) |  3.403  3.420 ( +0.500%)
webster     clang-9    3 |  123.1  122.3 ( -0.650%) |  3.403  3.420 ( +0.500%)
webster     clang-11   3 |  120.7  118.8 ( -1.574%) |  3.403  3.420 ( +0.500%)
webster     clang-12   3 |  117.9  122.1 ( +3.562%) |  3.403  3.420 ( +0.500%)
webster     gcc-4.8    4 |  124.4  122.4 ( -1.608%) |  3.455  3.475 ( +0.579%)
webster     gcc-5      4 |  114.5  121.4 ( +6.026%) |  3.455  3.475 ( +0.579%)
webster     gcc-6      4 |  118.2  118.1 ( -0.085%) |  3.455  3.475 ( +0.579%)
webster     gcc-7      4 |  120.9  119.8 ( -0.910%) |  3.455  3.475 ( +0.579%)
webster     gcc-8      4 |  121.0  122.4 ( +1.157%) |  3.455  3.475 ( +0.579%)
webster     gcc-10     4 |  124.3  119.6 ( -3.781%) |  3.455  3.475 ( +0.579%)
webster     clang-6.0  4 |  124.6  120.1 ( -3.612%) |  3.455  3.475 ( +0.579%)
webster     clang-7    4 |  122.6  119.1 ( -2.855%) |  3.455  3.475 ( +0.579%)
webster     clang-8    4 |  120.2  118.0 ( -1.830%) |  3.455  3.475 ( +0.579%)
webster     clang-9    4 |  118.9  121.1 ( +1.850%) |  3.455  3.475 ( +0.579%)
webster     clang-11   4 |  116.2  120.7 ( +3.873%) |  3.455  3.475 ( +0.579%)
webster     clang-12   4 |  121.4  121.2 ( -0.165%) |  3.455  3.475 ( +0.579%)
xml         gcc-4.8    3 |  313.2  308.7 ( -1.437%) |  8.357  8.363 ( +0.072%)
xml         gcc-5      3 |  306.9  313.1 ( +2.020%) |  8.357  8.363 ( +0.072%)
xml         gcc-6      3 |  300.0  304.7 ( +1.567%) |  8.357  8.363 ( +0.072%)
xml         gcc-7      3 |  313.5  312.9 ( -0.191%) |  8.357  8.363 ( +0.072%)
xml         gcc-8      3 |  315.3  315.4 ( +0.032%) |  8.357  8.363 ( +0.072%)
xml         gcc-10     3 |  308.6  310.1 ( +0.486%) |  8.357  8.363 ( +0.072%)
xml         clang-6.0  3 |  318.1  311.3 ( -2.138%) |  8.357  8.363 ( +0.072%)
xml         clang-7    3 |  309.8  308.6 ( -0.387%) |  8.357  8.363 ( +0.072%)
xml         clang-8    3 |  311.6  310.6 ( -0.321%) |  8.357  8.363 ( +0.072%)
xml         clang-9    3 |  313.1  312.9 ( -0.064%) |  8.357  8.363 ( +0.072%)
xml         clang-11   3 |  321.2  318.7 ( -0.778%) |  8.357  8.363 ( +0.072%)
xml         clang-12   3 |  315.9  315.1 ( -0.253%) |  8.357  8.363 ( +0.072%)
xml         gcc-4.8    4 |  313.2  317.0 ( +1.213%) |  8.384  8.390 ( +0.072%)
xml         gcc-5      4 |  305.4  313.7 ( +2.718%) |  8.384  8.390 ( +0.072%)
xml         gcc-6      4 |  292.7  311.8 ( +6.525%) |  8.384  8.390 ( +0.072%)
xml         gcc-7      4 |  310.0  312.3 ( +0.742%) |  8.384  8.390 ( +0.072%)
xml         gcc-8      4 |  316.9  313.2 ( -1.168%) |  8.384  8.390 ( +0.072%)
xml         gcc-10     4 |  310.3  308.9 ( -0.451%) |  8.384  8.390 ( +0.072%)
xml         clang-6.0  4 |  319.9  315.7 ( -1.313%) |  8.384  8.390 ( +0.072%)
xml         clang-7    4 |  310.3  309.6 ( -0.226%) |  8.384  8.390 ( +0.072%)
xml         clang-8    4 |  316.3  292.8 ( -7.430%) |  8.384  8.390 ( +0.072%)
xml         clang-9    4 |  319.4  317.2 ( -0.689%) |  8.384  8.390 ( +0.072%)
xml         clang-11   4 |  331.8  317.2 ( -4.400%) |  8.384  8.390 ( +0.072%)
xml         clang-12   4 |  315.3  319.7 ( +1.395%) |  8.384  8.390 ( +0.072%)
x-ray       gcc-4.8    3 |   71.3   77.0 ( +7.994%) |  1.393  1.393 ( +0.000%)
x-ray       gcc-5      3 |   69.8   77.5 (+11.032%) |  1.393  1.393 ( +0.000%)
x-ray       gcc-6      3 |   70.6   77.1 ( +9.207%) |  1.393  1.393 ( +0.000%)
x-ray       gcc-7      3 |   68.6   75.6 (+10.204%) |  1.393  1.393 ( +0.000%)
x-ray       gcc-8      3 |   67.4   74.4 (+10.386%) |  1.393  1.393 ( +0.000%)
x-ray       gcc-10     3 |   68.6   72.3 ( +5.394%) |  1.393  1.393 ( +0.000%)
x-ray       clang-6.0  3 |   75.7   76.3 ( +0.793%) |  1.393  1.393 ( +0.000%)
x-ray       clang-7    3 |   64.9   79.3 (+22.188%) |  1.393  1.393 ( +0.000%)
x-ray       clang-8    3 |   70.9   77.4 ( +9.168%) |  1.393  1.393 ( +0.000%)
x-ray       clang-9    3 |   66.1   74.8 (+13.162%) |  1.393  1.393 ( +0.000%)
x-ray       clang-11   3 |   68.2   75.3 (+10.411%) |  1.393  1.393 ( +0.000%)
x-ray       clang-12   3 |   66.3   76.8 (+15.837%) |  1.393  1.393 ( +0.000%)
x-ray       gcc-4.8    4 |   65.8   68.4 ( +3.951%) |  1.484  1.484 ( +0.000%)
x-ray       gcc-5      4 |   65.2   68.0 ( +4.294%) |  1.484  1.484 ( +0.000%)
x-ray       gcc-6      4 |   64.9   67.0 ( +3.236%) |  1.484  1.484 ( +0.000%)
x-ray       gcc-7      4 |   62.0   64.9 ( +4.677%) |  1.484  1.484 ( +0.000%)
x-ray       gcc-8      4 |   62.4   66.3 ( +6.250%) |  1.484  1.484 ( +0.000%)
x-ray       gcc-10     4 |   62.7   67.0 ( +6.858%) |  1.484  1.484 ( +0.000%)
x-ray       clang-6.0  4 |   67.9   65.3 ( -3.829%) |  1.484  1.484 ( +0.000%)
x-ray       clang-7    4 |   64.5   69.0 ( +6.977%) |  1.484  1.484 ( +0.000%)
x-ray       clang-8    4 |   66.1   70.8 ( +7.110%) |  1.484  1.484 ( +0.000%)
x-ray       clang-9    4 |   61.9   67.7 ( +9.370%) |  1.484  1.484 ( +0.000%)
x-ray       clang-11   4 |   64.7   67.4 ( +4.173%) |  1.484  1.484 ( +0.000%)
x-ray       clang-12   4 |   62.4   67.0 ( +7.372%) |  1.484  1.484 ( +0.000%)
silesia.tar gcc-4.8    3 |  146.2  149.0 ( +1.915%) |  3.179  3.187 ( +0.252%)
silesia.tar gcc-5      3 |  142.0  139.1 ( -2.042%) |  3.179  3.187 ( +0.252%)
silesia.tar gcc-6      3 |  146.6  150.0 ( +2.319%) |  3.179  3.187 ( +0.252%)
silesia.tar gcc-7      3 |  143.5  147.6 ( +2.857%) |  3.179  3.187 ( +0.252%)
silesia.tar gcc-8      3 |  144.8  145.5 ( +0.483%) |  3.179  3.187 ( +0.252%)
silesia.tar gcc-10     3 |  143.1  146.2 ( +2.166%) |  3.179  3.187 ( +0.252%)
silesia.tar clang-6.0  3 |  147.7  147.3 ( -0.271%) |  3.179  3.187 ( +0.252%)
silesia.tar clang-7    3 |  142.6  148.0 ( +3.787%) |  3.179  3.187 ( +0.252%)
silesia.tar clang-8    3 |  141.3  150.4 ( +6.440%) |  3.179  3.187 ( +0.252%)
silesia.tar clang-9    3 |  143.6  150.2 ( +4.596%) |  3.179  3.187 ( +0.252%)
silesia.tar clang-11   3 |  143.7  149.5 ( +4.036%) |  3.179  3.187 ( +0.252%)
silesia.tar clang-12   3 |  142.8  149.4 ( +4.622%) |  3.179  3.187 ( +0.252%)
silesia.tar gcc-4.8    4 |  135.9  139.8 ( +2.870%) |  3.237  3.246 ( +0.278%)
silesia.tar gcc-5      4 |  134.4  138.1 ( +2.753%) |  3.237  3.246 ( +0.278%)
silesia.tar gcc-6      4 |  134.2  139.7 ( +4.098%) |  3.237  3.246 ( +0.278%)
silesia.tar gcc-7      4 |  135.5  140.1 ( +3.395%) |  3.237  3.246 ( +0.278%)
silesia.tar gcc-8      4 |  137.0  140.0 ( +2.190%) |  3.237  3.246 ( +0.278%)
silesia.tar gcc-10     4 |  138.3  136.0 ( -1.663%) |  3.237  3.246 ( +0.278%)
silesia.tar clang-6.0  4 |  141.4  138.2 ( -2.263%) |  3.237  3.246 ( +0.278%)
silesia.tar clang-7    4 |  137.9  142.2 ( +3.118%) |  3.237  3.246 ( +0.278%)
silesia.tar clang-8    4 |  134.8  140.7 ( +4.377%) |  3.237  3.246 ( +0.278%)
silesia.tar clang-9    4 |  140.0  140.7 ( +0.500%) |  3.237  3.246 ( +0.278%)
silesia.tar clang-11   4 |  135.9  138.3 ( +1.766%) |  3.237  3.246 ( +0.278%)
silesia.tar clang-12   4 |  138.2  132.2 ( -4.342%) |  3.237  3.246 ( +0.278%)
```

Benchmarked on, as usual, an Intel Xeon E5-2680 v4 @ 2.40GHz.

</details>

On the whole we see improvements in ratio, and improvements on speed on less-compressible inputs. It seems like very compressible inputs are neutral on speed of even maybe slightly slower.

## Status

This PR is believed to be speed-positive, ratio-positive, and correct. 

### To-Do:

- [x] Correctness.
- [x] Match or improve ratio.
- [x] Match or improve speed.
- [x] Simplify DFast DMS implementation.
- [x] Benchmark.