### PR TITLE
fixbug CLI's -D fails when the argument is not a regular file

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -742,6 +742,8 @@ static size_t FIO_createDictBuffer(void** bufferPtr, const char* fileName, FIO_p
     if (fileHandle==NULL) EXM_THROW(31, "%s: %s", fileName, strerror(errno));
 
     fileSize = UTIL_getFileSize(fileName);
+    if (fileSize == UTIL_FILESIZE_UNKNOWN) 
+    	EXM_THROW(32, "This file format is not supported : Dictionary file %s\n", fileName);
     {
         size_t const dictSizeMax = prefs->patchFromMode ? prefs->memLimit : DICTSIZE_MAX;
         if (fileSize >  dictSizeMax) {


### PR DESCRIPTION
I have added a judgment on the length of the file here. If the length is equal to ‘-1’, it is considered to be a wrong file format, which is not currently supported, and the problem of #2874  is temporarily solved. 