### PR TITLE
Improve Module Map File

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
             name: "libzstd",
             path: "lib",
             sources: [ "common", "compress", "decompress", "dictBuilder" ],
-            publicHeadersPath: "modulemap",
+            publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath(".")
             ])

--- a/lib/module.modulemap
+++ b/lib/module.modulemap
@@ -1,0 +1,25 @@
+module libzstd [extern_c] {
+    header "zstd.h"
+    export *
+    config_macros [exhaustive] /* zstd.h */ \
+        ZSTD_STATIC_LINKING_ONLY, \
+        ZSTDLIB_VISIBLE, \
+        ZSTD_DLL_EXPORT, \
+        ZSTDLIB_STATIC_API, \
+        ZSTD_DISABLE_DEPRECATE_WARNINGS, \
+        ZSTD_CLEVEL_DEFAULT, \
+        /* zdict.h */ ZDICT_STATIC_LINKING_ONLY, \
+        ZDICTLIB_VISIBILITY, \
+        ZDICT_DISABLE_DEPRECATE_WARNINGS, \
+        /* zstd_errors.h */ ZSTDERRORLIB_VISIBILITY
+
+    module dictbuilder [extern_c] {
+        header "zdict.h"
+        export *
+    }
+
+    module errors [extern_c] {
+        header "zstd_errors.h"
+        export *
+    }
+}

--- a/lib/modulemap/module.modulemap
+++ b/lib/modulemap/module.modulemap
@@ -1,4 +1,0 @@
-module libzstd [extern_c] {
-    header "../zstd.h"
-    export *
-}


### PR DESCRIPTION
Internal discussion raised the question of how compatible zstd's headers are with C++ Modules, given that we use configuration macros to control what is exposed by `zstd.h`. This is a valid topic that is probably worth further discussion. It may be that the right approach is to expose a second `libzstd-static` module that exports the static definitions.

For the time being though, this PR makes several changes that seem worthwhile:

1. It adds modules for the dictionary builder and errors headers.
2. It captures all of the macros that are used to configure these headers. When the headers are imported as modules and one of these macros is defined the compiler issues a warning that it needs to be defined on the CLI. E.g.:
```
warning: definition of configuration macro 'ZSTD_STATIC_LINKING_ONLY' has no effect on the import of 'libzstd'; pass '-DZSTD_STATIC_LINKING_ONLY=...' on the command line to configure the module [-Wconfig-macros]
```
3. It promotes the `module.modulemap` file into the root of the lib directory. Experimentation shows that clang's `-fimplicit-module-maps` will find the module map when placed here, but not when it's put in a subdirectory.

I know the module map was initially added in #2858. I don't have the capability to test whether these changes are compatible. Ideally @cntrump could weigh in.

To-do: create tests that can be added to validate that zstd remains compatible with modules. This is complicated by the fact that support is still experimental and present in only the most recent compilers.