### PR TITLE
Restore ability to use clock_gettime() on posix systems

### DIFF
--- a/programs/benchfn.c
+++ b/programs/benchfn.c
@@ -13,11 +13,11 @@
 /* *************************************
 *  Includes
 ***************************************/
+#include "timefn.h"      /* UTIL_time_t, UTIL_getTime, set _POSIX_SOURCE */
 #include <stdlib.h>      /* malloc, free */
 #include <string.h>      /* memset */
 #include <assert.h>      /* assert */
 
-#include "timefn.h"        /* UTIL_time_t, UTIL_getTime */
 #include "benchfn.h"
 
 

--- a/programs/timefn.c
+++ b/programs/timefn.c
@@ -81,7 +81,7 @@ PTime UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd)
 }
 
 
-#elif TIMEFN_HAS_TIMESPEC_GET \
+#elif defined(TIMEFN_HAS_TIMESPEC_GET) \
     || defined(CLOCK_MONOTONIC) /* POSIX.1-2001 (optional) */
 
 #include <stdlib.h>   /* abort */
@@ -92,7 +92,7 @@ UTIL_time_t UTIL_getTime(void)
     /* time must be initialized, othersize it may fail msan test.
      * No good reason, likely a limitation of timespec_get() for some target */
     UTIL_time_t time = UTIL_TIME_INITIALIZER;
-#if TIMEFN_HAS_TIMESPEC_GET
+#if defined(TIMEFN_HAS_TIMESPEC_GET)
     /* favor timespec_get() as first choice for c11 targets */
     if (timespec_get(&time, TIME_UTC) != TIME_UTC) {
         perror("timefn::timespec_get");

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -55,10 +55,8 @@ extern "C" {
     typedef PTime UTIL_time_t;
     #define UTIL_TIME_INITIALIZER 0
 
-/* C11 requires timespec_get, but FreeBSD 11 lacks it, while still claiming C11 compliance.
-   Android also lacks it but does define TIME_UTC. */
 #elif (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */) \
-    && defined(TIME_UTC) && !defined(__ANDROID__)
+    || defined(CLOCK_MONOTONIC) /* POSIX.1-2001 (optional) */
 
     typedef struct timespec UTIL_time_t;
     #define UTIL_TIME_INITIALIZER { 0, 0 }

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -19,8 +19,8 @@ extern "C" {
 /*-****************************************
 *  Dependencies
 ******************************************/
-#define _POSIX_C_SOURCE	200809L /* clock_gettime */
-#include <time.h>         /* clock_t, clock, CLOCKS_PER_SEC */
+#include "platform.h"  /* set _POSIX_C_SOURCE */
+#include <time.h>      /* clock_t, clock, CLOCKS_PER_SEC */
 
 
 

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -19,6 +19,7 @@ extern "C" {
 /*-****************************************
 *  Dependencies
 ******************************************/
+#define _POSIX_C_SOURCE	200809L /* clock_gettime */
 #include <time.h>         /* clock_t, clock, CLOCKS_PER_SEC */
 
 
@@ -38,7 +39,11 @@ extern "C" {
   typedef unsigned long long PTime;  /* does not support compilers without long long support */
 #endif
 
-
+#define TIMEFN_HAS_TIMESPEC_GET \
+    (  defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */ \
+    && defined(TIME_UTC)  /* some OS, like FreeBSD 11, claim C11 compliance yet don't provide timespec_get */ \
+    && !defined(__ANDROID__) /* Android <= 10 even provides TIME_UTC but still does not provide timespec_get */ \
+    )
 
 /*-****************************************
 *  Time functions
@@ -55,7 +60,7 @@ extern "C" {
     typedef PTime UTIL_time_t;
     #define UTIL_TIME_INITIALIZER 0
 
-#elif (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */) \
+#elif TIMEFN_HAS_TIMESPEC_GET \
     || defined(CLOCK_MONOTONIC) /* POSIX.1-2001 (optional) */
 
     typedef struct timespec UTIL_time_t;

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -39,11 +39,13 @@ extern "C" {
   typedef unsigned long long PTime;  /* does not support compilers without long long support */
 #endif
 
-#define TIMEFN_HAS_TIMESPEC_GET \
-    (  defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */ \
+/* The following macro test is supposed to probe the existence of timespec_get() */
+#if (  defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */ \
     && defined(TIME_UTC)  /* some OS, like FreeBSD 11, claim C11 compliance yet don't provide timespec_get */ \
     && !defined(__ANDROID__) /* Android <= 10 even provides TIME_UTC but still does not provide timespec_get */ \
     )
+# define TIMEFN_HAS_TIMESPEC_GET
+#endif
 
 /*-****************************************
 *  Time functions
@@ -60,7 +62,7 @@ extern "C" {
     typedef PTime UTIL_time_t;
     #define UTIL_TIME_INITIALIZER 0
 
-#elif TIMEFN_HAS_TIMESPEC_GET \
+#elif defined(TIMEFN_HAS_TIMESPEC_GET) \
     || defined(CLOCK_MONOTONIC) /* POSIX.1-2001 (optional) */
 
     typedef struct timespec UTIL_time_t;

--- a/programs/zstdcli_trace.c
+++ b/programs/zstdcli_trace.c
@@ -6,15 +6,15 @@
  * LICENSE file in the root directory of this source tree) and the GPLv2 (found
  * in the COPYING file in the root directory of this source tree).
  * You may select, at your option, one of the above-listed licenses.
- */
+**/
 
-#include "zstdcli_trace.h"
+#include "timefn.h"  /* UTIL_clockSpanNano, UTIL_TIME_INITIALIZER, set _POSIX_C_SOURCE */
 
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "timefn.h"
-#include "util.h"
+#include "zstdcli_trace.h"
+#include "util.h"  /* UTIL_isRegularFile */
 
 #define ZSTD_STATIC_LINKING_ONLY
 #include "../lib/zstd.h"


### PR DESCRIPTION
When `timespec_get()` was unavailable,
`timefn` unit would fall back to `clock_t`,
which is unfortunately not good enough to measure speed in multi-threading scenarios.

@jbeich proposes a patch which re-enable `clock_gettime()` as an alternative for posix systems.
(I can't remember why it was removed...)
This extends the nb of platforms that can use a timer function compatible with multi-threading scenarios.
