### PR TITLE
Meson fixups for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,8 +92,8 @@ matrix:
         - make -C tests versionsTest
 
     # meson dedicated test
-    - name: Xenial (Meson + clang)    # ~15mn
-      dist: bionic
+    - name: Focal (Meson + clang)    # ~15mn
+      dist: focal
       language: cpp
       compiler: clang
       install:

--- a/build/meson/lib/meson.build
+++ b/build/meson/lib/meson.build
@@ -83,7 +83,8 @@ libzstd_c_args = []
 if cc_id == compiler_msvc
   if default_library_type != 'static'
     libzstd_sources += [windows_mod.compile_resources(
-      join_paths(zstd_rootdir, 'build/VS2010/libzstd-dll/libzstd-dll.rc'))]
+      join_paths(zstd_rootdir, 'build/VS2010/libzstd-dll/libzstd-dll.rc'),
+      include_directories: libzstd_includes)]
     libzstd_c_args += ['-DZSTD_DLL_EXPORT=1',
       '-DZSTD_HEAPMODE=0',
       '-D_CONSOLE',

--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -92,7 +92,7 @@ feature_lz4 = get_option('lz4')
 # Dependencies
 # =============================================================================
 
-libm_dep = cc.find_library('m', required: bin_tests)
+libm_dep = cc.find_library('m', required: false)
 thread_dep = dependency('threads', required: feature_multi_thread)
 use_multi_thread = thread_dep.found()
 # Arguments in dependency should be equivalent to those passed to pkg-config

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -66,7 +66,8 @@ endif
 if cc_id == compiler_msvc
   if default_library_type != 'static'
     zstd_programs_sources += [windows_mod.compile_resources(
-      join_paths(zstd_rootdir, 'build/VS2010/zstd/zstd.rc'))]
+      join_paths(zstd_rootdir, 'build/VS2010/zstd/zstd.rc'),
+      include_directories: libzstd_includes)]
   endif
 endif
 

--- a/build/meson/tests/valgrindTest.py
+++ b/build/meson/tests/valgrindTest.py
@@ -21,7 +21,7 @@ def valgrindTest(valgrind, datagen, fuzzer, zstd, fullbench):
 
   if subprocess.call([*VALGRIND_ARGS, zstd],
                      stdout=subprocess.DEVNULL) == 0:
-    raise subprocess.CalledProcessError('zstd without argument should have failed')
+    raise subprocess.SubprocessError('zstd without argument should have failed')
 
   with subprocess.Popen([datagen, '-g80'], stdout=subprocess.PIPE) as p1, \
        subprocess.Popen([*VALGRIND_ARGS, zstd, '-', '-c'],
@@ -30,7 +30,7 @@ def valgrindTest(valgrind, datagen, fuzzer, zstd, fullbench):
     p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
     p2.communicate()
     if p2.returncode != 0:
-      raise subprocess.CalledProcessError()
+      raise subprocess.SubprocessError()
 
   with subprocess.Popen([datagen, '-g16KB'], stdout=subprocess.PIPE) as p1, \
        subprocess.Popen([*VALGRIND_ARGS, zstd, '-vf', '-', '-c'],
@@ -39,7 +39,7 @@ def valgrindTest(valgrind, datagen, fuzzer, zstd, fullbench):
     p1.stdout.close()
     p2.communicate()
     if p2.returncode != 0:
-      raise subprocess.CalledProcessError()
+      raise subprocess.SubprocessError()
 
   with tempfile.NamedTemporaryFile() as tmp_fd:
     with subprocess.Popen([datagen, '-g2930KB'], stdout=subprocess.PIPE) as p1, \
@@ -48,7 +48,7 @@ def valgrindTest(valgrind, datagen, fuzzer, zstd, fullbench):
       p1.stdout.close()
       p2.communicate()
       if p2.returncode != 0:
-        raise subprocess.CalledProcessError()
+        raise subprocess.SubprocessError()
 
     subprocess.check_call([*VALGRIND_ARGS, zstd, '-vdf', tmp_fd.name, '-c'],
                           stdout=subprocess.DEVNULL)
@@ -60,7 +60,7 @@ def valgrindTest(valgrind, datagen, fuzzer, zstd, fullbench):
       p1.stdout.close()
       p2.communicate()
       if p2.returncode != 0:
-        raise subprocess.CalledProcessError()
+        raise subprocess.SubprocessError()
 
   subprocess.check_call([*VALGRIND_ARGS, fuzzer, '-T1mn', '-t1'])
   subprocess.check_call([*VALGRIND_ARGS, fullbench, '-i1'])


### PR DESCRIPTION
Three changes:
- MSVC did not build, because the resource compiler (`*.rc` files) was not instructed where to find zstd.h
- fix building the testsuite binaries on Windows, which doesn't have a separate libm
- console UI fixes for the valgrind wrapper