### PR TITLE
Update changelog for v1.5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,20 @@
+v1.5.1 (Dec, 2021)
+perf: rebalanced compression levels, to better match the intended speed/level curve, by @senhuang42
+perf: faster huffman decoder, using x64 assembly, by @terrelln
+perf: slightly faster high speed modes (strategies fast & dfast), by @felixhandte
+perf: improved binary size and faster compilation times, by @terrelln
+perf: new row64 mode, used notably in levels 11 & 12, by @senhuang42
+perf: minor compression ratio improvements for small data at high levels, by @cyan4973
+perf: reduced stack usage (mostly useful for Linux Kernel), by @terrelln
+perf: faster detection and skipping of incompressible blocks, by @bindhvo
+perf: on-demand reduced ZSTD_DCtx state size, using build macro ZSTD_DECODER_INTERNAL_BUFFER, at a small cost of performance, by @bindhvo
+build: allows hiding static symbols in the dynamic library, using build macro, by @skitt
+build: support for m68k (Motorola 68000's), by @cyan4973
+build: improved AIX support, by @Helflym
+build: improved meson unofficial build, by @eli-schwartz
+cli : report advanced parameters information when compressing in very verbose mode (``-vv`), by @Svetlitski-FB
+
+
 v1.5.0  (May 11, 2021)
 api: Various functions promoted from experimental to stable API: (#2579-2581, @senhuang42)
   `ZSTD_defaultCLevel()`


### PR DESCRIPTION
First `changelog` update in preparation of v1.5.1.
So far, I've opted for a restricted list, only featuring items that have a chance to be perceptible by end users.
This skips a lot of more minor items, representing a majority of merge activity for this version.
Therefore, if you believe more items should be added to this list, you are welcome to complete it.