### PR TITLE
[cli-tests] Fix zstd symlinks

### DIFF
--- a/tests/cli-tests/.gitignore
+++ b/tests/cli-tests/.gitignore
@@ -1,4 +1,6 @@
-scratch/
 !bin/
 !datagen
 !zstdcat
+
+scratch/
+bin/symlinks

--- a/tests/cli-tests/bin/zstd
+++ b/tests/cli-tests/bin/zstd
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+zstdname=$(basename $0)
+
 if [ -z "$EXEC_PREFIX" ]; then
-    "$ZSTD_BIN" $@
+    "$ZSTD_SYMLINK_DIR/$zstdname" $@
 else
-    $EXEC_PREFIX "$ZSTD_BIN" $@
+    $EXEC_PREFIX "$ZSTD_SYMLINK_DIR/$zstdname" $@
 fi

--- a/tests/cli-tests/run.py
+++ b/tests/cli-tests/run.py
@@ -21,6 +21,24 @@ import tempfile
 import typing
 
 
+ZSTD_SYMLINKS = [
+    "zstd",
+    "zstdmt",
+    "unzstd",
+    "zstdcat",
+    "zcat",
+    "gzip",
+    "gunzip",
+    "gzcat",
+    "lzma",
+    "unlzma",
+    "xz",
+    "unxz",
+    "lz4",
+    "unlz4",
+]
+
+
 EXCLUDED_DIRS = {
     "bin",
     "common",
@@ -592,6 +610,16 @@ def run_tests(test_suites: TestSuites, options: Options) -> bool:
         return False
 
 
+def setup_zstd_symlink_dir(zstd_symlink_dir: str, zstd: str) -> None:
+    assert os.path.join("bin", "symlinks") in zstd_symlink_dir
+    if not os.path.exists(zstd_symlink_dir):
+        os.makedirs(zstd_symlink_dir)
+    for symlink in ZSTD_SYMLINKS:
+        path = os.path.join(zstd_symlink_dir, symlink)
+        if os.path.exists(path):
+            os.remove(path)
+        os.symlink(zstd, path)
+
 if __name__ == "__main__":
     CLI_TEST_DIR = os.path.dirname(sys.argv[0])
     REPO_DIR = os.path.join(CLI_TEST_DIR, "..", "..")
@@ -655,17 +683,20 @@ if __name__ == "__main__":
         args.timeout = None
 
     args.test_dir = os.path.normpath(os.path.abspath(args.test_dir))
-    bin_dir = os.path.join(args.test_dir, "bin")
+    bin_dir = os.path.abspath(os.path.join(args.test_dir, "bin"))
+    zstd_symlink_dir = os.path.join(bin_dir, "symlinks")
     scratch_dir = os.path.join(args.test_dir, "scratch")
+
+    setup_zstd_symlink_dir(zstd_symlink_dir, os.path.abspath(args.zstd))
 
     env = {}
     if args.exec_prefix is not None:
         env["EXEC_PREFIX"] = args.exec_prefix
-    env["ZSTD_BIN"] = os.path.abspath(args.zstd)
+    env["ZSTD_SYMLINK_DIR"] = zstd_symlink_dir
     env["DATAGEN_BIN"] = os.path.abspath(args.datagen)
     env["ZSTDGREP_BIN"] = os.path.abspath(args.zstdgrep)
     env["COMMON"] = os.path.abspath(os.path.join(args.test_dir, "common"))
-    env["PATH"] = os.path.abspath(bin_dir) + ":" + os.getenv("PATH", "")
+    env["PATH"] = bin_dir + ":" + os.getenv("PATH", "")
 
     opts = Options(
         env=env,

--- a/tests/cli-tests/zstd-symlinks/setup
+++ b/tests/cli-tests/zstd-symlinks/setup
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+println "hello" > hello
+println "world" > world
+zstd hello world

--- a/tests/cli-tests/zstd-symlinks/zstdcat.sh
+++ b/tests/cli-tests/zstd-symlinks/zstdcat.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Test zstdcat symlink in bin/
+zstdcat hello.zst
+zstdcat hello.zst world
+zstdcat hello world.zst
+zstdcat hello.zst world.zst
+
+# Test local zstdcat symlink
+ln -s $(which zstd) ./zstdcat
+./zstdcat hello.zst

--- a/tests/cli-tests/zstd-symlinks/zstdcat.sh.stdout.exact
+++ b/tests/cli-tests/zstd-symlinks/zstdcat.sh.stdout.exact
@@ -1,0 +1,8 @@
+hello
+hello
+world
+hello
+world
+hello
+world
+hello


### PR DESCRIPTION
The zstd symlinks, notably `zstdcat`, weren't working as expected
because only the `tests/cli-tests/bin/zstd` wrapper was symlinked. We
still invoked `zstd` with the name `zstd`. The fix is to create a
directory of zstd symlinks in `tests/cli-tests/bin/symlinks` for each
name that zstd recognizes. And when `tets/cli-tests/bin/zstd` is
invoked, it selects the correct symlink to call.

See the test `zstd-cli/zstdcat.sh` for an example of how it would work.