### PR TITLE
Imply -q when stderr is not a tty

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -683,7 +683,7 @@ FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
         }
 #endif
         if (!prefs->overwrite) {
-            if (g_display_prefs.displayLevel <= 1) {
+            if (g_display_prefs.displayLevel == 0) {
                 /* No interaction possible */
                 DISPLAY("zstd: %s already exists; not overwritten  \n",
                         dstFileName);
@@ -1870,7 +1870,7 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
     /* init */
     assert(outFileName != NULL || suffix != NULL);
     if (outFileName != NULL) {   /* output into a single destination (stdout typically) */
-        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 1 /* displayLevelCutoff */)) {
+        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 0 /* displayLevelCutoff */)) {
             FIO_freeCResources(&ress);
             return 1;
         }
@@ -2810,7 +2810,7 @@ FIO_decompressMultipleFilenames(FIO_ctx_t* const fCtx,
     dRess_t ress = FIO_createDResources(prefs, dictFileName);
 
     if (outFileName) {
-        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 1 /* displayLevelCutoff */)) {
+        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 0 /* displayLevelCutoff */)) {
             FIO_freeDResources(ress);
             return 1;
         }

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -683,7 +683,7 @@ FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
         }
 #endif
         if (!prefs->overwrite) {
-            if (g_display_prefs.displayLevel == 0) {
+            if (g_display_prefs.displayLevel <= 1) {
                 /* No interaction possible */
                 DISPLAY("zstd: %s already exists; not overwritten  \n",
                         dstFileName);
@@ -1870,7 +1870,7 @@ int FIO_compressMultipleFilenames(FIO_ctx_t* const fCtx,
     /* init */
     assert(outFileName != NULL || suffix != NULL);
     if (outFileName != NULL) {   /* output into a single destination (stdout typically) */
-        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 0 /* displayLevelCutoff */)) {
+        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 1 /* displayLevelCutoff */)) {
             FIO_freeCResources(&ress);
             return 1;
         }
@@ -2810,7 +2810,7 @@ FIO_decompressMultipleFilenames(FIO_ctx_t* const fCtx,
     dRess_t ress = FIO_createDResources(prefs, dictFileName);
 
     if (outFileName) {
-        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 0 /* displayLevelCutoff */)) {
+        if (FIO_removeMultiFilesWarning(fCtx, prefs, outFileName, 1 /* displayLevelCutoff */)) {
             FIO_freeDResources(ress);
             return 1;
         }

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1365,12 +1365,7 @@ int main(int argCount, const char* argv[])
     /* No status message in pipe mode (stdin - stdout) */
     hasStdout = outFileName && !strcmp(outFileName,stdoutmark);
 
-    if (hasStdout && (g_displayLevel==2)) g_displayLevel=1;
-
-    /* If stderr is not a TTY, imply -q */
-    if (!IS_CONSOLE(stderr) && g_displayLevel == DISPLAY_LEVEL_DEFAULT) {
-        g_displayLevel--;
-    }
+    if ((hasStdout || !IS_CONSOLE(stderr)) && (g_displayLevel==2)) g_displayLevel=1;
 
     /* IO Stream/File */
     FIO_setHasStdoutOutput(fCtx, hasStdout);

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1163,6 +1163,11 @@ int main(int argCount, const char* argv[])
         UTIL_refFilename(filenames, argument);
     }
 
+    /* If stderr is not a TTY, imply -q */
+    if (!IS_CONSOLE(stderr) && g_displayLevel == DISPLAY_LEVEL_DEFAULT) {
+        g_displayLevel--;
+    }
+
     /* Welcome message (if verbose) */
     DISPLAYLEVEL(3, WELCOME_MESSAGE);
 

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1163,11 +1163,6 @@ int main(int argCount, const char* argv[])
         UTIL_refFilename(filenames, argument);
     }
 
-    /* If stderr is not a TTY, imply -q */
-    if (!IS_CONSOLE(stderr) && g_displayLevel == DISPLAY_LEVEL_DEFAULT) {
-        g_displayLevel--;
-    }
-
     /* Welcome message (if verbose) */
     DISPLAYLEVEL(3, WELCOME_MESSAGE);
 
@@ -1371,6 +1366,11 @@ int main(int argCount, const char* argv[])
     hasStdout = outFileName && !strcmp(outFileName,stdoutmark);
 
     if (hasStdout && (g_displayLevel==2)) g_displayLevel=1;
+
+    /* If stderr is not a TTY, imply -q */
+    if (!IS_CONSOLE(stderr) && g_displayLevel == DISPLAY_LEVEL_DEFAULT) {
+        g_displayLevel--;
+    }
 
     /* IO Stream/File */
     FIO_setHasStdoutOutput(fCtx, hasStdout);

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -257,7 +257,7 @@ zstd -d -f tmp.zst --memlimit=2K -c > $INTOVOID && die "decompression needs more
 zstd -d -f tmp.zst --memory=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
 zstd -d -f tmp.zst --memlimit-decompress=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
 println "test : overwrite protection"
-zstd -q tmp && die "overwrite check failed!"
+echo "no" | zstd -q tmp && die "overwrite check failed!"
 println "test : force overwrite"
 zstd -q -f tmp
 zstd -q --force tmp
@@ -266,7 +266,7 @@ rm -f tmpro tmpro.zst
 println foo > tmpro.zst
 println foo > tmpro
 chmod 400 tmpro.zst
-zstd -q tmpro && die "should have refused to overwrite read-only file"
+echo "no" | zstd -q tmpro && die "should have refused to overwrite read-only file"
 zstd -q -f tmpro
 println "test: --no-progress flag"
 zstd tmpro -c --no-progress | zstd -d -f -o "$INTOVOID" --no-progress
@@ -416,7 +416,7 @@ zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
 zstd -d tmp1.zst tmp2.zst -o tmp
 touch tmpexists
 zstd tmp1 tmp2 -f -o tmpexists
-zstd tmp1 tmp2 -q -o tmpexists && die "should have refused to overwrite"
+echo "no" | zstd tmp1 tmp2 -q -o tmpexists && die "should have refused to overwrite"
 println gooder > tmp_rm1
 println boi > tmp_rm2
 println worldly > tmp_rm3

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -257,7 +257,7 @@ zstd -d -f tmp.zst --memlimit=2K -c > $INTOVOID && die "decompression needs more
 zstd -d -f tmp.zst --memory=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
 zstd -d -f tmp.zst --memlimit-decompress=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
 println "test : overwrite protection"
-echo "no" | zstd -q tmp && die "overwrite check failed!"
+zstd -q tmp && die "overwrite check failed!"
 println "test : force overwrite"
 zstd -q -f tmp
 zstd -q --force tmp
@@ -266,7 +266,7 @@ rm -f tmpro tmpro.zst
 println foo > tmpro.zst
 println foo > tmpro
 chmod 400 tmpro.zst
-echo "no" | zstd -q tmpro && die "should have refused to overwrite read-only file"
+zstd -q tmpro && die "should have refused to overwrite read-only file"
 zstd -q -f tmpro
 println "test: --no-progress flag"
 zstd tmpro -c --no-progress | zstd -d -f -o "$INTOVOID" --no-progress
@@ -351,8 +351,8 @@ zstd < tmpPrompt -o tmpPrompt.zst -f    # should successfully overwrite with -f
 zstd -q -d -f tmpPrompt.zst -o tmpPromptRegenerated
 $DIFF tmpPromptRegenerated tmpPrompt    # the first 'y' character should not be swallowed
 
-echo 'yes' | zstd tmpPrompt -o tmpPrompt.zst  # accept piped "y" input to force overwrite when using files
-echo 'yes' | zstd < tmpPrompt -o tmpPrompt.zst && die "should have aborted immediately and failed to overwrite"
+echo 'yes' | zstd tmpPrompt -v -o tmpPrompt.zst  # accept piped "y" input to force overwrite when using files
+echo 'yes' | zstd < tmpPrompt -v -o tmpPrompt.zst && die "should have aborted immediately and failed to overwrite"
 zstd tmpPrompt - < tmpPrompt -o tmpPromp.zst --rm && die "should have aborted immediately and failed to remove"
 
 println "Test completed"
@@ -416,15 +416,15 @@ zstd tmp1.zst tmp2.zst -o "$INTOVOID" -f
 zstd -d tmp1.zst tmp2.zst -o tmp
 touch tmpexists
 zstd tmp1 tmp2 -f -o tmpexists
-echo "no" | zstd tmp1 tmp2 -q -o tmpexists && die "should have refused to overwrite"
+zstd tmp1 tmp2 -q -o tmpexists && die "should have refused to overwrite"
 println gooder > tmp_rm1
 println boi > tmp_rm2
 println worldly > tmp_rm3
-echo 'y' | zstd tmp_rm1 tmp_rm2 -o tmp_rm3.zst --rm     # tests the warning prompt for --rm with multiple inputs into once source
+echo 'y' | zstd tmp_rm1 tmp_rm2 -v -o tmp_rm3.zst --rm     # tests the warning prompt for --rm with multiple inputs into once source
 test ! -f tmp_rm1
 test ! -f tmp_rm2
 cp tmp_rm3.zst tmp_rm4.zst
-echo 'Y' | zstd -d tmp_rm3.zst tmp_rm4.zst -o tmp_rm_out --rm
+echo 'Y' | zstd -d tmp_rm3.zst tmp_rm4.zst -v -o tmp_rm_out --rm
 test ! -f tmp_rm3.zst
 test ! -f tmp_rm4.zst
 echo 'yes' | zstd tmp_rm_out tmp_rm3 -c --rm && die "compressing multiple files to stdout with --rm should fail unless -f is specified"

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -371,9 +371,9 @@ test ! -f tmp.zst   # tmp.zst should no longer be present
 println "test : should quietly not remove non-regular file"
 println hello > tmp
 zstd tmp -f -o "$DEVDEVICE" 2>tmplog > "$INTOVOID"
-grep -v "Refusing to remove non-regular file" tmplog
+grep "Refusing to remove non-regular file" tmplog && die
 rm -f tmplog
-zstd tmp -f -o "$INTOVOID" 2>&1 | grep -v "Refusing to remove non-regular file"
+zstd tmp -f -o "$INTOVOID" 2>&1 | grep "Refusing to remove non-regular file" && die
 println "test : --rm on stdin"
 println a | zstd --rm > $INTOVOID   # --rm should remain silent
 rm -f tmp


### PR DESCRIPTION
This avoids progress bar updates when inappropriate for stderr, to address https://github.com/facebook/zstd/issues/2816