### PR TITLE
Debug Windows CI failures

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -158,7 +158,7 @@ jobs:
         make -C tests test-fuzzer-stackmode
 
   mingw-long-test:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -175,7 +175,7 @@ jobs:
           CC=clang MOREFLAGS="-Werror -Wimplicit-fallthrough -O0" make -C lib -j libzstd.a ZSTD_LEGACY_SUPPORT=0
 
   cmake-visual-2019:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         include:
@@ -198,7 +198,7 @@ jobs:
         cmake.exe --build .
 
   visual-2019:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         platform: [x64, Win32]
@@ -330,7 +330,7 @@ jobs:
         LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make clean check
 
   mingw-short-test:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
@@ -367,7 +367,7 @@ jobs:
 
 
   visual-runtime-tests:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         platform: [x64, Win32]


### PR DESCRIPTION
This draft PR will allow me to ssh into a windows CI machine so I can debug the recent windows CI failures. For some reason the tests are passing on my zstd fork, so I have to create a PR on the main repo.