### PR TITLE
put </body> </html> in correct order

### DIFF
--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -1906,5 +1906,5 @@ ZSTDLIB_STATIC_API size_t ZSTD_compressBlock  (ZSTD_CCtx* cctx, void* dst, size_
 ZSTDLIB_STATIC_API size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 ZSTDLIB_STATIC_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* blockStart, size_t blockSize);  </b>/**< insert uncompressed block into `dctx` history. Useful for multi-blocks decompression. */<b>
 </pre></b><BR>
-</html>
 </body>
+</html>


### PR DESCRIPTION
In `doc/zstd-manual.html` closing tags are I opposite order - `</html>` precedes `</body>` which is, at least formally, incorrect. It will be rendered fine as they are very lays tags but they should be in correct order.
