### PR TITLE
[build] Fix oss-fuzz build with the dataflow sanitizer

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -233,6 +233,15 @@
 #  endif
 #endif
 
+/* detects whether we are being compiled undef dfsan */
+#ifndef ZSTD_DATAFLOW_SANITIZER
+# if __has_feature(dataflow_sanitizer)
+#  define ZSTD_DATAFLOW_SANITIZER 1
+# else
+#  define ZSTD_DATAFLOW_SANITIZER 0
+# endif
+#endif
+
 #if ZSTD_MEMORY_SANITIZER
 /* Not all platforms that support msan provide sanitizers/msan_interface.h.
  * We therefore declare the functions we need ourselves, rather than trying to

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -47,7 +47,7 @@
  * Disable when MSAN is enabled.
  */
 #if defined(__linux__) || defined(__linux) || defined(__APPLE__)
-# if ZSTD_MEMORY_SANITIZER
+# if ZSTD_MEMORY_SANITIZER || ZSTD_DATAFLOW_SANITIZER
 #  define HUF_ASM_SUPPORTED 0
 # else
 #  define HUF_ASM_SUPPORTED 1


### PR DESCRIPTION
The dataflow sanitizer requires all code to be instrumented. We can't
instrument the ASM function, so we have to disable it.