### PR TITLE
More checks on numeric input for `zstd` CLI

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -871,7 +871,7 @@ int main(int argCount, const char* argv[])
     int cLevel = init_cLevel();
     int cLevelLast = MINCLEVEL - 1;  /* lower than minimum */
     unsigned recursive = 0;
-    size_t memLimit = 0;
+    unsigned memLimit = 0;
     FileNamesTable* filenames = UTIL_allocateFileNamesTable((size_t)argCount);  /* argCount >= 1 */
     FileNamesTable* file_of_names = UTIL_allocateFileNamesTable((size_t)argCount);  /* argCount >= 1 */
     const char* programName = argv[0];
@@ -1038,9 +1038,9 @@ int main(int argCount, const char* argv[])
                 }
 #endif
                 if (longCommandWArg(&argument, "--threads")) { NEXT_UINT32(nbWorkers); continue; }
-                if (longCommandWArg(&argument, "--memlimit=")) { memLimit = readSizeTFromChar(&argument); continue; }
-                if (longCommandWArg(&argument, "--memory=")) { memLimit = readSizeTFromChar(&argument); continue; }
-                if (longCommandWArg(&argument, "--memlimit-decompress=")) { memLimit = readSizeTFromChar(&argument); continue; }
+                if (longCommandWArg(&argument, "--memlimit=")) { memLimit = readU32FromChar(&argument); continue; }
+                if (longCommandWArg(&argument, "--memory=")) { memLimit = readU32FromChar(&argument); continue; }
+                if (longCommandWArg(&argument, "--memlimit-decompress=")) { memLimit = readU32FromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--block-size=")) { blockSize = readSizeTFromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--maxdict")) { NEXT_UINT32(maxDictSize); continue; }
                 if (longCommandWArg(&argument, "--dictID")) { NEXT_UINT32(dictID); continue; }

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -871,7 +871,7 @@ int main(int argCount, const char* argv[])
     int cLevel = init_cLevel();
     int cLevelLast = MINCLEVEL - 1;  /* lower than minimum */
     unsigned recursive = 0;
-    unsigned memLimit = 0;
+    size_t memLimit = 0;
     FileNamesTable* filenames = UTIL_allocateFileNamesTable((size_t)argCount);  /* argCount >= 1 */
     FileNamesTable* file_of_names = UTIL_allocateFileNamesTable((size_t)argCount);  /* argCount >= 1 */
     const char* programName = argv[0];

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -275,6 +275,13 @@ zstd -d -f tmplimit.zst --memlimit=2K -c > $INTOVOID && die "decompression needs
 zstd -d -f tmplimit.zst --memory=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
 zstd -d -f tmplimit.zst --memlimit-decompress=2K -c > $INTOVOID && die "decompression needs more memory than allowed"  # long command
 rm -f tmplimit tmplimit.zst
+println foo > tmpmemory.zst
+println "test : zstd parameter parsing (must fail)"
+zstd -d -f tmpmemory.zst --memory= -c > $INTOVOID && die "memory parameter is in an invalid format"
+zstd -d -f tmpmemory.zst --memory=hello -c > $INTOVOID && die "memory parameter is in an invalid format"
+zstd -d -f tmpmemory.zst --memlimit=512LB -c > $INTOVOID && die "memory parameter is in an invalid format"
+zstd -d -f tmpmemory.zst --memlimit-decompress=512LiB -c > $INTOVOID && die "memory parameter is in an invalid format"
+rm tmpmemory.zst
 println "test : overwrite protection"
 zstd -q tmp && die "overwrite check failed!"
 println "test : force overwrite"


### PR DESCRIPTION
Closes https://github.com/facebook/zstd/issues/3070

- Added check for a possible invalid combination of numeric values in `zstd` CLI
- Does not perfectly cover all invalid combinations, but it's better than before
- Added some tests
- Slightly changes `--memory`, `--memlimit` and `--memlimit-decompress` to only be used with `=` at the end of the parameter
- `memLimit` type changed from `unsigned` to `size_t` to be more in line with `srcSizeHint`, as both refer to memory values