### PR TITLE
[contrib][linux] Fix a warning in zstd_reset_cstream()

### DIFF
--- a/contrib/linux-kernel/zstd_compress_module.c
+++ b/contrib/linux-kernel/zstd_compress_module.c
@@ -133,7 +133,7 @@ EXPORT_SYMBOL(zstd_init_cstream);
 size_t zstd_reset_cstream(zstd_cstream *cstream,
 	unsigned long long pledged_src_size)
 {
-	return ZSTD_resetCStream(cstream, pledged_src_size);
+	return ZSTD_CCtx_reset(cstream, pledged_src_size);
 }
 EXPORT_SYMBOL(zstd_reset_cstream);
 

--- a/contrib/linux-kernel/zstd_compress_module.c
+++ b/contrib/linux-kernel/zstd_compress_module.c
@@ -131,9 +131,9 @@ zstd_cstream *zstd_init_cstream(const zstd_parameters *parameters,
 EXPORT_SYMBOL(zstd_init_cstream);
 
 size_t zstd_reset_cstream(zstd_cstream *cstream,
-	unsigned long long pledged_src_size)
+	unsigned long long pledgedSrcSize)
 {
-	return ZSTD_CCtx_reset(cstream, pledged_src_size);
+	return ZSTD_CCtx_setPledgedSrcSize(cstream, pledgedSrcSize);
 }
 EXPORT_SYMBOL(zstd_reset_cstream);
 

--- a/contrib/linux-kernel/zstd_compress_module.c
+++ b/contrib/linux-kernel/zstd_compress_module.c
@@ -131,9 +131,13 @@ zstd_cstream *zstd_init_cstream(const zstd_parameters *parameters,
 EXPORT_SYMBOL(zstd_init_cstream);
 
 size_t zstd_reset_cstream(zstd_cstream *cstream,
-	unsigned long long pledgedSrcSize)
+	unsigned long long pledged_src_size)
 {
-	return ZSTD_CCtx_setPledgedSrcSize(cstream, pledgedSrcSize);
+	if (pledged_src_size == 0)
+		pledged_src_size = ZSTD_CONTENTSIZE_UNKNOWN;
+	ZSTD_FORWARD_IF_ERR( ZSTD_CCtx_reset(cstream, ZSTD_reset_session_only) );
+	ZSTD_FORWARD_IF_ERR( ZSTD_CCtx_setPledgedSrcSize(cstream, pledged_src_size) );
+	return 0;
 }
 EXPORT_SYMBOL(zstd_reset_cstream);
 


### PR DESCRIPTION
- This fixes the below warning:

../lib/zstd/zstd_compress_module.c: In function 'zstd_reset_cstream':
../lib/zstd/zstd_compress_module.c:136:9: warning: 'ZSTD_resetCStream' is deprecated [-Wdeprecated-declarations]
  136 |         return ZSTD_resetCStream(cstream, pledged_src_size);
      |         ^~~~~~
In file included from ../include/linux/zstd.h:26,
                 from ../lib/zstd/zstd_compress_module.c:15:
../include/linux/zstd_lib.h:2277:8: note: declared here
 2277 | size_t ZSTD_resetCStream(ZSTD_CStream* zcs, unsigned long long pledgedSrcSize);
      |        ^~~~~~~~~~~~~~~~~

ZSTD_resetCstream is deprecated and zstd_CCtx_reset is suggested to use hence let's switch to it.

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>