### PR TITLE
Stagger Stepping in Negative Levels

### DIFF
--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -99,7 +99,7 @@ ZSTD_compressBlock_fast_noDict_generic(
     U32* const hashTable = ms->hashTable;
     U32 const hlog = cParams->hashLog;
     /* support stepSize of 0 */
-    size_t const stepSize = cParams->targetLength + !(cParams->targetLength) - 1;
+    size_t const stepSize = cParams->targetLength + !(cParams->targetLength);
     const BYTE* const base = ms->window.base;
     const BYTE* const istart = (const BYTE*)src;
     const U32   endIndex = (U32)((size_t)(istart - base) + srcSize);
@@ -128,7 +128,8 @@ ZSTD_compressBlock_fast_noDict_generic(
     const BYTE* match0;
     size_t mLength;
 
-    size_t step;
+    size_t step0;
+    size_t step1;
     const BYTE* nextStep;
     const size_t kStepIncr = (1 << (kSearchStrength - 1));
 
@@ -144,13 +145,14 @@ ZSTD_compressBlock_fast_noDict_generic(
     /* start each op */
 _start: /* Requires: ip0 */
 
-    step = 1;
+    step0 = 1;
+    step1 = stepSize;
     nextStep = ip0 + kStepIncr;
 
     /* calculate positions, ip0 - anchor == 0, so we skip step calc */
-    ip1 = ip0 + step;
-    ip2 = ip1 + step + stepSize;
-    ip3 = ip2 + step;
+    ip1 = ip0 + step0;
+    ip2 = ip1 + step1;
+    ip3 = ip2 + step0;
 
     if (ip3 >= ilimit) {
         goto _cleanup;
@@ -234,15 +236,16 @@ _start: /* Requires: ip0 */
         if (ip2 >= nextStep) {
             PREFETCH_L1(ip1 + 64);
             PREFETCH_L1(ip1 + 128);
-            step++;
+            step0++;
+            step1++;
             nextStep += kStepIncr;
         }
 
         /* advance to next positions */
         ip0 = ip1;
         ip1 = ip2;
-        ip2 = ip2 + step + stepSize;
-        ip3 = ip2 + step;
+        ip2 = ip2 + step1;
+        ip3 = ip2 + step0;
     } while (ip3 < ilimit);
 
 _cleanup:

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -234,19 +234,19 @@ _start: /* Requires: ip0 */
         hash0 = hash1;
         hash1 = ZSTD_hashPtr(ip2, hlog, mls);
 
-        /* calculate step */
-        if (ip2 >= nextStep) {
-            PREFETCH_L1(ip1 + 64);
-            PREFETCH_L1(ip1 + 128);
-            step += 2;
-            nextStep += kStepIncr;
-        }
-
         /* advance to next positions */
         ip0 = ip1;
         ip1 = ip2;
         ip2 = ip0 + step;
         ip3 = ip1 + step;
+
+        /* calculate step */
+        if (ip2 >= nextStep) {
+            step++;
+            PREFETCH_L1(ip1 + 64);
+            PREFETCH_L1(ip1 + 128);
+            nextStep += kStepIncr;
+        }
     } while (ip3 < ilimit);
 
 _cleanup:

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -99,7 +99,7 @@ ZSTD_compressBlock_fast_noDict_generic(
     U32* const hashTable = ms->hashTable;
     U32 const hlog = cParams->hashLog;
     /* support stepSize of 0 */
-    size_t const stepSize = cParams->targetLength + !(cParams->targetLength);
+    size_t const stepSize = cParams->targetLength + !(cParams->targetLength) - 1;
     const BYTE* const base = ms->window.base;
     const BYTE* const istart = (const BYTE*)src;
     const U32   endIndex = (U32)((size_t)(istart - base) + srcSize);
@@ -144,13 +144,13 @@ ZSTD_compressBlock_fast_noDict_generic(
     /* start each op */
 _start: /* Requires: ip0 */
 
-    step = stepSize;
+    step = 1;
     nextStep = ip0 + kStepIncr;
 
     /* calculate positions, ip0 - anchor == 0, so we skip step calc */
-    ip1 = ip0 + stepSize;
-    ip2 = ip1 + stepSize;
-    ip3 = ip2 + stepSize;
+    ip1 = ip0 + step;
+    ip2 = ip1 + step + stepSize;
+    ip3 = ip2 + step;
 
     if (ip3 >= ilimit) {
         goto _cleanup;
@@ -241,7 +241,7 @@ _start: /* Requires: ip0 */
         /* advance to next positions */
         ip0 = ip1;
         ip1 = ip2;
-        ip2 = ip2 + step;
+        ip2 = ip2 + step + stepSize;
         ip3 = ip2 + step;
     } while (ip3 < ilimit);
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1970,7 +1970,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
                                                  3742, 3675, 3674, 3665, 3664,
                                                  3663, 3662, 3661, 3660, 3660,
                                                  3660, 3660, 3660 };
-            size_t const target_wdict_cSize[22+1] =  { 2830, 2896, 2890, 2820, 2940,
+            size_t const target_wdict_cSize[22+1] =  { 2830, 2896, 2893, 2820, 2940,
                                                        2950, 2950, 2925, 2900, 2891,
                                                        2910, 2910, 2910, 2780, 2775,
                                                        2765, 2760, 2755, 2754, 2753,

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -1,9 +1,9 @@
 Data,                               Config,                             Method,                             Total compressed size
-silesia.tar,                        level -5,                           compress simple,                    7359401
-silesia.tar,                        level -3,                           compress simple,                    6901672
-silesia.tar,                        level -1,                           compress simple,                    6182241
+silesia.tar,                        level -5,                           compress simple,                    6853608
+silesia.tar,                        level -3,                           compress simple,                    6505969
+silesia.tar,                        level -1,                           compress simple,                    6179026
 silesia.tar,                        level 0,                            compress simple,                    4854086
-silesia.tar,                        level 1,                            compress simple,                    5331946
+silesia.tar,                        level 1,                            compress simple,                    5327373
 silesia.tar,                        level 3,                            compress simple,                    4854086
 silesia.tar,                        level 4,                            compress simple,                    4791503
 silesia.tar,                        level 5,                            compress simple,                    4649987
@@ -15,9 +15,9 @@ silesia.tar,                        level 16,                           compress
 silesia.tar,                        level 19,                           compress simple,                    4267266
 silesia.tar,                        uncompressed literals,              compress simple,                    4854086
 silesia.tar,                        uncompressed literals optimal,      compress simple,                    4267266
-silesia.tar,                        huffman literals,                   compress simple,                    6182241
-github.tar,                         level -5,                           compress simple,                    66914
-github.tar,                         level -3,                           compress simple,                    52127
+silesia.tar,                        huffman literals,                   compress simple,                    6179026
+github.tar,                         level -5,                           compress simple,                    52110
+github.tar,                         level -3,                           compress simple,                    45678
 github.tar,                         level -1,                           compress simple,                    42560
 github.tar,                         level 0,                            compress simple,                    38831
 github.tar,                         level 1,                            compress simple,                    39200
@@ -33,11 +33,11 @@ github.tar,                         level 19,                           compress
 github.tar,                         uncompressed literals,              compress simple,                    38831
 github.tar,                         uncompressed literals optimal,      compress simple,                    32134
 github.tar,                         huffman literals,                   compress simple,                    42560
-silesia,                            level -5,                           compress cctx,                      7354675
-silesia,                            level -3,                           compress cctx,                      6902374
-silesia,                            level -1,                           compress cctx,                      6177565
+silesia,                            level -5,                           compress cctx,                      6852424
+silesia,                            level -3,                           compress cctx,                      6503413
+silesia,                            level -1,                           compress cctx,                      6172178
 silesia,                            level 0,                            compress cctx,                      4842075
-silesia,                            level 1,                            compress cctx,                      5309098
+silesia,                            level 1,                            compress cctx,                      5306426
 silesia,                            level 3,                            compress cctx,                      4842075
 silesia,                            level 4,                            compress cctx,                      4779186
 silesia,                            level 5,                            compress cctx,                      4638691
@@ -56,11 +56,11 @@ silesia,                            small chain log,                    compress
 silesia,                            explicit params,                    compress cctx,                      4794052
 silesia,                            uncompressed literals,              compress cctx,                      4842075
 silesia,                            uncompressed literals optimal,      compress cctx,                      4296880
-silesia,                            huffman literals,                   compress cctx,                      6177565
+silesia,                            huffman literals,                   compress cctx,                      6172178
 silesia,                            multithreaded with advanced params, compress cctx,                      4842075
-github,                             level -5,                           compress cctx,                      232315
+github,                             level -5,                           compress cctx,                      204411
 github,                             level -5 with dict,                 compress cctx,                      47294
-github,                             level -3,                           compress cctx,                      220760
+github,                             level -3,                           compress cctx,                      193253
 github,                             level -3 with dict,                 compress cctx,                      48047
 github,                             level -1,                           compress cctx,                      175468
 github,                             level -1 with dict,                 compress cctx,                      43527
@@ -97,11 +97,11 @@ github,                             uncompressed literals,              compress
 github,                             uncompressed literals optimal,      compress cctx,                      134064
 github,                             huffman literals,                   compress cctx,                      175468
 github,                             multithreaded with advanced params, compress cctx,                      141069
-silesia,                            level -5,                           zstdcli,                            7354723
-silesia,                            level -3,                           zstdcli,                            6902422
-silesia,                            level -1,                           zstdcli,                            6177613
+silesia,                            level -5,                           zstdcli,                            6852472
+silesia,                            level -3,                           zstdcli,                            6503461
+silesia,                            level -1,                           zstdcli,                            6172226
 silesia,                            level 0,                            zstdcli,                            4842123
-silesia,                            level 1,                            zstdcli,                            5309146
+silesia,                            level 1,                            zstdcli,                            5306474
 silesia,                            level 3,                            zstdcli,                            4842123
 silesia,                            level 4,                            zstdcli,                            4779234
 silesia,                            level 5,                            zstdcli,                            4638739
@@ -120,13 +120,13 @@ silesia,                            small chain log,                    zstdcli,
 silesia,                            explicit params,                    zstdcli,                            4795432
 silesia,                            uncompressed literals,              zstdcli,                            5120614
 silesia,                            uncompressed literals optimal,      zstdcli,                            4319566
-silesia,                            huffman literals,                   zstdcli,                            5326394
+silesia,                            huffman literals,                   zstdcli,                            5321394
 silesia,                            multithreaded with advanced params, zstdcli,                            5120614
-silesia.tar,                        level -5,                           zstdcli,                            7363866
-silesia.tar,                        level -3,                           zstdcli,                            6902158
-silesia.tar,                        level -1,                           zstdcli,                            6182939
+silesia.tar,                        level -5,                           zstdcli,                            6853994
+silesia.tar,                        level -3,                           zstdcli,                            6506742
+silesia.tar,                        level -1,                           zstdcli,                            6179765
 silesia.tar,                        level 0,                            zstdcli,                            4854164
-silesia.tar,                        level 1,                            zstdcli,                            5333183
+silesia.tar,                        level 1,                            zstdcli,                            5328534
 silesia.tar,                        level 3,                            zstdcli,                            4854164
 silesia.tar,                        level 4,                            zstdcli,                            4792352
 silesia.tar,                        level 5,                            zstdcli,                            4650946
@@ -146,11 +146,11 @@ silesia.tar,                        small chain log,                    zstdcli,
 silesia.tar,                        explicit params,                    zstdcli,                            4820713
 silesia.tar,                        uncompressed literals,              zstdcli,                            5122571
 silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4310145
-silesia.tar,                        huffman literals,                   zstdcli,                            5344915
+silesia.tar,                        huffman literals,                   zstdcli,                            5342054
 silesia.tar,                        multithreaded with advanced params, zstdcli,                            5122571
-github,                             level -5,                           zstdcli,                            234315
+github,                             level -5,                           zstdcli,                            206411
 github,                             level -5 with dict,                 zstdcli,                            48718
-github,                             level -3,                           zstdcli,                            222760
+github,                             level -3,                           zstdcli,                            195253
 github,                             level -3 with dict,                 zstdcli,                            47395
 github,                             level -1,                           zstdcli,                            177468
 github,                             level -1 with dict,                 zstdcli,                            45170
@@ -187,10 +187,10 @@ github,                             uncompressed literals,              zstdcli,
 github,                             uncompressed literals optimal,      zstdcli,                            159227
 github,                             huffman literals,                   zstdcli,                            144365
 github,                             multithreaded with advanced params, zstdcli,                            167911
-github.tar,                         level -5,                           zstdcli,                            66918
-github.tar,                         level -5 with dict,                 zstdcli,                            51529
-github.tar,                         level -3,                           zstdcli,                            52131
-github.tar,                         level -3 with dict,                 zstdcli,                            44246
+github.tar,                         level -5,                           zstdcli,                            52114
+github.tar,                         level -5 with dict,                 zstdcli,                            46502
+github.tar,                         level -3,                           zstdcli,                            45682
+github.tar,                         level -3 with dict,                 zstdcli,                            42181
 github.tar,                         level -1,                           zstdcli,                            42564
 github.tar,                         level -1 with dict,                 zstdcli,                            41140
 github.tar,                         level 0,                            zstdcli,                            38835
@@ -228,11 +228,11 @@ github.tar,                         uncompressed literals,              zstdcli,
 github.tar,                         uncompressed literals optimal,      zstdcli,                            35401
 github.tar,                         huffman literals,                   zstdcli,                            38857
 github.tar,                         multithreaded with advanced params, zstdcli,                            41529
-silesia,                            level -5,                           advanced one pass,                  7354675
-silesia,                            level -3,                           advanced one pass,                  6902374
-silesia,                            level -1,                           advanced one pass,                  6177565
+silesia,                            level -5,                           advanced one pass,                  6852424
+silesia,                            level -3,                           advanced one pass,                  6503413
+silesia,                            level -1,                           advanced one pass,                  6172178
 silesia,                            level 0,                            advanced one pass,                  4842075
-silesia,                            level 1,                            advanced one pass,                  5309098
+silesia,                            level 1,                            advanced one pass,                  5306426
 silesia,                            level 3,                            advanced one pass,                  4842075
 silesia,                            level 4,                            advanced one pass,                  4779186
 silesia,                            level 5 row 1,                      advanced one pass,                  4638691
@@ -260,13 +260,13 @@ silesia,                            small chain log,                    advanced
 silesia,                            explicit params,                    advanced one pass,                  4795432
 silesia,                            uncompressed literals,              advanced one pass,                  5120566
 silesia,                            uncompressed literals optimal,      advanced one pass,                  4319518
-silesia,                            huffman literals,                   advanced one pass,                  5326346
+silesia,                            huffman literals,                   advanced one pass,                  5321346
 silesia,                            multithreaded with advanced params, advanced one pass,                  5120566
-silesia.tar,                        level -5,                           advanced one pass,                  7359401
-silesia.tar,                        level -3,                           advanced one pass,                  6901672
-silesia.tar,                        level -1,                           advanced one pass,                  6182241
+silesia.tar,                        level -5,                           advanced one pass,                  6853608
+silesia.tar,                        level -3,                           advanced one pass,                  6505969
+silesia.tar,                        level -1,                           advanced one pass,                  6179026
 silesia.tar,                        level 0,                            advanced one pass,                  4854086
-silesia.tar,                        level 1,                            advanced one pass,                  5331946
+silesia.tar,                        level 1,                            advanced one pass,                  5327373
 silesia.tar,                        level 3,                            advanced one pass,                  4854086
 silesia.tar,                        level 4,                            advanced one pass,                  4791503
 silesia.tar,                        level 5 row 1,                      advanced one pass,                  4649987
@@ -294,11 +294,11 @@ silesia.tar,                        small chain log,                    advanced
 silesia.tar,                        explicit params,                    advanced one pass,                  4806855
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5122473
 silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4310141
-silesia.tar,                        huffman literals,                   advanced one pass,                  5344545
+silesia.tar,                        huffman literals,                   advanced one pass,                  5341685
 silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5122567
-github,                             level -5,                           advanced one pass,                  232315
+github,                             level -5,                           advanced one pass,                  204411
 github,                             level -5 with dict,                 advanced one pass,                  46718
-github,                             level -3,                           advanced one pass,                  220760
+github,                             level -3,                           advanced one pass,                  193253
 github,                             level -3 with dict,                 advanced one pass,                  45395
 github,                             level -1,                           advanced one pass,                  175468
 github,                             level -1 with dict,                 advanced one pass,                  43170
@@ -421,10 +421,10 @@ github,                             uncompressed literals,              advanced
 github,                             uncompressed literals optimal,      advanced one pass,                  157227
 github,                             huffman literals,                   advanced one pass,                  142365
 github,                             multithreaded with advanced params, advanced one pass,                  165911
-github.tar,                         level -5,                           advanced one pass,                  66914
-github.tar,                         level -5 with dict,                 advanced one pass,                  51525
-github.tar,                         level -3,                           advanced one pass,                  52127
-github.tar,                         level -3 with dict,                 advanced one pass,                  44242
+github.tar,                         level -5,                           advanced one pass,                  52110
+github.tar,                         level -5 with dict,                 advanced one pass,                  46498
+github.tar,                         level -3,                           advanced one pass,                  45678
+github.tar,                         level -3 with dict,                 advanced one pass,                  42177
 github.tar,                         level -1,                           advanced one pass,                  42560
 github.tar,                         level -1 with dict,                 advanced one pass,                  41136
 github.tar,                         level 0,                            advanced one pass,                  38831
@@ -546,11 +546,11 @@ github.tar,                         uncompressed literals,              advanced
 github.tar,                         uncompressed literals optimal,      advanced one pass,                  35397
 github.tar,                         huffman literals,                   advanced one pass,                  38853
 github.tar,                         multithreaded with advanced params, advanced one pass,                  41525
-silesia,                            level -5,                           advanced one pass small out,        7354675
-silesia,                            level -3,                           advanced one pass small out,        6902374
-silesia,                            level -1,                           advanced one pass small out,        6177565
+silesia,                            level -5,                           advanced one pass small out,        6852424
+silesia,                            level -3,                           advanced one pass small out,        6503413
+silesia,                            level -1,                           advanced one pass small out,        6172178
 silesia,                            level 0,                            advanced one pass small out,        4842075
-silesia,                            level 1,                            advanced one pass small out,        5309098
+silesia,                            level 1,                            advanced one pass small out,        5306426
 silesia,                            level 3,                            advanced one pass small out,        4842075
 silesia,                            level 4,                            advanced one pass small out,        4779186
 silesia,                            level 5 row 1,                      advanced one pass small out,        4638691
@@ -578,13 +578,13 @@ silesia,                            small chain log,                    advanced
 silesia,                            explicit params,                    advanced one pass small out,        4795432
 silesia,                            uncompressed literals,              advanced one pass small out,        5120566
 silesia,                            uncompressed literals optimal,      advanced one pass small out,        4319518
-silesia,                            huffman literals,                   advanced one pass small out,        5326346
+silesia,                            huffman literals,                   advanced one pass small out,        5321346
 silesia,                            multithreaded with advanced params, advanced one pass small out,        5120566
-silesia.tar,                        level -5,                           advanced one pass small out,        7359401
-silesia.tar,                        level -3,                           advanced one pass small out,        6901672
-silesia.tar,                        level -1,                           advanced one pass small out,        6182241
+silesia.tar,                        level -5,                           advanced one pass small out,        6853608
+silesia.tar,                        level -3,                           advanced one pass small out,        6505969
+silesia.tar,                        level -1,                           advanced one pass small out,        6179026
 silesia.tar,                        level 0,                            advanced one pass small out,        4854086
-silesia.tar,                        level 1,                            advanced one pass small out,        5331946
+silesia.tar,                        level 1,                            advanced one pass small out,        5327373
 silesia.tar,                        level 3,                            advanced one pass small out,        4854086
 silesia.tar,                        level 4,                            advanced one pass small out,        4791503
 silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4649987
@@ -612,11 +612,11 @@ silesia.tar,                        small chain log,                    advanced
 silesia.tar,                        explicit params,                    advanced one pass small out,        4806855
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5122473
 silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4310141
-silesia.tar,                        huffman literals,                   advanced one pass small out,        5344545
+silesia.tar,                        huffman literals,                   advanced one pass small out,        5341685
 silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5122567
-github,                             level -5,                           advanced one pass small out,        232315
+github,                             level -5,                           advanced one pass small out,        204411
 github,                             level -5 with dict,                 advanced one pass small out,        46718
-github,                             level -3,                           advanced one pass small out,        220760
+github,                             level -3,                           advanced one pass small out,        193253
 github,                             level -3 with dict,                 advanced one pass small out,        45395
 github,                             level -1,                           advanced one pass small out,        175468
 github,                             level -1 with dict,                 advanced one pass small out,        43170
@@ -739,10 +739,10 @@ github,                             uncompressed literals,              advanced
 github,                             uncompressed literals optimal,      advanced one pass small out,        157227
 github,                             huffman literals,                   advanced one pass small out,        142365
 github,                             multithreaded with advanced params, advanced one pass small out,        165911
-github.tar,                         level -5,                           advanced one pass small out,        66914
-github.tar,                         level -5 with dict,                 advanced one pass small out,        51525
-github.tar,                         level -3,                           advanced one pass small out,        52127
-github.tar,                         level -3 with dict,                 advanced one pass small out,        44242
+github.tar,                         level -5,                           advanced one pass small out,        52110
+github.tar,                         level -5 with dict,                 advanced one pass small out,        46498
+github.tar,                         level -3,                           advanced one pass small out,        45678
+github.tar,                         level -3 with dict,                 advanced one pass small out,        42177
 github.tar,                         level -1,                           advanced one pass small out,        42560
 github.tar,                         level -1 with dict,                 advanced one pass small out,        41136
 github.tar,                         level 0,                            advanced one pass small out,        38831
@@ -864,11 +864,11 @@ github.tar,                         uncompressed literals,              advanced
 github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35397
 github.tar,                         huffman literals,                   advanced one pass small out,        38853
 github.tar,                         multithreaded with advanced params, advanced one pass small out,        41525
-silesia,                            level -5,                           advanced streaming,                 7292053
-silesia,                            level -3,                           advanced streaming,                 6867875
-silesia,                            level -1,                           advanced streaming,                 6183923
+silesia,                            level -5,                           advanced streaming,                 6963781
+silesia,                            level -3,                           advanced streaming,                 6610376
+silesia,                            level -1,                           advanced streaming,                 6179294
 silesia,                            level 0,                            advanced streaming,                 4842075
-silesia,                            level 1,                            advanced streaming,                 5312694
+silesia,                            level 1,                            advanced streaming,                 5310178
 silesia,                            level 3,                            advanced streaming,                 4842075
 silesia,                            level 4,                            advanced streaming,                 4779186
 silesia,                            level 5 row 1,                      advanced streaming,                 4638691
@@ -896,13 +896,13 @@ silesia,                            small chain log,                    advanced
 silesia,                            explicit params,                    advanced streaming,                 4795452
 silesia,                            uncompressed literals,              advanced streaming,                 5120566
 silesia,                            uncompressed literals optimal,      advanced streaming,                 4319518
-silesia,                            huffman literals,                   advanced streaming,                 5332234
+silesia,                            huffman literals,                   advanced streaming,                 5327881
 silesia,                            multithreaded with advanced params, advanced streaming,                 5120566
-silesia.tar,                        level -5,                           advanced streaming,                 7260007
-silesia.tar,                        level -3,                           advanced streaming,                 6845151
-silesia.tar,                        level -1,                           advanced streaming,                 6187938
+silesia.tar,                        level -5,                           advanced streaming,                 7043687
+silesia.tar,                        level -3,                           advanced streaming,                 6671317
+silesia.tar,                        level -1,                           advanced streaming,                 6187457
 silesia.tar,                        level 0,                            advanced streaming,                 4859271
-silesia.tar,                        level 1,                            advanced streaming,                 5334890
+silesia.tar,                        level 1,                            advanced streaming,                 5333896
 silesia.tar,                        level 3,                            advanced streaming,                 4859271
 silesia.tar,                        level 4,                            advanced streaming,                 4797470
 silesia.tar,                        level 5 row 1,                      advanced streaming,                 4649992
@@ -930,11 +930,11 @@ silesia.tar,                        small chain log,                    advanced
 silesia.tar,                        explicit params,                    advanced streaming,                 4806873
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5127423
 silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4310141
-silesia.tar,                        huffman literals,                   advanced streaming,                 5350519
+silesia.tar,                        huffman literals,                   advanced streaming,                 5349624
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5122567
-github,                             level -5,                           advanced streaming,                 232315
+github,                             level -5,                           advanced streaming,                 204411
 github,                             level -5 with dict,                 advanced streaming,                 46718
-github,                             level -3,                           advanced streaming,                 220760
+github,                             level -3,                           advanced streaming,                 193253
 github,                             level -3 with dict,                 advanced streaming,                 45395
 github,                             level -1,                           advanced streaming,                 175468
 github,                             level -1 with dict,                 advanced streaming,                 43170
@@ -1057,10 +1057,10 @@ github,                             uncompressed literals,              advanced
 github,                             uncompressed literals optimal,      advanced streaming,                 157227
 github,                             huffman literals,                   advanced streaming,                 142365
 github,                             multithreaded with advanced params, advanced streaming,                 165911
-github.tar,                         level -5,                           advanced streaming,                 64132
-github.tar,                         level -5 with dict,                 advanced streaming,                 48642
-github.tar,                         level -3,                           advanced streaming,                 50964
-github.tar,                         level -3 with dict,                 advanced streaming,                 42750
+github.tar,                         level -5,                           advanced streaming,                 51420
+github.tar,                         level -5 with dict,                 advanced streaming,                 45495
+github.tar,                         level -3,                           advanced streaming,                 45077
+github.tar,                         level -3 with dict,                 advanced streaming,                 41627
 github.tar,                         level -1,                           advanced streaming,                 42536
 github.tar,                         level -1 with dict,                 advanced streaming,                 41198
 github.tar,                         level 0,                            advanced streaming,                 38831
@@ -1182,11 +1182,11 @@ github.tar,                         uncompressed literals,              advanced
 github.tar,                         uncompressed literals optimal,      advanced streaming,                 35397
 github.tar,                         huffman literals,                   advanced streaming,                 38874
 github.tar,                         multithreaded with advanced params, advanced streaming,                 41525
-silesia,                            level -5,                           old streaming,                      7292053
-silesia,                            level -3,                           old streaming,                      6867875
-silesia,                            level -1,                           old streaming,                      6183923
+silesia,                            level -5,                           old streaming,                      6963781
+silesia,                            level -3,                           old streaming,                      6610376
+silesia,                            level -1,                           old streaming,                      6179294
 silesia,                            level 0,                            old streaming,                      4842075
-silesia,                            level 1,                            old streaming,                      5312694
+silesia,                            level 1,                            old streaming,                      5310178
 silesia,                            level 3,                            old streaming,                      4842075
 silesia,                            level 4,                            old streaming,                      4779186
 silesia,                            level 5,                            old streaming,                      4638691
@@ -1199,12 +1199,12 @@ silesia,                            level 19,                           old stre
 silesia,                            no source size,                     old streaming,                      4842039
 silesia,                            uncompressed literals,              old streaming,                      4842075
 silesia,                            uncompressed literals optimal,      old streaming,                      4296880
-silesia,                            huffman literals,                   old streaming,                      6183923
-silesia.tar,                        level -5,                           old streaming,                      7260007
-silesia.tar,                        level -3,                           old streaming,                      6845151
-silesia.tar,                        level -1,                           old streaming,                      6187938
+silesia,                            huffman literals,                   old streaming,                      6179294
+silesia.tar,                        level -5,                           old streaming,                      7043687
+silesia.tar,                        level -3,                           old streaming,                      6671317
+silesia.tar,                        level -1,                           old streaming,                      6187457
 silesia.tar,                        level 0,                            old streaming,                      4859271
-silesia.tar,                        level 1,                            old streaming,                      5334890
+silesia.tar,                        level 1,                            old streaming,                      5333896
 silesia.tar,                        level 3,                            old streaming,                      4859271
 silesia.tar,                        level 4,                            old streaming,                      4797470
 silesia.tar,                        level 5,                            old streaming,                      4649992
@@ -1217,10 +1217,10 @@ silesia.tar,                        level 19,                           old stre
 silesia.tar,                        no source size,                     old streaming,                      4859267
 silesia.tar,                        uncompressed literals,              old streaming,                      4859271
 silesia.tar,                        uncompressed literals optimal,      old streaming,                      4267266
-silesia.tar,                        huffman literals,                   old streaming,                      6187938
-github,                             level -5,                           old streaming,                      232315
+silesia.tar,                        huffman literals,                   old streaming,                      6187457
+github,                             level -5,                           old streaming,                      204411
 github,                             level -5 with dict,                 old streaming,                      46718
-github,                             level -3,                           old streaming,                      220760
+github,                             level -3,                           old streaming,                      193253
 github,                             level -3 with dict,                 old streaming,                      45395
 github,                             level -1,                           old streaming,                      175468
 github,                             level -1 with dict,                 old streaming,                      43170
@@ -1251,10 +1251,10 @@ github,                             no source size with dict,           old stre
 github,                             uncompressed literals,              old streaming,                      136332
 github,                             uncompressed literals optimal,      old streaming,                      134064
 github,                             huffman literals,                   old streaming,                      175468
-github.tar,                         level -5,                           old streaming,                      64132
-github.tar,                         level -5 with dict,                 old streaming,                      48642
-github.tar,                         level -3,                           old streaming,                      50964
-github.tar,                         level -3 with dict,                 old streaming,                      42750
+github.tar,                         level -5,                           old streaming,                      51420
+github.tar,                         level -5 with dict,                 old streaming,                      45495
+github.tar,                         level -3,                           old streaming,                      45077
+github.tar,                         level -3 with dict,                 old streaming,                      41627
 github.tar,                         level -1,                           old streaming,                      42536
 github.tar,                         level -1 with dict,                 old streaming,                      41198
 github.tar,                         level 0,                            old streaming,                      38831
@@ -1284,11 +1284,11 @@ github.tar,                         no source size with dict,           old stre
 github.tar,                         uncompressed literals,              old streaming,                      38831
 github.tar,                         uncompressed literals optimal,      old streaming,                      32134
 github.tar,                         huffman literals,                   old streaming,                      42536
-silesia,                            level -5,                           old streaming advanced,             7292053
-silesia,                            level -3,                           old streaming advanced,             6867875
-silesia,                            level -1,                           old streaming advanced,             6183923
+silesia,                            level -5,                           old streaming advanced,             6963781
+silesia,                            level -3,                           old streaming advanced,             6610376
+silesia,                            level -1,                           old streaming advanced,             6179294
 silesia,                            level 0,                            old streaming advanced,             4842075
-silesia,                            level 1,                            old streaming advanced,             5312694
+silesia,                            level 1,                            old streaming advanced,             5310178
 silesia,                            level 3,                            old streaming advanced,             4842075
 silesia,                            level 4,                            old streaming advanced,             4779186
 silesia,                            level 5,                            old streaming advanced,             4638691
@@ -1308,13 +1308,13 @@ silesia,                            small chain log,                    old stre
 silesia,                            explicit params,                    old streaming advanced,             4795452
 silesia,                            uncompressed literals,              old streaming advanced,             4842075
 silesia,                            uncompressed literals optimal,      old streaming advanced,             4296880
-silesia,                            huffman literals,                   old streaming advanced,             6183923
+silesia,                            huffman literals,                   old streaming advanced,             6179294
 silesia,                            multithreaded with advanced params, old streaming advanced,             4842075
-silesia.tar,                        level -5,                           old streaming advanced,             7260007
-silesia.tar,                        level -3,                           old streaming advanced,             6845151
-silesia.tar,                        level -1,                           old streaming advanced,             6187938
+silesia.tar,                        level -5,                           old streaming advanced,             7043687
+silesia.tar,                        level -3,                           old streaming advanced,             6671317
+silesia.tar,                        level -1,                           old streaming advanced,             6187457
 silesia.tar,                        level 0,                            old streaming advanced,             4859271
-silesia.tar,                        level 1,                            old streaming advanced,             5334890
+silesia.tar,                        level 1,                            old streaming advanced,             5333896
 silesia.tar,                        level 3,                            old streaming advanced,             4859271
 silesia.tar,                        level 4,                            old streaming advanced,             4797470
 silesia.tar,                        level 5,                            old streaming advanced,             4649992
@@ -1334,11 +1334,11 @@ silesia.tar,                        small chain log,                    old stre
 silesia.tar,                        explicit params,                    old streaming advanced,             4806873
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4859271
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4267266
-silesia.tar,                        huffman literals,                   old streaming advanced,             6187938
+silesia.tar,                        huffman literals,                   old streaming advanced,             6187457
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4859271
-github,                             level -5,                           old streaming advanced,             241214
+github,                             level -5,                           old streaming advanced,             213265
 github,                             level -5 with dict,                 old streaming advanced,             49562
-github,                             level -3,                           old streaming advanced,             222937
+github,                             level -3,                           old streaming advanced,             196126
 github,                             level -3 with dict,                 old streaming advanced,             44956
 github,                             level -1,                           old streaming advanced,             181107
 github,                             level -1 with dict,                 old streaming advanced,             42383
@@ -1377,10 +1377,10 @@ github,                             uncompressed literals,              old stre
 github,                             uncompressed literals optimal,      old streaming advanced,             134064
 github,                             huffman literals,                   old streaming advanced,             181107
 github,                             multithreaded with advanced params, old streaming advanced,             141104
-github.tar,                         level -5,                           old streaming advanced,             64132
-github.tar,                         level -5 with dict,                 old streaming advanced,             48982
-github.tar,                         level -3,                           old streaming advanced,             50964
-github.tar,                         level -3 with dict,                 old streaming advanced,             43357
+github.tar,                         level -5,                           old streaming advanced,             51420
+github.tar,                         level -5 with dict,                 old streaming advanced,             46091
+github.tar,                         level -3,                           old streaming advanced,             45077
+github.tar,                         level -3 with dict,                 old streaming advanced,             42222
 github.tar,                         level -1,                           old streaming advanced,             42536
 github.tar,                         level -1 with dict,                 old streaming advanced,             41494
 github.tar,                         level 0,                            old streaming advanced,             38831
@@ -1433,8 +1433,8 @@ github,                             level 13 with dict,                 old stre
 github,                             level 16 with dict,                 old streaming cdict,                37577
 github,                             level 19 with dict,                 old streaming cdict,                37576
 github,                             no source size with dict,           old streaming cdict,                40654
-github.tar,                         level -5 with dict,                 old streaming cdict,                49146
-github.tar,                         level -3 with dict,                 old streaming cdict,                43468
+github.tar,                         level -5 with dict,                 old streaming cdict,                46276
+github.tar,                         level -3 with dict,                 old streaming cdict,                42354
 github.tar,                         level -1 with dict,                 old streaming cdict,                41662
 github.tar,                         level 0 with dict,                  old streaming cdict,                37956
 github.tar,                         level 1 with dict,                  old streaming cdict,                38761


### PR DESCRIPTION
#2749 returned the negative levels to pre-#1562 behavior. I.e., skipping `stepSize` positions every iteration. This PR emulates #1562-like stepping by applying the `stepSize` skip every other position.

This PR addresses #2827.

## Benchmarks

`silesia.tar` on `gcc-10`:

![Screenshot from 2021-12-13 17-14-03](https://user-images.githubusercontent.com/1154694/145898532-f6d0e677-acf5-4878-bc4e-db83e52c5087.png)

`silesia.tar` on `clang-13`:

![Screenshot from 2021-12-13 17-14-15](https://user-images.githubusercontent.com/1154694/145898668-89b1b274-4f61-4cf2-ba2b-db89e970fc46.png)

## Status

I believe this PR is ready for merge.