### PR TITLE
docs: adding ELI5 video to the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,15 @@
 
 
 <xmp theme="sandstone" style="display:none;">
+<a name="intro-video"></a>
+## Watch Introductory Video
+<div>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/k5XsiuxHv_A" 
+  title="Explain Like I'm 5: ZSTD" frameBorder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+  allowFullScreen ></iframe>
+</div>
+
 <a name="benchmarks"></a>
 Benchmarks
 ----------


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Recoil](https://recoiljs.org/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/12485205/155231936-1936b237-3a10-4f79-8f6a-dc751b059d7f.png">
