### PR TITLE
ZSTD CLI: Use buffered output

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -718,6 +718,17 @@ FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
         if (f == NULL) {
             DISPLAYLEVEL(1, "zstd: %s: %s\n", dstFileName, strerror(errno));
         }
+        /* An increased buffer size can provide a significant performance boost on some platforms.
+         * Note that providing a NULL buf with a size that's not 0 is not defined in ANSI C, but is defined
+         * in an extension. There are three possibilities here -
+         * 1. Libc supports the extended version and everything is good.
+         * 2. Libc ignores the size when buf is NULL, in which case everything will continue as if we didn't
+         *    call `setvbuf`.
+         * 3. We fail the call and execution continues but a warning message might be shown.
+         * In all cases due execution continues. For now, I believe that this is a more cost-effective
+         * solution than managing the buffers allocations ourselves (will require an API change). */
+        if(setvbuf(f, NULL, _IOFBF, 1 MB))
+            DISPLAYLEVEL(2, "Warning: setvbuf failed for %s\n", dstFileName);
         return f;
     }
 }


### PR DESCRIPTION
When opening an output file the zstd CLI will try to set it to buffered mode with a 1MB buffer.
Testing shown possible performance improvement on linux based machine and a major performance improvement on macOS:
```
comment                    dev  setvbuf  improvement
input_file      machine
enwik8.zst      desktop  0.210    0.211    -0.476190
                macbook  0.468    0.217    53.632479
                server   0.229    0.221     3.493450
silesia.tar.zst desktop  0.387    0.386     0.258398
                macbook  0.870    0.331    61.954023
                server   0.419    0.409     2.386635
```

Note: as per code comment, this usage of setvbuf might not be supported on legacy systems, but even in this case it shouldn't impact overall success of the execution.