### PR TITLE
Limit train samples

### DIFF
--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -40,6 +40,11 @@
 /*-*************************************
 *  Constants
 ***************************************/
+/**
+* There are 32bit indexes used to ref samples, so limit samples size to 4GB
+* on 64bit builds.
+* For 32bit builds 1 GB is an arbitrary memory limit.
+*/
 #define COVER_MAX_SAMPLES_SIZE (sizeof(size_t) == 8 ? ((unsigned)-1) : ((unsigned)1 GB))
 #define COVER_DEFAULT_SPLITPOINT 1.0
 

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -43,7 +43,9 @@
 /**
 * There are 32bit indexes used to ref samples, so limit samples size to 4GB
 * on 64bit builds.
-* For 32bit builds 1 GB is an arbitrary memory limit.
+* For 32bit builds we choose 1 GB.
+* Most 32bit platforms have 2GB user-mode addressable space and we allocate a large
+* contiguous buffer, so 1GB is already a high limit.
 */
 #define COVER_MAX_SAMPLES_SIZE (sizeof(size_t) == 8 ? ((unsigned)-1) : ((unsigned)1 GB))
 #define COVER_DEFAULT_SPLITPOINT 1.0

--- a/lib/dictBuilder/fastcover.c
+++ b/lib/dictBuilder/fastcover.c
@@ -32,6 +32,11 @@
 /*-*************************************
 *  Constants
 ***************************************/
+/**
+* There are 32bit indexes used to ref samples, so limit samples size to 4GB
+* on 64bit builds.
+* For 32bit builds 1 GB is an arbitrary memory limit.
+*/
 #define FASTCOVER_MAX_SAMPLES_SIZE (sizeof(size_t) == 8 ? ((unsigned)-1) : ((unsigned)1 GB))
 #define FASTCOVER_MAX_F 31
 #define FASTCOVER_MAX_ACCEL 10

--- a/lib/dictBuilder/fastcover.c
+++ b/lib/dictBuilder/fastcover.c
@@ -35,7 +35,9 @@
 /**
 * There are 32bit indexes used to ref samples, so limit samples size to 4GB
 * on 64bit builds.
-* For 32bit builds 1 GB is an arbitrary memory limit.
+* For 32bit builds we choose 1 GB.
+* Most 32bit platforms have 2GB user-mode addressable space and we allocate a large
+* contiguous buffer, so 1GB is already a high limit.
 */
 #define FASTCOVER_MAX_SAMPLES_SIZE (sizeof(size_t) == 8 ? ((unsigned)-1) : ((unsigned)1 GB))
 #define FASTCOVER_MAX_F 31

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -145,15 +145,15 @@ static unsigned DiB_loadFiles(void* buffer, size_t* bufferSizePtr,
         DISPLAYUPDATE(2, "Loading %s...       \r", fileNamesTable[fileIndex]);
 
         /* Load the first chunk of data from the file */
-        size_t const chunkSize = targetChunkSize > 0 ?
+        size_t const headSize = targetChunkSize > 0 ?
                                     MIN(fileSize, targetChunkSize) :
                                     MIN(fileSize, SAMPLESIZE_MAX );
-        if (totalDataLoaded + chunkSize > *bufferSizePtr)
+        if (totalDataLoaded + headSize > *bufferSizePtr)
             break;
 
         size_t fileDataLoaded = fread(
-            buff+totalDataLoaded, 1, chunkSize, f );
-        if (fileDataLoaded != chunkSize)
+            buff+totalDataLoaded, 1, headSize, f );
+        if (fileDataLoaded != headSize)
             EXM_THROW(11, "Pb reading %s", fileNamesTable[fileIndex]);
         sampleSizes[nbSamplesLoaded++] = fileDataLoaded;
         totalDataLoaded += fileDataLoaded;

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -49,6 +49,7 @@
 static const size_t g_maxMemory = (sizeof(size_t) == 4) ? (2 GB - 64 MB) : ((size_t)(512 MB) << sizeof(size_t));
 
 #define NOISELENGTH 32
+#define MAX_SAMPLES_SIZE (2 GB) /* training dataset limited to 2GB */
 
 
 /*-*************************************
@@ -272,6 +273,10 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
                            FASTCOVER_MEMMULT;
     size_t const maxMem =  DiB_findMaxMem(fs.totalSizeToLoad * memMult) / memMult;
     size_t loadedSize = (size_t) MIN ((unsigned long long)maxMem, fs.totalSizeToLoad);
+
+    /* Limit the total size of the training samples to 2GB */
+    if (loadedSize > MAX_SAMPLES_SIZE)
+        loadedSize = MAX_SAMPLES_SIZE;
     void* const srcBuffer = malloc(loadedSize+NOISELENGTH);
     int result = 0;
 
@@ -296,7 +301,9 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
 
     /* init */
     if (loadedSize < fs.totalSizeToLoad)
-        DISPLAYLEVEL(1, "Not enough memory; training on %u MB only...\n", (unsigned)(loadedSize >> 20));
+        DISPLAYLEVEL(1, "Trainig samples set too large (%u MB); training on %u MB only...\n",
+            (unsigned)(fs.totalSizeToLoad >> 20),
+            (unsigned)(loadedSize >> 20));
 
     /* Load input buffer */
     DISPLAYLEVEL(3, "Shuffling input files\n");

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -96,7 +96,7 @@ static UTIL_time_t g_displayClock = UTIL_TIME_INITIALIZER;
 static S64 DiB_getFileSize (const char * fileName)
 {
     U64 const fileSize = UTIL_getFileSize(fileName);
-    return (fileSize == UTIL_FILESIZE_UNKNOWN) ? -1 : fileSize;
+    return (fileSize == UTIL_FILESIZE_UNKNOWN) ? -1 : (S64)fileSize;
 }
 
 /* ********************************************************
@@ -305,7 +305,7 @@ static fileStats DiB_fileStats(const char** fileNamesTable, int nbFiles, int chu
         fs.totalSizeToLoad += MIN(fileSize, SAMPLESIZE_MAX);
       }
     }
-    DISPLAYLEVEL(4, "Training files are %lluKB, %d samples\n", fs.totalSizeToLoad >> 10, fs.nbSamples);
+    DISPLAYLEVEL(4, "Training files are %lldKB, %d samples\n", fs.totalSizeToLoad >> 10, fs.nbSamples);
     return fs;
 }
 
@@ -335,7 +335,6 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
     fs = DiB_fileStats(fileNamesTable, nbFiles, chunkSize, displayLevel);
 
     {
-        sampleSizes = (size_t*)malloc(fs.nbSamples * sizeof(size_t));
         int const memMult = params ? MEMMULT :
                             coverParams ? COVER_MEMMULT:
                             FASTCOVER_MEMMULT;
@@ -345,6 +344,7 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
         /* TODO: there is oportunity to stop DiB_fileStats() early when the data limit is reached */
         loadedSize = MIN( MIN(maxMem, fs.totalSizeToLoad), MAX_SAMPLES_SIZE );
         srcBuffer = malloc(loadedSize+NOISELENGTH);
+        sampleSizes = (size_t*)malloc(fs.nbSamples * sizeof(size_t));
     }
 
     /* Checks */

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -317,8 +317,9 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
 {
     fileStats fs;
     size_t* sampleSizes; /* vector of sample sizes. Each sample can be up to SAMPLESIZE_MAX */
-    size_t loadedSize; /* total data loaded for all samples */
-    void* srcBuffer;
+    int nbSamplesLoaded; /* nb of samples effectively loaded in srcBuffer */
+    size_t loadedSize; /* total data loaded in srcBuffer for all samples */
+    void* srcBuffer /* contiguous buffer with training data/samples */;
     void* const dictBuffer = malloc(maxDictSize);
     int result = 0;
 
@@ -374,7 +375,7 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
             (unsigned)(loadedSize / (1 MB)));
 
     /* Load input buffer */
-    int const nbSamplesLoaded = DiB_loadFiles(
+    nbSamplesLoaded = DiB_loadFiles(
         srcBuffer, &loadedSize, sampleSizes, fs.nbSamples, fileNamesTable,
         nbFiles, chunkSize, displayLevel);
 

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -150,7 +150,7 @@ static int DiB_loadFiles(
         /* If file-chunking is enabled, load the rest of the file as more samples */
         if (targetChunkSize > 0) {
             while( (S64)fileDataLoaded < fileSize && nbSamplesLoaded < sstSize ) {
-                size_t const chunkSize = MIN(fileSize-fileDataLoaded, targetChunkSize);
+                size_t const chunkSize = MIN((size_t)(fileSize-fileDataLoaded), targetChunkSize);
                 if (totalDataLoaded + chunkSize > *bufferSizePtr) /* buffer is full */
                     break;
 

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -268,7 +268,7 @@ typedef struct {
  *  provides the amount of data to be loaded and the resulting nb of samples.
  *  This is useful primarily for allocation purpose => sample buffer, and sample sizes table.
  */
-static fileStats DiB_fileStats(const char** fileNamesTable, int nbFiles, int chunkSize, int displayLevel)
+static fileStats DiB_fileStats(const char** fileNamesTable, int nbFiles, size_t chunkSize, int displayLevel)
 {
     fileStats fs;
     int n;
@@ -310,8 +310,8 @@ static fileStats DiB_fileStats(const char** fileNamesTable, int nbFiles, int chu
     return fs;
 }
 
-int DiB_trainFromFiles(const char* dictFileName, int maxDictSize,
-                       const char** fileNamesTable, int nbFiles, int chunkSize,
+int DiB_trainFromFiles(const char* dictFileName, size_t maxDictSize,
+                       const char** fileNamesTable, int nbFiles, size_t chunkSize,
                        ZDICT_legacy_params_t* params, ZDICT_cover_params_t* coverParams,
                        ZDICT_fastCover_params_t* fastCoverParams, int optimize)
 {
@@ -363,7 +363,7 @@ int DiB_trainFromFiles(const char* dictFileName, int maxDictSize,
         DISPLAYLEVEL(2, "!  Alternatively, split files into fixed-size blocks representative of samples, with -B# \n");
         EXM_THROW(14, "nb of samples too low");   /* we now clearly forbid this case */
     }
-    if (fs.totalSizeToLoad < maxDictSize * 8) {
+    if (fs.totalSizeToLoad < (S64)maxDictSize * 8) {
         DISPLAYLEVEL(2, "!  Warning : data size of samples too small for target dictionary size \n");
         DISPLAYLEVEL(2, "!  Samples should be about 100x larger than target dictionary size \n");
     }

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -149,7 +149,7 @@ static int DiB_loadFiles(
 
         /* If file-chunking is enabled, load the rest of the file as more samples */
         if (targetChunkSize > 0) {
-            while( fileDataLoaded < fileSize && nbSamplesLoaded < sstSize ) {
+            while( (S64)fileDataLoaded < fileSize && nbSamplesLoaded < sstSize ) {
                 size_t const chunkSize = MIN(fileSize-fileDataLoaded, targetChunkSize);
                 if (totalDataLoaded + chunkSize > *bufferSizePtr) /* buffer is full */
                     break;

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -257,7 +257,7 @@ static void DiB_saveDict(const char* dictFileName,
 }
 
 typedef struct {
-    U64 totalSizeToLoad;
+    S64 totalSizeToLoad;
     int nbSamples;
     int oneSampleTooLarge;
 } fileStats;
@@ -342,7 +342,7 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
         /* Limit the size of the training data to the free memory */
         /* Limit the size of the training data to 2GB */
         /* TODO: there is oportunity to stop DiB_fileStats() early when the data limit is reached */
-        loadedSize = MIN( MIN(maxMem, fs.totalSizeToLoad), MAX_SAMPLES_SIZE );
+        loadedSize = MIN( MIN((S64)maxMem, fs.totalSizeToLoad), MAX_SAMPLES_SIZE );
         srcBuffer = malloc(loadedSize+NOISELENGTH);
         sampleSizes = (size_t*)malloc(fs.nbSamples * sizeof(size_t));
     }
@@ -361,14 +361,14 @@ int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
         DISPLAYLEVEL(2, "!  Alternatively, split files into fixed-size blocks representative of samples, with -B# \n");
         EXM_THROW(14, "nb of samples too low");   /* we now clearly forbid this case */
     }
-    if (fs.totalSizeToLoad < (unsigned long long)maxDictSize * 8) {
+    if (fs.totalSizeToLoad < maxDictSize * 8) {
         DISPLAYLEVEL(2, "!  Warning : data size of samples too small for target dictionary size \n");
         DISPLAYLEVEL(2, "!  Samples should be about 100x larger than target dictionary size \n");
     }
 
     /* init */
-    if (loadedSize < fs.totalSizeToLoad)
-        DISPLAYLEVEL(1, "Trainig samples set too large (%u MB); training on %u MB only...\n",
+    if ((S64)loadedSize < fs.totalSizeToLoad)
+        DISPLAYLEVEL(1, "Training samples set too large (%u MB); training on %u MB only...\n",
             (unsigned)(fs.totalSizeToLoad >> 20),
             (unsigned)(loadedSize >> 20));
 

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -148,8 +148,8 @@ static int DiB_loadFiles(
             if (fileDataLoaded != headSize)
                 EXM_THROW(11, "Pb reading %s", fileNamesTable[fileIndex]);
         }
-        sampleSizes[nbSamplesLoaded++] = fileDataLoaded;
-        totalDataLoaded += fileDataLoaded;
+        sampleSizes[nbSamplesLoaded++] = (size_t)fileDataLoaded;
+        totalDataLoaded += (size_t)fileDataLoaded;
 
         /* If file-chunking is enabled, load the rest of the file as more samples */
         if (targetChunkSize > 0) {
@@ -344,7 +344,7 @@ int DiB_trainFromFiles(const char* dictFileName, int maxDictSize,
         /* Limit the size of the training data to the free memory */
         /* Limit the size of the training data to 2GB */
         /* TODO: there is oportunity to stop DiB_fileStats() early when the data limit is reached */
-        loadedSize = MIN( MIN((S64)maxMem, fs.totalSizeToLoad), MAX_SAMPLES_SIZE );
+        loadedSize = (size_t)MIN( MIN((S64)maxMem, fs.totalSizeToLoad), MAX_SAMPLES_SIZE );
         srcBuffer = malloc(loadedSize+NOISELENGTH);
         sampleSizes = (size_t*)malloc(fs.nbSamples * sizeof(size_t));
     }

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -139,8 +139,8 @@ static int DiB_loadFiles(
         /* Load the first chunk of data from the file */
         {
             int const headSize = targetChunkSize > 0 ?
-                                        MIN(fileSize, targetChunkSize) :
-                                        MIN(fileSize, SAMPLESIZE_MAX );
+                                        (int)MIN(fileSize, targetChunkSize) :
+                                        (int)MIN(fileSize, SAMPLESIZE_MAX );
             if (totalDataLoaded + headSize > *bufferSizePtr)
                 break;
 
@@ -154,7 +154,7 @@ static int DiB_loadFiles(
         /* If file-chunking is enabled, load the rest of the file as more samples */
         if (targetChunkSize > 0) {
             while( fileDataLoaded < fileSize && nbSamplesLoaded < sstSize ) {
-                int const chunkSize = MIN(fileSize-fileDataLoaded, targetChunkSize);
+                int const chunkSize = (int)MIN(fileSize-fileDataLoaded, targetChunkSize);
                 if (totalDataLoaded + chunkSize > *bufferSizePtr) /* buffer is full */
                     break;
 
@@ -289,7 +289,7 @@ static fileStats DiB_fileStats(const char** fileNamesTable, int nbFiles, int chu
       if (chunkSize > 0)
       {
         // TODO: is there a minimum sample size? Can we have a 1-byte sample?
-        fs.nbSamples += (fileSize + chunkSize-1) / chunkSize;
+        fs.nbSamples += (int)((fileSize + chunkSize-1) / chunkSize);
         fs.totalSizeToLoad += fileSize;
       }
       else {
@@ -310,8 +310,8 @@ static fileStats DiB_fileStats(const char** fileNamesTable, int nbFiles, int chu
     return fs;
 }
 
-int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
-                       const char** fileNamesTable, unsigned nbFiles, size_t chunkSize,
+int DiB_trainFromFiles(const char* dictFileName, int maxDictSize,
+                       const char** fileNamesTable, int nbFiles, int chunkSize,
                        ZDICT_legacy_params_t* params, ZDICT_cover_params_t* coverParams,
                        ZDICT_fastCover_params_t* fastCoverParams, int optimize)
 {

--- a/programs/dibio.h
+++ b/programs/dibio.h
@@ -31,8 +31,8 @@
     `parameters` is optional and can be provided with values set to 0, meaning "default".
     @return : 0 == ok. Any other : error.
 */
-int DiB_trainFromFiles(const char* dictFileName, int maxDictSize,
-                       const char** fileNamesTable, int nbFiles, int chunkSize,
+int DiB_trainFromFiles(const char* dictFileName, size_t maxDictSize,
+                       const char** fileNamesTable, int nbFiles, size_t chunkSize,
                        ZDICT_legacy_params_t* params, ZDICT_cover_params_t* coverParams,
                        ZDICT_fastCover_params_t* fastCoverParams, int optimize);
 

--- a/programs/dibio.h
+++ b/programs/dibio.h
@@ -31,8 +31,8 @@
     `parameters` is optional and can be provided with values set to 0, meaning "default".
     @return : 0 == ok. Any other : error.
 */
-int DiB_trainFromFiles(const char* dictFileName, unsigned maxDictSize,
-                       const char** fileNamesTable, unsigned nbFiles, size_t chunkSize,
+int DiB_trainFromFiles(const char* dictFileName, int maxDictSize,
+                       const char** fileNamesTable, int nbFiles, int chunkSize,
                        ZDICT_legacy_params_t* params, ZDICT_cover_params_t* coverParams,
                        ZDICT_fastCover_params_t* fastCoverParams, int optimize);
 

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1290,18 +1290,18 @@ int main(int argCount, const char* argv[])
             int const optimize = !coverParams.k || !coverParams.d;
             coverParams.nbThreads = (unsigned)nbWorkers;
             coverParams.zParams = zParams;
-            operationResult = DiB_trainFromFiles(outFileName, maxDictSize, filenames->fileNames, (unsigned)filenames->tableSize, blockSize, NULL, &coverParams, NULL, optimize);
+            operationResult = DiB_trainFromFiles(outFileName, maxDictSize, filenames->fileNames, (int)filenames->tableSize, blockSize, NULL, &coverParams, NULL, optimize);
         } else if (dict == fastCover) {
             int const optimize = !fastCoverParams.k || !fastCoverParams.d;
             fastCoverParams.nbThreads = (unsigned)nbWorkers;
             fastCoverParams.zParams = zParams;
-            operationResult = DiB_trainFromFiles(outFileName, maxDictSize, filenames->fileNames, (unsigned)filenames->tableSize, blockSize, NULL, NULL, &fastCoverParams, optimize);
+            operationResult = DiB_trainFromFiles(outFileName, maxDictSize, filenames->fileNames, (int)filenames->tableSize, blockSize, NULL, NULL, &fastCoverParams, optimize);
         } else {
             ZDICT_legacy_params_t dictParams;
             memset(&dictParams, 0, sizeof(dictParams));
             dictParams.selectivityLevel = dictSelect;
             dictParams.zParams = zParams;
-            operationResult = DiB_trainFromFiles(outFileName, maxDictSize, filenames->fileNames, (unsigned)filenames->tableSize, blockSize, &dictParams, NULL, NULL, 0);
+            operationResult = DiB_trainFromFiles(outFileName, maxDictSize, filenames->fileNames, (int)filenames->tableSize, blockSize, &dictParams, NULL, NULL, 0);
         }
 #else
         (void)dictCLevel; (void)dictSelect; (void)dictID;  (void)maxDictSize; /* not used when ZSTD_NODICT set */


### PR DESCRIPTION
- Limit loaded samples to 2GB.
- Fixes https://github.com/facebook/zstd/issues/2745 
- Support for --block-size option which enables chunking - the sample files are broken up into chunks and each chunk is a training sample.
- A sample is limited to 128KB.
- Rewrote the sample loading logic to be more expressive.
