### PR TITLE
[programs] Fix infinite loop when empty input is passed to trainer

### DIFF
--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -128,8 +128,11 @@ static int DiB_loadFiles(
     while ( nbSamplesLoaded < sstSize && fileIndex < nbFiles ) {
         size_t fileDataLoaded;
         S64 const fileSize = DiB_getFileSize(fileNamesTable[fileIndex]);
-        if (fileSize <= 0) /* skip if zero-size or file error */
+        if (fileSize <= 0) {
+            /* skip if zero-size or file error */
+            ++fileIndex;
             continue;
+        }
 
         f = fopen( fileNamesTable[fileIndex], "rb");
         if (f == NULL)

--- a/tests/cli-tests/dict-builder/empty-input.sh
+++ b/tests/cli-tests/dict-builder/empty-input.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+for i in $(seq 50); do
+    datagen -s$i > file$i
+done
+touch empty
+
+set -v
+zstd -q --train empty file*

--- a/tests/cli-tests/dict-builder/empty-input.sh.stderr.exact
+++ b/tests/cli-tests/dict-builder/empty-input.sh.stderr.exact
@@ -1,0 +1,1 @@
+zstd -q --train empty file*


### PR DESCRIPTION
When an empty input file was passed to the dictionary trainer, it would infinite loop.
The added test case exposes the bug, and is fixed with this PR.