### PR TITLE
Software pipeline for ZSTD_compressBlock_fast_extDict (+4-9% compression speed)

### DIFF
--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -690,7 +690,9 @@ _start: /* Requires: ip0 */
         }   }
 
         {   /* load match for ip[0] */
-            U32 const mval = idx >= dictStartIndex ? MEM_read32(idxBase + idx) : MEM_read32(ip0) ^ 1; /* guaranteed not to match */
+            U32 const mval = idx >= dictStartIndex ?
+                    MEM_read32(idxBase + idx) :
+                    MEM_read32(ip0) ^ 1; /* guaranteed not to match */
 
             /* check match at ip[0] */
             if (MEM_read32(ip0) == mval) {
@@ -716,7 +718,9 @@ _start: /* Requires: ip0 */
         hashTable[hash0] = current0;
 
         {   /* load match for ip[0] */
-            U32 const mval = idx >= dictStartIndex ? MEM_read32(idxBase + idx) : MEM_read32(ip0) ^ 1; /* guaranteed not to match */
+            U32 const mval = idx >= dictStartIndex ?
+                    MEM_read32(idxBase + idx) :
+                    MEM_read32(ip0) ^ 1; /* guaranteed not to match */
 
             /* check match at ip[0] */
             if (MEM_read32(ip0) == mval) {

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -587,11 +587,10 @@ static size_t ZSTD_compressBlock_fast_extDict_generic(
     U32* const hashTable = ms->hashTable;
     U32 const hlog = cParams->hashLog;
     /* support stepSize of 0 */
-    U32 const stepSize = cParams->targetLength + !(cParams->targetLength);
+    U32 const stepSize = cParams->targetLength + !(cParams->targetLength) + 1;
     const BYTE* const base = ms->window.base;
     const BYTE* const dictBase = ms->window.dictBase;
     const BYTE* const istart = (const BYTE*)src;
-    const BYTE* ip = istart;
     const BYTE* anchor = istart;
     const U32   endIndex = (U32)((size_t)(istart - base) + srcSize);
     const U32   lowLimit = ZSTD_getLowestMatchIndex(ms, endIndex, cParams->windowLog);
@@ -604,6 +603,29 @@ static size_t ZSTD_compressBlock_fast_extDict_generic(
     const BYTE* const iend = istart + srcSize;
     const BYTE* const ilimit = iend - 8;
     U32 offset_1=rep[0], offset_2=rep[1];
+    U32 offsetSaved = 0;
+
+    const BYTE* ip0 = istart;
+    const BYTE* ip1;
+    const BYTE* ip2;
+    const BYTE* ip3;
+    U32 current0;
+
+
+    size_t hash0; /* hash for ip0 */
+    size_t hash1; /* hash for ip1 */
+    U32 idx; /* match idx for ip0 */
+    const BYTE* idxBase; /* base pointer for idx */
+    U32 mval; /* src or dict value at match idx */
+
+    U32 offcode;
+    const BYTE* match0;
+    size_t mLength;
+    const BYTE* matchEnd = 0; /* initialize to avoid warning, assert != 0 later */
+
+    size_t step;
+    const BYTE* nextStep;
+    const size_t kStepIncr = (1 << (kSearchStrength - 1));
 
     (void)hasStep; /* not currently specialized on whether it's accelerated */
 
@@ -613,75 +635,200 @@ static size_t ZSTD_compressBlock_fast_extDict_generic(
     if (prefixStartIndex == dictStartIndex)
         return ZSTD_compressBlock_fast(ms, seqStore, rep, src, srcSize);
 
-    /* Search Loop */
-    while (ip < ilimit) {  /* < instead of <=, because (ip+1) */
-        const size_t h = ZSTD_hashPtr(ip, hlog, mls);
-        const U32    matchIndex = hashTable[h];
-        const BYTE* const matchBase = matchIndex < prefixStartIndex ? dictBase : base;
-        const BYTE*  match = matchBase + matchIndex;
-        const U32    curr = (U32)(ip-base);
-        const U32    repIndex = curr + 1 - offset_1;
+    /* start each op */
+_start: /* Requires: ip0 */
+
+    step = stepSize;
+    nextStep = ip0 + kStepIncr;
+
+    /* calculate positions, ip0 - anchor == 0, so we skip step calc */
+    ip1 = ip0 + 1;
+    ip2 = ip0 + step;
+    ip3 = ip2 + 1;
+
+    if (ip3 >= ilimit) {
+        goto _cleanup;
+    }
+
+    hash0 = ZSTD_hashPtr(ip0, hlog, mls);
+    hash1 = ZSTD_hashPtr(ip1, hlog, mls);
+
+    idx = hashTable[hash0];
+    idxBase = idx < prefixStartIndex ? dictBase : base;
+
+    do {
+        /* load repcode match for ip[2]*/
+        const U32 current2 = (U32)(ip2 - base);
+        const U32 repIndex = current2 - offset_1;
         const BYTE* const repBase = repIndex < prefixStartIndex ? dictBase : base;
-        const BYTE* const repMatch = repBase + repIndex;
-        hashTable[h] = curr;   /* update hash table */
-        DEBUGLOG(7, "offset_1 = %u , curr = %u", offset_1, curr);
+        U32 rval;
 
-        if ( ( ((U32)((prefixStartIndex-1) - repIndex) >= 3) /* intentional underflow */
-             & (offset_1 <= curr+1 - dictStartIndex) ) /* note: we are searching at curr+1 */
-           && (MEM_read32(repMatch) == MEM_read32(ip+1)) ) {
-            const BYTE* const repMatchEnd = repIndex < prefixStartIndex ? dictEnd : iend;
-            size_t const rLength = ZSTD_count_2segments(ip+1 +4, repMatch +4, iend, repMatchEnd, prefixStart) + 4;
-            ip++;
-            ZSTD_storeSeq(seqStore, (size_t)(ip-anchor), anchor, iend, REPCODE1_TO_OFFBASE, rLength);
-            ip += rLength;
-            anchor = ip;
+        /* load repcode match for ip[2] */
+        assert(offset_1 > 0);
+        if ( ( ((U32)(prefixStartIndex - repIndex) >= 4) /* intentional underflow */
+               & (offset_1 < current2 - dictStartIndex) ) ) {
+            rval = MEM_read32(repBase + repIndex);
         } else {
-            if ( (matchIndex < dictStartIndex) ||
-                 (MEM_read32(match) != MEM_read32(ip)) ) {
-                assert(stepSize >= 1);
-                ip += ((ip-anchor) >> kSearchStrength) + stepSize;
-                continue;
-            }
-            {   const BYTE* const matchEnd = matchIndex < prefixStartIndex ? dictEnd : iend;
-                const BYTE* const lowMatchPtr = matchIndex < prefixStartIndex ? dictStart : prefixStart;
-                U32 const offset = curr - matchIndex;
-                size_t mLength = ZSTD_count_2segments(ip+4, match+4, iend, matchEnd, prefixStart) + 4;
-                while (((ip>anchor) & (match>lowMatchPtr)) && (ip[-1] == match[-1])) { ip--; match--; mLength++; }   /* catch up */
-                offset_2 = offset_1; offset_1 = offset;  /* update offset history */
-                ZSTD_storeSeq(seqStore, (size_t)(ip-anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
-                ip += mLength;
-                anchor = ip;
-        }   }
+            rval = MEM_read32(ip2) ^ 1; /* guaranteed to not match. */
+        }
 
-        if (ip <= ilimit) {
-            /* Fill Table */
-            hashTable[ZSTD_hashPtr(base+curr+2, hlog, mls)] = curr+2;
-            hashTable[ZSTD_hashPtr(ip-2, hlog, mls)] = (U32)(ip-2-base);
-            /* check immediate repcode */
-            while (ip <= ilimit) {
-                U32 const current2 = (U32)(ip-base);
-                U32 const repIndex2 = current2 - offset_2;
-                const BYTE* const repMatch2 = repIndex2 < prefixStartIndex ? dictBase + repIndex2 : base + repIndex2;
-                if ( (((U32)((prefixStartIndex-1) - repIndex2) >= 3) & (offset_2 <= curr - dictStartIndex))  /* intentional overflow */
-                   && (MEM_read32(repMatch2) == MEM_read32(ip)) ) {
-                    const BYTE* const repEnd2 = repIndex2 < prefixStartIndex ? dictEnd : iend;
-                    size_t const repLength2 = ZSTD_count_2segments(ip+4, repMatch2+4, iend, repEnd2, prefixStart) + 4;
-                    { U32 const tmpOffset = offset_2; offset_2 = offset_1; offset_1 = tmpOffset; }  /* swap offset_2 <=> offset_1 */
-                    ZSTD_storeSeq(seqStore, 0 /*litlen*/, anchor, iend, REPCODE1_TO_OFFBASE, repLength2);
-                    hashTable[ZSTD_hashPtr(ip, hlog, mls)] = current2;
-                    ip += repLength2;
-                    anchor = ip;
-                    continue;
-                }
-                break;
-    }   }   }
+        /* write back hash table entry */
+        current0 = (U32)(ip0 - base);
+        hashTable[hash0] = current0;
+
+        /* check repcode at ip[2] */
+        if (MEM_read32(ip2) == rval) {
+            ip0 = ip2;
+            match0 = repBase + repIndex;
+            matchEnd = repIndex < prefixStartIndex ? dictEnd : iend;
+            assert((match0 != prefixStart) & (match0 != dictStart));
+            mLength = ip0[-1] == match0[-1];
+            ip0 -= mLength;
+            match0 -= mLength;
+            offcode = REPCODE1_TO_OFFBASE;
+            mLength += 4;
+            goto _match;
+        }
+
+        /* load match for ip[0] */
+        if (idx >= dictStartIndex) {
+            mval = MEM_read32(idxBase + idx);
+        } else {
+            mval = MEM_read32(ip0) ^ 1; /* guaranteed to not match. */
+        }
+
+        /* check match at ip[0] */
+        if (MEM_read32(ip0) == mval) {
+            /* found a match! */
+            goto _offset;
+        }
+
+        /* lookup ip[1] */
+        idx = hashTable[hash1];
+        idxBase = idx < prefixStartIndex ? dictBase : base;
+
+        /* hash ip[2] */
+        hash0 = hash1;
+        hash1 = ZSTD_hashPtr(ip2, hlog, mls);
+
+        /* advance to next positions */
+        ip0 = ip1;
+        ip1 = ip2;
+        ip2 = ip3;
+
+        /* write back hash table entry */
+        current0 = (U32)(ip0 - base);
+        hashTable[hash0] = current0;
+
+        /* load match for ip[0] */
+        if (idx >= dictStartIndex) {
+            mval = MEM_read32(idxBase + idx);
+        } else {
+            mval = MEM_read32(ip0) ^ 1; /* guaranteed to not match. */
+        }
+
+        /* check match at ip[0] */
+        if (MEM_read32(ip0) == mval) {
+            /* found a match! */
+            goto _offset;
+        }
+
+        /* lookup ip[1] */
+        idx = hashTable[hash1];
+        idxBase = idx < prefixStartIndex ? dictBase : base;
+
+        /* hash ip[2] */
+        hash0 = hash1;
+        hash1 = ZSTD_hashPtr(ip2, hlog, mls);
+
+        /* advance to next positions */
+        ip0 = ip1;
+        ip1 = ip2;
+        ip2 = ip0 + step;
+        ip3 = ip1 + step;
+
+        /* calculate step */
+        if (ip2 >= nextStep) {
+            step++;
+            PREFETCH_L1(ip1 + 64);
+            PREFETCH_L1(ip1 + 128);
+            nextStep += kStepIncr;
+        }
+    } while (ip3 < ilimit);
+
+_cleanup:
+    /* Note that there are probably still a couple positions we could search.
+     * However, it seems to be a meaningful performance hit to try to search
+     * them. So let's not. */
 
     /* save reps for next block */
-    rep[0] = offset_1;
-    rep[1] = offset_2;
+    rep[0] = offset_1 ? offset_1 : offsetSaved;
+    rep[1] = offset_2 ? offset_2 : offsetSaved;
 
     /* Return the last literals size */
     return (size_t)(iend - anchor);
+
+_offset: /* Requires: ip0, idx */
+
+    /* Compute the offset code. */
+    {   U32 const offset = current0 - idx;
+        const BYTE* const lowMatchPtr = idx < prefixStartIndex ? dictStart : prefixStart;
+        matchEnd = idx < prefixStartIndex ? dictEnd : iend;
+        match0 = idxBase + idx;
+        offset_2 = offset_1;
+        offset_1 = offset;
+        offcode = OFFSET_TO_OFFBASE(offset);
+        mLength = 4;
+
+        /* Count the backwards match length. */
+        while (((ip0>anchor) & (match0>lowMatchPtr)) && (ip0[-1] == match0[-1])) {
+            ip0--;
+            match0--;
+            mLength++;
+    }   }
+
+_match: /* Requires: ip0, match0, offcode */
+
+    /* Count the forward length. */
+    assert(matchEnd != 0);
+    mLength += ZSTD_count_2segments(ip0 + mLength, match0 + mLength, iend, matchEnd, prefixStart);
+
+    ZSTD_storeSeq(seqStore, (size_t)(ip0 - anchor), anchor, iend, offcode, mLength);
+
+    ip0 += mLength;
+    anchor = ip0;
+
+    /* write next hash table entry */
+    if (ip1 < ip0) {
+        hashTable[hash1] = (U32)(ip1 - base);
+    }
+
+    /* Fill table and check for immediate repcode. */
+    if (ip0 <= ilimit) {
+        /* Fill Table */
+        assert(base+current0+2 > istart);  /* check base overflow */
+        hashTable[ZSTD_hashPtr(base+current0+2, hlog, mls)] = current0+2;  /* here because current+2 could be > iend-8 */
+        hashTable[ZSTD_hashPtr(ip0-2, hlog, mls)] = (U32)(ip0-2-base);
+
+        assert(offset_2 > 0);
+        while (ip0 <= ilimit) {
+            U32 const repIndex2 = (U32)(ip0-base) - offset_2;
+            const BYTE* const repMatch2 = repIndex2 < prefixStartIndex ? dictBase + repIndex2 : base + repIndex2;
+            if ( (((U32)((prefixStartIndex-1) - repIndex2) >= 3) & (offset_2 <= (U32)(ip0-base) - dictStartIndex))  /* intentional overflow */
+                 && (MEM_read32(repMatch2) == MEM_read32(ip0)) ) {
+                const BYTE* const repEnd2 = repIndex2 < prefixStartIndex ? dictEnd : iend;
+                size_t const repLength2 = ZSTD_count_2segments(ip0+4, repMatch2+4, iend, repEnd2, prefixStart) + 4;
+                { U32 const tmpOffset = offset_2; offset_2 = offset_1; offset_1 = tmpOffset; }  /* swap offset_2 <=> offset_1 */
+                ZSTD_storeSeq(seqStore, 0 /*litlen*/, anchor, iend, REPCODE1_TO_OFFBASE, repLength2);
+                hashTable[ZSTD_hashPtr(ip0, hlog, mls)] = (U32)(ip0-base);
+                ip0 += repLength2;
+                anchor = ip0;
+                continue;
+            }
+            break;
+    }   }
+
+    goto _start;
 }
 
 ZSTD_GEN_FAST_FN(extDict, 4, 0)

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -581,13 +581,13 @@ size_t ZSTD_compressBlock_fast_dictMatchState(
 
 static size_t ZSTD_compressBlock_fast_extDict_generic(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
-        void const* src, size_t srcSize, U32 const mls, U32 const hasStep)
+        void const* src, size_t srcSize, U32 const mls, U32 const commonScenario)
 {
     const ZSTD_compressionParameters* const cParams = &ms->cParams;
     U32* const hashTable = ms->hashTable;
     U32 const hlog = cParams->hashLog;
     /* support stepSize of 0 */
-    size_t const stepSize = hasStep ? (cParams->targetLength + !(cParams->targetLength) + 1) : 2;
+    size_t const stepSize = commonScenario ? 2 : (cParams->targetLength + !(cParams->targetLength) + 1);
     const BYTE* const base = ms->window.base;
     const BYTE* const dictBase = ms->window.dictBase;
     const BYTE* const istart = (const BYTE*)src;
@@ -633,9 +633,13 @@ static size_t ZSTD_compressBlock_fast_extDict_generic(
 
     {   U32 const curr = (U32)(ip0 - base);
         U32 const maxRep = curr - dictStartIndex;
-        if (offset_2 >= maxRep) offset_2 = 0;
-        if (offset_1 >= maxRep) offset_1 = 0;
-    }
+        if (commonScenario) {
+            assert(offset_2 < maxRep);
+            assert(offset_1 < maxRep);
+        } else {
+            if (offset_2 >= maxRep) offset_2 = 0;
+            if (offset_1 >= maxRep) offset_1 = 0;
+    }   }
 
     /* start each op */
 _start: /* Requires: ip0 */
@@ -665,7 +669,7 @@ _start: /* Requires: ip0 */
             const BYTE* const repBase = repIndex < prefixStartIndex ? dictBase : base;
             U32 rval;
             if ( ((U32)(prefixStartIndex - repIndex) >= 4) /* intentional underflow */
-                 & (offset_1 > 0) ) {
+                 & (commonScenario | (offset_1 > 0)) ) {
                 rval = MEM_read32(repBase + repIndex);
             } else {
                 rval = MEM_read32(ip2) ^ 1; /* guaranteed to not match. */
@@ -690,7 +694,9 @@ _start: /* Requires: ip0 */
         }   }
 
         {   /* load match for ip[0] */
-            U32 const mval = idx >= dictStartIndex ? MEM_read32(idxBase + idx) : MEM_read32(ip0) ^ 1; /* guaranteed not to match */
+            U32 const mval = idx >= dictStartIndex ?
+                    MEM_read32(idxBase + idx) :
+                    MEM_read32(ip0) ^ 1; /* guaranteed not to match */
 
             /* check match at ip[0] */
             if (MEM_read32(ip0) == mval) {
@@ -716,7 +722,9 @@ _start: /* Requires: ip0 */
         hashTable[hash0] = current0;
 
         {   /* load match for ip[0] */
-            U32 const mval = idx >= dictStartIndex ? MEM_read32(idxBase + idx) : MEM_read32(ip0) ^ 1; /* guaranteed not to match */
+            U32 const mval = idx >= dictStartIndex ?
+                    MEM_read32(idxBase + idx) :
+                    MEM_read32(ip0) ^ 1; /* guaranteed not to match */
 
             /* check match at ip[0] */
             if (MEM_read32(ip0) == mval) {
@@ -804,7 +812,7 @@ _match: /* Requires: ip0, match0, offcode, matchEnd */
         while (ip0 <= ilimit) {
             U32 const repIndex2 = (U32)(ip0-base) - offset_2;
             const BYTE* const repMatch2 = repIndex2 < prefixStartIndex ? dictBase + repIndex2 : base + repIndex2;
-            if ( (((U32)((prefixStartIndex-1) - repIndex2) >= 3) & (offset_2 > 0))  /* intentional underflow */
+            if ( (((U32)((prefixStartIndex-1) - repIndex2) >= 3) & (commonScenario | (offset_2 > 0)))  /* intentional underflow */
                  && (MEM_read32(repMatch2) == MEM_read32(ip0)) ) {
                 const BYTE* const repEnd2 = repIndex2 < prefixStartIndex ? dictEnd : iend;
                 size_t const repLength2 = ZSTD_count_2segments(ip0+4, repMatch2+4, iend, repEnd2, prefixStart) + 4;
@@ -836,8 +844,17 @@ size_t ZSTD_compressBlock_fast_extDict(
         void const* src, size_t srcSize)
 {
     U32 const mls = ms->cParams.minMatch;
+    const BYTE* const istart = (const BYTE*)src;
+    const BYTE* const base = ms->window.base;
+    const U32 endIndex = (U32)((size_t)(istart - base) + srcSize);
+    const U32 lowLimit = ZSTD_getLowestMatchIndex(ms, endIndex, ms->cParams.windowLog);
+    U32 const curr = (U32)(istart - base);
+    U32 const maxRep = curr - lowLimit;
+    U32 const repOffsetsAreValid = (rep[0] < maxRep) & (rep[1] < maxRep);
+
+    assert((rep[0] > 0) & (rep[1] > 0));
     assert(ms->dictMatchState == NULL);
-    if (ms->cParams.targetLength > 1) {
+    if ((ms->cParams.targetLength <= 1) & repOffsetsAreValid) {
         switch (mls) {
             default: /* includes case 3 */
             case 4 :

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -59,15 +59,15 @@ silesia,                            uncompressed literals optimal,      compress
 silesia,                            huffman literals,                   compress cctx,                      6172178
 silesia,                            multithreaded with advanced params, compress cctx,                      4842075
 github,                             level -5,                           compress cctx,                      204411
-github,                             level -5 with dict,                 compress cctx,                      47294
+github,                             level -5 with dict,                 compress cctx,                      52059
 github,                             level -3,                           compress cctx,                      193253
-github,                             level -3 with dict,                 compress cctx,                      48047
+github,                             level -3 with dict,                 compress cctx,                      46787
 github,                             level -1,                           compress cctx,                      175468
-github,                             level -1 with dict,                 compress cctx,                      43527
+github,                             level -1 with dict,                 compress cctx,                      43585
 github,                             level 0,                            compress cctx,                      136332
 github,                             level 0 with dict,                  compress cctx,                      41534
 github,                             level 1,                            compress cctx,                      142365
-github,                             level 1 with dict,                  compress cctx,                      42157
+github,                             level 1 with dict,                  compress cctx,                      42259
 github,                             level 3,                            compress cctx,                      136332
 github,                             level 3 with dict,                  compress cctx,                      41534
 github,                             level 4,                            compress cctx,                      136199
@@ -188,15 +188,15 @@ github,                             uncompressed literals optimal,      zstdcli,
 github,                             huffman literals,                   zstdcli,                            144365
 github,                             multithreaded with advanced params, zstdcli,                            167911
 github.tar,                         level -5,                           zstdcli,                            52114
-github.tar,                         level -5 with dict,                 zstdcli,                            46502
+github.tar,                         level -5 with dict,                 zstdcli,                            51074
 github.tar,                         level -3,                           zstdcli,                            45682
-github.tar,                         level -3 with dict,                 zstdcli,                            42181
+github.tar,                         level -3 with dict,                 zstdcli,                            44660
 github.tar,                         level -1,                           zstdcli,                            42564
-github.tar,                         level -1 with dict,                 zstdcli,                            41140
+github.tar,                         level -1 with dict,                 zstdcli,                            41155
 github.tar,                         level 0,                            zstdcli,                            38835
 github.tar,                         level 0 with dict,                  zstdcli,                            37999
 github.tar,                         level 1,                            zstdcli,                            39204
-github.tar,                         level 1 with dict,                  zstdcli,                            38288
+github.tar,                         level 1 with dict,                  zstdcli,                            38093
 github.tar,                         level 3,                            zstdcli,                            38835
 github.tar,                         level 3 with dict,                  zstdcli,                            37999
 github.tar,                         level 4,                            zstdcli,                            38897
@@ -312,8 +312,8 @@ github,                             level 1,                            advanced
 github,                             level 1 with dict,                  advanced one pass,                  41682
 github,                             level 1 with dict dms,              advanced one pass,                  41682
 github,                             level 1 with dict dds,              advanced one pass,                  41682
-github,                             level 1 with dict copy,             advanced one pass,                  41674
-github,                             level 1 with dict load,             advanced one pass,                  43755
+github,                             level 1 with dict copy,             advanced one pass,                  41698
+github,                             level 1 with dict load,             advanced one pass,                  43814
 github,                             level 3,                            advanced one pass,                  136332
 github,                             level 3 with dict,                  advanced one pass,                  41148
 github,                             level 3 with dict dms,              advanced one pass,                  41148
@@ -422,11 +422,11 @@ github,                             uncompressed literals optimal,      advanced
 github,                             huffman literals,                   advanced one pass,                  142365
 github,                             multithreaded with advanced params, advanced one pass,                  165911
 github.tar,                         level -5,                           advanced one pass,                  52110
-github.tar,                         level -5 with dict,                 advanced one pass,                  46498
+github.tar,                         level -5 with dict,                 advanced one pass,                  51070
 github.tar,                         level -3,                           advanced one pass,                  45678
-github.tar,                         level -3 with dict,                 advanced one pass,                  42177
+github.tar,                         level -3 with dict,                 advanced one pass,                  44656
 github.tar,                         level -1,                           advanced one pass,                  42560
-github.tar,                         level -1 with dict,                 advanced one pass,                  41136
+github.tar,                         level -1 with dict,                 advanced one pass,                  41151
 github.tar,                         level 0,                            advanced one pass,                  38831
 github.tar,                         level 0 with dict,                  advanced one pass,                  37995
 github.tar,                         level 0 with dict dms,              advanced one pass,                  38003
@@ -434,11 +434,11 @@ github.tar,                         level 0 with dict dds,              advanced
 github.tar,                         level 0 with dict copy,             advanced one pass,                  37995
 github.tar,                         level 0 with dict load,             advanced one pass,                  37956
 github.tar,                         level 1,                            advanced one pass,                  39200
-github.tar,                         level 1 with dict,                  advanced one pass,                  38284
+github.tar,                         level 1 with dict,                  advanced one pass,                  38089
 github.tar,                         level 1 with dict dms,              advanced one pass,                  38294
 github.tar,                         level 1 with dict dds,              advanced one pass,                  38294
-github.tar,                         level 1 with dict copy,             advanced one pass,                  38284
-github.tar,                         level 1 with dict load,             advanced one pass,                  38724
+github.tar,                         level 1 with dict copy,             advanced one pass,                  38089
+github.tar,                         level 1 with dict load,             advanced one pass,                  38364
 github.tar,                         level 3,                            advanced one pass,                  38831
 github.tar,                         level 3 with dict,                  advanced one pass,                  37995
 github.tar,                         level 3 with dict dms,              advanced one pass,                  38003
@@ -630,8 +630,8 @@ github,                             level 1,                            advanced
 github,                             level 1 with dict,                  advanced one pass small out,        41682
 github,                             level 1 with dict dms,              advanced one pass small out,        41682
 github,                             level 1 with dict dds,              advanced one pass small out,        41682
-github,                             level 1 with dict copy,             advanced one pass small out,        41674
-github,                             level 1 with dict load,             advanced one pass small out,        43755
+github,                             level 1 with dict copy,             advanced one pass small out,        41698
+github,                             level 1 with dict load,             advanced one pass small out,        43814
 github,                             level 3,                            advanced one pass small out,        136332
 github,                             level 3 with dict,                  advanced one pass small out,        41148
 github,                             level 3 with dict dms,              advanced one pass small out,        41148
@@ -740,11 +740,11 @@ github,                             uncompressed literals optimal,      advanced
 github,                             huffman literals,                   advanced one pass small out,        142365
 github,                             multithreaded with advanced params, advanced one pass small out,        165911
 github.tar,                         level -5,                           advanced one pass small out,        52110
-github.tar,                         level -5 with dict,                 advanced one pass small out,        46498
+github.tar,                         level -5 with dict,                 advanced one pass small out,        51070
 github.tar,                         level -3,                           advanced one pass small out,        45678
-github.tar,                         level -3 with dict,                 advanced one pass small out,        42177
+github.tar,                         level -3 with dict,                 advanced one pass small out,        44656
 github.tar,                         level -1,                           advanced one pass small out,        42560
-github.tar,                         level -1 with dict,                 advanced one pass small out,        41136
+github.tar,                         level -1 with dict,                 advanced one pass small out,        41151
 github.tar,                         level 0,                            advanced one pass small out,        38831
 github.tar,                         level 0 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 0 with dict dms,              advanced one pass small out,        38003
@@ -752,11 +752,11 @@ github.tar,                         level 0 with dict dds,              advanced
 github.tar,                         level 0 with dict copy,             advanced one pass small out,        37995
 github.tar,                         level 0 with dict load,             advanced one pass small out,        37956
 github.tar,                         level 1,                            advanced one pass small out,        39200
-github.tar,                         level 1 with dict,                  advanced one pass small out,        38284
+github.tar,                         level 1 with dict,                  advanced one pass small out,        38089
 github.tar,                         level 1 with dict dms,              advanced one pass small out,        38294
 github.tar,                         level 1 with dict dds,              advanced one pass small out,        38294
-github.tar,                         level 1 with dict copy,             advanced one pass small out,        38284
-github.tar,                         level 1 with dict load,             advanced one pass small out,        38724
+github.tar,                         level 1 with dict copy,             advanced one pass small out,        38089
+github.tar,                         level 1 with dict load,             advanced one pass small out,        38364
 github.tar,                         level 3,                            advanced one pass small out,        38831
 github.tar,                         level 3 with dict,                  advanced one pass small out,        37995
 github.tar,                         level 3 with dict dms,              advanced one pass small out,        38003
@@ -864,11 +864,11 @@ github.tar,                         uncompressed literals,              advanced
 github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35397
 github.tar,                         huffman literals,                   advanced one pass small out,        38853
 github.tar,                         multithreaded with advanced params, advanced one pass small out,        41525
-silesia,                            level -5,                           advanced streaming,                 6963781
-silesia,                            level -3,                           advanced streaming,                 6610376
-silesia,                            level -1,                           advanced streaming,                 6179294
+silesia,                            level -5,                           advanced streaming,                 6852424
+silesia,                            level -3,                           advanced streaming,                 6503413
+silesia,                            level -1,                           advanced streaming,                 6172179
 silesia,                            level 0,                            advanced streaming,                 4842075
-silesia,                            level 1,                            advanced streaming,                 5310178
+silesia,                            level 1,                            advanced streaming,                 5306426
 silesia,                            level 3,                            advanced streaming,                 4842075
 silesia,                            level 4,                            advanced streaming,                 4779186
 silesia,                            level 5 row 1,                      advanced streaming,                 4666323
@@ -896,13 +896,13 @@ silesia,                            small chain log,                    advanced
 silesia,                            explicit params,                    advanced streaming,                 4795452
 silesia,                            uncompressed literals,              advanced streaming,                 5120566
 silesia,                            uncompressed literals optimal,      advanced streaming,                 4319518
-silesia,                            huffman literals,                   advanced streaming,                 5327881
+silesia,                            huffman literals,                   advanced streaming,                 5321346
 silesia,                            multithreaded with advanced params, advanced streaming,                 5120566
-silesia.tar,                        level -5,                           advanced streaming,                 7043687
-silesia.tar,                        level -3,                           advanced streaming,                 6671317
-silesia.tar,                        level -1,                           advanced streaming,                 6187457
+silesia.tar,                        level -5,                           advanced streaming,                 6853609
+silesia.tar,                        level -3,                           advanced streaming,                 6505969
+silesia.tar,                        level -1,                           advanced streaming,                 6179028
 silesia.tar,                        level 0,                            advanced streaming,                 4859271
-silesia.tar,                        level 1,                            advanced streaming,                 5333896
+silesia.tar,                        level 1,                            advanced streaming,                 5327377
 silesia.tar,                        level 3,                            advanced streaming,                 4859271
 silesia.tar,                        level 4,                            advanced streaming,                 4797470
 silesia.tar,                        level 5 row 1,                      advanced streaming,                 4677748
@@ -930,7 +930,7 @@ silesia.tar,                        small chain log,                    advanced
 silesia.tar,                        explicit params,                    advanced streaming,                 4806873
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5127423
 silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4310141
-silesia.tar,                        huffman literals,                   advanced streaming,                 5349624
+silesia.tar,                        huffman literals,                   advanced streaming,                 5341688
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5122567
 github,                             level -5,                           advanced streaming,                 204411
 github,                             level -5 with dict,                 advanced streaming,                 46718
@@ -948,8 +948,8 @@ github,                             level 1,                            advanced
 github,                             level 1 with dict,                  advanced streaming,                 41682
 github,                             level 1 with dict dms,              advanced streaming,                 41682
 github,                             level 1 with dict dds,              advanced streaming,                 41682
-github,                             level 1 with dict copy,             advanced streaming,                 41674
-github,                             level 1 with dict load,             advanced streaming,                 43755
+github,                             level 1 with dict copy,             advanced streaming,                 41698
+github,                             level 1 with dict load,             advanced streaming,                 43814
 github,                             level 3,                            advanced streaming,                 136332
 github,                             level 3 with dict,                  advanced streaming,                 41148
 github,                             level 3 with dict dms,              advanced streaming,                 41148
@@ -1057,24 +1057,24 @@ github,                             uncompressed literals,              advanced
 github,                             uncompressed literals optimal,      advanced streaming,                 157227
 github,                             huffman literals,                   advanced streaming,                 142365
 github,                             multithreaded with advanced params, advanced streaming,                 165911
-github.tar,                         level -5,                           advanced streaming,                 51420
-github.tar,                         level -5 with dict,                 advanced streaming,                 45495
-github.tar,                         level -3,                           advanced streaming,                 45077
-github.tar,                         level -3 with dict,                 advanced streaming,                 41627
-github.tar,                         level -1,                           advanced streaming,                 42536
-github.tar,                         level -1 with dict,                 advanced streaming,                 41198
+github.tar,                         level -5,                           advanced streaming,                 52110
+github.tar,                         level -5 with dict,                 advanced streaming,                 51070
+github.tar,                         level -3,                           advanced streaming,                 45678
+github.tar,                         level -3 with dict,                 advanced streaming,                 44656
+github.tar,                         level -1,                           advanced streaming,                 42560
+github.tar,                         level -1 with dict,                 advanced streaming,                 41151
 github.tar,                         level 0,                            advanced streaming,                 38831
 github.tar,                         level 0 with dict,                  advanced streaming,                 37995
 github.tar,                         level 0 with dict dms,              advanced streaming,                 38003
 github.tar,                         level 0 with dict dds,              advanced streaming,                 38003
 github.tar,                         level 0 with dict copy,             advanced streaming,                 37995
 github.tar,                         level 0 with dict load,             advanced streaming,                 37956
-github.tar,                         level 1,                            advanced streaming,                 39270
-github.tar,                         level 1 with dict,                  advanced streaming,                 38316
-github.tar,                         level 1 with dict dms,              advanced streaming,                 38326
-github.tar,                         level 1 with dict dds,              advanced streaming,                 38326
-github.tar,                         level 1 with dict copy,             advanced streaming,                 38316
-github.tar,                         level 1 with dict load,             advanced streaming,                 38761
+github.tar,                         level 1,                            advanced streaming,                 39200
+github.tar,                         level 1 with dict,                  advanced streaming,                 38089
+github.tar,                         level 1 with dict dms,              advanced streaming,                 38294
+github.tar,                         level 1 with dict dds,              advanced streaming,                 38294
+github.tar,                         level 1 with dict copy,             advanced streaming,                 38089
+github.tar,                         level 1 with dict load,             advanced streaming,                 38364
 github.tar,                         level 3,                            advanced streaming,                 38831
 github.tar,                         level 3 with dict,                  advanced streaming,                 37995
 github.tar,                         level 3 with dict dms,              advanced streaming,                 38003
@@ -1180,13 +1180,13 @@ github.tar,                         small chain log,                    advanced
 github.tar,                         explicit params,                    advanced streaming,                 41385
 github.tar,                         uncompressed literals,              advanced streaming,                 41525
 github.tar,                         uncompressed literals optimal,      advanced streaming,                 35397
-github.tar,                         huffman literals,                   advanced streaming,                 38874
+github.tar,                         huffman literals,                   advanced streaming,                 38853
 github.tar,                         multithreaded with advanced params, advanced streaming,                 41525
-silesia,                            level -5,                           old streaming,                      6963781
-silesia,                            level -3,                           old streaming,                      6610376
-silesia,                            level -1,                           old streaming,                      6179294
+silesia,                            level -5,                           old streaming,                      6852424
+silesia,                            level -3,                           old streaming,                      6503413
+silesia,                            level -1,                           old streaming,                      6172179
 silesia,                            level 0,                            old streaming,                      4842075
-silesia,                            level 1,                            old streaming,                      5310178
+silesia,                            level 1,                            old streaming,                      5306426
 silesia,                            level 3,                            old streaming,                      4842075
 silesia,                            level 4,                            old streaming,                      4779186
 silesia,                            level 5,                            old streaming,                      4666323
@@ -1199,12 +1199,12 @@ silesia,                            level 19,                           old stre
 silesia,                            no source size,                     old streaming,                      4842039
 silesia,                            uncompressed literals,              old streaming,                      4842075
 silesia,                            uncompressed literals optimal,      old streaming,                      4296686
-silesia,                            huffman literals,                   old streaming,                      6179294
-silesia.tar,                        level -5,                           old streaming,                      7043687
-silesia.tar,                        level -3,                           old streaming,                      6671317
-silesia.tar,                        level -1,                           old streaming,                      6187457
+silesia,                            huffman literals,                   old streaming,                      6172179
+silesia.tar,                        level -5,                           old streaming,                      6853609
+silesia.tar,                        level -3,                           old streaming,                      6505969
+silesia.tar,                        level -1,                           old streaming,                      6179028
 silesia.tar,                        level 0,                            old streaming,                      4859271
-silesia.tar,                        level 1,                            old streaming,                      5333896
+silesia.tar,                        level 1,                            old streaming,                      5327377
 silesia.tar,                        level 3,                            old streaming,                      4859271
 silesia.tar,                        level 4,                            old streaming,                      4797470
 silesia.tar,                        level 5,                            old streaming,                      4677748
@@ -1217,7 +1217,7 @@ silesia.tar,                        level 19,                           old stre
 silesia.tar,                        no source size,                     old streaming,                      4859267
 silesia.tar,                        uncompressed literals,              old streaming,                      4859271
 silesia.tar,                        uncompressed literals optimal,      old streaming,                      4267266
-silesia.tar,                        huffman literals,                   old streaming,                      6187457
+silesia.tar,                        huffman literals,                   old streaming,                      6179028
 github,                             level -5,                           old streaming,                      204411
 github,                             level -5 with dict,                 old streaming,                      46718
 github,                             level -3,                           old streaming,                      193253
@@ -1251,16 +1251,16 @@ github,                             no source size with dict,           old stre
 github,                             uncompressed literals,              old streaming,                      136332
 github,                             uncompressed literals optimal,      old streaming,                      134064
 github,                             huffman literals,                   old streaming,                      175468
-github.tar,                         level -5,                           old streaming,                      51420
-github.tar,                         level -5 with dict,                 old streaming,                      45495
-github.tar,                         level -3,                           old streaming,                      45077
-github.tar,                         level -3 with dict,                 old streaming,                      41627
-github.tar,                         level -1,                           old streaming,                      42536
-github.tar,                         level -1 with dict,                 old streaming,                      41198
+github.tar,                         level -5,                           old streaming,                      52110
+github.tar,                         level -5 with dict,                 old streaming,                      51070
+github.tar,                         level -3,                           old streaming,                      45678
+github.tar,                         level -3 with dict,                 old streaming,                      44656
+github.tar,                         level -1,                           old streaming,                      42560
+github.tar,                         level -1 with dict,                 old streaming,                      41151
 github.tar,                         level 0,                            old streaming,                      38831
 github.tar,                         level 0 with dict,                  old streaming,                      37995
-github.tar,                         level 1,                            old streaming,                      39270
-github.tar,                         level 1 with dict,                  old streaming,                      38316
+github.tar,                         level 1,                            old streaming,                      39200
+github.tar,                         level 1 with dict,                  old streaming,                      38089
 github.tar,                         level 3,                            old streaming,                      38831
 github.tar,                         level 3 with dict,                  old streaming,                      37995
 github.tar,                         level 4,                            old streaming,                      38893
@@ -1283,12 +1283,12 @@ github.tar,                         no source size,                     old stre
 github.tar,                         no source size with dict,           old streaming,                      38000
 github.tar,                         uncompressed literals,              old streaming,                      38831
 github.tar,                         uncompressed literals optimal,      old streaming,                      32134
-github.tar,                         huffman literals,                   old streaming,                      42536
-silesia,                            level -5,                           old streaming advanced,             6963781
-silesia,                            level -3,                           old streaming advanced,             6610376
-silesia,                            level -1,                           old streaming advanced,             6179294
+github.tar,                         huffman literals,                   old streaming,                      42560
+silesia,                            level -5,                           old streaming advanced,             6852424
+silesia,                            level -3,                           old streaming advanced,             6503413
+silesia,                            level -1,                           old streaming advanced,             6172179
 silesia,                            level 0,                            old streaming advanced,             4842075
-silesia,                            level 1,                            old streaming advanced,             5310178
+silesia,                            level 1,                            old streaming advanced,             5306426
 silesia,                            level 3,                            old streaming advanced,             4842075
 silesia,                            level 4,                            old streaming advanced,             4779186
 silesia,                            level 5,                            old streaming advanced,             4666323
@@ -1308,13 +1308,13 @@ silesia,                            small chain log,                    old stre
 silesia,                            explicit params,                    old streaming advanced,             4795452
 silesia,                            uncompressed literals,              old streaming advanced,             4842075
 silesia,                            uncompressed literals optimal,      old streaming advanced,             4296686
-silesia,                            huffman literals,                   old streaming advanced,             6179294
+silesia,                            huffman literals,                   old streaming advanced,             6172179
 silesia,                            multithreaded with advanced params, old streaming advanced,             4842075
-silesia.tar,                        level -5,                           old streaming advanced,             7043687
-silesia.tar,                        level -3,                           old streaming advanced,             6671317
-silesia.tar,                        level -1,                           old streaming advanced,             6187457
+silesia.tar,                        level -5,                           old streaming advanced,             6853609
+silesia.tar,                        level -3,                           old streaming advanced,             6505969
+silesia.tar,                        level -1,                           old streaming advanced,             6179028
 silesia.tar,                        level 0,                            old streaming advanced,             4859271
-silesia.tar,                        level 1,                            old streaming advanced,             5333896
+silesia.tar,                        level 1,                            old streaming advanced,             5327377
 silesia.tar,                        level 3,                            old streaming advanced,             4859271
 silesia.tar,                        level 4,                            old streaming advanced,             4797470
 silesia.tar,                        level 5,                            old streaming advanced,             4677748
@@ -1334,7 +1334,7 @@ silesia.tar,                        small chain log,                    old stre
 silesia.tar,                        explicit params,                    old streaming advanced,             4806873
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4859271
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4267266
-silesia.tar,                        huffman literals,                   old streaming advanced,             6187457
+silesia.tar,                        huffman literals,                   old streaming advanced,             6179028
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4859271
 github,                             level -5,                           old streaming advanced,             213265
 github,                             level -5 with dict,                 old streaming advanced,             49562
@@ -1377,16 +1377,16 @@ github,                             uncompressed literals,              old stre
 github,                             uncompressed literals optimal,      old streaming advanced,             134064
 github,                             huffman literals,                   old streaming advanced,             181107
 github,                             multithreaded with advanced params, old streaming advanced,             141104
-github.tar,                         level -5,                           old streaming advanced,             51420
-github.tar,                         level -5 with dict,                 old streaming advanced,             46091
-github.tar,                         level -3,                           old streaming advanced,             45077
-github.tar,                         level -3 with dict,                 old streaming advanced,             42222
-github.tar,                         level -1,                           old streaming advanced,             42536
-github.tar,                         level -1 with dict,                 old streaming advanced,             41494
+github.tar,                         level -5,                           old streaming advanced,             52110
+github.tar,                         level -5 with dict,                 old streaming advanced,             50985
+github.tar,                         level -3,                           old streaming advanced,             45678
+github.tar,                         level -3 with dict,                 old streaming advanced,             44729
+github.tar,                         level -1,                           old streaming advanced,             42560
+github.tar,                         level -1 with dict,                 old streaming advanced,             41589
 github.tar,                         level 0,                            old streaming advanced,             38831
 github.tar,                         level 0 with dict,                  old streaming advanced,             38013
-github.tar,                         level 1,                            old streaming advanced,             39270
-github.tar,                         level 1 with dict,                  old streaming advanced,             38934
+github.tar,                         level 1,                            old streaming advanced,             39200
+github.tar,                         level 1 with dict,                  old streaming advanced,             38359
 github.tar,                         level 3,                            old streaming advanced,             38831
 github.tar,                         level 3 with dict,                  old streaming advanced,             38013
 github.tar,                         level 4,                            old streaming advanced,             38893
@@ -1416,7 +1416,7 @@ github.tar,                         small chain log,                    old stre
 github.tar,                         explicit params,                    old streaming advanced,             41385
 github.tar,                         uncompressed literals,              old streaming advanced,             38831
 github.tar,                         uncompressed literals optimal,      old streaming advanced,             32134
-github.tar,                         huffman literals,                   old streaming advanced,             42536
+github.tar,                         huffman literals,                   old streaming advanced,             42560
 github.tar,                         multithreaded with advanced params, old streaming advanced,             38831
 github,                             level -5 with dict,                 old streaming cdict,                46718
 github,                             level -3 with dict,                 old streaming cdict,                45395
@@ -1433,11 +1433,11 @@ github,                             level 13 with dict,                 old stre
 github,                             level 16 with dict,                 old streaming cdict,                37577
 github,                             level 19 with dict,                 old streaming cdict,                37576
 github,                             no source size with dict,           old streaming cdict,                40654
-github.tar,                         level -5 with dict,                 old streaming cdict,                46276
-github.tar,                         level -3 with dict,                 old streaming cdict,                42354
-github.tar,                         level -1 with dict,                 old streaming cdict,                41662
+github.tar,                         level -5 with dict,                 old streaming cdict,                51189
+github.tar,                         level -3 with dict,                 old streaming cdict,                44821
+github.tar,                         level -1 with dict,                 old streaming cdict,                41775
 github.tar,                         level 0 with dict,                  old streaming cdict,                37956
-github.tar,                         level 1 with dict,                  old streaming cdict,                38761
+github.tar,                         level 1 with dict,                  old streaming cdict,                38364
 github.tar,                         level 3 with dict,                  old streaming cdict,                37956
 github.tar,                         level 4 with dict,                  old streaming cdict,                37927
 github.tar,                         level 5 with dict,                  old streaming cdict,                38999
@@ -1463,11 +1463,11 @@ github,                             level 13 with dict,                 old stre
 github,                             level 16 with dict,                 old streaming advanced cdict,       40789
 github,                             level 19 with dict,                 old streaming advanced cdict,       37576
 github,                             no source size with dict,           old streaming advanced cdict,       40608
-github.tar,                         level -5 with dict,                 old streaming advanced cdict,       44307
-github.tar,                         level -3 with dict,                 old streaming advanced cdict,       41359
-github.tar,                         level -1 with dict,                 old streaming advanced cdict,       41322
+github.tar,                         level -5 with dict,                 old streaming advanced cdict,       50854
+github.tar,                         level -3 with dict,                 old streaming advanced cdict,       44571
+github.tar,                         level -1 with dict,                 old streaming advanced cdict,       41477
 github.tar,                         level 0 with dict,                  old streaming advanced cdict,       38013
-github.tar,                         level 1 with dict,                  old streaming advanced cdict,       39002
+github.tar,                         level 1 with dict,                  old streaming advanced cdict,       38168
 github.tar,                         level 3 with dict,                  old streaming advanced cdict,       38013
 github.tar,                         level 4 with dict,                  old streaming advanced cdict,       38063
 github.tar,                         level 5 with dict,                  old streaming advanced cdict,       38997


### PR DESCRIPTION
## Summary
Using similar techniques as https://github.com/facebook/zstd/pull/2749 and https://github.com/facebook/zstd/pull/3086, improves level-1 compression speed by 4-9% on a dataset of HTML headers between 8 and 16KB (the dataset has ratio 3.03 w/o dictionary, 4.92 with a 110KB dictionary). Dictionary compression speed improvements hold across gcc/clang and a variety of dictionary temperatures and sizes. Additionally, compression speed for level-1 streaming compression (i.e. `zstd --single-thread silesia.tar`) is improved by 4-5%.

Compression ratio is also slightly improved. For example, the compressed size of silesia.tar is reduced by 0.1%.

## Preliminary results
I have added final measurements below, preliminary measurements are still here if you are interested:
<details>

### Dictionary compression
I used the experimental setup described in https://github.com/facebook/zstd/pull/3086 (see the section titled "Final Results"). On the 4KB dictionary, speed improvements are 4-5% across all temperatures and compilers. On the larger dictionaries (more realistic), speed improvements are 6-9% across all temperatures and compilers.

<details>
<summary>Dictionary compression speed improvements at level 1 (preliminary)</summary>

```
/Users/embg/results0415/html_16K/cold/4K
	gcc11: 5.4% (± 0.0%)
	clang12: 4.3% (± 0.1%)

/Users/embg/results0415/html_16K/cold/32K
	gcc11: 8.5% (± 0.0%)
	clang12: 6.2% (± 0.1%)

/Users/embg/results0415/html_16K/cold/110K
	gcc11: 9.1% (± 0.1%)
	clang12: 6.6% (± 0.1%)

/Users/embg/results0415/html_16K/warm/4K
	gcc11: 5.6% (± 0.1%)
	clang12: 4.5% (± 0.1%)

/Users/embg/results0415/html_16K/warm/32K
	gcc11: 8.4% (± 0.1%)
	clang12: 6.4% (± 0.2%)

/Users/embg/results0415/html_16K/warm/110K
	gcc11: 8.2% (± 0.9%)
	clang12: 6.9% (± 1.0%)

/Users/embg/results0415/html_16K/hot/4K
	gcc11: 5.8% (± 0.1%)
	clang12: 4.6% (± 0.1%)

/Users/embg/results0415/html_16K/hot/32K
	gcc11: 8.4% (± 0.1%)
	clang12: 6.1% (± 0.1%)

/Users/embg/results0415/html_16K/hot/110K
	gcc11: 7.9% (± 0.1%)
	clang12: 5.7% (± 0.1%)
```
</details>

There were small improvements in compression ratio at all dictionary sizes. The compressed size of the full html16K dataset was reduced as follows: 0.18% with the 110KB dictionary, 0.22% with the 32KB dictionary, and 0.52% with the 4KB dictionary.

### Streaming compression
Compression speed was measured via `time ./zstd_bin -1 --single-thread silesia.tar`. I timed each binary a few times interleaved and took the best time for each one. I tested the same compilers as for dictionary compression (gcc11 and clang12) and used the same setup (same CPU, core isolation, turbo disabled).

|         | 460780f (dev) | 3536262 (this PR) | % improvement |
|---------|---------------|-------------------|---------------|
| gcc11   | 1.49 (s) user          | 1.41 (s) user             | 5.4%          |
| clang12 | 1.47 (s) user         | 1.41  (s) user          | 4.1%          |

The compressed size of silesia.tar is reduced by 0.17%. 
</details>

## Final results

### Dictionary compression
I used the experimental setup described in https://github.com/facebook/zstd/pull/3086 (see the section titled "Final Results"). The final dictionary perf numbers are very close to the preliminary numbers, except the clang win is about 1% higher now on most scenarios. Gcc numbers are almost identical.

My follow-up commits on this PR did not touch ratio so that is unchanged. See the Preliminary Results section for a discussion of the ratio impacts.

<details>
<summary>Dictionary compression speed improvements at level 1 (final)</summary>

```	
results0502/html_16K/cold/4K
	gcc11: 5.5% (± 0.1%)
	clang12: 5.4% (± 0.1%)

results0502/html_16K/cold/32K
	gcc11: 8.5% (± 0.1%)
	clang12: 6.7% (± 0.1%)

results0502/html_16K/cold/110K
	gcc11: 9.2% (± 0.1%)
	clang12: 7.2% (± 0.1%)

results0502/html_16K/warm/4K
	gcc11: 5.6% (± 0.1%)
	clang12: 5.6% (± 0.1%)

results0502/html_16K/warm/32K
	gcc11: 8.5% (± 0.2%)
	clang12: 6.7% (± 0.2%)

results0502/html_16K/warm/110K
	gcc11: 8.5% (± 0.7%)
	clang12: 7.8% (± 1.3%)

results0502/html_16K/hot/4K
	gcc11: 5.7% (± 0.1%)
	clang12: 5.5% (± 0.0%)

results0502/html_16K/hot/32K
	gcc11: 8.4% (± 0.1%)
	clang12: 6.3% (± 0.2%)

results0502/html_16K/hot/110K
	gcc11: 8.0% (± 0.1%)
	clang12: 5.9% (± 0.1%)
```

</details>

### Streaming compression
User time numbers are for `zstd <LEVEL> --single-thread /mnt/ramdisk/silesia.tar -o /dev/null`

I used core isolation and disabled turbo. Benchmarking method was roughly “run many many times interleaved, take the lowest number that I’ve seen at least twice for each binary”. Speed variations were around 3% due to background load on the server. 

**Everything is speed AND ratio neutral/positive except fast level 3, which trades 2.7% speed regression for 2.4% ratio improvement** (very good tradeoff IMO). Also worth noting that fast level 2 has a significant ratio improvement for no cost in speed. Fast level 1 has a significant speed improvement but no meaningful change in ratio.

| Level:   | 460780 gcc11           | ac371b gcc11           | 460780 clang12         | ac371b clang12         |
|----------|------------------------|------------------------|------------------------|------------------------|
| -1       | 1.49 (s), 34.69% ratio | 1.41 (s), 34.63% ratio | 1.45 (s), 34.69% ratio | 1.39 (s), 34.63% ratio |
| --fast=1 | 1.35 (s), 41.10% ratio | 1.29 (s), 41.04% ratio | 1.33 (s), 41.10% ratio | 1.27 (s), 41.04% ratio |
| --fast=2 | 1.18 (s), 43.56% ratio | 1.19 (s), 42.68% ratio | 1.17 (s), 43.56% ratio | 1.17 (s), 42.68% ratio |
| --fast=3 | 1.08 (s), 45.77% ratio | 1.11 (s), 44.66% ratio | 1.06 (s), 45.77% ratio | 1.10 (s), 44.66% ratio |

## What didn't work
* **A simpler pipeline with only two positions (ip0/ip1)**. This is what I tried initially, following my DMS pipeline in https://github.com/facebook/zstd/pull/3086. gcc wins were well over 5%, but unfortunately clang speed regressed a few %. I tried a couple approaches to fix the clang regression (documented [here](https://github.com/embg/zstd/pull/16)), but none of them worked. In the end, I decided to rewrite the pipeline closer to @felixhandte's noDict implementation, and this fixed the clang regression.
* **Optimizing backwards match length calculation**. The current implementation calculates backwards match length byte by byte. This creates a ton of branch mispredictions whenever the backwards match length is non-zero. I tried to rewrite this code to look back 8 bytes at a time, reducing branch mispredictions. Unfortunately, the increased overhead seems to have slightly outweighed the benefit from better branch prediction, with speed regressions around 1%. My commits are saved [here](https://github.com/embg/zstd/pull/20).

## Future work
Compression speed could be optimized for cold dictionaries by prefetching the dictionary content starting from dictEnd. The hash table is warm because this is extDict, but in a cold dictionary situation the dictionary content is still cold. I did not pursue this optimization because my code does not have cold dictionary gating. I am not sure how prevalent cold extDict compression is, depending on the prevalence this might be worth pursuing.
