### PR TITLE
[contrib][linux] Fix build after introducing ASM HUF implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dictionary
 NUL
 
 # Build artefacts
+contrib/linux-kernel/linux/
 projects/
 bin/
 .buckd/

--- a/contrib/linux-kernel/linux.mk
+++ b/contrib/linux-kernel/linux.mk
@@ -12,6 +12,7 @@ obj-$(CONFIG_ZSTD_COMPRESS) += zstd_compress.o
 obj-$(CONFIG_ZSTD_DECOMPRESS) += zstd_decompress.o
 
 ccflags-y += -O3
+ccflags-y += -Wno-error=deprecated-declarations
 
 zstd_compress-y := \
 		zstd_compress_module.o \

--- a/contrib/linux-kernel/linux.mk
+++ b/contrib/linux-kernel/linux.mk
@@ -42,6 +42,7 @@ zstd_decompress-y := \
 		common/fse_decompress.o \
 		common/zstd_common.o \
 		decompress/huf_decompress.o \
+		decompress/huf_decompress_amd64.o \
 		decompress/zstd_ddict.o \
 		decompress/zstd_decompress.o \
 		decompress/zstd_decompress_block.o \


### PR DESCRIPTION
This mostly fixes kernel build after introducing ASM HUF implementation, but also adds the ability to build the kernel with recently landed `CONFIG_WERROR` while in-kernel ZSTD library still uses the functions deprecated in 1.5.0.

Compile and run time tested on Linux 5.15-rc2 with Clang 12.