### PR TITLE
Lazy parameters adaptation - buffered mode

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -412,6 +412,10 @@ struct ZSTD_CCtx_s {
     ZSTD_inBuffer expectedInBuffer;
     size_t expectedOutBufferSize;
 
+    /* storage before initialization */
+    char* preBuff; /* when != NULL => size == ZSTD_BLOCKSIZE_MAX */
+    size_t preFilled; /* must be < ZSTD_BLOCKSIZE_MAX */
+
     /* Dictionary */
     ZSTD_localDict localDict;
     const ZSTD_CDict* cdict;

--- a/lib/compress/zstd_cwksp.h
+++ b/lib/compress/zstd_cwksp.h
@@ -584,7 +584,7 @@ MEM_STATIC void ZSTD_cwksp_init(ZSTD_cwksp* ws, void* start, size_t size, ZSTD_c
 }
 
 MEM_STATIC size_t ZSTD_cwksp_create(ZSTD_cwksp* ws, size_t size, ZSTD_customMem customMem) {
-    void* workspace = ZSTD_customMalloc(size, customMem);
+    void* const workspace = ZSTD_customMalloc(size, customMem);
     DEBUGLOG(4, "cwksp: creating new workspace with %zd bytes", size);
     RETURN_ERROR_IF(workspace == NULL, memory_allocation, "NULL pointer!");
     ZSTD_cwksp_init(ws, workspace, size, ZSTD_cwksp_dynamic_alloc);
@@ -592,7 +592,7 @@ MEM_STATIC size_t ZSTD_cwksp_create(ZSTD_cwksp* ws, size_t size, ZSTD_customMem 
 }
 
 MEM_STATIC void ZSTD_cwksp_free(ZSTD_cwksp* ws, ZSTD_customMem customMem) {
-    void *ptr = ws->workspace;
+    void* const ptr = ws->workspace;
     DEBUGLOG(4, "cwksp: freeing workspace");
     ZSTD_memset(ws, 0, sizeof(ZSTD_cwksp));
     ZSTD_customFree(ptr, customMem);

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -1364,8 +1364,8 @@ github,                             level 16,                           old stre
 github,                             level 16 with dict,                 old streaming advanced,             40789
 github,                             level 19,                           old streaming advanced,             134064
 github,                             level 19 with dict,                 old streaming advanced,             37576
-github,                             no source size,                     old streaming advanced,             140599
-github,                             no source size with dict,           old streaming advanced,             40608
+github,                             no source size,                     old streaming advanced,             104512
+github,                             no source size with dict,           old streaming advanced,             36283
 github,                             long distance mode,                 old streaming advanced,             141104
 github,                             multithreaded,                      old streaming advanced,             141104
 github,                             multithreaded long distance mode,   old streaming advanced,             141104


### PR DESCRIPTION
This is a follow up to #2974, which was limited to `ZSTD_stableInBuffer` mode.

In this PR, input data is just buffered, until a full block is reached, or a `flush()` or `end()` order arrives.
This makes it possible to do late parameters adaptation when input is smaller than a full block, which is especially important for very small data, in order to use less resource and more appropriate parameters.
This (generally) results in better compression ratio, and also better speed, especially for newly allocated contexts, and as such can be seen as a follow up to #2969.

This proposal uses an additional buffer to buffer the first block before context initialization.
The issue with this proposal is that it's not compatible with `initStatic`.
Using the existing context for buffering would be another possibility, but it's more complex to do when the context doesn't exist, or is too small. And there is also the tricky topic of transferring data from the old to the new context at initialization time, which is especially dangerous when they are overlapping, which happens with `initStatic,` and will likely require some dedicated code. So there is some balance to find with complexity.

Anyway, this PR is at least good enough to start a discussion.