### PR TITLE
Use unused functions to appease Visual Studio

### DIFF
--- a/lib/compress/huf_compress.c
+++ b/lib/compress/huf_compress.c
@@ -471,8 +471,7 @@ static void HUF_swapNodes(nodeElt* a, nodeElt* b) {
 }
 
 /* Returns 0 if the huffNode array is not sorted by descending count */
-UNUSED_ATTR
-static int HUF_isSorted(nodeElt huffNode[], U32 const maxSymbolValue1) {
+MEM_STATIC int HUF_isSorted(nodeElt huffNode[], U32 const maxSymbolValue1) {
     U32 i;
     for (i = 1; i < maxSymbolValue1; ++i) {
         if (huffNode[i].count > huffNode[i-1].count) {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3737,16 +3737,6 @@ static size_t ZSTD_compressBlock_splitBlock(ZSTD_CCtx* zc,
     return cSize;
 }
 
-/* ZSTD_convertBlockSequencesToSeqStore()
- * Converts an array of ZSTD_Sequence* with the corresponding original src buffer into
- * the seqStore of a cctx.
- *
- * Returns 0 on success, ZSTD_error on failure.
- */
-static UNUSED_ATTR size_t ZSTD_convertBlockSequencesToSeqStore(ZSTD_CCtx* cctx,
-                                  const ZSTD_Sequence* inSeqs, size_t inSeqsSize,
-                                  const void* src, size_t srcSize);
-
 static size_t ZSTD_compressBlock_internal(ZSTD_CCtx* zc,
                                         void* dst, size_t dstCapacity,
                                         const void* src, size_t srcSize, U32 frame)
@@ -5834,13 +5824,6 @@ static size_t ZSTD_copySequencesToSeqStoreExplicitBlockDelim(ZSTD_CCtx* cctx, ZS
     RETURN_ERROR_IF(ip != iend, corruption_detected, "Blocksize doesn't agree with block delimiter!");
     seqPos->idx = idx+1;
     return 0;
-}
-
-static size_t ZSTD_convertBlockSequencesToSeqStore(ZSTD_CCtx* cctx,
-                                  const ZSTD_Sequence* inSeqs, size_t inSeqsSize,
-                                  const void* src, size_t srcSize) {
-    ZSTD_sequencePosition dummySeqPos = {0, 0, 0};
-    return ZSTD_copySequencesToSeqStoreExplicitBlockDelim(cctx, &dummySeqPos, inSeqs, inSeqsSize, src, srcSize);
 }
 
 /* Returns the number of bytes to move the current read position back by. Only non-zero


### PR DESCRIPTION
Will need to be merged before #2845 to check that tests pass.
Unfortunately, Visual Studio doesn't have a good way of specifying unused static functions. It seems only versions below 2015 complain about this.

The alternative to this is to suppress warning C4505 for these files:
```
#ifdef _MSC_VER    /* Visual Studio */
#  pragma warning(disable : 4505)        /* disable: C4505: unused function */
#endif
```

To the beginning of `huf_compress.c` and `zstd_compress.c`.