### PR TITLE
meson: fix type error for integer option

### DIFF
--- a/build/meson/meson_options.txt
+++ b/build/meson/meson_options.txt
@@ -10,7 +10,7 @@
 
 # Read guidelines from https://wiki.gnome.org/Initiatives/GnomeGoals/MesonPorting
 
-option('legacy_level', type: 'integer', min: 0, max: 7, value: '5',
+option('legacy_level', type: 'integer', min: 0, max: 7, value: 5,
   description: 'Support any legacy format: 7 to 1 for v0.7+ to v0.1+')
 option('debug_level', type: 'integer', min: 0, max: 9, value: 1,
   description: 'Enable run-time debug. See lib/common/debug.h')


### PR DESCRIPTION
meson forgave using the wrong type, but this isn't guaranteed. muon simply failed.