### PR TITLE
fix issue 44108

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3443,8 +3443,11 @@ ZSTD_resolveRepcodeToRawOffset(const U32 rep[ZSTD_REP_NUM], const U32 offBase, c
     if (adjustedRepCode == ZSTD_REP_NUM) {
         /* litlength == 0 and offCode == 2 implies selection of first repcode - 1
          * This is only valid if it results in a valid offset value, aka > 0.
+         * Note : it may happen that `rep[0]==1` in exceptional circumstances.
+         * In which case this function will return 0, which is an invalid offset.
+         * It's not an issue though, since this value will be
+         * compared and discarded within ZSTD_seqStore_resolveOffCodes().
          */
-        assert(rep[0] > 1);
         return rep[0] - 1;
     }
     return rep[adjustedRepCode];


### PR DESCRIPTION
credit to oss-fuzz

In rare circumstances, the block-splitter might cut a new block at the exact beginning of a repcode.
In which case, since litlength=0, if the repcode expected 1+ literals in front, its signification changes.

Thankfully, this scenario is controlled in `ZSTD_seqStore_resolveOffCodes()`,
and the repcode is transformed into a raw offset when its new meaning is incorrect.

In more complex scenarios, the previous block might be emitted as uncompressed at a later decision stage,
thus modifying the expected repcode history.
In the specific case discovered by oss-fuzz, the first block is emitted as uncompressed,
so the repcode history remains at its starting default values: 1,4,8.

But since the starting repcode is repcode3, and the literal length is == 0,
its meaning is now : = repcode1 - 1.
Since repcode1==1, it results in an offset value of 0, which is invalid.

So that's what the `assert()` was verifying : the result of the repcode translation should be a valid offset.
And since it was not, it was firing.

But actually, it doesn't matter, because this result will then be compared to reality,
and since it's an invalid offset, it will necessarily be discarded if incorrect,
then the repcode will be replaced by a raw offset.

So the `assert()` is not useful.
Furthermore, it's incorrect, because it assumes this situation cannot happen, while it actually can happen, as just described in above scenario.