### PR TITLE
programs/timefn: Don't use clock() on Unix when C < 11 to improve multi-thread benchmark

### DIFF
--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -55,10 +55,8 @@ extern "C" {
     typedef PTime UTIL_time_t;
     #define UTIL_TIME_INITIALIZER 0
 
-/* C11 requires timespec_get, but FreeBSD 11 lacks it, while still claiming C11 compliance.
-   Android also lacks it but does define TIME_UTC. */
 #elif (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */) \
-    && defined(TIME_UTC) && !defined(__ANDROID__)
+    || defined(CLOCK_MONOTONIC) /* POSIX.1-2001 (optional) */
 
     typedef struct timespec UTIL_time_t;
     #define UTIL_TIME_INITIALIZER { 0, 0 }


### PR DESCRIPTION
Fixes https://github.com/facebook/zstd/issues/3163
See also https://github.com/freebsd/freebsd-src/commit/6882d53b7fb8
See also https://github.com/aosp-mirror/platform_bionic/commit/78e9ebc3b968

C90 aka `clock()` fallback being suboptimal seems to be known issue:
https://github.com/facebook/zstd/blob/b7b7edb3a3017ac8e16d7eb2dbede45168560c58/programs/timefn.c#L138-L143
