### PR TITLE
Revert opt outlining change

### DIFF
--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -253,10 +253,11 @@ static U32 ZSTD_litLengthPrice(U32 const litLength, const optState_t* const optP
  * Provides the cost of the match part (offset + matchLength) of a sequence
  * Must be combined with ZSTD_fullLiteralsCost() to get the full cost of a sequence.
  * optLevel: when <2, favors small offset for decompression speed (improved cache efficiency) */
-static U32 ZSTD_getMatchPrice(U32 const offset,
-                              U32 const matchLength,
-                        const optState_t* const optPtr,
-                              int const optLevel)
+FORCE_INLINE_TEMPLATE U32
+ZSTD_getMatchPrice(U32 const offset,
+                   U32 const matchLength,
+             const optState_t* const optPtr,
+                   int const optLevel)
 {
     U32 price;
     U32 const offCode = ZSTD_highbit32(offset+1);
@@ -484,9 +485,11 @@ static U32 ZSTD_insertBt1(
     }
 }
 
-static void ZSTD_updateTree_internal(ZSTD_matchState_t* ms,
-                               const BYTE* const ip, const BYTE* const iend,
-                               const U32 mls, const ZSTD_dictMode_e dictMode)
+FORCE_INLINE_TEMPLATE
+void ZSTD_updateTree_internal(
+                ZSTD_matchState_t* ms,
+                const BYTE* const ip, const BYTE* const iend,
+                const U32 mls, const ZSTD_dictMode_e dictMode)
 {
     const BYTE* const base = ms->window.base;
     U32 const target = (U32)(ip - base);
@@ -508,7 +511,8 @@ void ZSTD_updateTree(ZSTD_matchState_t* ms, const BYTE* ip, const BYTE* iend) {
     ZSTD_updateTree_internal(ms, ip, iend, ms->cParams.minMatch, ZSTD_noDict);
 }
 
-static U32 ZSTD_insertBtAndGetAllMatches (
+FORCE_INLINE_TEMPLATE
+U32 ZSTD_insertBtAndGetAllMatches (
                     ZSTD_match_t* matches,   /* store result (found matches) in this table (presumed large enough) */
                     ZSTD_matchState_t* ms,
                     U32* nextToUpdate3,
@@ -741,7 +745,7 @@ static U32 ZSTD_insertBtAndGetAllMatches (
 }
 
 
-static U32 ZSTD_BtGetAllMatches (
+FORCE_INLINE_TEMPLATE U32 ZSTD_BtGetAllMatches (
                         ZSTD_match_t* matches,   /* store result (match found, increasing size) in this table */
                         ZSTD_matchState_t* ms,
                         U32* nextToUpdate3,
@@ -928,7 +932,7 @@ listStats(const U32* table, int lastEltID)
 
 #endif
 
-static size_t
+FORCE_INLINE_TEMPLATE size_t
 ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                                seqStore_t* seqStore,
                                U32 rep[ZSTD_REP_NUM],


### PR DESCRIPTION
#2763 regressed performance of `opt` by about ~7%.

There are 5 inlined functions in `opt`. I've re-tested the performance with and without inlining of each one separately.

The only function that can be outlined without any obvious regression on `gcc` is `ZSTD_getMatchPrice()`. But even then, it saves a negligible 4KB of binary size and no discernible compile speed difference, and the speed changes are not obviously better.


```
benched on level 16 silesia.tar, gcc-11
All inlined: 5.90 MB/s
ZSTD_compressBlock_opt_generic outlined: 5.82 MB/s
ZSTD_BtGetAllMatches outlined: 5.79 MB/s
ZSTD_insertBtAndGetAllMatches outlined: 5.78 MB/s
ZSTD_updateTree_internal outlined: 5.82 MB/s
ZSTD_getMatchPrice outlined: 5.86 MB/s (equal performance for level 17-19 though, and on enwik7).
```

Seeing this, it doesn't seem worth it to have outlined these functions. Cumulatively, the effect of outlining all of them saves a lot on binary size and compile speed, but the speed trade-off is too severe.
