### PR TITLE
[CircleCI] Fix short-tests-0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,13 @@ jobs:
           name: Test
           command: |
             ./tests/test-license.py
-            cc -v; CFLAGS="-O0 -Werror -pedantic" make all && make clean
-            make c99build         && make clean
-            make c11build         && make clean
-            make -j regressiontest&& make clean
-            make shortest         && make clean
-            make cxxtest          && make clean
+            cc -v
+            CFLAGS="-O0 -Werror -pedantic" make allmost; make clean
+            make c99build; make clean
+            make c11build; make clean
+            make -j regressiontest; make clean
+            make shortest; make clean
+            make cxxtest; make clean
   # the second half of the jobs are in this test
   short-tests-1:
     docker:

--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -10,6 +10,13 @@ on:
     branches: [ dev, release, actionsTest ]
 
 jobs:
+  make-all:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: make all
+      run: make all
+
   # lasts ~24mn
   make-test:
     runs-on: ubuntu-latest

--- a/examples/common.h
+++ b/examples/common.h
@@ -57,7 +57,7 @@ typedef enum {
  * Check the zstd error code and die if an error occurred after printing a
  * message.
  */
-#define CHECK_ZSTD(fn, ...)                                      \
+#define CHECK_ZSTD(fn)                                           \
     do {                                                         \
         size_t const err = (fn);                                 \
         CHECK(!ZSTD_isError(err), "%s", ZSTD_getErrorName(err)); \

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -258,7 +258,10 @@
 # elif ZSTD_HAS_CPP_ATTRIBUTE(fallthrough)
 #  define ZSTD_FALLTHROUGH [[fallthrough]]
 # elif __has_attribute(__fallthrough__)
-#  define ZSTD_FALLTHROUGH __attribute__((__fallthrough__))
+/* Leading semicolon is to satisfy gcc-11 with -pedantic. Without the semicolon
+ * gcc complains about: a label can only be part of a statement and a declaration is not a statement.
+ */
+#  define ZSTD_FALLTHROUGH ; __attribute__((__fallthrough__))
 # else
 #  define ZSTD_FALLTHROUGH
 # endif

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1333,7 +1333,7 @@ typedef struct {
     searchMax_f searchMax;
 } ZSTD_LazyVTable;
 
-#define GEN_ZSTD_BT_VTABLE(dictMode, mls, ...)                                        \
+#define GEN_ZSTD_BT_VTABLE(dictMode, mls)                                             \
     static size_t ZSTD_BtFindBestMatch_##dictMode##_##mls(                            \
             ZSTD_matchState_t* ms,                                                    \
             const BYTE* ip, const BYTE* const iLimit,                                 \
@@ -1346,7 +1346,7 @@ typedef struct {
         ZSTD_BtFindBestMatch_##dictMode##_##mls                                       \
     };
 
-#define GEN_ZSTD_HC_VTABLE(dictMode, mls, ...)                                        \
+#define GEN_ZSTD_HC_VTABLE(dictMode, mls)                                             \
     static size_t ZSTD_HcFindBestMatch_##dictMode##_##mls(                            \
             ZSTD_matchState_t* ms,                                                    \
             const BYTE* ip, const BYTE* const iLimit,                                 \

--- a/lib/decompress/huf_decompress_amd64.S
+++ b/lib/decompress/huf_decompress_amd64.S
@@ -62,15 +62,6 @@
 #define vard2  r10d
 #define vard3  r11d
 
-/* Helper macro: args if idx != 4. */
-#define IF_NOT_4_0(...) __VA_ARGS__
-#define IF_NOT_4_1(...) __VA_ARGS__
-#define IF_NOT_4_2(...) __VA_ARGS__
-#define IF_NOT_4_3(...) __VA_ARGS__
-#define IF_NOT_4_4(...)
-#define IF_NOT_4_(idx, ...) IF_NOT_4_##idx(__VA_ARGS__)
-#define IF_NOT_4(idx, ...) IF_NOT_4_(idx, __VA_ARGS__)
-
 /* Calls X(N) for each stream 0, 1, 2, 3. */
 #define FOR_EACH_STREAM(X) \
     X(0);                  \
@@ -211,11 +202,11 @@ HUF_decompress4X1_usingDTable_internal_bmi2_asm_loop:
     movb %ah, idx(%op##n)
 
 /* Assumes GET_NEXT_DELT has been called.
- * Calls DECODE_FROM_DELT then GET_NEXT_DELT if n < 4
+ * Calls DECODE_FROM_DELT then GET_NEXT_DELT
  */
-#define DECODE(n, idx)              \
+#define DECODE_AND_GET_NEXT(n, idx) \
     DECODE_FROM_DELT(n, idx);       \
-    IF_NOT_4(idx, GET_NEXT_DELT(n))
+    GET_NEXT_DELT(n)                \
 
 /* // ctz & nbBytes is stored in bits[n]
  * // nbBits is stored in %rax
@@ -254,11 +245,11 @@ HUF_decompress4X1_usingDTable_internal_bmi2_asm_loop:
     /* Decode 5 symbols in each of the 4 streams (20 total)
      * Must have called GET_NEXT_DELT for each stream
      */
-    FOR_EACH_STREAM_WITH_INDEX(DECODE, 0)
-    FOR_EACH_STREAM_WITH_INDEX(DECODE, 1)
-    FOR_EACH_STREAM_WITH_INDEX(DECODE, 2)
-    FOR_EACH_STREAM_WITH_INDEX(DECODE, 3)
-    FOR_EACH_STREAM_WITH_INDEX(DECODE, 4)
+    FOR_EACH_STREAM_WITH_INDEX(DECODE_AND_GET_NEXT, 0)
+    FOR_EACH_STREAM_WITH_INDEX(DECODE_AND_GET_NEXT, 1)
+    FOR_EACH_STREAM_WITH_INDEX(DECODE_AND_GET_NEXT, 2)
+    FOR_EACH_STREAM_WITH_INDEX(DECODE_AND_GET_NEXT, 3)
+    FOR_EACH_STREAM_WITH_INDEX(DECODE_FROM_DELT, 4)
 
     /* Load ip[1,2,3] from stack (var[] aliases them)
      * ip[] is needed for RELOAD_BITS

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1855,7 +1855,7 @@ static int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double co
             && oldTestLog /* at least one test happened */ && resetAllowed) {
             maxTestSize = FUZ_randomLength(&lseed, oldTestLog+2);
             maxTestSize = MIN(maxTestSize, srcBufferSize-16);
-            {   U64 const pledgedSrcSize = (FUZ_rand(&lseed) & 3) ? ZSTD_CONTENTSIZE_UNKNOWN : maxTestSize; 
+            {   U64 const pledgedSrcSize = (FUZ_rand(&lseed) & 3) ? ZSTD_CONTENTSIZE_UNKNOWN : maxTestSize;
                 CHECK_Z( ZSTD_CCtx_reset(zc, ZSTD_reset_session_only) );
                 CHECK_Z( ZSTD_CCtx_setPledgedSrcSize(zc, pledgedSrcSize) );
             }
@@ -2357,7 +2357,7 @@ static int fuzzerTests_newAPI(U32 seed, int nbTests, int startTest,
 
         /* multi - fragments decompression test */
         if (!dictSize /* don't reset if dictionary : could be different */ && (FUZ_rand(&lseed) & 1)) {
-            DISPLAYLEVEL(5, "resetting DCtx (dict:%p) \n", dict);
+            DISPLAYLEVEL(5, "resetting DCtx (dict:%p) \n", (void const*)dict);
             CHECK_Z( ZSTD_resetDStream(zd) );
         } else {
             if (dictSize)


### PR DESCRIPTION
short-tests-0 were silently failing. I think because of the `&& make clean` construction. Switch to `;` instead.

Fix the reported build errors.