### PR TITLE
Software pipeline for ZSTD_compressBlock_fast_dictMatchState (+5-6% compression speed)

### DIFF
--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -380,7 +380,6 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
     U32 const stepSize = cParams->targetLength + !(cParams->targetLength);
     const BYTE* const base = ms->window.base;
     const BYTE* const istart = (const BYTE*)src;
-    const BYTE* ip = istart;
     const BYTE* anchor = istart;
     const U32   prefixStartIndex = ms->window.dictLimit;
     const BYTE* const prefixStart = base + prefixStartIndex;
@@ -397,15 +396,24 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
     const BYTE* const dictStart    = dictBase + dictStartIndex;
     const BYTE* const dictEnd      = dms->window.nextSrc;
     const U32 dictIndexDelta       = prefixStartIndex - (U32)(dictEnd - dictBase);
-    const U32 dictAndPrefixLength  = (U32)(ip - prefixStart + dictEnd - dictStart);
+    const U32 dictAndPrefixLength  = (U32)(istart - prefixStart + dictEnd - dictStart);
     const U32 dictHLog             = dictCParams->hashLog;
     const BYTE* dictPrefetchPtr    = dictEnd;
     const BYTE* const dictPrefetchLimit = dictPrefetchPtr - MIN(dictEnd - dictStart, 102400); /* 100KB */
 
+    /* pipeline variables */
+    const BYTE* ip0 = istart;
+    const BYTE* ip1;
+    size_t hash0;
+    size_t hash1;
+    size_t dictHash; /* inside the do{} loop, this is the hash for ip1 */
+    U32 matchIndex;
+    U32 dictMatchIndex;
+
     /* if a dictionary is still attached, it necessarily means that
      * it is within window size. So we just check it. */
     const U32 maxDistance = 1U << cParams->windowLog;
-    const U32 endIndex = (U32)((size_t)(ip - base) + srcSize);
+    const U32 endIndex = (U32)((size_t)(istart - base) + srcSize);
     assert(endIndex - prefixStartIndex <= maxDistance);
     (void)maxDistance; (void)endIndex;   /* these variables are not used when assert() is disabled */
 
@@ -417,24 +425,38 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
     /* init */
     DEBUGLOG(5, "ZSTD_compressBlock_fast_dictMatchState_generic");
-    ip += (dictAndPrefixLength == 0);
+    ip0 += (dictAndPrefixLength == 0);
     /* dictMatchState repCode checks don't currently handle repCode == 0
      * disabling. */
     assert(offset_1 <= dictAndPrefixLength);
     assert(offset_2 <= dictAndPrefixLength);
 
+_start: /* Requires: ip0 */
+    assert(ip0 == anchor);
+    ip1 = ip0 + 1;
+
+    if (ip1 >= ilimit) {
+        goto _cleanup;
+    }
+
+    hash0 = ZSTD_hashPtr(ip0, hlog, mls);
+    dictHash = ZSTD_hashPtr(ip0, dictHLog, mls);
+    dictMatchIndex = dictHashTable[dictHash];
+    matchIndex = hashTable[hash0];
+    hash1 = ZSTD_hashPtr(ip1, hlog, mls);
+    dictHash = ZSTD_hashPtr(ip1, dictHLog, mls);
+    PREFETCH_L1(dictHashTable + dictHash);
+
     /* Main Search Loop */
-    while (ip < ilimit) {   /* < instead of <=, because repcode check at (ip+1) */
+    do {
         size_t mLength;
-        size_t const h = ZSTD_hashPtr(ip, hlog, mls);
-        U32 const curr = (U32)(ip-base);
-        U32 const matchIndex = hashTable[h];
+        U32 const curr = (U32)(ip0-base);
         const BYTE* match = base + matchIndex;
         const U32 repIndex = curr + 1 - offset_1;
         const BYTE* repMatch = (repIndex < prefixStartIndex) ?
                                dictBase + (repIndex - dictIndexDelta) :
                                base + repIndex;
-        hashTable[h] = curr;   /* update hash table */
+        hashTable[hash0] = curr;   /* update hash table */
 
         if (dictPrefetchPtr >= dictPrefetchLimit) {
             PREFETCH_L2(dictPrefetchPtr);
@@ -443,81 +465,96 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
         }
 
         if ( ((U32)((prefixStartIndex-1) - repIndex) >= 3) /* intentional underflow : ensure repIndex isn't overlapping dict + prefix */
-          && (MEM_read32(repMatch) == MEM_read32(ip+1)) ) {
+          && (MEM_read32(repMatch) == MEM_read32(ip0+1)) ) {
             const BYTE* const repMatchEnd = repIndex < prefixStartIndex ? dictEnd : iend;
-            mLength = ZSTD_count_2segments(ip+1+4, repMatch+4, iend, repMatchEnd, prefixStart) + 4;
-            ip++;
-            ZSTD_storeSeq(seqStore, (size_t)(ip-anchor), anchor, iend, REPCODE1_TO_OFFBASE, mLength);
+            mLength = ZSTD_count_2segments(ip0+1+4, repMatch+4, iend, repMatchEnd, prefixStart) + 4;
+            ip0++;
+            ZSTD_storeSeq(seqStore, (size_t)(ip0-anchor), anchor, iend, REPCODE1_TO_OFFBASE, mLength);
         } else if ( (matchIndex <= prefixStartIndex) ) {
-            size_t const dictHash = ZSTD_hashPtr(ip, dictHLog, mls);
-            U32 const dictMatchIndex = dictHashTable[dictHash];
             const BYTE* dictMatch = dictBase + dictMatchIndex;
             if (dictMatchIndex <= dictStartIndex ||
-                MEM_read32(dictMatch) != MEM_read32(ip)) {
+                MEM_read32(dictMatch) != MEM_read32(ip0)) {
                 assert(stepSize >= 1);
-                ip += ((ip-anchor) >> kSearchStrength) + stepSize;
+                dictMatchIndex = dictHashTable[dictHash];
+                matchIndex = hashTable[hash1];
+                ip0 = ip1;
+                ip1 = ip1 + ((ip1-anchor) >> kSearchStrength) + stepSize;
+                hash0 = hash1;
+                hash1 = ZSTD_hashPtr(ip1, hlog, mls);
+                dictHash = ZSTD_hashPtr(ip1, dictHLog, mls);
+                PREFETCH_L1(dictHashTable + dictHash);
                 continue;
             } else {
                 /* found a dict match */
                 U32 const offset = (U32)(curr-dictMatchIndex-dictIndexDelta);
-                mLength = ZSTD_count_2segments(ip+4, dictMatch+4, iend, dictEnd, prefixStart) + 4;
-                while (((ip>anchor) & (dictMatch>dictStart))
-                     && (ip[-1] == dictMatch[-1])) {
-                    ip--; dictMatch--; mLength++;
+                mLength = ZSTD_count_2segments(ip0+4, dictMatch+4, iend, dictEnd, prefixStart) + 4;
+                while (((ip0>anchor) & (dictMatch>dictStart))
+                     && (ip0[-1] == dictMatch[-1])) {
+                    ip0--; dictMatch--; mLength++;
                 } /* catch up */
                 offset_2 = offset_1;
                 offset_1 = offset;
-                ZSTD_storeSeq(seqStore, (size_t)(ip-anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
+                ZSTD_storeSeq(seqStore, (size_t)(ip0-anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
             }
-        } else if (MEM_read32(match) != MEM_read32(ip)) {
+        } else if (MEM_read32(match) != MEM_read32(ip0)) {
             /* it's not a match, and we're not going to check the dictionary */
             assert(stepSize >= 1);
-            ip += ((ip-anchor) >> kSearchStrength) + stepSize;
+            dictMatchIndex = dictHashTable[dictHash];
+            matchIndex = hashTable[hash1];
+            ip0 = ip1;
+            ip1 = ip1 + ((ip1-anchor) >> kSearchStrength) + stepSize;
+            hash0 = hash1;
+            hash1 = ZSTD_hashPtr(ip1, hlog, mls);
+            dictHash = ZSTD_hashPtr(ip1, dictHLog, mls);
+            PREFETCH_L1(dictHashTable + dictHash);
             continue;
         } else {
             /* found a regular match */
-            U32 const offset = (U32)(ip-match);
-            mLength = ZSTD_count(ip+4, match+4, iend) + 4;
-            while (((ip>anchor) & (match>prefixStart))
-                 && (ip[-1] == match[-1])) { ip--; match--; mLength++; } /* catch up */
+            U32 const offset = (U32)(ip0-match);
+            mLength = ZSTD_count(ip0+4, match+4, iend) + 4;
+            while (((ip0>anchor) & (match>prefixStart))
+                 && (ip0[-1] == match[-1])) { ip0--; match--; mLength++; } /* catch up */
             offset_2 = offset_1;
             offset_1 = offset;
-            ZSTD_storeSeq(seqStore, (size_t)(ip-anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
+            ZSTD_storeSeq(seqStore, (size_t)(ip0-anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
         }
 
         /* match found */
-        ip += mLength;
-        anchor = ip;
+        ip0 += mLength;
+        anchor = ip0;
 
-        if (ip <= ilimit) {
+        if (ip0 <= ilimit) {
             /* Fill Table */
             assert(base+curr+2 > istart);  /* check base overflow */
             hashTable[ZSTD_hashPtr(base+curr+2, hlog, mls)] = curr+2;  /* here because curr+2 could be > iend-8 */
-            hashTable[ZSTD_hashPtr(ip-2, hlog, mls)] = (U32)(ip-2-base);
+            hashTable[ZSTD_hashPtr(ip0-2, hlog, mls)] = (U32)(ip0-2-base);
 
             /* check immediate repcode */
-            while (ip <= ilimit) {
-                U32 const current2 = (U32)(ip-base);
+            while (ip0 <= ilimit) {
+                U32 const current2 = (U32)(ip0-base);
                 U32 const repIndex2 = current2 - offset_2;
                 const BYTE* repMatch2 = repIndex2 < prefixStartIndex ?
                         dictBase - dictIndexDelta + repIndex2 :
                         base + repIndex2;
                 if ( ((U32)((prefixStartIndex-1) - (U32)repIndex2) >= 3 /* intentional overflow */)
-                   && (MEM_read32(repMatch2) == MEM_read32(ip)) ) {
+                   && (MEM_read32(repMatch2) == MEM_read32(ip0)) ) {
                     const BYTE* const repEnd2 = repIndex2 < prefixStartIndex ? dictEnd : iend;
-                    size_t const repLength2 = ZSTD_count_2segments(ip+4, repMatch2+4, iend, repEnd2, prefixStart) + 4;
+                    size_t const repLength2 = ZSTD_count_2segments(ip0+4, repMatch2+4, iend, repEnd2, prefixStart) + 4;
                     U32 tmpOffset = offset_2; offset_2 = offset_1; offset_1 = tmpOffset;   /* swap offset_2 <=> offset_1 */
                     ZSTD_storeSeq(seqStore, 0, anchor, iend, REPCODE1_TO_OFFBASE, repLength2);
-                    hashTable[ZSTD_hashPtr(ip, hlog, mls)] = current2;
-                    ip += repLength2;
-                    anchor = ip;
+                    hashTable[ZSTD_hashPtr(ip0, hlog, mls)] = current2;
+                    ip0 += repLength2;
+                    anchor = ip0;
                     continue;
                 }
                 break;
             }
         }
-    }
 
+        goto _start; /* found match, reset pipeline */
+    } while (ip1 < ilimit);
+
+_cleanup:
     /* save reps for next block */
     rep[0] = offset_1 ? offset_1 : offsetSaved;
     rep[1] = offset_2 ? offset_2 : offsetSaved;

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -447,9 +447,6 @@ _start: /* Requires: ip0 */
     hash1 = ZSTD_hashPtr(ip1, hlog, mls);
     dictHash = ZSTD_hashPtr(ip1, dictHLog, mls);
 
-    PREFETCH_L1(hashTable + hash1);
-    PREFETCH_L1(dictHashTable + dictHash);
-
     /* Main Search Loop */
     while (1) {
         const BYTE* match = base + matchIndex;
@@ -519,9 +516,6 @@ _start: /* Requires: ip0 */
         hash0 = hash1;
         hash1 = ZSTD_hashPtr(ip1, hlog, mls);
         dictHash = ZSTD_hashPtr(ip1, dictHLog, mls);
-
-        PREFETCH_L1(hashTable + hash1);
-        PREFETCH_L1(dictHashTable + dictHash);
     }
 
 _match:

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -424,11 +424,11 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
     /* Outer search loop */
     assert(stepSize >= 1);
-    while (ip1 <= ilimit) { /* repcode check at (ip0 + 1) is safe because ip0 < ip1 */
+    while (ip1 <= ilimit) {   /* repcode check at (ip0 + 1) is safe because ip0 < ip1 */
         size_t mLength;
         size_t hash0 = ZSTD_hashPtr(ip0, hlog, mls);
-        size_t dictHash = ZSTD_hashPtr(ip0, dictHLog, mls);
-        U32 dictMatchIndex = dictHashTable[dictHash];
+        const size_t dictHash0 = ZSTD_hashPtr(ip0, dictHLog, mls);
+        U32 dictMatchIndex = dictHashTable[dictHash0];
         U32 matchIndex = hashTable[hash0];
         U32 curr = (U32)(ip0 - base);
         size_t step = stepSize;
@@ -437,26 +437,26 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
         /* Inner search loop */
         while (1) {
-            const BYTE *match = base + matchIndex;
+            const BYTE* match = base + matchIndex;
             const U32 repIndex = curr + 1 - offset_1;
-            const BYTE *repMatch = (repIndex < prefixStartIndex) ?
+            const BYTE* repMatch = (repIndex < prefixStartIndex) ?
                                    dictBase + (repIndex - dictIndexDelta) :
                                    base + repIndex;
-            size_t hash1 = ZSTD_hashPtr(ip1, hlog, mls);
-            dictHash = ZSTD_hashPtr(ip1, dictHLog, mls);
+            const size_t hash1 = ZSTD_hashPtr(ip1, hlog, mls);
+            const size_t dictHash1 = ZSTD_hashPtr(ip1, dictHLog, mls);
             hashTable[hash0] = curr;   /* update hash table */
 
             if (((U32) ((prefixStartIndex - 1) - repIndex) >=
                  3) /* intentional underflow : ensure repIndex isn't overlapping dict + prefix */
                 && (MEM_read32(repMatch) == MEM_read32(ip0 + 1))) {
-                const BYTE *const repMatchEnd = repIndex < prefixStartIndex ? dictEnd : iend;
+                const BYTE* const repMatchEnd = repIndex < prefixStartIndex ? dictEnd : iend;
                 mLength = ZSTD_count_2segments(ip0 + 1 + 4, repMatch + 4, iend, repMatchEnd, prefixStart) + 4;
                 ip0++;
                 ZSTD_storeSeq(seqStore, (size_t) (ip0 - anchor), anchor, iend, REPCODE1_TO_OFFBASE, mLength);
                 break;
             } else if (matchIndex <= prefixStartIndex) {
                 /* We only look for a dict match if the normal matchIndex is invalid */
-                const BYTE *dictMatch = dictBase + dictMatchIndex;
+                const BYTE* dictMatch = dictBase + dictMatchIndex;
                 if (dictMatchIndex > dictStartIndex &&
                     MEM_read32(dictMatch) == MEM_read32(ip0)) {
                     /* found a dict match */
@@ -490,7 +490,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
             }
 
             /* Prepare for next iteration */
-            dictMatchIndex = dictHashTable[dictHash];
+            dictMatchIndex = dictHashTable[dictHash1];
             matchIndex = hashTable[hash1];
 
             if (ip1 >= nextStep) {
@@ -503,7 +503,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
             curr = (U32)(ip0 - base);
             hash0 = hash1;
-        }
+        }   /* end inner search loop */
 
         /* match found */
         assert(mLength);

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -424,7 +424,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
     /* Outer search loop */
     assert(stepSize >= 1);
-    while (ip1 < ilimit) {   /* < instead of <=, because repcode check at (ip+1) */
+    while (ip1 <= ilimit) { /* repcode check at (ip0 + 1) is safe because ip0 < ip1 */
         size_t mLength;
         size_t hash0 = ZSTD_hashPtr(ip0, hlog, mls);
         size_t dictHash = ZSTD_hashPtr(ip0, dictHLog, mls);
@@ -491,7 +491,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
             matchIndex = hashTable[hash1];
             ip0 = ip1;
             ip1 = ip1 + ((ip1 - anchor) >> kSearchStrength) + stepSize;
-            if (ip1 >= ilimit) goto _cleanup;
+            if (ip1 > ilimit) goto _cleanup;
             curr = (U32)(ip0 - base);
             hash0 = hash1;
         }

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -431,6 +431,9 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
         U32 dictMatchIndex = dictHashTable[dictHash];
         U32 matchIndex = hashTable[hash0];
         U32 curr = (U32)(ip0 - base);
+        size_t step = stepSize;
+        const size_t kStepIncr = 1 << kSearchStrength;
+        const BYTE* nextStep = ip0 + kStepIncr;
 
         /* Inner search loop */
         while (1) {
@@ -489,9 +492,15 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
             /* Prepare for next iteration */
             dictMatchIndex = dictHashTable[dictHash];
             matchIndex = hashTable[hash1];
+
+            if (ip1 >= nextStep) {
+                step++;
+                nextStep += kStepIncr;
+            }
             ip0 = ip1;
-            ip1 = ip1 + ((ip1 - anchor) >> kSearchStrength) + stepSize;
+            ip1 = ip1 + step;
             if (ip1 > ilimit) goto _cleanup;
+
             curr = (U32)(ip0 - base);
             hash0 = hash1;
         }


### PR DESCRIPTION
## Summary
Using similar techniques as https://github.com/facebook/zstd/pull/2749, improves compression speed by 5-6% on a dataset of HTML headers between 0 and 8KB (the dataset has ratio 2.32 w/o dictionary, 3.41 with dictionary). This PR doesn't specifically address the cold dictionary scenario, which is something I'd like to explore in the future, but it does improve cold dictionary performance (as well as hot dictionary performance, see plots below).

## Plan to merge
@Cyan4973 , @felixhandte , and I are in agreement regarding which measurements are required to merge this change. Because the full suite of measurements will take some work to produce, I am only including two experiments for now. Once I get all nits and feedback resolved, and have a final version of the code ready to merge, I will do the full suite and post results in this thread.

## Ratio regression
~~This change regresses compression ratio by 0.1% on the html8K dataset (4350234 bytes -> 4354095 bytes). This is because we no longer search the very last position. It may be possible to fix this without killing the perf win -- however I think @felixhandte struggled to do this for noDict, so I didn't attempt it for now. Let me know if this regression is a blocker.~~

**EDIT:** [6cba817](https://github.com/facebook/zstd/pull/3086/commits/6cba817c8f2eff8a387b17033a02ec88eab4648e) fixes the ratio regression (at least on html8K) with no performance cost! Thanks @felixhandte for pointing out this fix.

It is still possible that this PR will cause zstd not to search the last position -- this would occur in a situation where the matchfinder is in accelerated search mode when it hits the end of the input. However, across the entire html8K dataset, this change in the parsing strategy did not regress compressed size by even a single byte. So there is essentially no ratio tradeoff with this PR.

## Preliminary results
<details>
<summary>Cold dictionary</summary>
<img width="756" alt="Screen Shot 2022-03-04 at 2 25 30 PM" src="https://user-images.githubusercontent.com/12179121/156850861-e7cc9f20-2d8a-4d80-ab80-409f87490b71.png">
</details>
<details>
<summary>Hot dictionary</summary>
<img width="756" alt="Screen Shot 2022-03-04 at 2 32 39 PM" src="https://user-images.githubusercontent.com/12179121/156850863-b55931af-de9b-45cd-8d18-7e57c306fc1f.png">
</details>

## Final results
I benchmarked on a Intel(R) Xeon(R) D-2191A CPU @ 1.60GHz CentOS machine with core isolation and turbo disabled. I measured all combinations of the following variables:
* Dataset: html8K vs. github-users
* Compiler: gcc 11.1.1 vs. clang 12.0.1
* Dictionary temperature: hot vs. warm vs. cold
    * Hot = 1 CDict, 0.1MB working set size (L2 cache). Warm = 100 CDicts, 8-15MB working set size (roughly L3 cache). Cold = 10000 CDicts, >1GB working set size (main memory).
* Dictionary size: 4K vs 32K vs 110K

I modified the [largeNbDicts](https://github.com/facebook/zstd/tree/dev/contrib/largeNbDicts) benchmark to append the max speed over 10 iterations to a CSV file. I ran each scenario 10 times interleaved ([bash script](https://gist.github.com/embg/a2b570e5180a64257e5f16c67826cb96)) to eliminate bias from background processes competing for main memory / L3 bandwidth. I then used the [bootstrap method](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html) to compute confidence intervals for the percent increase in speed, `(optimized / dev) - 1` ([python script](https://gist.github.com/embg/10cc75c9639382d715cf570e4cd292cc)).

### Summary of results
**Regressions**

_All scenarios are speed-positive except github-users with 4K dict_. The latter scenarios have small regressions, between 0.2% and 1.6% depending on dict temperature. This is due to the extremely high compression ratio on github-users (which reduced the win for all github-users dict sizes). Every time a match is found, the pipeline has to reset, killing the wins from pipelining when there are no matches found. **Most real-world datasets have much lower compression ratio, and most real-world dictionaries are much larger than 4K.** So the regression only affects an extremely unrealistic use-case.

Again: html8K was speed-positive across all scenarios. github-users with 32K and 110K dicts were speed-positive across all scenarios. This regression is only for github-users with 4K dict size.

**Wins**

_All html8K scenarios are 5%+ wins on gcc_. For html8K with 32K dictionary size, the gcc wins are 7%+ for all temperatures. The largest win I measured was `9.8% (± 0.2%)` on html_8K/cold/110K with gcc.

clang is speed positive across all scenarios, but wins are more like 1-3% (this makes sense, since I only measured gcc in my exploration).

github-users wins for 32K dict and 110K dict are also around 1-3%. As discussed above, this is due to the extremely high compression ratio of github-users, which is not representative of most real-world data.

### Full data
* [Percent wins for all scenarios](https://gist.github.com/embg/1b8244d709a0bd60a7f78e57244a4334)
* [Percent wins + raw speeds for all scenarios](https://gist.github.com/embg/c46019a12efda519088e4f063388f990)
    * Note: gcc and clang speeds for a single scenario can be compared, since those experiments were interleaved. Speeds across different scenarios cannot be compared, since those measurements were not interleaved (thus the background noise could have been different).
    
## Rejected optimizations
* **L1 prefetching the dictMatchIndex / matchIndex**. Together with pipelining, this was speed-positive for hot dict, but the win was very small. It basically killed the win from pipelining.
    * Theory: L1 prefetching tied up Line Fill Buffers, of which there are only 12 on Skylake Server, delaying more urgent reads / writes.
* **Various L2 prefetches**. These were speed-positive for cold dict, but huge regression for hot dict. I cannot land them without adding cold-dict detection for compression, which I plan to do in a future PR. L2 prefetches are thus out of scope for this PR.
* **[Optimize pipeline initialization after a match is found](https://github.com/embg/zstd/pull/13/commits/ba87837f8631af81b0156825193b99b61cdcf5fa)**. This ended up killing about half of the total pipelining win on html8K. Perhaps the extra branches outweighed the win from more extensive pipelining?
* **Replace ZSTD_count_2segments with ZSTD_count**. For some reason this was a clear loss. Not sure why, it should have been a small win. Didn't spend time to investigate. 

## Future work
I did not try deeper pipelines, or combining pipelining with loop unrolling (as we have in noDict). It is completely possible that either of those directions could lead to bigger wins. Since I hit the noDict wins with a less complex pipeline (and even exceeded them in some important scenarios), I did not try these more complex optimizations.

## Conclusion
There are big wins for html8K, and every realistic scenario I tested is speed-positive. Even for an unrealistic worst-case scenario (github-hot-4K-gcc), the speed regression was only 1.6%. The ratio regression has been addressed. This PR is ready to merge!
