### PR TITLE
Trigger Release Artifact Generation on Publish

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -3,7 +3,7 @@ name: publish-release-artifacts
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   publish-release-artifacts:


### PR DESCRIPTION
We previously triggered release artifact generation on release creation. We sometimes observed that the action failed to run. I hypothesized that we were hitting rate limiting or something. I just stumbled across [this documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release), which says:

> Note: Workflows are not triggered for the `created`, `edited`, or `deleted` activity types for draft releases. When you create your release through the GitHub browser UI, your release may automatically be saved as a draft.

This must have been what was happening. This commit therefore changes the trigger to the `published` activity. This should be more reliable.

This does have the unfortunate side effect that artifacts won't be generated or attached until *after* the release has been published, which is what I was trying to avoid by using the `created` activity. Oh well.