### PR TITLE
[license] Fix license header of huf_decompress_amd64.S

### DIFF
--- a/lib/decompress/huf_decompress_amd64.S
+++ b/lib/decompress/huf_decompress_amd64.S
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
 #include "../common/portability_macros.h"
 
 /* Stack marking

--- a/tests/test-license.py
+++ b/tests/test-license.py
@@ -43,6 +43,7 @@ SUFFIXES = [
     "Makefile",
     ".mk",
     ".py",
+    ".S",
 ]
 
 # License should certainly be in the first 10 KB.


### PR DESCRIPTION
* Add the license header for `huf_decompress_amd64.S`
* Add `.S` files to the `test-license.py` test

Fixes #2945.