### PR TITLE
"Short cache" optimization for level 1-4 DMS (+5-30% compression speed)

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2131,9 +2131,17 @@ static size_t ZSTD_resetCCtx_byCopyingCDict(ZSTD_CCtx* cctx,
                                                             : 0;
         size_t const hSize =  (size_t)1 << cdict_cParams->hashLog;
 
-        ZSTD_memcpy(cctx->blockState.matchState.hashTable,
-               cdict->matchState.hashTable,
-               hSize * sizeof(U32));
+        if (cctx->appliedParams.cParams.strategy == ZSTD_fast){
+            size_t i;
+            for (i=0; i < hSize; i++) {
+                cctx->blockState.matchState.hashTable[i] = cdict->matchState.hashTable[i] >> 8; // TODO make this reference macro
+            }
+        } else {
+            ZSTD_memcpy(cctx->blockState.matchState.hashTable,
+                cdict->matchState.hashTable,
+                hSize * sizeof(U32));
+        }
+
         /* Do not copy cdict's chainTable if cctx has parameters such that it would not use chainTable */
         if (ZSTD_allocateChainTable(cctx->appliedParams.cParams.strategy, cctx->appliedParams.useRowMatchFinder, 0 /* forDDSDict */)) {
             ZSTD_memcpy(cctx->blockState.matchState.chainTable,
@@ -4205,7 +4213,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
                                          ZSTD_cwksp* ws,
                                          ZSTD_CCtx_params const* params,
                                          const void* src, size_t srcSize,
-                                         ZSTD_dictTableLoadMethod_e dtlm)
+                                         ZSTD_dictTableLoadMethod_e dtlm, U32 const forCCtx)
 {
     const BYTE* ip = (const BYTE*) src;
     const BYTE* const iend = ip + srcSize;
@@ -4252,7 +4260,7 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
     switch(params->cParams.strategy)
     {
     case ZSTD_fast:
-        ZSTD_fillHashTable(ms, iend, dtlm);
+        ZSTD_fillHashTable(ms, iend, dtlm, forCCtx);
         break;
     case ZSTD_dfast:
         ZSTD_fillDoubleHashTable(ms, iend, dtlm);
@@ -4421,7 +4429,8 @@ static size_t ZSTD_loadZstdDictionary(ZSTD_compressedBlockState_t* bs,
                                       ZSTD_CCtx_params const* params,
                                       const void* dict, size_t dictSize,
                                       ZSTD_dictTableLoadMethod_e dtlm,
-                                      void* workspace)
+                                      void* workspace,
+                                      U32 const forCCtx)
 {
     const BYTE* dictPtr = (const BYTE*)dict;
     const BYTE* const dictEnd = dictPtr + dictSize;
@@ -4439,7 +4448,7 @@ static size_t ZSTD_loadZstdDictionary(ZSTD_compressedBlockState_t* bs,
     {
         size_t const dictContentSize = (size_t)(dictEnd - dictPtr);
         FORWARD_IF_ERROR(ZSTD_loadDictionaryContent(
-            ms, NULL, ws, params, dictPtr, dictContentSize, dtlm), "");
+            ms, NULL, ws, params, dictPtr, dictContentSize, dtlm, forCCtx), "");
     }
     return dictID;
 }
@@ -4455,7 +4464,8 @@ ZSTD_compress_insertDictionary(ZSTD_compressedBlockState_t* bs,
                          const void* dict, size_t dictSize,
                                ZSTD_dictContentType_e dictContentType,
                                ZSTD_dictTableLoadMethod_e dtlm,
-                               void* workspace)
+                               void* workspace,
+                               U32 const forCCtx)
 {
     DEBUGLOG(4, "ZSTD_compress_insertDictionary (dictSize=%u)", (U32)dictSize);
     if ((dict==NULL) || (dictSize<8)) {
@@ -4467,13 +4477,13 @@ ZSTD_compress_insertDictionary(ZSTD_compressedBlockState_t* bs,
 
     /* dict restricted modes */
     if (dictContentType == ZSTD_dct_rawContent)
-        return ZSTD_loadDictionaryContent(ms, ls, ws, params, dict, dictSize, dtlm);
+        return ZSTD_loadDictionaryContent(ms, ls, ws, params, dict, dictSize, dtlm, forCCtx);
 
     if (MEM_readLE32(dict) != ZSTD_MAGIC_DICTIONARY) {
         if (dictContentType == ZSTD_dct_auto) {
             DEBUGLOG(4, "raw content dictionary detected");
             return ZSTD_loadDictionaryContent(
-                ms, ls, ws, params, dict, dictSize, dtlm);
+                ms, ls, ws, params, dict, dictSize, dtlm, forCCtx);
         }
         RETURN_ERROR_IF(dictContentType == ZSTD_dct_fullDict, dictionary_wrong, "");
         assert(0);   /* impossible */
@@ -4481,7 +4491,7 @@ ZSTD_compress_insertDictionary(ZSTD_compressedBlockState_t* bs,
 
     /* dict as full zstd dictionary */
     return ZSTD_loadZstdDictionary(
-        bs, ms, ws, params, dict, dictSize, dtlm, workspace);
+        bs, ms, ws, params, dict, dictSize, dtlm, workspace, forCCtx);
 }
 
 #define ZSTD_USE_CDICT_PARAMS_SRCSIZE_CUTOFF (128 KB)
@@ -4524,11 +4534,11 @@ static size_t ZSTD_compressBegin_internal(ZSTD_CCtx* cctx,
                         cctx->blockState.prevCBlock, &cctx->blockState.matchState,
                         &cctx->ldmState, &cctx->workspace, &cctx->appliedParams, cdict->dictContent,
                         cdict->dictContentSize, cdict->dictContentType, dtlm,
-                        cctx->entropyWorkspace)
+                        cctx->entropyWorkspace, 1)
               : ZSTD_compress_insertDictionary(
                         cctx->blockState.prevCBlock, &cctx->blockState.matchState,
                         &cctx->ldmState, &cctx->workspace, &cctx->appliedParams, dict, dictSize,
-                        dictContentType, dtlm, cctx->entropyWorkspace);
+                        dictContentType, dtlm, cctx->entropyWorkspace, 1);
         FORWARD_IF_ERROR(dictID, "ZSTD_compress_insertDictionary failed");
         assert(dictID <= UINT_MAX);
         cctx->dictID = (U32)dictID;
@@ -4832,7 +4842,8 @@ static size_t ZSTD_initCDict_internal(
         {   size_t const dictID = ZSTD_compress_insertDictionary(
                     &cdict->cBlockState, &cdict->matchState, NULL, &cdict->workspace,
                     &params, cdict->dictContent, cdict->dictContentSize,
-                    dictContentType, ZSTD_dtlm_full, cdict->entropyWorkspace);
+                    dictContentType, ZSTD_dtlm_full, cdict->entropyWorkspace,
+                    params.cParams.strategy == ZSTD_fast ? 0 : 1);
             FORWARD_IF_ERROR(dictID, "ZSTD_compress_insertDictionary failed");
             assert(dictID <= (size_t)(U32)-1);
             cdict->dictID = (U32)dictID;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4842,8 +4842,7 @@ static size_t ZSTD_initCDict_internal(
         {   size_t const dictID = ZSTD_compress_insertDictionary(
                     &cdict->cBlockState, &cdict->matchState, NULL, &cdict->workspace,
                     &params, cdict->dictContent, cdict->dictContentSize,
-                    dictContentType, ZSTD_dtlm_full, cdict->entropyWorkspace,
-                    params.cParams.strategy == ZSTD_fast ? 0 : 1);
+                    dictContentType, ZSTD_dtlm_full, cdict->entropyWorkspace, 0);
             FORWARD_IF_ERROR(dictID, "ZSTD_compress_insertDictionary failed");
             assert(dictID <= (size_t)(U32)-1);
             cdict->dictID = (U32)dictID;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4228,7 +4228,8 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
                                          ZSTD_cwksp* ws,
                                          ZSTD_CCtx_params const* params,
                                          const void* src, size_t srcSize,
-                                         ZSTD_dictTableLoadMethod_e dtlm, U32 const forCCtx)
+                                         ZSTD_dictTableLoadMethod_e dtlm,
+                                         ZSTD_tableFillPurpose_e tfp)
 {
     const BYTE* ip = (const BYTE*) src;
     const BYTE* const iend = ip + srcSize;
@@ -4275,10 +4276,10 @@ static size_t ZSTD_loadDictionaryContent(ZSTD_matchState_t* ms,
     switch(params->cParams.strategy)
     {
     case ZSTD_fast:
-        ZSTD_fillHashTable(ms, iend, dtlm, forCCtx);
+        ZSTD_fillHashTable(ms, iend, dtlm, tfp);
         break;
     case ZSTD_dfast:
-        ZSTD_fillDoubleHashTable(ms, iend, dtlm, forCCtx);
+        ZSTD_fillDoubleHashTable(ms, iend, dtlm, tfp);
         break;
 
     case ZSTD_greedy:
@@ -4445,7 +4446,7 @@ static size_t ZSTD_loadZstdDictionary(ZSTD_compressedBlockState_t* bs,
                                       const void* dict, size_t dictSize,
                                       ZSTD_dictTableLoadMethod_e dtlm,
                                       void* workspace,
-                                      U32 const forCCtx)
+                                      ZSTD_tableFillPurpose_e tfp)
 {
     const BYTE* dictPtr = (const BYTE*)dict;
     const BYTE* const dictEnd = dictPtr + dictSize;
@@ -4463,7 +4464,7 @@ static size_t ZSTD_loadZstdDictionary(ZSTD_compressedBlockState_t* bs,
     {
         size_t const dictContentSize = (size_t)(dictEnd - dictPtr);
         FORWARD_IF_ERROR(ZSTD_loadDictionaryContent(
-            ms, NULL, ws, params, dictPtr, dictContentSize, dtlm, forCCtx), "");
+            ms, NULL, ws, params, dictPtr, dictContentSize, dtlm, tfp), "");
     }
     return dictID;
 }
@@ -4480,7 +4481,7 @@ ZSTD_compress_insertDictionary(ZSTD_compressedBlockState_t* bs,
                                ZSTD_dictContentType_e dictContentType,
                                ZSTD_dictTableLoadMethod_e dtlm,
                                void* workspace,
-                               U32 const forCCtx)
+                               ZSTD_tableFillPurpose_e tfp)
 {
     DEBUGLOG(4, "ZSTD_compress_insertDictionary (dictSize=%u)", (U32)dictSize);
     if ((dict==NULL) || (dictSize<8)) {
@@ -4492,13 +4493,13 @@ ZSTD_compress_insertDictionary(ZSTD_compressedBlockState_t* bs,
 
     /* dict restricted modes */
     if (dictContentType == ZSTD_dct_rawContent)
-        return ZSTD_loadDictionaryContent(ms, ls, ws, params, dict, dictSize, dtlm, forCCtx);
+        return ZSTD_loadDictionaryContent(ms, ls, ws, params, dict, dictSize, dtlm, tfp);
 
     if (MEM_readLE32(dict) != ZSTD_MAGIC_DICTIONARY) {
         if (dictContentType == ZSTD_dct_auto) {
             DEBUGLOG(4, "raw content dictionary detected");
             return ZSTD_loadDictionaryContent(
-                ms, ls, ws, params, dict, dictSize, dtlm, forCCtx);
+                ms, ls, ws, params, dict, dictSize, dtlm, tfp);
         }
         RETURN_ERROR_IF(dictContentType == ZSTD_dct_fullDict, dictionary_wrong, "");
         assert(0);   /* impossible */
@@ -4506,7 +4507,7 @@ ZSTD_compress_insertDictionary(ZSTD_compressedBlockState_t* bs,
 
     /* dict as full zstd dictionary */
     return ZSTD_loadZstdDictionary(
-        bs, ms, ws, params, dict, dictSize, dtlm, workspace, forCCtx);
+        bs, ms, ws, params, dict, dictSize, dtlm, workspace, tfp);
 }
 
 #define ZSTD_USE_CDICT_PARAMS_SRCSIZE_CUTOFF (128 KB)
@@ -4549,11 +4550,11 @@ static size_t ZSTD_compressBegin_internal(ZSTD_CCtx* cctx,
                         cctx->blockState.prevCBlock, &cctx->blockState.matchState,
                         &cctx->ldmState, &cctx->workspace, &cctx->appliedParams, cdict->dictContent,
                         cdict->dictContentSize, cdict->dictContentType, dtlm,
-                        cctx->entropyWorkspace, 1)
+                        cctx->entropyWorkspace, ZSTD_tfp_forCCtx)
               : ZSTD_compress_insertDictionary(
                         cctx->blockState.prevCBlock, &cctx->blockState.matchState,
                         &cctx->ldmState, &cctx->workspace, &cctx->appliedParams, dict, dictSize,
-                        dictContentType, dtlm, cctx->entropyWorkspace, 1);
+                        dictContentType, dtlm, cctx->entropyWorkspace, ZSTD_tfp_forCCtx);
         FORWARD_IF_ERROR(dictID, "ZSTD_compress_insertDictionary failed");
         assert(dictID <= UINT_MAX);
         cctx->dictID = (U32)dictID;
@@ -4857,7 +4858,7 @@ static size_t ZSTD_initCDict_internal(
         {   size_t const dictID = ZSTD_compress_insertDictionary(
                     &cdict->cBlockState, &cdict->matchState, NULL, &cdict->workspace,
                     &params, cdict->dictContent, cdict->dictContentSize,
-                    dictContentType, ZSTD_dtlm_full, cdict->entropyWorkspace, 0);
+                    dictContentType, ZSTD_dtlm_full, cdict->entropyWorkspace, ZSTD_tfp_forCDict);
             FORWARD_IF_ERROR(dictID, "ZSTD_compress_insertDictionary failed");
             assert(dictID <= (size_t)(U32)-1);
             cdict->dictID = (U32)dictID;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1373,6 +1373,13 @@ ZSTD_adjustCParams_internal(ZSTD_compressionParameters cPar,
     if (cPar.windowLog < ZSTD_WINDOWLOG_ABSOLUTEMIN)
         cPar.windowLog = ZSTD_WINDOWLOG_ABSOLUTEMIN;  /* minimum wlog required for valid frame header */
 
+    if (mode == ZSTD_cpm_createCDict && ZSTD_CDictIndicesAreTagged(&cPar)) {
+        U32 const maxShortCacheHashLog = 32 - ZSTD_SHORT_CACHE_TAG_BITS;
+        if (cPar.hashLog > maxShortCacheHashLog) {
+            cPar.hashLog = maxShortCacheHashLog;
+        }
+    }
+
     return cPar;
 }
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -745,27 +745,27 @@ ZSTD_count_2segments(const BYTE* ip, const BYTE* match,
  *  Hashes
  ***************************************/
 static const U32 prime3bytes = 506832829U;
-static U32    ZSTD_hash3(U32 u, U32 h) { return ((u << (32-24)) * prime3bytes)  >> (32-h) ; }
+static U32    ZSTD_hash3(U32 u, U32 h) { assert(h <= 32); return ((u << (32-24)) * prime3bytes)  >> (32-h) ; }
 MEM_STATIC size_t ZSTD_hash3Ptr(const void* ptr, U32 h) { return ZSTD_hash3(MEM_readLE32(ptr), h); } /* only in zstd_opt.h */
 
 static const U32 prime4bytes = 2654435761U;
-static U32    ZSTD_hash4(U32 u, U32 h) { return (u * prime4bytes) >> (32-h) ; }
+static U32    ZSTD_hash4(U32 u, U32 h) { assert(h <= 32); return (u * prime4bytes) >> (32-h) ; }
 static size_t ZSTD_hash4Ptr(const void* ptr, U32 h) { return ZSTD_hash4(MEM_read32(ptr), h); }
 
 static const U64 prime5bytes = 889523592379ULL;
-static size_t ZSTD_hash5(U64 u, U32 h) { return (size_t)(((u  << (64-40)) * prime5bytes) >> (64-h)) ; }
+static size_t ZSTD_hash5(U64 u, U32 h) { assert(h <= 64); return (size_t)(((u  << (64-40)) * prime5bytes) >> (64-h)) ; }
 static size_t ZSTD_hash5Ptr(const void* p, U32 h) { return ZSTD_hash5(MEM_readLE64(p), h); }
 
 static const U64 prime6bytes = 227718039650203ULL;
-static size_t ZSTD_hash6(U64 u, U32 h) { return (size_t)(((u  << (64-48)) * prime6bytes) >> (64-h)) ; }
+static size_t ZSTD_hash6(U64 u, U32 h) { assert(h <= 64); return (size_t)(((u  << (64-48)) * prime6bytes) >> (64-h)) ; }
 static size_t ZSTD_hash6Ptr(const void* p, U32 h) { return ZSTD_hash6(MEM_readLE64(p), h); }
 
 static const U64 prime7bytes = 58295818150454627ULL;
-static size_t ZSTD_hash7(U64 u, U32 h) { return (size_t)(((u  << (64-56)) * prime7bytes) >> (64-h)) ; }
+static size_t ZSTD_hash7(U64 u, U32 h) { assert(h <= 64); return (size_t)(((u  << (64-56)) * prime7bytes) >> (64-h)) ; }
 static size_t ZSTD_hash7Ptr(const void* p, U32 h) { return ZSTD_hash7(MEM_readLE64(p), h); }
 
 static const U64 prime8bytes = 0xCF1BBCDCB7A56463ULL;
-static size_t ZSTD_hash8(U64 u, U32 h) { return (size_t)(((u) * prime8bytes) >> (64-h)) ; }
+static size_t ZSTD_hash8(U64 u, U32 h) { assert(h <= 64); return (size_t)(((u) * prime8bytes) >> (64-h)) ; }
 static size_t ZSTD_hash8Ptr(const void* p, U32 h) { return ZSTD_hash8(MEM_readLE64(p), h); }
 
 MEM_STATIC FORCE_INLINE_ATTR

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1264,6 +1264,16 @@ MEM_STATIC void ZSTD_debugTable(const U32* table, U32 max)
 
 #endif
 
+#define ZSTD_SHORT_CACHE_TAG_BITS 8
+#define ZSTD_SHORT_CACHE_TAG_MASK ((1u << ZSTD_SHORT_CACHE_TAG_BITS) - 1)
+
+/* Helper function for ZSTD_fillHashTable and ZSTD_fillDoubleHashTable */
+MEM_STATIC void writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U32 index) {
+    size_t const hash = hashAndTag >> ZSTD_SHORT_CACHE_TAG_BITS;
+    U32 const tag = (U32)(hashAndTag & ZSTD_SHORT_CACHE_TAG_MASK);
+    assert(index >> (32 - ZSTD_SHORT_CACHE_TAG_BITS) == 0);
+    hashTable[hash] = (index << ZSTD_SHORT_CACHE_TAG_BITS) | tag;
+}
 
 #if defined (__cplusplus)
 }

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1264,6 +1264,14 @@ MEM_STATIC void ZSTD_debugTable(const U32* table, U32 max)
 
 #endif
 
+/* Short Cache */
+
+typedef enum {
+    /* TODO: this is a good place to document short cache */
+    ZSTD_tfp_forCCtx = 0,
+    ZSTD_tfp_forCDict = 1
+} ZSTD_tableFillPurpose_e;
+
 #define ZSTD_SHORT_CACHE_TAG_BITS 8
 #define ZSTD_SHORT_CACHE_TAG_MASK ((1u << ZSTD_SHORT_CACHE_TAG_BITS) - 1)
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1277,8 +1277,8 @@ MEM_STATIC void ZSTD_debugTable(const U32* table, U32 max)
  *     3. Check if *ip == *(base + index)
  * In dictionary compression, loading *(base + index) is often an L2 or even L3 miss.
  *
- * Short cache is an optimization which allows us to avoid step 3 most of the time.
- * With short cache, the flow becomes:
+ * Short cache is an optimization which allows us to avoid step 3 most of the time
+ * when the data doesn't actually match. With short cache, the flow becomes:
  *     1. Compute (hash, currentTag) at ip. currentTag is an 8-bit independent hash at ip.
  *     2. Load (index, matchTag) from hashTable[hash]. See ZSTD_writeTaggedIndex to understand how this works.
  *     3. Only if currentTag == matchTag, check *ip == *(base + index). Otherwise, continue.

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1289,8 +1289,8 @@ MEM_STATIC void ZSTD_writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U
 
 /* Helper function for short cache matchfinders */
 MEM_STATIC int ZSTD_comparePackedTags(size_t packedTag1, size_t packedTag2) {
-    U32 tag1 = packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK;
-    U32 tag2 = packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK;
+    U32 const tag1 = packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK;
+    U32 const tag2 = packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK;
     return tag1 == tag2;
 }
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1287,6 +1287,13 @@ MEM_STATIC void ZSTD_writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U
     hashTable[hash] = (index << ZSTD_SHORT_CACHE_TAG_BITS) | tag;
 }
 
+/* Helper function for short cache matchfinders */
+MEM_STATIC int ZSTD_comparePackedTags(size_t packedTag1, size_t packedTag2) {
+    U32 tag1 = packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK;
+    U32 tag2 = packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK;
+    return tag1 == tag2;
+}
+
 #if defined (__cplusplus)
 }
 #endif

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1276,7 +1276,8 @@ MEM_STATIC void ZSTD_debugTable(const U32* table, U32 max)
 #define ZSTD_SHORT_CACHE_TAG_BITS 8
 #define ZSTD_SHORT_CACHE_TAG_MASK ((1u << ZSTD_SHORT_CACHE_TAG_BITS) - 1)
 
-/* Helper function for ZSTD_fillHashTable and ZSTD_fillDoubleHashTable */
+/* Helper function for ZSTD_fillHashTable and ZSTD_fillDoubleHashTable.
+ * Unpacks hashAndTag into (hash, tag), then packs (index, tag) into hashTable[hash]. */
 MEM_STATIC void ZSTD_writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U32 index) {
     size_t const hash = hashAndTag >> ZSTD_SHORT_CACHE_TAG_BITS;
     U32 const tag = (U32)(hashAndTag & ZSTD_SHORT_CACHE_TAG_MASK);
@@ -1284,7 +1285,8 @@ MEM_STATIC void ZSTD_writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U
     hashTable[hash] = (index << ZSTD_SHORT_CACHE_TAG_BITS) | tag;
 }
 
-/* Helper function for short cache matchfinders */
+/* Helper function for short cache matchfinders.
+ * Unpacks tag1 and tag2 from lower bits of packedTag1 and packedTag2, then checks if the tags match. */
 MEM_STATIC int ZSTD_comparePackedTags(size_t packedTag1, size_t packedTag2) {
     U32 const tag1 = packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK;
     U32 const tag2 = packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -771,6 +771,10 @@ static size_t ZSTD_hash8Ptr(const void* p, U32 h) { return ZSTD_hash8(MEM_readLE
 MEM_STATIC FORCE_INLINE_ATTR
 size_t ZSTD_hashPtr(const void* p, U32 hBits, U32 mls)
 {
+    /* Although some of these hashes do support hBits up to 64, some do not.
+     * To be on the safe side, always avoid hBits > 32. */
+    assert(hBits <= 32);
+
     switch(mls)
     {
     default:
@@ -1276,7 +1280,7 @@ typedef enum {
 #define ZSTD_SHORT_CACHE_TAG_MASK ((1u << ZSTD_SHORT_CACHE_TAG_BITS) - 1)
 
 /* Helper function for ZSTD_fillHashTable and ZSTD_fillDoubleHashTable */
-MEM_STATIC void writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U32 index) {
+MEM_STATIC void ZSTD_writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U32 index) {
     size_t const hash = hashAndTag >> ZSTD_SHORT_CACHE_TAG_BITS;
     U32 const tag = (U32)(hashAndTag & ZSTD_SHORT_CACHE_TAG_MASK);
     assert(index >> (32 - ZSTD_SHORT_CACHE_TAG_BITS) == 0);

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -434,6 +434,7 @@ struct ZSTD_CCtx_s {
 };
 
 typedef enum { ZSTD_dtlm_fast, ZSTD_dtlm_full } ZSTD_dictTableLoadMethod_e;
+typedef enum { ZSTD_tfp_forCCtx, ZSTD_tfp_forCDict } ZSTD_tableFillPurpose_e;
 
 typedef enum {
     ZSTD_noDict = 0,
@@ -1270,11 +1271,7 @@ MEM_STATIC void ZSTD_debugTable(const U32* table, U32 max)
 
 /* Short Cache */
 
-typedef enum {
-    /* TODO: this is a good place to document short cache */
-    ZSTD_tfp_forCCtx = 0,
-    ZSTD_tfp_forCDict = 1
-} ZSTD_tableFillPurpose_e;
+/* TODO: this is a good place to document short cache */
 
 #define ZSTD_SHORT_CACHE_TAG_BITS 8
 #define ZSTD_SHORT_CACHE_TAG_MASK ((1u << ZSTD_SHORT_CACHE_TAG_BITS) - 1)

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -11,6 +11,16 @@
 #include "zstd_compress_internal.h"
 #include "zstd_double_fast.h"
 
+#define ZSTD_DFAST_TAG_BITS 8
+#define ZSTD_DFAST_TAG_MASK ((1u << ZSTD_DFAST_TAG_BITS) - 1)
+
+MEM_STATIC FORCE_INLINE_ATTR
+void writeTaggedIndex(U32* const hashTable, size_t hashAndTag, U32 index) {
+    size_t const hash = hashAndTag >> ZSTD_DFAST_TAG_BITS;
+    U32 const tag = (U32)(hashAndTag & ZSTD_DFAST_TAG_MASK);
+    assert(index >> (32 - ZSTD_DFAST_TAG_BITS) == 0);
+    hashTable[hash] = (index << ZSTD_DFAST_TAG_BITS) | tag;
+}
 
 void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
                               void const* end, ZSTD_dictTableLoadMethod_e dtlm)
@@ -23,7 +33,7 @@ void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
     U32  const hBitsS = cParams->chainLog;
     const BYTE* const base = ms->window.base;
     const BYTE* ip = base + ms->nextToUpdate;
-    const BYTE* const iend = ((const BYTE*)end) - HASH_READ_SIZE;
+    const BYTE* const iend = MIN((const BYTE*)end, base + (1u << (32 - ZSTD_DFAST_TAG_BITS))) - HASH_READ_SIZE;
     const U32 fastHashFillStep = 3;
 
     /* Always insert every fastHashFillStep position into the hash tables.
@@ -34,12 +44,14 @@ void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
         U32 const curr = (U32)(ip - base);
         U32 i;
         for (i = 0; i < fastHashFillStep; ++i) {
-            size_t const smHash = ZSTD_hashPtr(ip + i, hBitsS, mls);
-            size_t const lgHash = ZSTD_hashPtr(ip + i, hBitsL, 8);
-            if (i == 0)
-                hashSmall[smHash] = curr + i;
-            if (i == 0 || hashLarge[lgHash] == 0)
-                hashLarge[lgHash] = curr + i;
+            size_t const smHashAndTag = ZSTD_hashPtr(ip + i, hBitsS + ZSTD_DFAST_TAG_BITS, mls);
+            size_t const lgHashAndTag = ZSTD_hashPtr(ip + i, hBitsL + ZSTD_DFAST_TAG_BITS, 8);
+            if (i == 0) {
+                writeTaggedIndex(hashSmall, smHashAndTag, curr + i);
+            }
+            if (i == 0 || hashLarge[lgHashAndTag >> ZSTD_DFAST_TAG_BITS] == 0) {
+                writeTaggedIndex(hashLarge, lgHashAndTag, curr + i);
+            }
             /* Only load extra positions for ZSTD_dtlm_full */
             if (dtlm == ZSTD_dtlm_fast)
                 break;

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -84,12 +84,12 @@ static void ZSTD_fillDoubleHashTableForCCtx(ZSTD_matchState_t* ms,
 void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
                         const void* const end,
                         ZSTD_dictTableLoadMethod_e dtlm,
-                        const U32 forCCtx) // TODO enum
+                        ZSTD_tableFillPurpose_e tfp)
 {
-    if (forCCtx) {
-        ZSTD_fillDoubleHashTableForCCtx(ms, end, dtlm);
-    } else {
+    if (tfp == ZSTD_tfp_forCDict) {
         ZSTD_fillDoubleHashTableForCDict(ms, end, dtlm);
+    } else {
+        ZSTD_fillDoubleHashTableForCCtx(ms, end, dtlm);
     }
 }
 

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -363,8 +363,8 @@ size_t ZSTD_compressBlock_doubleFast_dictMatchState_generic(
         size_t const dictHashAndTagS = ZSTD_hashPtr(ip, dictHBitsS, mls);
         U32 const dictMatchIndexAndTagL = dictHashLong[dictHashAndTagL >> ZSTD_SHORT_CACHE_TAG_BITS];
         U32 const dictMatchIndexAndTagS = dictHashSmall[dictHashAndTagS >> ZSTD_SHORT_CACHE_TAG_BITS];
-        size_t const dictTagsMatchL = (dictMatchIndexAndTagL & ZSTD_SHORT_CACHE_TAG_MASK) == (dictHashAndTagL & ZSTD_SHORT_CACHE_TAG_MASK);
-        size_t const dictTagsMatchS = (dictMatchIndexAndTagS & ZSTD_SHORT_CACHE_TAG_MASK) == (dictHashAndTagS & ZSTD_SHORT_CACHE_TAG_MASK);
+        size_t const dictTagsMatchL = ZSTD_comparePackedTags(dictMatchIndexAndTagL, dictHashAndTagL);
+        size_t const dictTagsMatchS = ZSTD_comparePackedTags(dictMatchIndexAndTagS, dictHashAndTagS);
         U32 const curr = (U32)(ip-base);
         U32 const matchIndexL = hashLong[h2];
         U32 matchIndexS = hashSmall[h];
@@ -433,7 +433,7 @@ _search_next_long:
             size_t const dictHashAndTagL3 = ZSTD_hashPtr(ip+1, dictHBitsL, 8);
             U32 const matchIndexL3 = hashLong[hl3];
             U32 const dictMatchIndexAndTagL3 = dictHashLong[dictHashAndTagL3 >> ZSTD_SHORT_CACHE_TAG_BITS];
-            size_t const dictTagsMatchL3 = (dictMatchIndexAndTagL3 & ZSTD_SHORT_CACHE_TAG_BITS) == (dictHashAndTagL3 & ZSTD_SHORT_CACHE_TAG_BITS);
+            size_t const dictTagsMatchL3 = ZSTD_comparePackedTags(dictMatchIndexAndTagL3, dictHashAndTagL3);
             const BYTE* matchL3 = base + matchIndexL3;
             hashLong[hl3] = curr + 1;
 

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -363,8 +363,8 @@ size_t ZSTD_compressBlock_doubleFast_dictMatchState_generic(
         size_t const dictHashAndTagS = ZSTD_hashPtr(ip, dictHBitsS, mls);
         U32 const dictMatchIndexAndTagL = dictHashLong[dictHashAndTagL >> ZSTD_SHORT_CACHE_TAG_BITS];
         U32 const dictMatchIndexAndTagS = dictHashSmall[dictHashAndTagS >> ZSTD_SHORT_CACHE_TAG_BITS];
-        size_t const dictTagsMatchL = ZSTD_comparePackedTags(dictMatchIndexAndTagL, dictHashAndTagL);
-        size_t const dictTagsMatchS = ZSTD_comparePackedTags(dictMatchIndexAndTagS, dictHashAndTagS);
+        int const dictTagsMatchL = ZSTD_comparePackedTags(dictMatchIndexAndTagL, dictHashAndTagL);
+        int const dictTagsMatchS = ZSTD_comparePackedTags(dictMatchIndexAndTagS, dictHashAndTagS);
         U32 const curr = (U32)(ip-base);
         U32 const matchIndexL = hashLong[h2];
         U32 matchIndexS = hashSmall[h];
@@ -433,7 +433,7 @@ _search_next_long:
             size_t const dictHashAndTagL3 = ZSTD_hashPtr(ip+1, dictHBitsL, 8);
             U32 const matchIndexL3 = hashLong[hl3];
             U32 const dictMatchIndexAndTagL3 = dictHashLong[dictHashAndTagL3 >> ZSTD_SHORT_CACHE_TAG_BITS];
-            size_t const dictTagsMatchL3 = ZSTD_comparePackedTags(dictMatchIndexAndTagL3, dictHashAndTagL3);
+            int const dictTagsMatchL3 = ZSTD_comparePackedTags(dictMatchIndexAndTagL3, dictHashAndTagL3);
             const BYTE* matchL3 = base + matchIndexL3;
             hashLong[hl3] = curr + 1;
 

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -36,10 +36,10 @@ static void ZSTD_fillDoubleHashTableForCDict(ZSTD_matchState_t* ms,
             size_t const smHashAndTag = ZSTD_hashPtr(ip + i, hBitsS, mls);
             size_t const lgHashAndTag = ZSTD_hashPtr(ip + i, hBitsL, 8);
             if (i == 0) {
-                writeTaggedIndex(hashSmall, smHashAndTag, curr + i);
+                ZSTD_writeTaggedIndex(hashSmall, smHashAndTag, curr + i);
             }
             if (i == 0 || hashLarge[lgHashAndTag >> ZSTD_SHORT_CACHE_TAG_BITS] == 0) {
-                writeTaggedIndex(hashLarge, lgHashAndTag, curr + i);
+                ZSTD_writeTaggedIndex(hashLarge, lgHashAndTag, curr + i);
             }
             /* Only load extra positions for ZSTD_dtlm_full */
             if (dtlm == ZSTD_dtlm_fast)

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -22,7 +22,7 @@ static void ZSTD_fillDoubleHashTableForCDict(ZSTD_matchState_t* ms,
     U32  const hBitsS = cParams->chainLog + ZSTD_SHORT_CACHE_TAG_BITS;
     const BYTE* const base = ms->window.base;
     const BYTE* ip = base + ms->nextToUpdate;
-    const BYTE* const iend = MIN((const BYTE*)end, base + (1u << (32 - ZSTD_SHORT_CACHE_TAG_BITS))) - HASH_READ_SIZE;
+    const BYTE* const iend = ((const BYTE*)end) - HASH_READ_SIZE;
     const U32 fastHashFillStep = 3;
 
     /* Always insert every fastHashFillStep position into the hash tables.

--- a/lib/compress/zstd_double_fast.h
+++ b/lib/compress/zstd_double_fast.h
@@ -19,7 +19,7 @@ extern "C" {
 #include "zstd_compress_internal.h"     /* ZSTD_CCtx, size_t */
 
 void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
-                              void const* end, ZSTD_dictTableLoadMethod_e dtlm);
+                              void const* end, ZSTD_dictTableLoadMethod_e dtlm, const U32 forCCtx);
 size_t ZSTD_compressBlock_doubleFast(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize);

--- a/lib/compress/zstd_double_fast.h
+++ b/lib/compress/zstd_double_fast.h
@@ -19,7 +19,8 @@ extern "C" {
 #include "zstd_compress_internal.h"     /* ZSTD_CCtx, size_t */
 
 void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
-                              void const* end, ZSTD_dictTableLoadMethod_e dtlm, const U32 forCCtx);
+                              void const* end, ZSTD_dictTableLoadMethod_e dtlm,
+                              ZSTD_tableFillPurpose_e tfp);
 size_t ZSTD_compressBlock_doubleFast(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize);

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -505,27 +505,33 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
                 ip0++;
                 ZSTD_storeSeq(seqStore, (size_t) (ip0 - anchor), anchor, iend, REPCODE1_TO_OFFBASE, mLength);
                 break;
-            } else if ((matchIndex <= prefixStartIndex) & (dictMatchTag == currTag)) {
+            }
+
+            if (dictMatchTag == currTag) {
                 /* We only look for a dict match if the normal matchIndex is invalid */
                 const BYTE* dictMatch = dictBase + dictMatchIndex;
 //                TODO size_t const currTag = dictHashAndTag1 & ZSTD_FAST_TAG_BITS; TODO
                 if (dictMatchIndex > dictStartIndex &&
                     MEM_read32(dictMatch) == MEM_read32(ip0)) {
-                    /* found a dict match */
-                    U32 const offset = (U32) (curr - dictMatchIndex - dictIndexDelta);
-                    mLength = ZSTD_count_2segments(ip0 + 4, dictMatch + 4, iend, dictEnd, prefixStart) + 4;
-                    while (((ip0 > anchor) & (dictMatch > dictStart))
-                           && (ip0[-1] == dictMatch[-1])) {
-                        ip0--;
-                        dictMatch--;
-                        mLength++;
-                    } /* catch up */
-                    offset_2 = offset_1;
-                    offset_1 = offset;
-                    ZSTD_storeSeq(seqStore, (size_t) (ip0 - anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
-                    break;
+                    if (matchIndex <= prefixStartIndex) {
+                        /* found a dict match */
+                        U32 const offset = (U32) (curr - dictMatchIndex - dictIndexDelta);
+                        mLength = ZSTD_count_2segments(ip0 + 4, dictMatch + 4, iend, dictEnd, prefixStart) + 4;
+                        while (((ip0 > anchor) & (dictMatch > dictStart))
+                            && (ip0[-1] == dictMatch[-1])) {
+                            ip0--;
+                            dictMatch--;
+                            mLength++;
+                        } /* catch up */
+                        offset_2 = offset_1;
+                        offset_1 = offset;
+                        ZSTD_storeSeq(seqStore, (size_t) (ip0 - anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
+                        break;
+                    }
                 }
-            } else if (matchIndex > prefixStartIndex && MEM_read32(match) == MEM_read32(ip0)) {
+            }
+
+            if (matchIndex > prefixStartIndex && MEM_read32(match) == MEM_read32(ip0)) {
                 /* found a regular match */
                 U32 const offset = (U32) (ip0 - match);
                 mLength = ZSTD_count(ip0 + 4, match + 4, iend) + 4;

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -476,9 +476,8 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
         size_t hash0 = ZSTD_hashPtr(ip0, hlog, mls);
 
         size_t const dictHashAndTag0 = ZSTD_hashPtr(ip0, dictHLog + ZSTD_FAST_TAG_BITS, mls);
-        U32 dictMatchIndex = dictHashTable[dictHashAndTag0 >> ZSTD_FAST_TAG_BITS] >> ZSTD_FAST_TAG_BITS;
-        U32 dictMatchTag = dictHashTable[dictHashAndTag0 >> ZSTD_FAST_TAG_BITS] & ZSTD_FAST_TAG_MASK;
-        size_t currTag = dictHashAndTag0 & ZSTD_FAST_TAG_MASK;
+        U32 dictMatchIndexAndTag = dictHashTable[dictHashAndTag0 >> ZSTD_FAST_TAG_BITS];
+        size_t dictTagsMatch = (dictMatchIndexAndTag & ZSTD_FAST_TAG_MASK) == (dictHashAndTag0 & ZSTD_FAST_TAG_MASK);
 
         U32 matchIndex = hashTable[hash0];
         U32 curr = (U32)(ip0 - base);
@@ -507,8 +506,9 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
                 break;
             }
 
-            if (dictMatchTag == currTag) {
+            if (dictTagsMatch) {
                 /* found a possible dict match */
+                const U32 dictMatchIndex = dictMatchIndexAndTag >> ZSTD_FAST_TAG_BITS;
                 const BYTE* dictMatch = dictBase + dictMatchIndex;
                 if (dictMatchIndex > dictStartIndex &&
                     MEM_read32(dictMatch) == MEM_read32(ip0)) {
@@ -547,9 +547,8 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
             }
 
             /* Prepare for next iteration */
-            dictMatchIndex = dictHashTable[dictHashAndTag1 >> ZSTD_FAST_TAG_BITS] >> ZSTD_FAST_TAG_BITS;
-            dictMatchTag = dictHashTable[dictHashAndTag1 >> ZSTD_FAST_TAG_BITS] & ZSTD_FAST_TAG_MASK;
-            currTag = dictHashAndTag1 & ZSTD_FAST_TAG_MASK;
+            dictMatchIndexAndTag = dictHashTable[dictHashAndTag1 >> ZSTD_FAST_TAG_BITS];
+            dictTagsMatch = (dictMatchIndexAndTag & ZSTD_FAST_TAG_MASK) == (dictHashAndTag1 & ZSTD_FAST_TAG_MASK);
             matchIndex = hashTable[hash1];
 
             if (ip1 >= nextStep) {

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -505,11 +505,11 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
                 ip0++;
                 ZSTD_storeSeq(seqStore, (size_t) (ip0 - anchor), anchor, iend, REPCODE1_TO_OFFBASE, mLength);
                 break;
-            } else if (matchIndex <= prefixStartIndex) {
+            } else if ((matchIndex <= prefixStartIndex) & (dictMatchTag == currTag)) {
                 /* We only look for a dict match if the normal matchIndex is invalid */
                 const BYTE* dictMatch = dictBase + dictMatchIndex;
 //                TODO size_t const currTag = dictHashAndTag1 & ZSTD_FAST_TAG_BITS; TODO
-                if (( (dictMatchIndex > dictStartIndex) & (dictMatchTag == currTag) ) &&
+                if (dictMatchIndex > dictStartIndex &&
                     MEM_read32(dictMatch) == MEM_read32(ip0)) {
                     /* found a dict match */
                     U32 const offset = (U32) (curr - dictMatchIndex - dictIndexDelta);
@@ -525,7 +525,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
                     ZSTD_storeSeq(seqStore, (size_t) (ip0 - anchor), anchor, iend, OFFSET_TO_OFFBASE(offset), mLength);
                     break;
                 }
-            } else if (MEM_read32(match) == MEM_read32(ip0)) {
+            } else if (matchIndex > prefixStartIndex && MEM_read32(match) == MEM_read32(ip0)) {
                 /* found a regular match */
                 U32 const offset = (U32) (ip0 - match);
                 mLength = ZSTD_count(ip0 + 4, match + 4, iend) + 4;

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -75,12 +75,12 @@ static void ZSTD_fillHashTableForCCtx(ZSTD_matchState_t* ms,
 void ZSTD_fillHashTable(ZSTD_matchState_t* ms,
                         const void* const end,
                         ZSTD_dictTableLoadMethod_e dtlm,
-                        const U32 forCCtx)
+                        ZSTD_tableFillPurpose_e tfp)
 {
-    if (forCCtx) {
-        ZSTD_fillHashTableForCCtx(ms, end, dtlm);
-    } else {
+    if (tfp == ZSTD_tfp_forCDict) {
         ZSTD_fillHashTableForCDict(ms, end, dtlm);
+    } else {
+        ZSTD_fillHashTableForCCtx(ms, end, dtlm);
     }
 }
 

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -508,13 +508,12 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
             }
 
             if (dictMatchTag == currTag) {
-                /* We only look for a dict match if the normal matchIndex is invalid */
+                /* found a possible dict match */
                 const BYTE* dictMatch = dictBase + dictMatchIndex;
-//                TODO size_t const currTag = dictHashAndTag1 & ZSTD_FAST_TAG_BITS; TODO
                 if (dictMatchIndex > dictStartIndex &&
                     MEM_read32(dictMatch) == MEM_read32(ip0)) {
+                    /* We only look for a dict match if the normal matchIndex is invalid */
                     if (matchIndex <= prefixStartIndex) {
-                        /* found a dict match */
                         U32 const offset = (U32) (curr - dictMatchIndex - dictIndexDelta);
                         mLength = ZSTD_count_2segments(ip0 + 4, dictMatch + 4, iend, dictEnd, prefixStart) + 4;
                         while (((ip0 > anchor) & (dictMatch > dictStart))

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -508,7 +508,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
         size_t const dictHashAndTag0 = ZSTD_hashPtr(ip0, dictHBits, mls);
         U32 dictMatchIndexAndTag = dictHashTable[dictHashAndTag0 >> ZSTD_SHORT_CACHE_TAG_BITS];
-        size_t dictTagsMatch = (dictMatchIndexAndTag & ZSTD_SHORT_CACHE_TAG_MASK) == (dictHashAndTag0 & ZSTD_SHORT_CACHE_TAG_MASK);
+        size_t dictTagsMatch = ZSTD_comparePackedTags(dictMatchIndexAndTag, dictHashAndTag0);
 
         U32 matchIndex = hashTable[hash0];
         U32 curr = (U32)(ip0 - base);
@@ -579,7 +579,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
             /* Prepare for next iteration */
             dictMatchIndexAndTag = dictHashTable[dictHashAndTag1 >> ZSTD_SHORT_CACHE_TAG_BITS];
-            dictTagsMatch = (dictMatchIndexAndTag & ZSTD_SHORT_CACHE_TAG_MASK) == (dictHashAndTag1 & ZSTD_SHORT_CACHE_TAG_MASK);
+            dictTagsMatch = ZSTD_comparePackedTags(dictMatchIndexAndTag, dictHashAndTag1);
             matchIndex = hashTable[hash1];
 
             if (ip1 >= nextStep) {

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -24,6 +24,10 @@ static void ZSTD_fillHashTableForCDict(ZSTD_matchState_t* ms,
     const BYTE* const iend = ((const BYTE*)end) - HASH_READ_SIZE;
     const U32 fastHashFillStep = 3;
 
+    /* Currently, we always use ZSTD_dtlm_full for filling CDict tables.
+     * Feel free to remove this assert if there's a good reason! */
+    assert(dtlm == ZSTD_dtlm_full);
+
     /* Always insert every fastHashFillStep position into the hash table.
      * Insert the other positions if their hash entry is empty.
      */
@@ -54,6 +58,10 @@ static void ZSTD_fillHashTableForCCtx(ZSTD_matchState_t* ms,
     const BYTE* ip = base + ms->nextToUpdate;
     const BYTE* const iend = ((const BYTE*)end) - HASH_READ_SIZE;
     const U32 fastHashFillStep = 3;
+
+    /* Currently, we always use ZSTD_dtlm_fast for filling CCtx tables.
+     * Feel free to remove this assert if there's a good reason! */
+    assert(dtlm == ZSTD_dtlm_fast);
 
     /* Always insert every fastHashFillStep position into the hash table.
      * Insert the other positions if their hash entry is empty.

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -21,7 +21,7 @@ static void ZSTD_fillHashTableForCDict(ZSTD_matchState_t* ms,
     U32  const mls = cParams->minMatch;
     const BYTE* const base = ms->window.base;
     const BYTE* ip = base + ms->nextToUpdate;
-    const BYTE* const iend = MIN((const BYTE*)end, base + (1u << (32 - ZSTD_SHORT_CACHE_TAG_BITS))) - HASH_READ_SIZE;
+    const BYTE* const iend = ((const BYTE*)end) - HASH_READ_SIZE;
     const U32 fastHashFillStep = 3;
 
     /* Always insert every fastHashFillStep position into the hash table.

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -538,12 +538,12 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
             }
 
             if (dictTagsMatch) {
-                /* found a possible dict match */
+                /* Found a possible dict match */
                 const U32 dictMatchIndex = dictMatchIndexAndTag >> ZSTD_SHORT_CACHE_TAG_BITS;
                 const BYTE* dictMatch = dictBase + dictMatchIndex;
                 if (dictMatchIndex > dictStartIndex &&
                     MEM_read32(dictMatch) == MEM_read32(ip0)) {
-                    /* We only look for a dict match if the normal matchIndex is invalid */
+                    /* To replicate extDict parse behavior, we only use dict matches when the normal matchIndex is invalid */
                     if (matchIndex <= prefixStartIndex) {
                         U32 const offset = (U32) (curr - dictMatchIndex - dictIndexDelta);
                         mLength = ZSTD_count_2segments(ip0 + 4, dictMatch + 4, iend, dictEnd, prefixStart) + 4;

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -508,7 +508,7 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
 
         size_t const dictHashAndTag0 = ZSTD_hashPtr(ip0, dictHBits, mls);
         U32 dictMatchIndexAndTag = dictHashTable[dictHashAndTag0 >> ZSTD_SHORT_CACHE_TAG_BITS];
-        size_t dictTagsMatch = ZSTD_comparePackedTags(dictMatchIndexAndTag, dictHashAndTag0);
+        int dictTagsMatch = ZSTD_comparePackedTags(dictMatchIndexAndTag, dictHashAndTag0);
 
         U32 matchIndex = hashTable[hash0];
         U32 curr = (U32)(ip0 - base);

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -30,7 +30,7 @@ static void ZSTD_fillHashTableForCDict(ZSTD_matchState_t* ms,
     for ( ; ip + fastHashFillStep < iend + 2; ip += fastHashFillStep) {
         U32 const curr = (U32)(ip - base);
         {   size_t const hashAndTag = ZSTD_hashPtr(ip, hBits, mls);
-            writeTaggedIndex(hashTable, hashAndTag, curr);   }
+            ZSTD_writeTaggedIndex(hashTable, hashAndTag, curr);   }
 
         if (dtlm == ZSTD_dtlm_fast) continue;
         /* Only load extra positions for ZSTD_dtlm_full */
@@ -38,7 +38,7 @@ static void ZSTD_fillHashTableForCDict(ZSTD_matchState_t* ms,
             for (p = 1; p < fastHashFillStep; ++p) {
                 size_t const hashAndTag = ZSTD_hashPtr(ip + p, hBits, mls);
                 if (hashTable[hashAndTag >> ZSTD_SHORT_CACHE_TAG_BITS] == 0) {  /* not yet filled */
-                    writeTaggedIndex(hashTable, hashAndTag, curr + p);
+                    ZSTD_writeTaggedIndex(hashTable, hashAndTag, curr + p);
                 }   }   }   }
 }
 

--- a/lib/compress/zstd_fast.h
+++ b/lib/compress/zstd_fast.h
@@ -19,7 +19,8 @@ extern "C" {
 #include "zstd_compress_internal.h"
 
 void ZSTD_fillHashTable(ZSTD_matchState_t* ms,
-                        void const* end, ZSTD_dictTableLoadMethod_e dtlm, U32 forCCtx);
+                        void const* end, ZSTD_dictTableLoadMethod_e dtlm,
+                        ZSTD_tableFillPurpose_e tfp);
 size_t ZSTD_compressBlock_fast(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize);

--- a/lib/compress/zstd_fast.h
+++ b/lib/compress/zstd_fast.h
@@ -19,7 +19,7 @@ extern "C" {
 #include "zstd_compress_internal.h"
 
 void ZSTD_fillHashTable(ZSTD_matchState_t* ms,
-                        void const* end, ZSTD_dictTableLoadMethod_e dtlm);
+                        void const* end, ZSTD_dictTableLoadMethod_e dtlm, U32 forCCtx);
 size_t ZSTD_compressBlock_fast(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -242,11 +242,11 @@ static size_t ZSTD_ldm_fillFastTables(ZSTD_matchState_t* ms,
     switch(ms->cParams.strategy)
     {
     case ZSTD_fast:
-        ZSTD_fillHashTable(ms, iend, ZSTD_dtlm_fast, 1);
+        ZSTD_fillHashTable(ms, iend, ZSTD_dtlm_fast, 1); // TODO replace with enum
         break;
 
     case ZSTD_dfast:
-        ZSTD_fillDoubleHashTable(ms, iend, ZSTD_dtlm_fast);
+        ZSTD_fillDoubleHashTable(ms, iend, ZSTD_dtlm_fast, 1); // TODO replace with enum
         break;
 
     case ZSTD_greedy:

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -242,7 +242,7 @@ static size_t ZSTD_ldm_fillFastTables(ZSTD_matchState_t* ms,
     switch(ms->cParams.strategy)
     {
     case ZSTD_fast:
-        ZSTD_fillHashTable(ms, iend, ZSTD_dtlm_fast);
+        ZSTD_fillHashTable(ms, iend, ZSTD_dtlm_fast, 1);
         break;
 
     case ZSTD_dfast:

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -242,11 +242,11 @@ static size_t ZSTD_ldm_fillFastTables(ZSTD_matchState_t* ms,
     switch(ms->cParams.strategy)
     {
     case ZSTD_fast:
-        ZSTD_fillHashTable(ms, iend, ZSTD_dtlm_fast, 1); // TODO replace with enum
+        ZSTD_fillHashTable(ms, iend, ZSTD_dtlm_fast, ZSTD_tfp_forCCtx);
         break;
 
     case ZSTD_dfast:
-        ZSTD_fillDoubleHashTable(ms, iend, ZSTD_dtlm_fast, 1); // TODO replace with enum
+        ZSTD_fillDoubleHashTable(ms, iend, ZSTD_dtlm_fast, ZSTD_tfp_forCCtx);
         break;
 
     case ZSTD_greedy:


### PR DESCRIPTION
## TLDR
This PR increases dictionary compression speed for small inputs (< 8KB at levels 1-2, < 16KB at levels 3-4) by 5-30%. The win is especially large when dictionaries are cold, i.e. in L3 cache or main memory.

## Description of the optimization
Short cache is a change to fast/dfast CDict hashtable construction which allows the corresponding matchfinders to avoid unnecessary memory loads. A picture is worth 2^10 words:

![short_cache_diagram](https://user-images.githubusercontent.com/12179121/174373786-9264993a-0675-4089-9295-101bebf61ecf.png)

The circle at the bottom of the diagram is where matchfinders use a dictionary index (loaded from the CDict hashtable) to load some position from the dictionary and compare it to the current position. Short cache allows us to prevent that load with high probability when the current position and dictionary position *do not match*. This is the common case in nearly all scenarios, and will usually prevent an L2 or even L3 cache miss.

How do we prevent the load? When the CDict hashtable is constructed, we insert an 8-bit independent hash (called a "tag") into the lower bits of each entry. We can do that since dictionary indices are less than 24 bits (this PR adds code to guarantee that), so we can pack an index and tag into a single `U32`. In the matchfinder loop, we unpack the index and tag from the CDict hashtable, compute a tag at the current position, and only load the dictionary position *if the tags match*.

## Preliminary win measurements
<details>

Level 1:
![results0518c](https://user-images.githubusercontent.com/12179121/171701211-be08f830-a048-45dd-a8b1-6263dc6f19f4.png)

Level 3:
![newplot (2)](https://user-images.githubusercontent.com/12179121/171701439-d283afd0-e874-4710-b818-d9c817a1bd3a.png)

</details>

## Final win measurements
The final measurements are comparable to the preliminary ones. Note that fast/hot/gcc/110K goes from 0% to -1% (this is on top of my previous fast DMS pipeline which increased the speed of that scenario by more than 5%). I didn't find any other regressions relative to dev. Regressions from preliminary to final seem to roughly cancel out improvements, and I don't think it's worth digging into which are measurement noise vs real changes. These are good win graphs and I think we should land them.

Benchmarking environment (machine, core isolation, etc) was the same as for https://github.com/facebook/zstd/pull/3086 -- see that PR for details.

Level 1:
![newplot (7)](https://user-images.githubusercontent.com/12179121/173674863-644d3cac-f63e-47c5-a96e-6ca3bc43c3c3.png)


Level 3:
![newplot (6)](https://user-images.githubusercontent.com/12179121/173671619-ca5c3e6c-b571-42e1-982d-d665f67f3359.png)

## Regression
The tags added by short cache need to be removed from the CDict hashtable when it is copied into the CCtx for extDict compression. This turns a normal memcpy into a vectorized shift-and-write loop. In a microbenchmark, I found that SSE2 shift-and-write is 2x slower than memcpy, while AVX2 is 1.5x slower. Note that we only pay this cost when using extDict for dictionary compression. Streaming compression is not affected.

I measured the regression for level2 and level4 extDict. I chose those levels because they use at least 2x larger hashtables than the much more common levels 1 and 3. Thus, level2 and level4 upper-bound the regression (I confirmed this with measurements on level1 and level3).

The AVX2 numbers are for binaries compiled with `-march=core-avx2`. I will add AVX2 dynamic dispatch before our next open source release to ensure that binaries not compiled with `-march=core-avx2` can still benefit from those instructions when available.

![newplot (13)](https://user-images.githubusercontent.com/12179121/174652949-423fe64a-d654-4c66-afa1-7ee64cfbc11e.png)

---
- [x] Respond to initial code review
- [x] Update the PR description with a summary of the changes and more information on measurements.
- [ ] Add discussion of the (negligible) ratio impact.
- [x] Add documentation to the code itself (see marked location in `zstd_compress_internal.h`).
- [x] Add measurements to the PR description regarding the `byCopyingCDict` regression.

Out of scope (will be a separate PR):
- ~~Add AVX2 dynamic dispatch for the (minor) performance regression in `ZSTD_resetCCtx_byCopyingCDict`.~~