### PR TITLE
[largeNbDicts] Second try at fixing decompression segfault to always create compressInstructions

### DIFF
--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -582,7 +582,8 @@ compressInstructions createCompressInstructions(cdict_collection_t dictionaries,
     compressInstructions ci;
     ci.cctx = ZSTD_createCCtx();
     CONTROL(ci.cctx != NULL);
-    ZSTD_CCtx_setParametersUsingCCtxParams(ci.cctx, cctxParams);
+    if (cctxParams)
+      ZSTD_CCtx_setParametersUsingCCtxParams(ci.cctx, cctxParams);
     ci.nbDicts = dictionaries.nbCDict;
     ci.dictNb = 0;
     ci.dictionaries = dictionaries;
@@ -697,9 +698,8 @@ static int benchMem(slice_collection_t dstBlocks, slice_collection_t srcBlocks,
             BMK_createTimedFnState(total_time_ms, ms_per_round);
 
     decompressInstructions di = createDecompressInstructions(ddictionaries);
-    compressInstructions ci;
-    if (benchCompression)
-      ci = createCompressInstructions(cdictionaries, cctxParams);
+    compressInstructions ci =
+        createCompressInstructions(cdictionaries, cctxParams);
     void* payload = benchCompression ? (void*)&ci : (void*)&di;
     BMK_benchParams_t const bp = {
         .benchFn = benchCompression ? compress : decompress,


### PR DESCRIPTION
Summary:
Freeing an uninitialized pointer is undefined behavior. This caused a segfault
when compiling the benchmark with Clang -O3 and benching decompression.

Test Plan:
make and run