### PR TITLE
Add detection when compiling with Clang and Ninja under Windows

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -106,7 +106,7 @@ if (MSVC)
 endif ()
 
 # With MSVC static library needs to be renamed to avoid conflict with import library
-if (MSVC)
+if (MSVC OR (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     set(STATIC_LIBRARY_BASE_NAME zstd_static)
 else ()
     set(STATIC_LIBRARY_BASE_NAME zstd)


### PR DESCRIPTION
According to the [Clang documentation](https://clang.llvm.org/docs/MSVCCompatibility.html) Clang creates MSVC-compatible libraries by default when compiling for Windows. This includes the names of the resulting library files.
This fixes the ninja error `multiple rules generate lib/zstd.lib [-w dupbuild=err]` for Clang under Windows.

Fixes #2248 and propably #2770 