### PR TITLE
fix the assertion in readLinesFromFile

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -418,7 +418,7 @@ readLinesFromFile(void* dst, size_t dstCapacity,
     while ( !feof(inputFile) ) {
         size_t const lineLength = readLineFromFile(buf+pos, dstCapacity-pos, inputFile);
         if (lineLength == 0) break;
-        assert(pos + lineLength < dstCapacity);
+        assert(pos + lineLength <= dstCapacity); /* '=' for inputFile not terminated with '\n' */
         pos += lineLength;
         ++nbFiles;
     }

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -735,11 +735,11 @@ test -f tmp4
 
 println "test : survive the list of files with too long filenames (--filelist=FILE)"
 datagen -g5M > tmp_badList
-zstd -f --filelist=tmp_badList && die "should have failed : file name length is too long"
+zstd -qq -f --filelist=tmp_badList && die "should have failed : file name length is too long"  # printing very long text garbage on console will cause CI failure
 
 println "test : survive a list of files which is text garbage (--filelist=FILE)"
 datagen > tmp_badList
-zstd -f --filelist=tmp_badList && die "should have failed : list is text garbage"
+zstd -qq -f --filelist=tmp_badList && die "should have failed : list is text garbage"  # printing very long text garbage on console will cause CI failure
 
 println "test : survive a list of files which is binary garbage (--filelist=FILE)"
 datagen -P0 -g1M > tmp_badList


### PR DESCRIPTION
When the file is not terminated by endline, readLineFromFile will append
a '\0' for the last line.  In this case pos + lineLength == dstCapacity.