### PR TITLE
Add exposed window buffer mode

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -276,7 +276,8 @@ MEM_STATIC size_t ZSTD_limitCopy(void* dst, size_t dstCapacity, const void* src,
 /* Controls whether the input/output buffer is buffered or stable. */
 typedef enum {
     ZSTD_bm_buffered = 0,  /* Buffer the input/output */
-    ZSTD_bm_stable = 1     /* ZSTD_inBuffer/ZSTD_outBuffer is stable */
+    ZSTD_bm_stable = 1,    /* ZSTD_inBuffer/ZSTD_outBuffer is stable */
+    ZSTD_bm_expose = 2     /* Set ZSTD_outBuffer to internal window */
 } ZSTD_bufferMode_e;
 
 

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -2160,6 +2160,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
             }
         case zdss_flush:
             {   size_t const toFlushSize = zds->outEnd - zds->outStart;
+                size_t flushedSize;
                 if (zds->outBufferMode == ZSTD_bm_expose)
                 {
                     output->dst = op = zds->outBuff + zds->outStart;
@@ -2169,7 +2170,7 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
                     someMoreWork = 0;
                     break;
                 }
-                size_t const flushedSize = ZSTD_limitCopy(op, (size_t)(oend-op), zds->outBuff + zds->outStart, toFlushSize);
+                flushedSize = ZSTD_limitCopy(op, (size_t)(oend-op), zds->outBuff + zds->outStart, toFlushSize);
                 op += flushedSize;
                 zds->outStart += flushedSize;
                 if (flushedSize != toFlushSize) {

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -91,7 +91,7 @@ typedef enum { ZSTDds_getFrameHeaderSize, ZSTDds_decodeFrameHeader,
                ZSTDds_decodeSkippableHeader, ZSTDds_skipFrame } ZSTD_dStage;
 
 typedef enum { zdss_init=0, zdss_loadHeader,
-               zdss_read, zdss_load, zdss_flush } ZSTD_dStreamStage;
+               zdss_read, zdss_load, zdss_flush, zdss_flushdone } ZSTD_dStreamStage;
 
 typedef enum {
     ZSTD_use_indefinitely = -1,  /* Use the dictionary indefinitely */

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -664,7 +664,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     DISPLAYLEVEL(3, "test%3i : ZSTD_decompressStream() single pass on empty frame : ", testNb++);
     {   ZSTD_DCtx* dctx = ZSTD_createDCtx();
         size_t const dctxSize = ZSTD_sizeof_DCtx(dctx);
-        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_stableOutBuffer, 1));
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_stable));
 
         outBuff.dst = decodedBuffer;
         outBuff.pos = 0;
@@ -684,13 +684,13 @@ static int basicUnitTests(U32 seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
-    /* Decompression with ZSTD_d_stableOutBuffer */
+    /* Decompression with ZSTD_d_outBufferMode == ZSTD_bufmode_stable */
     cSize = ZSTD_compress(compressedBuffer, compressedBufferSize, CNBuffer, CNBufferSize, 1);
     CHECK_Z(cSize);
     {   ZSTD_DCtx* dctx = ZSTD_createDCtx();
         size_t const dctxSize0 = ZSTD_sizeof_DCtx(dctx);
         size_t dctxSize1;
-        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_stableOutBuffer, 1));
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_stable));
 
         outBuff.dst = decodedBuffer;
         outBuff.pos = 0;
@@ -725,7 +725,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         DISPLAYLEVEL(3, "test%3i : ZSTD_decompressStream() stable out buffer too small : ", testNb++);
         ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
-        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_stableOutBuffer, 1));
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_stable));
         inBuff.src = compressedBuffer;
         inBuff.size = cSize;
         inBuff.pos = 0;
@@ -738,7 +738,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         DISPLAYLEVEL(3, "test%3i : ZSTD_decompressStream() stable out buffer modified : ", testNb++);
         ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
-        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_stableOutBuffer, 1));
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_stable));
         inBuff.src = compressedBuffer;
         inBuff.size = cSize - 1;
         inBuff.pos = 0;
@@ -754,7 +754,7 @@ static int basicUnitTests(U32 seed, double compressibility)
 
         DISPLAYLEVEL(3, "test%3i : ZSTD_decompressStream() buffered output : ", testNb++);
         ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
-        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_stableOutBuffer, 0));
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_buffered));
         outBuff.pos = 0;
         inBuff.pos = 0;
         inBuff.size = 0;
@@ -765,6 +765,58 @@ static int basicUnitTests(U32 seed, double compressibility)
         CHECK(outBuff.pos != CNBufferSize, "Wrong size!");
         CHECK(memcmp(CNBuffer, outBuff.dst, CNBufferSize) != 0, "Corruption!");
         CHECK(!(dctxSize1 < ZSTD_sizeof_DCtx(dctx)), "Output buffer allocated");
+        DISPLAYLEVEL(3, "OK \n");
+
+        ZSTD_freeDCtx(dctx);
+    }
+
+    /* Decompression with ZSTD_d_outBufferMode == ZSTD_bufmode_expose */
+    {   ZSTD_DCtx* dctx = ZSTD_createDCtx();
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_expose));
+
+        DISPLAYLEVEL(3, "test%3i : ZSTD_decompressStream() exposed window all input: ", testNb++);
+        inBuff.src = compressedBuffer;
+        inBuff.pos = 0;
+        inBuff.size = cSize;
+        outBuff.dst = NULL; /* Set by decomp */
+        outBuff.size = 0;   /* Set by decomp */
+        outBuff.pos = 0;    /* Not used */
+        size_t total = 0;
+        while (inBuff.pos < cSize) {
+            CHECK_Z(ZSTD_decompressStream(dctx, &outBuff, &inBuff));
+            CHECK(!outBuff.dst != !outBuff.size, "Should have both dst & size set or neither");
+            if (outBuff.size) {
+                CHECK(memcmp((char*)CNBuffer + total, outBuff.dst, outBuff.size) != 0, "Corruption!");
+                total += outBuff.size;
+                outBuff.size = 0; /* Acknowledge */
+                outBuff.dst = NULL;
+            }
+        }
+        CHECK(total != CNBufferSize, "Wrong size!");
+        DISPLAYLEVEL(3, "OK \n");
+
+        DISPLAYLEVEL(3, "test%3i : ZSTD_decompressStream() exposed window piecemeal : ", testNb++);
+        ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_expose));
+        inBuff.src = compressedBuffer;
+        inBuff.pos = 0;
+        inBuff.size = 0;
+        outBuff.dst = NULL; /* Set by decomp */
+        outBuff.size = 0;   /* Set by decomp */
+        outBuff.pos = 0;    /* Not used */
+        total = 0;
+        while (inBuff.pos < cSize) {
+            inBuff.size += MIN(cSize - inBuff.pos, 1 + (FUZ_rand(&coreSeed) & 15));
+            CHECK_Z(ZSTD_decompressStream(dctx, &outBuff, &inBuff));
+            CHECK(!outBuff.dst != !outBuff.size, "Should have both dst & size set or neither");
+            if (outBuff.size) {
+                CHECK(memcmp((char*)CNBuffer + total, outBuff.dst, outBuff.size) != 0, "Corruption!");
+                total += outBuff.size;
+                outBuff.size = 0; /* Acknowledge */
+                outBuff.dst = NULL;
+            }
+        }
+        CHECK(total != CNBufferSize, "Wrong size!");
         DISPLAYLEVEL(3, "OK \n");
 
         ZSTD_freeDCtx(dctx);

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -772,16 +772,17 @@ static int basicUnitTests(U32 seed, double compressibility)
 
     /* Decompression with ZSTD_d_outBufferMode == ZSTD_bufmode_expose */
     {   ZSTD_DCtx* dctx = ZSTD_createDCtx();
-        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_expose));
-
+        int mustfail = 0;
+        size_t total = 0;
+        size_t dec = 0;
         DISPLAYLEVEL(3, "test%3i : ZSTD_decompressStream() exposed window all input: ", testNb++);
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_expose));
         inBuff.src = compressedBuffer;
         inBuff.pos = 0;
         inBuff.size = cSize;
         outBuff.dst = NULL; /* Set by decomp */
         outBuff.size = 0;   /* Set by decomp */
         outBuff.pos = 0;    /* Not used */
-        size_t total = 0;
         while (inBuff.pos < cSize) {
             CHECK_Z(ZSTD_decompressStream(dctx, &outBuff, &inBuff));
             CHECK(!outBuff.dst != !outBuff.size, "Should have both dst & size set or neither");
@@ -828,10 +829,9 @@ static int basicUnitTests(U32 seed, double compressibility)
         outBuff.dst = NULL; /* Set by decomp */
         outBuff.size = 0;   /* Set by decomp */
         outBuff.pos = 0;    /* Not used */
-        int mustfail = 0;
         while (inBuff.pos < cSize) {
             inBuff.size += MIN(cSize - inBuff.pos, 1 + (FUZ_rand(&coreSeed) & 15));
-            size_t dec = ZSTD_decompressStream(dctx, &outBuff, &inBuff);
+            dec = ZSTD_decompressStream(dctx, &outBuff, &inBuff);
             if (mustfail) {
                 CHECK(ZSTD_getErrorCode(dec) != ZSTD_error_dstBuffer_wrong, "should fail when output is not cleared");
                 break; /* failed as it should -> done here */


### PR DESCRIPTION
Related to and discussed in #3004

This change renames `ZSTD_d_stableOutBuffer` to `ZSTD_d_outBufferMode` and adds a 3rd setting:
```
typedef enum {
    ZSTD_bufmode_buffered = 0,
    ZSTD_bufmode_stable = 1,
    ZSTD_bufmode_expose = 2, /* <-- new */
} ZSTD_bufmode_e;
```
The change is ABI-compatible.
Temporary source compatibility could be done by re-adding the original
```
#define ZSTD_d_stableOutBuffer ZSTD_d_experimentalParam2
```
to zstd.h until the parameter is no longer considered experimental.

--- What this does ---

`ZSTD_bufmode_expose` gives a user direct read access into the LZ-window instead of flushing it with a memcpy.

Instead of fiddling with an external buffer like the usual code:
```
ZSTD_inBuffer in = { /* compressed data */ };
for(...) {
    char buf[SOME_SIZE];
    ZSTD_outBuffer out = { &buf[0], sizeof(buf), 0 };
    size_t r = ZSTD_decompressStream(dctx, &out, &in)
    .... handle error ....
    fwrite(out.dst, 1, out.pos, file);
}
```
we can now do this, completely avoiding an extra copy:
```
ZSTD_DCtx_setParameter(dctx, ZSTD_d_outBufferMode, ZSTD_bufmode_expose)
ZSTD_inBuffer in = { /* compressed data */ };
ZSTD_outBuffer out = { 0, 0, 0 };
for(...) {
    size_t r = ZSTD_decompressStream(dctx, &out, &in)
    .... handle error ....
    if(out.size) { /* stays 0 until there is output */
        fwrite(out.dst, 1, out.size, file);
        out.size = 0; out.dst = NULL; /* acknowledge */
    }
}
```
This is very nice for a streaming scenario where the consumer does not care about the exact size of the decompressed data and where the buffer is located in memory, as described in [the ryg blog](https://fgiesen.wordpress.com/2011/11/21/buffer-centric-io/).
I guess avoiding the extra copy should also cause less cache thrashing but i didn't try to measure that.


Things left to discuss:
`ZSTD_bufmode_expose` is currently only implemented for decompression.
Since compression is quite resource-hungry this would not benefit from an exposed window. But it'd be nice to have the same API available for compression as well.
What about renaming `ZSTD_c_stable{In|Out}Buffer` to `ZSTD_c_outBufferMode` for consistency? (Didn't touch that so far because i wanted to avoid cluttering up the PR more that it is already.)
Anything else left to do?

EDIT: Except for the C90 compat. Clang and vs19 are happy so i didn't see this. Oh well.
EDIT2: Fixed derp in the external buffer example block above, that was supposed to fwrite using pos, not size. In the exposed buffer block below, pos is always == 0. I considered setting output pos=size to ease a transition to this type of buffer handling but it caused some annoying side effects in the code that checks/handles pos so i didn't go there (mainly the pos<=size invariant, didn't want to touch that)

(cc @terrelln)