### PR TITLE
Issue #3070

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -373,6 +373,47 @@ zstd tmpPrompt - < tmpPrompt -o tmpPromp.zst --rm && die "should have aborted im
 println "Test completed"
 
 
+
+#check we reset memory when it is incorrectly formed, and that we warn the user as well
+println "\n===>  Test: CLI memory only passes correctly formed input"
+
+if !( echo hello | zstd -vvvv --memory=32LB 2>&1 $INTOVOID | grep -q 'memory=134217728')
+then die "Invalid memory parameter has not been reset to default, parsing is not working. Please correct"
+fi
+
+if !( echo hello | zstd -vvvv --memory=32LB 2>&1 $INTOVOID | grep -q 'warning: poorly formed parameter')
+then die "Invalid memory parameter is not warning the user and is silently failing"
+fi
+
+if !( echo hello | zstd -vvvv --memory=hello 2>&1 $INTOVOID | grep -q 'memory=134217728')
+then die "Invalid memory parameter has not been reset to default, parsing is not working. Please correct"
+fi
+
+if !( echo hello | zstd -vvvv --memory=hello 2>&1 $INTOVOID | grep -q 'warning: poorly formed parameter')
+then die "Invalid memory parameter is not warning the user and is silently failing"
+fi
+
+if !( echo hello | zstd -vvvv --memory=MB45 2>&1 $INTOVOID | grep -q 'memory=134217728')
+then die "Invalid memory parameter has not been reset to default, parsing is not working. Please correct"
+fi
+
+if !( echo hello | zstd -vvvv --memory=MB45 2>&1 $INTOVOID | grep -q 'warning: poorly formed parameter')
+then die "Invalid memory parameter is not warning the user and is silently failing"
+fi
+
+#check valid memory input are not warning
+println "\n===>  Test: CLI memory does not incorrectly warn on good input"
+
+if ( echo hello | zstd -vvvv --memory=32KB 2>&1 $INTOVOID | grep -q 'warning: poorly formed parameter')
+then die "Valid memory parameter is incorrectly warning"
+fi
+
+if ( echo hello | zstd -vvvv --memory=1024 2>&1 $INTOVOID | grep -q 'warning: poorly formed parameter')
+then die "Valid memory parameter is incorrectly warning"
+fi
+
+
+
 println "\n===>  recursive mode test "
 # combination of -r with empty list of input file
 zstd -c -r < tmp > tmp.zst


### PR DESCRIPTION
Fix for https://github.com/facebook/zstd/issues/3070

Notes:
In cases where the inputs are not well formed in terms of suffix (or non numerical prefix) the program will warn and use a default value. 

As default this can be found very simply by checking for a null value, but there was an edge case on testing where the "zstd=" command doesn't use white space (which means we need to check both /0 and ',' as well). This does mean that inputs such as "--memory=3,000KB" won't work. This is assumed satisfactory. 

There is a potential follow up task here where very small values are allowed since they follow a valid syntax - ie "--memory=15", but if there is a minimum we need, that may be useful to warn the user about, and clamp input in that way. 

Have added more tests to the playTests script, which checks for a warning and that we reset default behavior on poorly formed input, but that we don't warn for valid input. 

Testing:
Have verified that the #3070 issue is indeed fixed, and that the above added tests pass now, but did not in the earlier dev branch. 