### PR TITLE
Add Copyright Notice to Github Pages Page Footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,6 +449,7 @@ Peazip is a free multi-platforms archiver by Giorgio Tani with [support for Zsta
     rel="noreferrer noopener">
     Terms
   </a>
+  Copyright © Meta Platforms, Inc.
 </div>
 
 


### PR DESCRIPTION
T106302328 is complaining that we don't have one.