### PR TITLE
Fix small file passthrough

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2346,7 +2346,10 @@ static int FIO_decompressFrames(FIO_ctx_t* const fCtx,
             break;   /* no more input */
         }
         readSomething = 1;   /* there is at least 1 byte in srcFile */
-        if (ress.readCtx->srcBufferLoaded < toRead) {
+        if (ress.readCtx->srcBufferLoaded < toRead) { /* not enough input to check magic number */
+            if ((prefs->overwrite) && !strcmp (dstFileName, stdoutmark)) {  /* pass-through mode */
+                return FIO_passThrough(&ress);
+            }
             DISPLAYLEVEL(1, "zstd: %s: unknown header \n", srcFileName);
             return 1;
         }

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -808,6 +808,16 @@ println "Hello world 1!" | zstd -df
 println "Hello world 2!" | zstd -dcf
 println "Hello world 3!" > tmp1
 zstd -dcf tmp1
+println "" | zstd -df > tmp1
+println "" > tmp2
+$DIFF -q tmp1 tmp2
+println "1" | zstd -df > tmp1
+println "1" > tmp2
+$DIFF -q tmp1 tmp2
+println "12" | zstd -df > tmp1
+println "12" > tmp2
+$DIFF -q tmp1 tmp2
+rm -rf tmp*
 
 
 println "\n===>  frame concatenation "


### PR DESCRIPTION
Fixes passthrough on files with fewer than 4 magic bytes by checking if passthrough is enabled before exiting with an error. If force is enabled and destination is `stdout`, the bytes are copied as-is to the output.

Changes:
- add a check for passthrough if we read fewer than 4 bytes (`zstd` magic length)
- add a test to ensure passthrough works on short files

fixes: #3210
review @terrelln 