### PR TITLE
Avoid Using Deprecated Functions in Deprecated Code

### DIFF
--- a/lib/deprecated/zbuff_compress.c
+++ b/lib/deprecated/zbuff_compress.c
@@ -15,6 +15,7 @@
 ***************************************/
 #define ZBUFF_STATIC_LINKING_ONLY
 #include "zbuff.h"
+#include "error_private.h"
 
 
 /*-***********************************************************
@@ -72,36 +73,33 @@ size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* zbc,
                                    const void* dict, size_t dictSize,
                                    ZSTD_parameters params, unsigned long long pledgedSrcSize)
 {
-    size_t ret;
     if (pledgedSrcSize==0) pledgedSrcSize = ZSTD_CONTENTSIZE_UNKNOWN;  /* preserve "0 == unknown" behavior */
-    ret = ZSTD_CCtx_reset(zbc, ZSTD_reset_session_only);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setPledgedSrcSize(zbc, pledgedSrcSize);
+    FORWARD_IF_ERROR(ZSTD_CCtx_reset(zbc, ZSTD_reset_session_only), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setPledgedSrcSize(zbc, pledgedSrcSize), "");
 
-    ret = ZSTD_isError(ret) ? ret : ZSTD_checkCParams(params.cParams);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_windowLog, params.cParams.windowLog);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_hashLog, params.cParams.hashLog);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_chainLog, params.cParams.chainLog);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_searchLog, params.cParams.searchLog);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_minMatch, params.cParams.minMatch);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_targetLength, params.cParams.targetLength);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_strategy, params.cParams.strategy);
+    FORWARD_IF_ERROR(ZSTD_checkCParams(params.cParams), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_windowLog, params.cParams.windowLog), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_hashLog, params.cParams.hashLog), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_chainLog, params.cParams.chainLog), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_searchLog, params.cParams.searchLog), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_minMatch, params.cParams.minMatch), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_targetLength, params.cParams.targetLength), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_strategy, params.cParams.strategy), "");
 
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_contentSizeFlag, params.fParams.contentSizeFlag);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_checksumFlag, params.fParams.checksumFlag);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_dictIDFlag, params.fParams.noDictIDFlag);
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_contentSizeFlag, params.fParams.contentSizeFlag), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_checksumFlag, params.fParams.checksumFlag), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_dictIDFlag, params.fParams.noDictIDFlag), "");
 
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_loadDictionary(zbc, dict, dictSize);
-    return ZSTD_isError(ret) ? ret : 0;
+    FORWARD_IF_ERROR(ZSTD_CCtx_loadDictionary(zbc, dict, dictSize), "");
+    return 0;
 }
-
 
 size_t ZBUFF_compressInitDictionary(ZBUFF_CCtx* zbc, const void* dict, size_t dictSize, int compressionLevel)
 {
-    size_t ret;
-    ret = ZSTD_CCtx_reset(zbc, ZSTD_reset_session_only);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_compressionLevel, compressionLevel);
-    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_loadDictionary(zbc, dict, dictSize);
-    return ZSTD_isError(ret) ? ret : 0;
+    FORWARD_IF_ERROR(ZSTD_CCtx_reset(zbc, ZSTD_reset_session_only), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_setParameter(zbc, ZSTD_c_compressionLevel, compressionLevel), "");
+    FORWARD_IF_ERROR(ZSTD_CCtx_loadDictionary(zbc, dict, dictSize), "");
+    return 0;
 }
 
 size_t ZBUFF_compressInit(ZBUFF_CCtx* zbc, int compressionLevel)

--- a/lib/deprecated/zbuff_compress.c
+++ b/lib/deprecated/zbuff_compress.c
@@ -72,14 +72,36 @@ size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* zbc,
                                    const void* dict, size_t dictSize,
                                    ZSTD_parameters params, unsigned long long pledgedSrcSize)
 {
+    size_t ret;
     if (pledgedSrcSize==0) pledgedSrcSize = ZSTD_CONTENTSIZE_UNKNOWN;  /* preserve "0 == unknown" behavior */
-    return ZSTD_initCStream_advanced(zbc, dict, dictSize, params, pledgedSrcSize);
+    ret = ZSTD_CCtx_reset(zbc, ZSTD_reset_session_only);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setPledgedSrcSize(zbc, pledgedSrcSize);
+
+    ret = ZSTD_isError(ret) ? ret : ZSTD_checkCParams(params.cParams);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_windowLog, params.cParams.windowLog);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_hashLog, params.cParams.hashLog);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_chainLog, params.cParams.chainLog);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_searchLog, params.cParams.searchLog);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_minMatch, params.cParams.minMatch);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_targetLength, params.cParams.targetLength);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_strategy, params.cParams.strategy);
+
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_contentSizeFlag, params.fParams.contentSizeFlag);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_checksumFlag, params.fParams.checksumFlag);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_dictIDFlag, params.fParams.noDictIDFlag);
+
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_loadDictionary(zbc, dict, dictSize);
+    return ZSTD_isError(ret) ? ret : 0;
 }
 
 
 size_t ZBUFF_compressInitDictionary(ZBUFF_CCtx* zbc, const void* dict, size_t dictSize, int compressionLevel)
 {
-    return ZSTD_initCStream_usingDict(zbc, dict, dictSize, compressionLevel);
+    size_t ret;
+    ret = ZSTD_CCtx_reset(zbc, ZSTD_reset_session_only);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_setParameter(zbc, ZSTD_c_compressionLevel, compressionLevel);
+    ret = ZSTD_isError(ret) ? ret : ZSTD_CCtx_loadDictionary(zbc, dict, dictSize);
+    return ZSTD_isError(ret) ? ret : 0;
 }
 
 size_t ZBUFF_compressInit(ZBUFF_CCtx* zbc, int compressionLevel)

--- a/lib/deprecated/zbuff_compress.c
+++ b/lib/deprecated/zbuff_compress.c
@@ -15,7 +15,7 @@
 ***************************************/
 #define ZBUFF_STATIC_LINKING_ONLY
 #include "zbuff.h"
-#include "error_private.h"
+#include "../common/error_private.h"
 
 
 /*-***********************************************************


### PR DESCRIPTION
`lib/deprecated` is no longer built by zstd's bundled build files. However,
users may try to build these files when they import the source tree into
their own build systems. And if they have `-Wdeprecated-declarations` on,
this can produce warnings.

This PR migrates these files away from using deprecated declarations.

This addresses #2767.