### PR TITLE
Fix CI failures by adding apt-get update to Github Actions

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -156,7 +156,6 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         sudo apt-get -qqq update
-        make arminstall
         make valgrindinstall
         make -C tests valgrindTest
         make clean

--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -75,6 +75,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: ASan + UBSan + Test Zstd, 32bit mode
       run: |
+        sudo apt-get -qqq update
         make libc6install
         make -j uasan-test-zstd32 V=1
 
@@ -88,6 +89,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: gcc-8 + ASan + UBSan + Fuzz Test
       run: |
+        sudo apt-get -qqq update
         make gcc8install
         CC=gcc-8 FUZZER_FLAGS="--long-tests" make clean uasan-fuzztest
 
@@ -97,6 +99,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: ASan + UBSan + Fuzz Test 32bit
       run: |
+        sudo apt-get -qqq update
         make libc6install
         CFLAGS="-O3 -m32" FUZZER_FLAGS="--long-tests" make uasan-fuzztest
 
@@ -152,6 +155,8 @@ jobs:
     - name: valgrind + fuzz test stack mode    # ~ 7mn
       shell: 'script -q -e -c "bash {0}"'
       run: |
+        sudo apt-get -qqq update
+        make arminstall
         make valgrindinstall
         make -C tests valgrindTest
         make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,6 @@ matrix:
     - name: ARM Build Test (on Trusty)
       dist: trusty
       script:
-        - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157 3CB3BD13 A15703C6 C17EAB57
         - make arminstall
         - make armbuild
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
     - name: ARM Build Test (on Trusty)
       dist: trusty
       script:
+        - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157 3CB3BD13 A15703C6 C17EAB57
         - make arminstall
         - make armbuild
 

--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,8 @@ tsan-%: clean
 
 .PHONY: apt-install
 apt-install:
-	sudo apt-get update
+	# TODO: uncomment once issue 3011 is resolved and remove hack from Github Actions .yml
+	# sudo apt-get update
 	sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install $(APT_PACKAGES)
 
 .PHONY: apt-add-repo

--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,7 @@ tsan-%: clean
 
 .PHONY: apt-install
 apt-install:
+	sudo apt-get update
 	sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install $(APT_PACKAGES)
 
 .PHONY: apt-add-repo


### PR DESCRIPTION
Following advice from [here](https://github.com/actions/virtual-environments/issues/675) and [here](https://serverfault.com/questions/1070642/ubuntu-package-revision-not-found-in-github-actions), add `sudo apt-get update` to hopefully avoid this CI error:
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev-i386_2.31-0ubuntu9.2_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-x32_2.31-0ubuntu9.2_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev-x32_2.31-0ubuntu9.2_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
make[1]: *** [Makefile:337: apt-install] Error 100
make: *** [Makefile:355: libc6install] Error 2
make[1]: Leaving directory '/home/runner/work/zstd/zstd'
Error: Process completed with exit code 2.
```
The first time I ran CI on this commit (on a [PR](https://github.com/embg/zstd/pull/12) in embg/zstd) I got a weird failure on a different job, but the second time everything passed. I propose we land this for now (if it passes CI on facebook/zstd), and if the issue persists there are some other things in the first link above that we can try.