### PR TITLE
meson: for internal linkage, link to both libzstd and a static copy of it

### DIFF
--- a/build/meson/lib/meson.build
+++ b/build/meson/lib/meson.build
@@ -126,6 +126,35 @@ libzstd = library('zstd',
 libzstd_dep = declare_dependency(link_with: libzstd,
   include_directories: libzstd_includes)
 
+# we link to both:
+# - the shared library (for public symbols)
+# - the static library (for private symbols)
+#
+# this is needed because internally private symbols are used all the time, and
+# -fvisibility=hidden means those cannot be found
+if get_option('default_library') == 'static'
+  libzstd_static = libzstd
+  libzstd_internal_dep = libzstd_dep
+else
+  if get_option('default_library') == 'shared'
+    libzstd_static = static_library('zstd_objlib',
+      objects: libzstd.extract_all_objects(recursive: true),
+      build_by_default: false)
+  else
+    libzstd_static = libzstd.get_static_lib()
+  endif
+
+  if cc_id == compiler_msvc
+    # msvc does not actually support linking to both, but errors out with:
+    #   error LNK2005: ZSTD_<foo> already defined in zstd.lib(zstd-1.dll)
+    libzstd_internal_dep = declare_dependency(link_with: libzstd_static)
+  else
+    libzstd_internal_dep = declare_dependency(link_with: libzstd,
+      # the static library must be linked after the shared one
+      dependencies: declare_dependency(link_with: libzstd_static))
+  endif
+endif
+
 pkgconfig.generate(libzstd,
   name: 'libzstd',
   filebase: 'libzstd',

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -19,12 +19,7 @@ zstd_programs_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
   join_paths(zstd_rootdir, 'programs/benchzstd.c'),
   join_paths(zstd_rootdir, 'programs/datagen.c'),
   join_paths(zstd_rootdir, 'programs/dibio.c'),
-  join_paths(zstd_rootdir, 'programs/zstdcli_trace.c'),
-  # needed due to use of private symbol + -fvisibility=hidden
-  join_paths(zstd_rootdir, 'lib/common/xxhash.c'),
-  join_paths(zstd_rootdir, 'lib/common/pool.c'),
-  join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
-  join_paths(zstd_rootdir, 'lib/common/error_private.c')]
+  join_paths(zstd_rootdir, 'programs/zstdcli_trace.c')]
 
 zstd_deps = [ libzstd_dep ]
 zstd_c_args = libzstd_debug_cflags
@@ -75,6 +70,12 @@ zstd = executable('zstd',
   zstd_programs_sources,
   c_args: zstd_c_args,
   dependencies: zstd_deps,
+  # needed due to use of private symbol + -fvisibility=hidden
+  objects: libzstd.extract_objects(
+    join_paths(zstd_rootdir, 'lib/common/xxhash.c'),
+    join_paths(zstd_rootdir, 'lib/common/pool.c'),
+    join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
+    join_paths(zstd_rootdir, 'lib/common/error_private.c')),
   export_dynamic: export_dynamic_on_windows, # Since Meson 0.45.0
   install: true)
 
@@ -82,16 +83,18 @@ zstd_frugal_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
   join_paths(zstd_rootdir, 'programs/timefn.c'),
   join_paths(zstd_rootdir, 'programs/util.c'),
   join_paths(zstd_rootdir, 'programs/fileio.c'),
-  join_paths(zstd_rootdir, 'programs/fileio_asyncio.c'),
-  join_paths(zstd_rootdir, 'lib/common/pool.c'),
-  join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
-  join_paths(zstd_rootdir, 'lib/common/error_private.c')]
+  join_paths(zstd_rootdir, 'programs/fileio_asyncio.c')]
 
 # Minimal target, with only zstd compression and decompression.
 # No bench. No legacy.
 executable('zstd-frugal',
   zstd_frugal_sources,
   dependencies: zstd_frugal_deps,
+  # needed due to use of private symbol + -fvisibility=hidden
+  objects: libzstd.extract_objects(
+    join_paths(zstd_rootdir, 'lib/common/pool.c'),
+    join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
+    join_paths(zstd_rootdir, 'lib/common/error_private.c')),
   c_args: zstd_frugal_c_args,
   install: true)
 

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -21,10 +21,10 @@ zstd_programs_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
   join_paths(zstd_rootdir, 'programs/dibio.c'),
   join_paths(zstd_rootdir, 'programs/zstdcli_trace.c')]
 
-zstd_deps = [ libzstd_dep ]
+zstd_deps = [ libzstd_internal_dep ]
 zstd_c_args = libzstd_debug_cflags
 
-zstd_frugal_deps = [ libzstd_dep ]
+zstd_frugal_deps = [ libzstd_internal_dep ]
 zstd_frugal_c_args = [ '-DZSTD_NOBENCH', '-DZSTD_NODICT', '-DZSTD_NOTRACE' ]
 
 if use_multi_thread
@@ -70,12 +70,6 @@ zstd = executable('zstd',
   zstd_programs_sources,
   c_args: zstd_c_args,
   dependencies: zstd_deps,
-  # needed due to use of private symbol + -fvisibility=hidden
-  objects: libzstd.extract_objects(
-    join_paths(zstd_rootdir, 'lib/common/xxhash.c'),
-    join_paths(zstd_rootdir, 'lib/common/pool.c'),
-    join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
-    join_paths(zstd_rootdir, 'lib/common/error_private.c')),
   export_dynamic: export_dynamic_on_windows, # Since Meson 0.45.0
   install: true)
 
@@ -90,11 +84,6 @@ zstd_frugal_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
 executable('zstd-frugal',
   zstd_frugal_sources,
   dependencies: zstd_frugal_deps,
-  # needed due to use of private symbol + -fvisibility=hidden
-  objects: libzstd.extract_objects(
-    join_paths(zstd_rootdir, 'lib/common/pool.c'),
-    join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
-    join_paths(zstd_rootdir, 'lib/common/error_private.c')),
   c_args: zstd_frugal_c_args,
   install: true)
 

--- a/build/meson/tests/meson.build
+++ b/build/meson/tests/meson.build
@@ -38,7 +38,7 @@ testcommon_sources = [join_paths(zstd_rootdir, 'programs/datagen.c'),
 testcommon = static_library('testcommon',
   testcommon_sources,
   # needed due to use of private symbol + -fvisibility=hidden
-  objects: libzstd.extract_all_objects(recursive: false))
+  link_with: libzstd_static)
 
 testcommon_dep = declare_dependency(link_with: testcommon,
   dependencies: libzstd_deps,

--- a/build/meson/tests/meson.build
+++ b/build/meson/tests/meson.build
@@ -116,11 +116,7 @@ decodecorpus = executable('decodecorpus',
   dependencies: [ testcommon_dep, libm_dep ],
   install: false)
 
-poolTests_sources = [join_paths(zstd_rootdir, 'tests/poolTests.c'),
-  join_paths(zstd_rootdir, 'lib/common/pool.c'),
-  join_paths(zstd_rootdir, 'lib/common/threading.c'),
-  join_paths(zstd_rootdir, 'lib/common/zstd_common.c'),
-  join_paths(zstd_rootdir, 'lib/common/error_private.c')]
+poolTests_sources = [join_paths(zstd_rootdir, 'tests/poolTests.c')]
 poolTests = executable('poolTests',
   poolTests_sources,
   include_directories: test_includes,


### PR DESCRIPTION
Partial, Meson-only implementation of #2976 for non-MSVC builds.

Due to the prevalence of private symbol reuse, linking to a shared library is simply utterly unreliable, but we still want to defer to the shared library for installable applications. By linking to both, we can share symbols where possible, and statically link where needed.

This means we no longer need to manually track every file that needs to be extracted and reused.

The flip side is that MSVC completely does not support this, so for MSVC builds we just link to a full static copy even where -Ddefault_library=shared.

As a side benefit, by using library inclusion rather than including extra explicit object files, the zstd program shrinks in size slightly (~4kb).