### PR TITLE
Handle newer less versions in zstdless testing

### DIFF
--- a/tests/cli-tests/cltools/zstdless.sh
+++ b/tests/cli-tests/cltools/zstdless.sh
@@ -7,4 +7,4 @@ zstdless file.zst
 println "+ pass parameters"
 zstdless -N file.zst # This parameter does not produce line #s when piped, but still serves to test that the flag went to less and not zstd
 println "+ bad path"
-zstdless bad.zst
+zstdless bad.zst >&2

--- a/tests/cli-tests/run.py
+++ b/tests/cli-tests/run.py
@@ -704,6 +704,7 @@ if __name__ == "__main__":
     env["ZSTDLESS_BIN"] = os.path.abspath(args.zstdless)
     env["COMMON"] = os.path.abspath(os.path.join(args.test_dir, "common"))
     env["PATH"] = bin_dir + ":" + os.getenv("PATH", "")
+    env["LC_ALL"] = "C"
 
     opts = Options(
         env=env,


### PR DESCRIPTION
Newer less versions appear to have changed how stderr
and stdout are showing error messages. hardcode the
expected behavior to make the tests pass with any less version.
    
Also set locale to C so that the strings are matching.