### PR TITLE
Fix typo

### DIFF
--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -932,7 +932,7 @@ ZSTDLIB_API unsigned ZSTD_getDictID_fromFrame(const void* src, size_t srcSize);
  * Advanced dictionary and prefix API (Requires v1.4.0+)
  *
  * This API allows dictionaries to be used with ZSTD_compress2(),
- * ZSTD_compressStream2(), and ZSTD_decompress(). Dictionaries are sticky, and
+ * ZSTD_compressStream2(), and ZSTD_decompressDCtx(). Dictionaries are sticky, and
  * only reset with the context is reset with ZSTD_reset_parameters or
  * ZSTD_reset_session_and_parameters. Prefixes are single-use.
  ******************************************************************************/


### PR DESCRIPTION
Fixes #2740 

This PR fixes a small typo in [this](https://github.com/facebook/zstd/blob/6ee70bae4632ce4f77f4aada0c519ef095633ecf/lib/zstd.h#L935) line of `zstd/lib/zstd.h`