### PR TITLE
Print zlib/lz4/lzma library versions in verbose version output

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -69,6 +69,40 @@ UTIL_time_t g_displayClock = UTIL_TIME_INITIALIZER;
 #  include <lz4.h>
 #endif
 
+char const* FIO_zlibVersion(void)
+{
+#if defined(ZSTD_GZCOMPRESS) || defined(ZSTD_GZDECOMPRESS)
+    return zlibVersion();
+#else
+    return "Unsupported";
+#endif
+}
+
+char const* FIO_lz4Version(void)
+{
+#if defined(ZSTD_LZ4COMPRESS) || defined(ZSTD_LZ4DECOMPRESS)
+    /* LZ4_versionString() added in v1.7.3 */
+#   if LZ4_VERSION_NUMBER >= 10703
+        return LZ4_versionString();
+#   else
+#       define ZSTD_LZ4_VERSION LZ4_VERSION_MAJOR.LZ4_VERSION_MINOR.LZ4_VERSION_RELEASE
+#       define ZSTD_LZ4_VERSION_STRING ZSTD_EXPAND_AND_QUOTE(ZSTD_LZ4_VERSION)
+        return ZSTD_LZ4_VERSION_STRING;
+#   endif
+#else
+    return "Unsupported";
+#endif
+}
+
+char const* FIO_lzmaVersion(void)
+{
+#if defined(ZSTD_LZMACOMPRESS) || defined(ZSTD_LZMADECOMPRESS)
+    return lzma_version_string();
+#else
+    return "Unsupported";
+#endif
+}
+
 
 /*-*************************************
 *  Constants

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -166,6 +166,9 @@ int FIO_checkFilenameCollisions(const char** filenameTable, unsigned nbFiles);
 /* custom crash signal handler */
 void FIO_addAbortHandler(void);
 
+char const* FIO_zlibVersion(void);
+char const* FIO_lz4Version(void);
+char const* FIO_lzmaVersion(void);
 
 
 #if defined (__cplusplus)

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -637,6 +637,11 @@ static void printVersion(void)
     #endif
         DISPLAYOUT("\n");
         if (g_displayLevel >= 4) {
+            /* library versions */
+            DISPLAYOUT("zlib version %s\n", FIO_zlibVersion());
+            DISPLAYOUT("lz4 version %s\n", FIO_lz4Version());
+            DISPLAYOUT("lzma version %s\n", FIO_lzmaVersion());
+
             /* posix support */
         #ifdef _POSIX_C_SOURCE
             DISPLAYOUT("_POSIX_C_SOURCE defined: %ldL\n", (long) _POSIX_C_SOURCE);

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -183,6 +183,7 @@ else
 fi
 
 
+zstd -vvV
 
 println "\n===>  simple tests "
 


### PR DESCRIPTION
Knowing the version of zlib/lz4/lzma we're linking against is very
useful for debugging issues with those libraries, so print it out in the
verbosity 4 version output.

Also print this information at the top of `playTests.sh`.