### PR TITLE
fix for -r on empty directory 

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1366,8 +1366,8 @@ int main(int argCount, const char* argv[])
        was a number of empty directories. In this case
        stdin and stdout should not be used */
        if (nbInputFileNames > 0 ){
-        DISPLAYLEVEL(2, "please provide correct input file(s) or non-empty directories -- ignored \n");
-        CLEAN_RETURN(2);
+        DISPLAYLEVEL(1, "please provide correct input file(s) or non-empty directories -- ignored \n");
+        CLEAN_RETURN(0);
        }
        UTIL_refFilename(filenames, stdinmark);
     }

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -393,7 +393,7 @@ zstd -c -r < tmp > tmp.zst
 # combination of -r with empty folder
 mkdir -p tmpEmptyDir
 zstd -r tmpEmptyDir 2>tmplog2
-if [grep "aborting" tmplog2]; then
+if [ grep "aborting" tmplog2 ]; then
   println "Should not abort on empty directory"
   rm -rf tmplog2
   rm -rf tmpEmptyDir

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -392,14 +392,7 @@ zstd -c -r < tmp > tmp.zst
 
 # combination of -r with empty folder
 mkdir -p tmpEmptyDir
-zstd -r tmpEmptyDir 2>tmplog2
-if [ grep "aborting" tmplog2 ]; then
-  println "Should not abort on empty directory"
-  rm -rf tmplog2
-  rm -rf tmpEmptyDir
-  die
-fi
-rm -rf tmplog2
+zstd -r tmpEmptyDir
 rm -rf tmpEmptyDir
 
 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -390,6 +390,18 @@ println "\n===>  recursive mode test "
 # combination of -r with empty list of input file
 zstd -c -r < tmp > tmp.zst
 
+# combination of -r with empty folder
+mkdir -p tmpEmptyDir
+zstd -r tmpEmptyDir 2>tmplog2
+if [grep "aborting" tmplog2]; then
+  println "Should not abort on empty directory"
+  rm -rf tmplog2
+  rm -rf tmpEmptyDir
+  die
+fi
+rm -rf tmplog2
+rm -rf tmpEmptyDir
+
 
 println "\n===>  file removal"
 zstd -f --rm tmp


### PR DESCRIPTION
fix for -r on empty directory resulted in zstd waiting for input from stdin. this fix makes zstd exit without erroring
but printing a warning message explaining that there were no files or non-empty directories to process. 