### PR TITLE
Remove code duplication in exec sequence

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -868,8 +868,11 @@ size_t ZSTD_execSequenceEndInner(BYTE* op,
     assert(oLitEnd < op + sequenceLength);
 
     /* copy literals */
-    if(isSplitLitBuffer)
+    if(isSplitLitBuffer) {
+        RETURN_ERROR_IF(op > *litPtr && op < *litPtr + sequence.litLength, dstSize_tooSmall,
+                        "output should not catch up to and overwrite literal buffer");
         ZSTD_safecopyDstBeforeSrc(op, *litPtr, sequence.litLength);
+    }
     else
         ZSTD_safecopy(op, oend_w, *litPtr, sequence.litLength, ZSTD_no_overlap);
     op = oLitEnd;


### PR DESCRIPTION
Removed code duplication in exec sequence and consolidated the flow for split / non-split buffers.
Maintained performance benefits of separate functions by moving most of the code into inlined templates that are inlined into the specialized functions with a constant choosing the correct behavior.

I inspected the binary to make sure compilation works as expected on clang. Also ran benchmarks on levels 1-15 on clang-12, gcc-7, gcc-8, gcc-9 and gcc-10 with synthesized data. Benchmarks showed performance is on par with dev.