### PR TITLE
Bugfix and new features for largeNbDicts benchmark

### DIFF
--- a/contrib/largeNbDicts/README.md
+++ b/contrib/largeNbDicts/README.md
@@ -14,12 +14,20 @@ Command line :
 ```
 largeNbDicts [Options] filename(s)
 
-Options :
--r           : recursively load all files in subdirectories (default: off)
--B#          : split input into blocks of size # (default: no split)
--#           : use compression level # (default: 3)
--D #         : use # as a dictionary (default: create one)
--i#          : nb benchmark rounds (default: 6)
---nbDicts=#  : set nb of dictionaries to # (default: one per block)
--h           : help (this text)
+Options : 
+-z          : benchmark compression (default) 
+-d          : benchmark decompression 
+-r          : recursively load all files in subdirectories (default: off) 
+-B#         : split input into blocks of size # (default: no split) 
+-#          : use compression level # (default: 3) 
+-D #        : use # as a dictionary (default: create one) 
+-i#         : nb benchmark rounds (default: 6) 
+--nbBlocks=#: use # blocks for bench (default: one per file) 
+--nbDicts=# : create # dictionaries for bench (default: one per block) 
+-h          : help (this text) 
+ 
+Advanced Options (see zstd.h for documentation) : 
+--dedicated-dict-search
+--dict-content-type=#
+--dict-attach-pref=#
 ```


### PR DESCRIPTION
* Fix crash in dictionary creation logic (in the largeNbDicts tool, not zstd)
* Add `--dict-content-type` and `--dict-attach-pref` CLI options
* Update docs