### PR TITLE
Async write for decompression

### DIFF
--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -20,14 +20,24 @@ zstd_programs_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
   join_paths(zstd_rootdir, 'programs/dibio.c'),
   join_paths(zstd_rootdir, 'programs/zstdcli_trace.c'),
   # needed due to use of private symbol + -fvisibility=hidden
-  join_paths(zstd_rootdir, 'lib/common/xxhash.c')]
-
-zstd_c_args = libzstd_debug_cflags
-if use_multi_thread
-  zstd_c_args += [ '-DZSTD_MULTITHREAD' ]
-endif
+  join_paths(zstd_rootdir, 'lib/common/xxhash.c'),
+  join_paths(zstd_rootdir, 'lib/common/pool.c'),
+  join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
+  join_paths(zstd_rootdir, 'lib/common/error_private.c')]
 
 zstd_deps = [ libzstd_dep ]
+zstd_c_args = libzstd_debug_cflags
+
+zstd_frugal_deps = [ libzstd_dep ]
+zstd_frugal_c_args = [ '-DZSTD_NOBENCH', '-DZSTD_NODICT', '-DZSTD_NOTRACE' ]
+
+if use_multi_thread
+  zstd_deps += [ thread_dep ]
+  zstd_c_args += [ '-DZSTD_MULTITHREAD' ]
+  zstd_frugal_deps += [ thread_dep ]
+  zstd_frugal_c_args += [ '-DZSTD_MULTITHREAD' ]
+endif
+
 if use_zlib
   zstd_deps += [ zlib_dep ]
   zstd_c_args += [ '-DZSTD_GZCOMPRESS', '-DZSTD_GZDECOMPRESS' ]
@@ -69,14 +79,17 @@ zstd = executable('zstd',
 zstd_frugal_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
   join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
-  join_paths(zstd_rootdir, 'programs/fileio.c')]
+  join_paths(zstd_rootdir, 'programs/fileio.c'),
+  join_paths(zstd_rootdir, 'lib/common/pool.c'),
+  join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
+  join_paths(zstd_rootdir, 'lib/common/error_private.c')]
 
 # Minimal target, with only zstd compression and decompression.
 # No bench. No legacy.
 executable('zstd-frugal',
   zstd_frugal_sources,
-  dependencies: libzstd_dep,
-  c_args: [ '-DZSTD_NOBENCH', '-DZSTD_NODICT', '-DZSTD_NOTRACE' ],
+  dependencies: zstd_frugal_deps,
+  c_args: zstd_frugal_c_args,
   install: true)
 
 install_data(join_paths(zstd_rootdir, 'programs/zstdgrep'),

--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -96,9 +96,7 @@ static void* POOL_thread(void* opaque) {
             /* If the intended queue size was 0, signal after finishing job */
             ZSTD_pthread_mutex_lock(&ctx->queueMutex);
             ctx->numThreadsBusy--;
-            if (ctx->queueSize == 1) {
-                ZSTD_pthread_cond_signal(&ctx->queuePushCond);
-            }
+            ZSTD_pthread_cond_signal(&ctx->queuePushCond);
             ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
         }
     }  /* for (;;) */
@@ -188,6 +186,17 @@ void POOL_free(POOL_ctx *ctx) {
     ZSTD_customFree(ctx->queue, ctx->customMem);
     ZSTD_customFree(ctx->threads, ctx->customMem);
     ZSTD_customFree(ctx, ctx->customMem);
+}
+
+/*! POOL_joinJobs() :
+ *  Waits for all queued jobs to finish executing.
+ */
+void POOL_joinJobs(POOL_ctx* ctx) {
+    ZSTD_pthread_mutex_lock(&ctx->queueMutex);
+    while(!ctx->queueEmpty || ctx->numThreadsBusy > 0) {
+        ZSTD_pthread_cond_wait(&ctx->queuePushCond, &ctx->queueMutex);
+    }
+    ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
 }
 
 void ZSTD_freeThreadPool (ZSTD_threadPool* pool) {
@@ -329,6 +338,11 @@ void POOL_free(POOL_ctx* ctx) {
     assert(!ctx || ctx == &g_poolCtx);
     (void)ctx;
 }
+
+void POOL_joinJobs(POOL_ctx* ctx){
+    assert(!ctx || ctx == &g_poolCtx);
+    (void)ctx;
+};
 
 int POOL_resize(POOL_ctx* ctx, size_t numThreads) {
     (void)ctx; (void)numThreads;

--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -342,7 +342,7 @@ void POOL_free(POOL_ctx* ctx) {
 void POOL_joinJobs(POOL_ctx* ctx){
     assert(!ctx || ctx == &g_poolCtx);
     (void)ctx;
-};
+}
 
 int POOL_resize(POOL_ctx* ctx, size_t numThreads) {
     (void)ctx; (void)numThreads;

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -38,6 +38,12 @@ POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize,
  */
 void POOL_free(POOL_ctx* ctx);
 
+
+/*! POOL_joinJobs() :
+ *  Waits for all queued jobs to finish executing.
+ */
+void POOL_joinJobs(POOL_ctx* ctx);
+
 /*! POOL_resize() :
  *  Expands or shrinks pool's number of threads.
  *  This is more efficient than releasing + creating a new context,

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -109,6 +109,7 @@ void FIO_setAllowBlockDevices(FIO_prefs_t* const prefs, int allowBlockDevices);
 void FIO_setPatchFromMode(FIO_prefs_t* const prefs, int value);
 void FIO_setContentSize(FIO_prefs_t* const prefs, int value);
 void FIO_displayCompressionParameters(const FIO_prefs_t* prefs);
+void FIO_setAsyncIOFlag(FIO_prefs_t* const prefs, unsigned value);
 
 /* FIO_ctx_t functions */
 void FIO_setNbFilesTotal(FIO_ctx_t* const fCtx, int value);

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -239,9 +239,12 @@ static void usage_advanced(const char* programName)
 #ifndef ZSTD_NODECOMPRESS
     DISPLAYOUT( "\n");
     DISPLAYOUT( "Advanced decompression arguments : \n");
-    DISPLAYOUT( " -l     : print information about zstd compressed files \n");
-    DISPLAYOUT( "--test  : test compressed file integrity \n");
-    DISPLAYOUT( " -M#    : Set a memory usage limit for decompression \n");
+    DISPLAYOUT( " -l        : print information about zstd compressed files \n");
+    DISPLAYOUT( "--test     : test compressed file integrity \n");
+    DISPLAYOUT( " -M#       : Set a memory usage limit for decompression \n");
+#ifdef ZSTD_MULTITHREAD
+    DISPLAYOUT( "--[no-]asyncio  : use threaded asynchronous IO for output (default: disabled) \n");
+#endif
 # if ZSTD_SPARSE_DEFAULT
     DISPLAYOUT( "--[no-]sparse : sparse mode (default: enabled on file, disabled on stdout) \n");
 # else
@@ -912,6 +915,8 @@ int main(int argCount, const char* argv[])
                 if (!strcmp(argument, "--sparse")) { FIO_setSparseWrite(prefs, 2); continue; }
                 if (!strcmp(argument, "--no-sparse")) { FIO_setSparseWrite(prefs, 0); continue; }
                 if (!strcmp(argument, "--test")) { operation=zom_test; continue; }
+                if (!strcmp(argument, "--asyncio")) { FIO_setAsyncIOFlag(prefs, 1); continue;}
+                if (!strcmp(argument, "--no-asyncio")) { FIO_setAsyncIOFlag(prefs, 0); continue;}
                 if (!strcmp(argument, "--train")) { operation=zom_train; if (outFileName==NULL) outFileName=g_defaultDictName; continue; }
                 if (!strcmp(argument, "--no-dictID")) { FIO_setDictIDFlag(prefs, 0); continue; }
                 if (!strcmp(argument, "--keep")) { FIO_setRemoveSrcFile(prefs, 0); continue; }

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1576,21 +1576,43 @@ elif [ "$longCSize19wlog23" -gt "$optCSize19wlog23" ]; then
 fi
 
 println "\n===>  zstd asyncio decompression tests "
-roundTripTest -g8M "3 --asyncio"
-roundTripTest -g8M "3 --no-asyncio"
+
+addFrame() {
+    datagen -g2M -s$2 >> tmp_uncompressed
+    datagen -g2M -s$2 | zstd --format=$1 >> tmp_compressed.zst
+}
+
+addTwoFrames() {
+  addFrame $1 1
+  addFrame $1 2
+}
+
+testAsyncIO() {
+  roundTripTest -g2M "3 --asyncio --format=$1"
+  roundTripTest -g2M "3 --no-asyncio --format=$1"
+}
+
+rm -f tmp_compressed tmp_uncompressed
+testAsyncIO zstd
+addTwoFrames zstd
 if [ $GZIPMODE -eq 1 ]; then
-  roundTripTest -g8M "3 --format=gzip --asyncio"
-  roundTripTest -g8M "3 --format=gzip --no-asyncio"
+  testAsyncIO gzip
+  addTwoFrames gzip
 fi
 if [ $LZMAMODE -eq 1 ]; then
-  roundTripTest -g8M "3 --format=lzma --asyncio"
-  roundTripTest -g8M "3 --format=lzma --no-asyncio"
+  testAsyncIO lzma
+  addTwoFrames lzma
 fi
 if [ $LZ4MODE -eq 1 ]; then
-  roundTripTest -g8M "3 --format=lz4 --asyncio"
-  roundTripTest -g8M "3 --format=lz4 --no-asyncio"
+  testAsyncIO lz4
+  addTwoFrames lz4
 fi
-
+cat tmp_uncompressed | $MD5SUM > tmp2
+zstd -d tmp_compressed.zst --asyncio -c | $MD5SUM > tmp1
+$DIFF -q tmp1 tmp2
+rm tmp1
+zstd -d tmp_compressed.zst --no-asyncio -c | $MD5SUM > tmp1
+$DIFF -q tmp1 tmp2
 
 if [ "$1" != "--test-large-data" ]; then
     println "Skipping large data tests"

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1575,6 +1575,22 @@ elif [ "$longCSize19wlog23" -gt "$optCSize19wlog23" ]; then
     exit 1
 fi
 
+println "\n===>  zstd asyncio decompression tests "
+roundTripTest -g8M "3 --asyncio"
+roundTripTest -g8M "3 --no-asyncio"
+if [ $GZIPMODE -eq 1 ]; then
+  roundTripTest -g8M "3 --format=gzip --asyncio"
+  roundTripTest -g8M "3 --format=gzip --no-asyncio"
+fi
+if [ $LZMAMODE -eq 1 ]; then
+  roundTripTest -g8M "3 --format=lzma --asyncio"
+  roundTripTest -g8M "3 --format=lzma --no-asyncio"
+fi
+if [ $LZ4MODE -eq 1 ]; then
+  roundTripTest -g8M "3 --format=lz4 --asyncio"
+  roundTripTest -g8M "3 --format=lz4 --no-asyncio"
+fi
+
 
 if [ "$1" != "--test-large-data" ]; then
     println "Skipping large data tests"


### PR DESCRIPTION
Changes:
- Added `--[no-]asyncio` flag for CLI decompression.
- Replaced dstBuffer in decompression with a pool of write jobs.
- Added an ability to execute write jobs in a separate thread.
- Added an ability to wait (join) on all jobs in a thread pool (queue and running).
- Fixed bug in multiframe decompression in lz4.

Benchmarked total runtime (real time) of decompression on 3 machines, these are the runtime improvements in %:
```
flag                     --asyncio  --no-asyncio  improvement
input_file      machine
enwik8.zst      desktop      0.168         0.211    20.379147
                macbook      0.296         0.556    46.762590
                server       0.195         0.241    19.087137
silesia.tar.zst desktop      0.285         0.388    26.546392
                macbook      0.634         0.982    35.437882
                server       0.337         0.439    23.234624
```
Notes:
- user & system time / cpu utilization is mostly the same and might even be higher, but total time is reduced because we wait less time on IO
- Impact might be even bigger on bigger files as we also measure initialization here
