### PR TITLE
Clarify benchmark chunking docstring

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -209,7 +209,7 @@ Benchmark arguments :
  -b#    : benchmark file(s), using # compression level (default: 3)
  -e#    : test all compression levels successively from -b# to -e# (default: 1)
  -i#    : minimum evaluation time in seconds (default: 3s)
- -B#    : cut file into independent blocks of size # (default: no block)
+ -B#    : cut file into independent chunks of size # (default: no chunking)
  -S     : output one benchmark result per input file (default: consolidated result)
 --priority=rt : set process priority to real-time
 ```

--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -356,7 +356,7 @@ minimum evaluation time, in seconds (default: 3s), benchmark mode only
 .
 .TP
 \fB\-B#\fR, \fB\-\-block\-size=#\fR
-cut file(s) into independent blocks of size # (default: no block)
+cut file(s) into independent chunks of size # (default: no chunking)
 .
 .TP
 \fB\-\-priority=rt\fR

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -470,7 +470,7 @@ BENCHMARK
 * `-i#`:
     minimum evaluation time, in seconds (default: 3s), benchmark mode only
 * `-B#`, `--block-size=#`:
-    cut file(s) into independent blocks of size # (default: no block)
+    cut file(s) into independent chunks of size # (default: no chunking)
 * `--priority=rt`:
     set process priority to real-time
 

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -284,7 +284,7 @@ static void usage_advanced(const char* programName)
     DISPLAYOUT("  -b#                  benchmark file(s), using # compression level (default: %d)\n", ZSTDCLI_CLEVEL_DEFAULT);
     DISPLAYOUT("  -e#                  test all compression levels successively from -b# to -e# (default: 1)\n");
     DISPLAYOUT("  -i#                  minimum evaluation time in seconds (default: 3s)\n");
-    DISPLAYOUT("  -B#                  cut file into independent blocks of size # (default: no block)\n");
+    DISPLAYOUT("  -B#                  cut file into independent chunks of size # (default: no chunking)\n");
     DISPLAYOUT("  -S                   output one benchmark result per input file (default: consolidated result)\n");
     DISPLAYOUT("     --priority=rt     set process priority to real-time\n");
 #endif

--- a/zlibWrapper/examples/zwrapbench.c
+++ b/zlibWrapper/examples/zwrapbench.c
@@ -836,7 +836,7 @@ static int usage(const char* programName)
     DISPLAY( " -b#    : benchmark file(s), using # compression level (default : %d) \n", ZSTDCLI_CLEVEL_DEFAULT);
     DISPLAY( " -e#    : test all compression levels from -bX to # (default: %d)\n", ZSTDCLI_CLEVEL_DEFAULT);
     DISPLAY( " -i#    : minimum evaluation time in seconds (default : 3s)\n");
-    DISPLAY( " -B#    : cut file into independent blocks of size # (default: no block)\n");
+    DISPLAY( " -B#    : cut file into independent chunks of size # (default: no chunking)\n");
     return 0;
 }
 


### PR DESCRIPTION
I spoke with a user today who thought `-B#` controls the zstd block size in benchmarks, rather than controlling the chunk size (to split a large compression into many independent small compressions). This leads to severe misinterpretation of results, because the latter interpretation affects compression ratio very differently than the former. I think the proposed doc update can prevent this misunderstanding going forward.