### PR TITLE
build:cmake: enable ZSTD legacy support by default

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -82,7 +82,7 @@ message(STATUS "CMAKE_INSTALL_LIBDIR: ${CMAKE_INSTALL_LIBDIR}")
 #-----------------------------------------------------------------------------
 
 # Legacy support
-option(ZSTD_LEGACY_SUPPORT "LEGACY SUPPORT" OFF)
+option(ZSTD_LEGACY_SUPPORT "LEGACY SUPPORT" ON)
 
 if (ZSTD_LEGACY_SUPPORT)
     message(STATUS "ZSTD_LEGACY_SUPPORT defined!")

--- a/build/cmake/README.md
+++ b/build/cmake/README.md
@@ -37,7 +37,7 @@ cmake -LH ..
 Bool options can be set to `ON/OFF` with `-D[option]=[ON/OFF]`. You can configure cmake options like this:
 ```sh
 cd build/cmake/builddir
-cmake -DZSTD_BUILD_TESTS=ON -DZSTD_LEGACY_SUPPORT=ON ..
+cmake -DZSTD_BUILD_TESTS=ON -DZSTD_LEGACY_SUPPORT=OFF ..
 make
 ```
 


### PR DESCRIPTION
I would like to enable support of legacy formats in CMAKE builds by default. 

Backwards compatibility is by default enabled for the [VS](https://github.com/facebook/zstd/blob/e47e674cd09583ff0503f0f6defd6d23d8b718d3/build/VS2010/libzstd/libzstd.vcxproj#L184), [make](https://github.com/facebook/zstd/blob/c7e8315d886677e7d3fb81c56ff244fc1c808d7f/lib/libzstd.mk#L19) and [meson](https://github.com/facebook/zstd/blob/e47e674cd09583ff0503f0f6defd6d23d8b718d3/build/meson/meson_options.txt#L13) builds, and disabled for [cmake](https://github.com/facebook/zstd/blob/e47e674cd09583ff0503f0f6defd6d23d8b718d3/build/cmake/CMakeLists.txt#L85) and [single-file](https://github.com/facebook/zstd/blob/e47e674cd09583ff0503f0f6defd6d23d8b718d3/build/single_file_libs/zstd-in.c#L41) builds. 

I think single-file build is special, so it makes sense keep it disabled.
