### PR TITLE
Fix broken Travi CI build - installing pip for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ matrix:
           travis_retry curl -o ~/ninja.zip -L 'https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip' &&
           unzip ~/ninja.zip -d ~/.local/bin
         - |
-          travis_retry curl -o ~/get-pip.py -L 'https://bootstrap.pypa.io/get-pip.py' &&
+          travis_retry curl -o ~/get-pip.py -L 'https://bootstrap.pypa.io/pip/3.6/get-pip.py' &&
           python3 ~/get-pip.py --user &&
           pip3 install --user meson
       script:


### PR DESCRIPTION
Pip install script no longer supports python3.6 by default, switched to a script that does.