### PR TITLE
Fix performance degradation with -m32

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -188,8 +188,13 @@ static void ZSTD_copy16(void* dst, const void* src) {
     vst1q_u8((uint8_t*)dst, vld1q_u8((const uint8_t*)src));
 #elif defined(ZSTD_ARCH_X86_SSE2)
     _mm_storeu_si128((__m128i*)dst, _mm_loadu_si128((const __m128i*)src));
-#else
+#elif defined(__clang__)
     ZSTD_memmove(dst, src, 16);
+#else
+    /* ZSTD_memmove is not inlined properly by gcc */
+    BYTE copy16_buf[16];
+    ZSTD_memcpy(copy16_buf, src, 16);
+    ZSTD_memcpy(dst, copy16_buf, 16);
 #endif
 }
 #define COPY16(d,s) { ZSTD_copy16(d,s); d+=16; s+=16; }


### PR DESCRIPTION
Addresses performance issues caused by gcc failing to properly inline ZSTD_memmove when used inside ZSTD_copy16 macro.  This change (from the original ZSTD_memcpy) was necessary because changes to the dctx handling now make overlap in memory a possibility.  That original change was introduced in 6a7ede3dfccbf3e0a5928b4224a039c260dcff72 and had a negative impact of about 15% when compiling with the -m32 flag and using gcc.

Performance when applying this change to that commit is reduced to a 5% drop for -m32 using gcc.  Performance improvement of this fix when applied to the current HEAD and using -m32 is 10%.

Performance testing indicates the loss was primarily due to this inlining behavior and not alignment issues.  Continuing to try different approaches to see if there is a way to recoup the remaining performance loss.