### PR TITLE
Add warning when multi-thread decompression is requested

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1236,6 +1236,9 @@ int main(int argCount, const char* argv[])
             DISPLAYLEVEL(3, "Note: %d physical core(s) detected \n", nbWorkers);
         }
     }
+    if ((operation==zom_decompress) && (!singleThread) && (nbWorkers > 1)) {
+        DISPLAYLEVEL(2, "Warning : decompression does not support multi-threading\n");
+    }
 #else
     (void)singleThread; (void)nbWorkers; (void)defaultLogicalCores;
 #endif

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1226,6 +1226,9 @@ int main(int argCount, const char* argv[])
     DISPLAYLEVEL(3, WELCOME_MESSAGE);
 
 #ifdef ZSTD_MULTITHREAD
+    if ((operation==zom_decompress) && (!singleThread) && (nbWorkers > 1)) {
+        DISPLAYLEVEL(2, "Warning : decompression does not support multi-threading\n");
+    }
     if ((nbWorkers==0) && (!singleThread)) {
         /* automatically set # workers based on # of reported cpus */
         if (defaultLogicalCores) {
@@ -1235,9 +1238,6 @@ int main(int argCount, const char* argv[])
             nbWorkers = UTIL_countPhysicalCores();
             DISPLAYLEVEL(3, "Note: %d physical core(s) detected \n", nbWorkers);
         }
-    }
-    if ((operation==zom_decompress) && (!singleThread) && (nbWorkers > 1)) {
-        DISPLAYLEVEL(2, "Warning : decompression does not support multi-threading\n");
     }
 #else
     (void)singleThread; (void)nbWorkers; (void)defaultLogicalCores;

--- a/tests/cli-tests/compression/multi-threaded.sh
+++ b/tests/cli-tests/compression/multi-threaded.sh
@@ -9,3 +9,7 @@ zstd --rsyncable -f file                ; zstd -t file.zst
 zstd -T0 -f file                        ; zstd -t file.zst
 zstd -T0 --auto-threads=logical -f file ; zstd -t file.zst
 zstd -T0 --auto-threads=physical -f file; zstd -t file.zst
+
+# multi-thread decompression warning test
+zstd -T0 -f file                        ; zstd -t file.zst; zstd -T0 -d file.zst -o file3
+zstd -T0 -f file                        ; zstd -t file.zst; zstd -T2 -d file.zst -o file4

--- a/tests/cli-tests/compression/multi-threaded.sh.stderr.exact
+++ b/tests/cli-tests/compression/multi-threaded.sh.stderr.exact
@@ -1,0 +1,1 @@
+Warning : decompression does not support multi-threading


### PR DESCRIPTION
address https://github.com/facebook/zstd/issues/2918

When user pass in argument for both decompression and multi-thread, print a warning message
to indicate that multi-threaded decompression is not supported.