### PR TITLE
[test] Test that the exec-stack bit isn't set on libzstd.so

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -117,11 +117,11 @@ jobs:
         make -C zlibWrapper test
         make -C zlibWrapper valgrindTest
 
-  lz4-threadpool-partial-libs:
+  lz4-threadpool-libs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: LZ4, thread pool, and partial libs testslib wrapper test
+    - name: LZ4, thread pool, and libs build testslib wrapper test
       run: |
         make lz4install
         make -C tests test-lz4
@@ -129,7 +129,7 @@ jobs:
         make clean
         make -C tests test-pool
         make clean
-        bash tests/libzstd_partial_builds.sh
+        bash tests/libzstd_builds.sh
 
   gcc-make-tests-32bit:
     runs-on: ubuntu-latest

--- a/tests/libzstd_builds.sh
+++ b/tests/libzstd_builds.sh
@@ -23,14 +23,19 @@ mustBeAbsent() {
 
 # default compilation : all features enabled - no zbuff
 $ECHO "testing default library compilation"
-CFLAGS= make -C $DIR/../lib libzstd.a > $INTOVOID
+CFLAGS= make -C $DIR/../lib libzstd libzstd.a > $INTOVOID
 nm $DIR/../lib/libzstd.a | $GREP "\.o" > tmplog
 isPresent "zstd_compress.o"
 isPresent "zstd_decompress.o"
 isPresent "zdict.o"
 isPresent "zstd_v07.o"
 mustBeAbsent "zbuff_compress.o"
-$RM $DIR/../lib/libzstd.a tmplog
+$RM tmplog
+
+# Check that the exec-stack bit isn't set
+readelf -lW $DIR/../lib/libzstd.so | $GREP "GNU_STACK" > tmplog
+mustBeAbsent "RWE"
+$RM $DIR/../lib/libzstd.a $DIR/../lib/libzstd.so* tmplog
 
 # compression disabled => also disable zdict
 $ECHO "testing with compression disabled"


### PR DESCRIPTION
Tests that libzstd.so doesn't have the exec-stack bit set using
readelf. If the stack is marked executable systemd will refuse
to link against zstd. We now test that it isn't set on every PR.

Adds a test for PR #2857
Fixes Issue #2865