### PR TITLE
Mark Huffman Decoder Assembly `noexecstack` on All Architectures

### DIFF
--- a/lib/decompress/huf_decompress_amd64.S
+++ b/lib/decompress/huf_decompress_amd64.S
@@ -3,7 +3,7 @@
 /* Stack marking
  * ref: https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
  */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/lib/decompress/huf_decompress_amd64.S
+++ b/lib/decompress/huf_decompress_amd64.S
@@ -1,13 +1,13 @@
 #include "../common/portability_macros.h"
 
-#if ZSTD_ENABLE_ASM_X86_64_BMI2
-
 /* Stack marking
  * ref: https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
  */
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif
+
+#if ZSTD_ENABLE_ASM_X86_64_BMI2
 
 /* Calling convention:
  *

--- a/lib/decompress/huf_decompress_amd64.S
+++ b/lib/decompress/huf_decompress_amd64.S
@@ -3,7 +3,7 @@
 /* Stack marking
  * ref: https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
  */
-#if defined(__ELF__)
+#if defined(__ELF__) && defined(__GNUC__)
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/lib/libzstd.mk
+++ b/lib/libzstd.mk
@@ -101,26 +101,13 @@ FLAGS     = $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 ifndef ALREADY_APPENDED_NOEXECSTACK
 export ALREADY_APPENDED_NOEXECSTACK := 1
 ifeq ($(shell echo "int main(int argc, char* argv[]) { (void)argc; (void)argv; return 0; }" | $(CC) $(FLAGS) -z noexecstack -x c -Werror - -o $(VOID) 2>$(VOID) && echo 1 || echo 0),1)
-$(info Supports noexecstack linker flag!)
-$(info $(LDFLAGS))
 LDFLAGS += -z noexecstack
-$(info $(LDFLAGS))
-else
-$(info Doesn't support noexecstack linker flag!)
 endif
 ifeq ($(shell echo | $(CC) $(FLAGS) -Wa,--noexecstack -x assembler -Werror -c - -o $(VOID) 2>$(VOID) && echo 1 || echo 0),1)
-$(info Supports noexecstack assembler flag!)
-$(info $(CFLAGS))
 CFLAGS += -Wa,--noexecstack
-$(info $(CFLAGS))
 else ifeq ($(shell echo | $(CC) $(FLAGS) -Qunused-arguments -Wa,--noexecstack -x assembler -Werror -c - -o $(VOID) 2>$(VOID) && echo 1 || echo 0),1)
 # See e.g.: https://github.com/android/ndk/issues/171
-$(info Supports noexecstack assembler flag with unused arg suppression!)
-$(info $(CFLAGS))
 CFLAGS += -Qunused-arguments -Wa,--noexecstack
-$(info $(CFLAGS))
-else
-$(info Doesn't support noexecstack assembler flag!)
 endif
 endif
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -62,8 +62,6 @@ else
   EXT =
 endif
 
-VOID = /dev/null
-
 # thread detection
 NO_THREAD_MSG := ==> no threads, building without multithreading support
 HAVE_PTHREAD := $(shell printf '$(NUM_SYMBOL)include <pthread.h>\nint main(void) { return 0; }' > have_pthread.c && $(CC) $(FLAGS) -o have_pthread$(EXT) have_pthread.c -pthread 2> $(VOID) && rm have_pthread$(EXT) && echo 1 || echo 0; rm have_pthread.c)

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -304,6 +304,15 @@ zstd -d -f tmp_corrupt.zst --no-check
 zstd -d -f tmp_corrupt.zst --check --no-check # final flag overrides
 zstd -d -f tmp.zst --no-check
 
+if [ "$isWindows" = false ]; then
+  if [ -n "$(which readelf)" ]; then
+    println "test: check if binary has executable stack"
+    file "$ZSTD_BIN"
+    readelf -lW "$ZSTD_BIN"
+    readelf -lW "$ZSTD_BIN" | grep 'GNU_STACK .* RW ' || die "zstd binary has executable stack!"
+  fi
+fi
+
 println "\n===> zstdgrep tests"
 ln -sf "$ZSTD_BIN" zstdcat
 rm -f tmp_grep

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -306,9 +306,7 @@ zstd -d -f tmp.zst --no-check
 
 if [ "$isWindows" = false ]; then
   if [ -n "$(which readelf)" ]; then
-    println "test: check if binary has executable stack"
-    file "$ZSTD_BIN"
-    readelf -lW "$ZSTD_BIN"
+    println "test: check if binary has executable stack (#2963)"
     readelf -lW "$ZSTD_BIN" | grep 'GNU_STACK .* RW ' || die "zstd binary has executable stack!"
   fi
 fi


### PR DESCRIPTION
Apparently, even when the assembly file is empty (because `ZSTD_ENABLE_ASM_X86_64_BMI2` is false), it still is marked as possibly needing an executable stack and so the whole library is marked as such. This commit applies a simple patch for this problem by moving the noexecstack indication outside the macro guard.

In addition, this PR ships flags to the Makefile-driven builds to explicitly request a non-executable stack. This ought to be redundant, but it appears on at least one platform (MIPS) to succeed where the source code note fails.

This PR builds on #2857.

This PR addresses #2963.