### PR TITLE
Remove Dependencies to Allow the Zstd Binary to Dynamically Link to the Library

### DIFF
--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -31,9 +31,14 @@
 #include "timefn.h"      /* UTIL_time_t */
 #include "benchfn.h"
 #include "../lib/common/mem.h"
+#ifndef ZSTD_STATIC_LINKING_ONLY
 #define ZSTD_STATIC_LINKING_ONLY
+#endif
 #include "../lib/zstd.h"
 #include "datagen.h"     /* RDG_genBuffer */
+#ifndef XXH_INLINE_ALL
+#define XXH_INLINE_ALL
+#endif
 #include "../lib/common/xxhash.h"
 #include "benchzstd.h"
 #include "../lib/zstd_errors.h"

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -31,7 +31,6 @@
 
 #include "timefn.h"         /* UTIL_time_t, UTIL_clockSpanMicro, UTIL_getTime */
 #include "../lib/common/mem.h"  /* read */
-#include "../lib/common/error_private.h"
 #include "dibio.h"
 
 


### PR DESCRIPTION
This PR avoids dependencies on symbols that are not exported in the dynamic library.

I believe this works. However, I'm not sure that (a) this is really a worthwhile goal and (b) that this is a good solution for that goal. Your feedback is welcome.

This PR resolves #2950.