### PR TITLE
Fix Up #2659; Build libzstd.pc Whenever Building the Lib on Unix

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -175,7 +175,7 @@ endif  # if windows
 libzstd : $(LIBZSTD)
 
 .PHONY: lib
-lib : libzstd.a libzstd libzstd.pc
+lib : libzstd.a libzstd
 
 
 # note : do not define lib-mt or lib-release as .PHONY
@@ -246,24 +246,12 @@ clean:
 	$(RM) -r obj/*
 	@echo Cleaning library completed
 
-libzstd.pc:
-libzstd.pc: libzstd.pc.in
-	@echo creating pkgconfig
-	@sed $(SED_ERE_OPT) \
-		-e 's|@PREFIX@|$(PREFIX)|' \
-		-e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
-		-e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \
-		-e 's|@LIBDIR@|$(PCLIBPREFIX)$(PCLIBDIR)|' \
-		-e 's|@VERSION@|$(VERSION)|' \
-		-e 's|@LIBS_PRIVATE@|$(LDFLAGS_DYNLIB)|' \
-		$< >$@
-
 #-----------------------------------------------------------------------------
 # make install is validated only for below listed environments
 #-----------------------------------------------------------------------------
 ifneq (,$(filter $(UNAME),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku AIX))
 
-all: libzstd.pc
+lib: libzstd.pc
 
 HAS_EXPLICIT_EXEC_PREFIX := $(if $(or $(EXEC_PREFIX),$(exec_prefix)),1,)
 
@@ -307,6 +295,17 @@ endif
 INSTALL_PROGRAM ?= $(INSTALL)
 INSTALL_DATA    ?= $(INSTALL) -m 644
 
+
+libzstd.pc: libzstd.pc.in
+	@echo creating pkgconfig
+	@sed $(SED_ERE_OPT) \
+	        -e 's|@PREFIX@|$(PREFIX)|' \
+	        -e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
+	        -e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \
+	        -e 's|@LIBDIR@|$(PCLIBPREFIX)$(PCLIBDIR)|' \
+	        -e 's|@VERSION@|$(VERSION)|' \
+	        -e 's|@LIBS_PRIVATE@|$(LDFLAGS_DYNLIB)|' \
+	        $< >$@
 
 .PHONY: install
 install: install-pc install-static install-shared install-includes

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -308,7 +308,7 @@ endif  # if windows
 libzstd : $(LIBZSTD)
 
 .PHONY: lib
-lib : libzstd.a libzstd
+lib : libzstd.a libzstd libzstd.pc
 
 
 # note : do not define lib-mt or lib-release as .PHONY
@@ -371,6 +371,18 @@ clean:
 	$(RM) -r obj/*
 	@echo Cleaning library completed
 
+libzstd.pc:
+libzstd.pc: libzstd.pc.in
+	@echo creating pkgconfig
+	@sed $(SED_ERE_OPT) \
+		-e 's|@PREFIX@|$(PREFIX)|' \
+		-e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
+		-e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \
+		-e 's|@LIBDIR@|$(PCLIBPREFIX)$(PCLIBDIR)|' \
+		-e 's|@VERSION@|$(VERSION)|' \
+		-e 's|@LIBS_PRIVATE@|$(LDFLAGS_DYNLIB)|' \
+		$< >$@
+
 #-----------------------------------------------------------------------------
 # make install is validated only for below listed environments
 #-----------------------------------------------------------------------------
@@ -420,17 +432,6 @@ endif
 INSTALL_PROGRAM ?= $(INSTALL)
 INSTALL_DATA    ?= $(INSTALL) -m 644
 
-
-libzstd.pc:
-libzstd.pc: libzstd.pc.in
-	@echo creating pkgconfig
-	@sed $(SED_ERE_OPT) \
-	        -e 's|@PREFIX@|$(PREFIX)|' \
-	        -e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
-          -e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \
-          -e 's|@LIBDIR@|$(PCLIBPREFIX)$(PCLIBDIR)|' \
-          -e 's|@VERSION@|$(VERSION)|' \
-          $< >$@
 
 .PHONY: install
 install: install-pc install-static install-shared install-includes

--- a/lib/libzstd.pc.in
+++ b/lib/libzstd.pc.in
@@ -12,4 +12,5 @@ Description: fast lossless compression algorithm library
 URL: http://www.zstd.net/
 Version: @VERSION@
 Libs: -L${libdir} -lzstd
+Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
This PR builds on #2659 to add `-pthread` to `libzstd.pc` when the library is built with multithreading. It also promotes the `.pc` file to be built whenever the library is built (on Unix--unlike the original PR which builds it everywhere).