### PR TITLE
Fix SPM warning: umbrella header for module 'libzstd' does not include header 'xxx.h'

### DIFF
--- a/lib/modulemap/module.modulemap
+++ b/lib/modulemap/module.modulemap
@@ -1,4 +1,4 @@
 module libzstd [extern_c] {
-    umbrella header "zstd-umbrella.h"
+    header "../zstd.h"
     export *
 }

--- a/lib/modulemap/module.modulemap
+++ b/lib/modulemap/module.modulemap
@@ -1,4 +1,4 @@
-module libzstd {
-    umbrella header "../zstd.h"
+module libzstd [extern_c] {
+    umbrella header "zstd-umbrella.h"
     export *
 }

--- a/lib/modulemap/zstd-umbrella.h
+++ b/lib/modulemap/zstd-umbrella.h
@@ -1,0 +1,1 @@
+#include "../zstd.h"

--- a/lib/modulemap/zstd-umbrella.h
+++ b/lib/modulemap/zstd-umbrella.h
@@ -1,1 +1,0 @@
-#include "../zstd.h"


### PR DESCRIPTION
When add zstd as dependency:

```swift
// swift-tools-version:5.0
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
...
    dependencies: [
        // Dependencies declare other packages that this package depends on.
        .package(url: "https://github.com/facebook/zstd.git", .branch("dev")),
    ]
...
)
```

Build package:

```
swift build
```

Many warnings about `umbrella header for module 'libzstd'`:

```
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_compress_internal.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/hist.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_ldm.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_ldm_geartab.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_lazy.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_opt.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_cwksp.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/clevels.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_compress_literals.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_double_fast.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstdmt_compress.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_compress_superblock.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_compress_sequences.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/compress/zstd_fast.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header 'zdict.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/dictBuilder/cover.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/dictBuilder/divsufsort.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/decompress/zstd_decompress_block.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/decompress/zstd_decompress_internal.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/decompress/zstd_ddict.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_v03.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_v07.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_v04.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_v01.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_v05.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_v02.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_legacy.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/legacy/zstd_v06.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/zstd_trace.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/xxhash.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/debug.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/pool.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/compiler.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/threading.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/error_private.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/bitstream.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/cpu.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/huf.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/zstd_deps.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/mem.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/fse.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/common/zstd_internal.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header 'zstd_errors.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "../zstd.h"
        ^
./zstd/lib/zstd.h:2563:1: warning: umbrella header for module 'libzstd' does not include header '/deprecated/zbuff.h'

^
[31/31] Build complete!
```

> Any headers not included by the umbrella header should have explicit header declarations. Use the -Wincomplete-umbrella warning option to ask Clang to complain about headers not covered by the umbrella header or the module map.
>
> https://clang.llvm.org/docs/Modules.html#header-declaration

So, It needs an umbrella header wrap `zstd.h`