### PR TITLE
display a warning message when using C90 clock_t 

### DIFF
--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -13,7 +13,7 @@
 *  Tuning parameters
 ****************************************/
 #ifndef BMK_TIMETEST_DEFAULT_S   /* default minimum time per test */
-#define BMK_TIMETEST_DEFAULT_S 3
+# define BMK_TIMETEST_DEFAULT_S 3
 #endif
 
 
@@ -386,6 +386,13 @@ BMK_benchMemAdvancedNoAlloc(
     } else {
         RDG_genBuffer(compressedBuffer, maxCompressedSize, 0.10, 0.50, 1);
     }
+
+#if defined(UTIL_TIME_USES_C90_CLOCK)
+    if (adv->nbWorkers > 1) {
+        OUTPUTLEVEL(2, "Warning : time measurements restricted to C90 clock_t. \n")
+        OUTPUTLEVEL(2, "Warning : using C90 clock_t leads to incorrect measurements in multithreading mode. \n")
+    }
+#endif
 
     /* Bench */
     {   U64 const crcOrig = (adv->mode == BMK_decodeOnly) ? 0 : XXH64(srcBuffer, srcSize, 0);

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -65,6 +65,7 @@ extern "C" {
 
 #else   /* relies on standard C90 (note : clock_t measurements can be wrong when using multi-threading) */
 
+    #define UTIL_TIME_USES_C90_CLOCK
     typedef clock_t UTIL_time_t;
     #define UTIL_TIME_INITIALIZER 0
 


### PR DESCRIPTION
for MultiThreading speed measurements.

This will make issues such as #3163 at least easier to understand.