### PR TITLE
[contrib] largeNbDicts bugfix + improvements

### DIFF
--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -715,6 +715,7 @@ static int benchMem(slice_collection_t dstBlocks,
         assert(csvFile);
         fprintf(csvFile, "%s\n", exeName);
     } else {
+        free(csvFileName);
         csvFile = fopen(csvFileName, "at");
         assert(csvFile);
     }

--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -715,7 +715,7 @@ static int benchMem(slice_collection_t dstBlocks,
         assert(csvFile);
         fprintf(csvFile, "%s\n", exeName);
     } else {
-        free(csvFileName);
+        fclose(csvFile);
         csvFile = fopen(csvFileName, "at");
         assert(csvFile);
     }


### PR DESCRIPTION
These are local changes I've been cherry-picking on builds for a while. Figured it's time to put them on GitHub.
* Fixes a bug in the memory estimation found by @terrelln 
* Fixes a bug which prevented `forceAttach/forceCopy` from working properly (`ZSTD_compress_usingCDict -> ZSTD_compress2`)
* Prints results to a csv file with the executable name
    * The idea is you bake the commit hash and compiler into the executable name. (This is my setup).
    * largeNbDicts will append the best speed to the CSV file, so you can run multiple times and then get statistics. I like to interleave runs between different versions to correct for background load changes.
    * I have a benchmark runner script which creates a directory tree of CSV files for different scenarios, and then a python script which aggregates all the statistics. Will put them on GitHub when I have time :)