### PR TITLE
x86-64: Enable Intel CET

### DIFF
--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -134,4 +134,15 @@
 # define ZSTD_ENABLE_ASM_X86_64_BMI2 0
 #endif
 
+/*
+ * For x86 ELF targets, add .note.gnu.property section for Intel CET in
+ * assembly sources when CET is enabled.
+ */
+#if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__)) \
+    && defined(__has_include)
+# if __has_include(<cet.h>)
+#  include <cet.h>
+# endif
+#endif
+
 #endif /* ZSTD_PORTABILITY_MACROS_H */


### PR DESCRIPTION
Intel Control-flow Enforcement Technology (CET):

https://en.wikipedia.org/wiki/Control-flow_integrity#Intel_Control-flow_Enforcement_Technology

requires that on Linux, all linker input files are marked as CET enabled
in .note.gnu.property section.  For high-level language source codes,
.note.gnu.property section is added by compiler with the -fcf-protection
option.  For assembly sources, include <cet.h> to add .note.gnu.property
section.