### PR TITLE
Remove executable flag from GNU_STACK segment

### DIFF
--- a/lib/decompress/huf_decompress_amd64.S
+++ b/lib/decompress/huf_decompress_amd64.S
@@ -1,5 +1,12 @@
 #if !defined(HUF_DISABLE_ASM) && defined(__x86_64__)
 
+/* Stack marking
+ * ref: https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
+ */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
+
 /* Calling convention:
  *
  * %rdi contains the first argument: HUF_DecompressAsmArgs*.


### PR DESCRIPTION
Putting stack marking into every assembly file is required to indicate
that the stack does not need to be executable.
Executable flag on stack conflicts with some security measures, Systemd
MemoryDenyWriteExecute=yes for example.

The current dev branch produces libzstd.so that uses executable GNU_STACK on Linux amd64 machines. It makes some of systemd daemons crash as they cannot load the library because of systemd security option `MemoryDenyWriteExecute=yes`

```
$ readelf -lW lib/libzstd.so | grep RWE
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RWE 0x10
```

This executable stack makes systemd angry. Systemd has a security option `MemoryDenyWriteExecute=yes` that blocks memory allocation with writable and executable flags on.

To emulate the option, on ubuntu 21.10,
```
$ sudo systemd-run -t -p MemoryDenyWriteExecute=yes /lib/systemd/systemd-timesyncd -v
Running as unit: run-u782.service
Press ^] three times within 1s to disconnect TTY.
/lib/systemd/systemd-timesyncd: error while loading shared libraries: libzstd.so.1: cannot enable executable stack as shared object requires: Operation not permitted
```
