### PR TITLE
[WIP] fix #2966 part 2 : do not initialize tag space

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -328,7 +328,8 @@ size_t ZSTD_CCtxParams_reset(ZSTD_CCtx_params* params)
     return ZSTD_CCtxParams_init(params, ZSTD_CLEVEL_DEFAULT);
 }
 
-size_t ZSTD_CCtxParams_init(ZSTD_CCtx_params* cctxParams, int compressionLevel) {
+size_t ZSTD_CCtxParams_init(ZSTD_CCtx_params* cctxParams, int compressionLevel)
+{
     RETURN_ERROR_IF(!cctxParams, GENERIC, "NULL pointer!");
     ZSTD_memset(cctxParams, 0, sizeof(*cctxParams));
     cctxParams->compressionLevel = compressionLevel;
@@ -1779,7 +1780,6 @@ ZSTD_reset_matchState(ZSTD_matchState_t* ms,
         {   /* Row match finder needs an additional table of hashes ("tags") */
             size_t const tagTableSize = hSize*sizeof(U16);
             ms->tagTable = (U16*)ZSTD_cwksp_reserve_aligned(ws, tagTableSize);
-            if (ms->tagTable) ZSTD_memset(ms->tagTable, 0, tagTableSize);
         }
         {   /* Switch to 32-entry rows if searchLog is 5 (or more) */
             U32 const rowLog = BOUNDED(4, cParams->searchLog, 6);
@@ -6307,7 +6307,9 @@ ZSTD_compressionParameters ZSTD_getCParams(int compressionLevel, unsigned long l
  *  same idea as ZSTD_getCParams()
  * @return a `ZSTD_parameters` structure (instead of `ZSTD_compressionParameters`).
  *  Fields of `ZSTD_frameParameters` are set to default values */
-static ZSTD_parameters ZSTD_getParams_internal(int compressionLevel, unsigned long long srcSizeHint, size_t dictSize, ZSTD_cParamMode_e mode) {
+static ZSTD_parameters
+ZSTD_getParams_internal(int compressionLevel, unsigned long long srcSizeHint, size_t dictSize, ZSTD_cParamMode_e mode)
+{
     ZSTD_parameters params;
     ZSTD_compressionParameters const cParams = ZSTD_getCParams_internal(compressionLevel, srcSizeHint, dictSize, mode);
     DEBUGLOG(5, "ZSTD_getParams (cLevel=%i)", compressionLevel);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1780,6 +1780,15 @@ ZSTD_reset_matchState(ZSTD_matchState_t* ms,
         {   /* Row match finder needs an additional table of hashes ("tags") */
             size_t const tagTableSize = hSize*sizeof(U16);
             ms->tagTable = (U16*)ZSTD_cwksp_reserve_aligned(ws, tagTableSize);
+            #if ZSTD_MEMORY_SANITIZER
+                /* The rowHash algorithm has the ability to work with uninitialized tag space.
+                 * It doesn't matter if the tag space is initially correct or not,
+                 * at worst it will incorrectly "hint" at a match position
+                 * which is then properly filtered out by indices analysis.
+                 * There is also no requirement to start the series of tag from position "0".
+                 * */
+                __msan_unpoison(ms->tagTable, tagTableSize);
+            #endif
         }
         {   /* Switch to 32-entry rows if searchLog is 5 (or more) */
             U32 const rowLog = BOUNDED(4, cParams->searchLog, 6);


### PR DESCRIPTION
This diff disables `tag` initialization when using the `rowHash` mode. This initialization was unconditional, but it becomes the dominating operation when compressing small data in streaming mode (see issue #2966).

I could not find a good reason to initialize `tags`. It just makes `tag` values start at `0`, but `0` is just a regular `tag` value, it's not more significant than any other `tag` value. Worst case, there will be a wrong hint of match presence, but even that should be filtered out by distance analysis, which remains active through indices validation. So this won't impact compression result.

Now, initially, I was suspicious that it would work, because the `tag` space is 2x larger than it should be, suggesting additional space is used for something else than `tag` values, like determining the starting position in the row (which would be an overkill memory budget, but that's a different topic). But to my surprise, this change passes all tests successfully, suggesting `rowHash` is even resilient to a random start position.
_Edit_ : it seems to finally break on `msan + fuzzer` test below, so that's something worth looking into.

The end result is significant. When combined with #2969, the compression speed of `rowHash` on small data increases dramatically, as can be seen below (#2969 is required, as otherwise the impact of `tag` initialization is just lost as part of a larger initialization issue).

The following measurement is taken on a core `i7-9700K` (turbo disabled) with `fullbench -b41`, using `geldings.txt` as sample (a small text file). The test corresponds to a scenario using `ZSTD_compressStream()` without the benefit of knowing the small sample size beforehand.

| level | v1.5.1 | #2969 + this PR | comment
| --- | ---:| ---:| --- |
| 1 | 101 MB/s | 113 MB/s |
| 2 |  67 MB/s | 112 MB/s |
| 3 |  31 MB/s |  94 MB/s |
| 4 |  14 MB/s |  93 MB/s |
| 5 |   9 MB/s |  54 MB/s | `rowHash`
| 6 | 8.7 MB/s |  50 MB/s | `rowHash`
| 7 | 4.6 MB/s |  50 MB/s | `rowHash`
| 8 | 4.5 MB/s |  48 MB/s | `rowHash`
| 9 | 1.7 MB/s |  48 MB/s | `rowHash`
|10 | 0.8 MB/s |  45 MB/s | `rowHash`
|11 | 0.8 MB/s |  39 MB/s | `rowHash`
|12 | 0.4 MB/s |  39 MB/s | `rowHash`
|13 | 0.6 MB/s |  38 MB/s |

cc @terrelln : there might be some side-effects which are not properly captured by the tests, such as potential reproducibility issues but with a low enough probability that it's too difficult to reproduce during CI tests. And maybe other side effects worth looking into.

**Note** : WIP, not for merge