### PR TITLE
zlibWrapper: Update for zlib 1.2.12

### DIFF
--- a/zlibWrapper/examples/example.c
+++ b/zlibWrapper/examples/example.c
@@ -56,26 +56,26 @@ z_const char hello[] = "hello, hello! I said hello, hello!";
 const char dictionary[] = "hello, hello!";
 uLong dictId; /* Adler32 value of the dictionary */
 
-void test_deflate       OF((Byte *compr, uLong comprLen));
-void test_inflate       OF((Byte *compr, uLong comprLen,
+void test_deflate       _Z_OF((Byte *compr, uLong comprLen));
+void test_inflate       _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_large_deflate OF((Byte *compr, uLong comprLen,
+void test_large_deflate _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_large_inflate OF((Byte *compr, uLong comprLen,
+void test_large_inflate _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_flush         OF((Byte *compr, uLong *comprLen));
-void test_sync          OF((Byte *compr, uLong comprLen,
+void test_flush         _Z_OF((Byte *compr, uLong *comprLen));
+void test_sync          _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_dict_deflate  OF((Byte *compr, uLong comprLen));
-void test_dict_inflate  OF((Byte *compr, uLong comprLen,
+void test_dict_deflate  _Z_OF((Byte *compr, uLong comprLen));
+void test_dict_inflate  _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-int  main               OF((int argc, char *argv[]));
+int  main               _Z_OF((int argc, char *argv[]));
 
 
 #ifdef Z_SOLO
 
-void *myalloc OF((void *, unsigned, unsigned));
-void myfree OF((void *, void *));
+void *myalloc _Z_OF((void *, unsigned, unsigned));
+void myfree _Z_OF((void *, void *));
 
 void *myalloc(q, n, m)
     void *q;
@@ -102,9 +102,9 @@ static free_func zfree = myfree;
 static alloc_func zalloc = (alloc_func)0;
 static free_func zfree = (free_func)0;
 
-void test_compress      OF((Byte *compr, uLong comprLen,
+void test_compress      _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_gzio          OF((const char *fname,
+void test_gzio          _Z_OF((const char *fname,
                             Byte *uncompr, uLong uncomprLen));
 
 /* ===========================================================================

--- a/zlibWrapper/examples/example_original.c
+++ b/zlibWrapper/examples/example_original.c
@@ -51,26 +51,26 @@ z_const char hello[] = "hello, hello!";
 const char dictionary[] = "hello";
 uLong dictId; /* Adler32 value of the dictionary */
 
-void test_deflate       OF((Byte *compr, uLong comprLen));
-void test_inflate       OF((Byte *compr, uLong comprLen,
+void test_deflate       _Z_OF((Byte *compr, uLong comprLen));
+void test_inflate       _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_large_deflate OF((Byte *compr, uLong comprLen,
+void test_large_deflate _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_large_inflate OF((Byte *compr, uLong comprLen,
+void test_large_inflate _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_flush         OF((Byte *compr, uLong *comprLen));
-void test_sync          OF((Byte *compr, uLong comprLen,
+void test_flush         _Z_OF((Byte *compr, uLong *comprLen));
+void test_sync          _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_dict_deflate  OF((Byte *compr, uLong comprLen));
-void test_dict_inflate  OF((Byte *compr, uLong comprLen,
+void test_dict_deflate  _Z_OF((Byte *compr, uLong comprLen));
+void test_dict_inflate  _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-int  main               OF((int argc, char *argv[]));
+int  main               _Z_OF((int argc, char *argv[]));
 
 
 #ifdef Z_SOLO
 
-void *myalloc OF((void *, unsigned, unsigned));
-void myfree OF((void *, void *));
+void *myalloc _Z_OF((void *, unsigned, unsigned));
+void myfree _Z_OF((void *, void *));
 
 void *myalloc(q, n, m)
     void *q;
@@ -94,9 +94,9 @@ static free_func zfree = myfree;
 static alloc_func zalloc = (alloc_func)0;
 static free_func zfree = (free_func)0;
 
-void test_compress      OF((Byte *compr, uLong comprLen,
+void test_compress      _Z_OF((Byte *compr, uLong comprLen,
                             Byte *uncompr, uLong uncomprLen));
-void test_gzio          OF((const char *fname,
+void test_gzio          _Z_OF((const char *fname,
                             Byte *uncompr, uLong uncomprLen));
 
 /* ===========================================================================

--- a/zlibWrapper/examples/minigzip.c
+++ b/zlibWrapper/examples/minigzip.c
@@ -64,7 +64,7 @@
 
 #if !defined(Z_HAVE_UNISTD_H) && !defined(_LARGEFILE64_SOURCE)
 #ifndef WIN32 /* unlink already in stdio.h for WIN32 */
-  extern int unlink OF((const char *));
+  extern int unlink _Z_OF((const char *));
 #endif
 #endif
 
@@ -154,8 +154,8 @@ static void pwinerror (s)
 #  include <unistd.h>       /* for unlink() */
 #endif
 
-void *myalloc OF((void *, unsigned, unsigned));
-void myfree OF((void *, void *));
+void *myalloc _Z_OF((void *, unsigned, unsigned));
+void myfree _Z_OF((void *, void *));
 
 void *myalloc(q, n, m)
     void *q;
@@ -180,9 +180,9 @@ typedef struct gzFile_s {
     z_stream strm;
 } *gzFile;
 
-gzFile gzopen OF((const char *, const char *));
-gzFile gzdopen OF((int, const char *));
-gzFile gz_open OF((const char *, int, const char *));
+gzFile gzopen _Z_OF((const char *, const char *));
+gzFile gzdopen _Z_OF((int, const char *));
+gzFile gz_open _Z_OF((const char *, int, const char *));
 
 gzFile gzopen(path, mode)
 const char *path;
@@ -236,7 +236,7 @@ gzFile gz_open(path, fd, mode)
     return gz;
 }
 
-int gzwrite OF((gzFile, const void *, unsigned));
+int gzwrite _Z_OF((gzFile, const void *, unsigned));
 
 int gzwrite(gz, buf, len)
     gzFile gz;
@@ -260,7 +260,7 @@ int gzwrite(gz, buf, len)
     return len;
 }
 
-int gzread OF((gzFile, void *, unsigned));
+int gzread _Z_OF((gzFile, void *, unsigned));
 
 int gzread(gz, buf, len)
     gzFile gz;
@@ -297,7 +297,7 @@ int gzread(gz, buf, len)
     return len - strm->avail_out;
 }
 
-int gzclose OF((gzFile));
+int gzclose _Z_OF((gzFile));
 
 int gzclose(gz)
     gzFile gz;
@@ -326,7 +326,7 @@ int gzclose(gz)
     return Z_OK;
 }
 
-const char *gzerror OF((gzFile, int *));
+const char *gzerror _Z_OF((gzFile, int *));
 
 const char *gzerror(gz, err)
     gzFile gz;
@@ -340,15 +340,15 @@ const char *gzerror(gz, err)
 
 char *prog;
 
-void error            OF((const char *msg));
-void gz_compress      OF((FILE   *in, gzFile out));
+void error            _Z_OF((const char *msg));
+void gz_compress      _Z_OF((FILE   *in, gzFile out));
 #ifdef USE_MMAP
-int  gz_compress_mmap OF((FILE   *in, gzFile out));
+int  gz_compress_mmap _Z_OF((FILE   *in, gzFile out));
 #endif
-void gz_uncompress    OF((gzFile in, FILE   *out));
-void file_compress    OF((char  *file, char *mode));
-void file_uncompress  OF((char  *file));
-int  main             OF((int argc, char *argv[]));
+void gz_uncompress    _Z_OF((gzFile in, FILE   *out));
+void file_compress    _Z_OF((char  *file, char *mode));
+void file_uncompress  _Z_OF((char  *file));
+int  main             _Z_OF((int argc, char *argv[]));
 
 /* ===========================================================================
  * Display error message and exit

--- a/zlibWrapper/gzcompatibility.h
+++ b/zlibWrapper/gzcompatibility.h
@@ -11,10 +11,10 @@
 
 
 #if ZLIB_VERNUM <= 0x1240
-ZEXTERN int ZEXPORT gzclose_r OF((gzFile file));
-ZEXTERN int ZEXPORT gzclose_w OF((gzFile file));
-ZEXTERN int ZEXPORT gzbuffer OF((gzFile file, unsigned size));
-ZEXTERN z_off_t ZEXPORT gzoffset OF((gzFile file));
+ZEXTERN int ZEXPORT gzclose_r _Z_OF((gzFile file));
+ZEXTERN int ZEXPORT gzclose_w _Z_OF((gzFile file));
+ZEXTERN int ZEXPORT gzbuffer _Z_OF((gzFile file, unsigned size));
+ZEXTERN z_off_t ZEXPORT gzoffset _Z_OF((gzFile file));
 
 #if !defined(_WIN32) && defined(Z_LARGE64)
 #  define z_off64_t off64_t
@@ -40,7 +40,7 @@ struct gzFile_s {
 #if ZLIB_VERNUM <= 0x1270
 #if defined(_WIN32) && !defined(Z_SOLO)
 #    include <stddef.h>         /* for wchar_t */
-ZEXTERN gzFile         ZEXPORT gzopen_w OF((const wchar_t *path,
+ZEXTERN gzFile         ZEXPORT gzopen_w _Z_OF((const wchar_t *path,
                                             const char *mode));
 #endif
 #endif
@@ -61,8 +61,8 @@ ZEXTERN gzFile         ZEXPORT gzopen_w OF((const wchar_t *path,
 #  endif
 #  undef z_longlong
 #endif
-ZEXTERN z_size_t ZEXPORT gzfread OF((voidp buf, z_size_t size, z_size_t nitems,
+ZEXTERN z_size_t ZEXPORT gzfread _Z_OF((voidp buf, z_size_t size, z_size_t nitems,
                                      gzFile file));
-ZEXTERN z_size_t ZEXPORT gzfwrite OF((voidpc buf, z_size_t size,
+ZEXTERN z_size_t ZEXPORT gzfwrite _Z_OF((voidpc buf, z_size_t size,
                                       z_size_t nitems, gzFile file));
 #endif

--- a/zlibWrapper/gzguts.h
+++ b/zlibWrapper/gzguts.h
@@ -126,8 +126,8 @@
 
 /* gz* functions always use library allocation functions */
 #ifndef STDC
-  extern voidp  malloc OF((uInt size));
-  extern void   free   OF((voidpf ptr));
+  extern voidp  malloc _Z_OF((uInt size));
+  extern void   free   _Z_OF((voidpf ptr));
 #endif
 
 /* get errno and strerror definition */
@@ -145,10 +145,10 @@
 
 /* provide prototypes for these when building zlib without LFS */
 #if !defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0
-    ZEXTERN gzFile ZEXPORT gzopen64 OF((const char *, const char *));
-    ZEXTERN z_off64_t ZEXPORT gzseek64 OF((gzFile, z_off64_t, int));
-    ZEXTERN z_off64_t ZEXPORT gztell64 OF((gzFile));
-    ZEXTERN z_off64_t ZEXPORT gzoffset64 OF((gzFile));
+    ZEXTERN gzFile ZEXPORT gzopen64 _Z_OF((const char *, const char *));
+    ZEXTERN z_off64_t ZEXPORT gzseek64 _Z_OF((gzFile, z_off64_t, int));
+    ZEXTERN z_off64_t ZEXPORT gztell64 _Z_OF((gzFile));
+    ZEXTERN z_off64_t ZEXPORT gzoffset64 _Z_OF((gzFile));
 #endif
 
 /* default memLevel */
@@ -213,9 +213,9 @@ typedef union {
 } gz_statep;
 
 /* shared functions */
-void ZLIB_INTERNAL gz_error OF((gz_statep, int, const char *));
+void ZLIB_INTERNAL gz_error _Z_OF((gz_statep, int, const char *));
 #if defined UNDER_CE
-char ZLIB_INTERNAL *gz_strwinerror OF((DWORD error));
+char ZLIB_INTERNAL *gz_strwinerror _Z_OF((DWORD error));
 #endif
 
 /* GT_OFF(x), where x is an unsigned value, is true if x > maximum z_off64_t
@@ -224,6 +224,6 @@ char ZLIB_INTERNAL *gz_strwinerror OF((DWORD error));
 #ifdef INT_MAX
 #  define GT_OFF(x) (sizeof(int) == sizeof(z_off64_t) && (x) > INT_MAX)
 #else
-unsigned ZLIB_INTERNAL gz_intmax OF((void));
+unsigned ZLIB_INTERNAL gz_intmax _Z_OF((void));
 #  define GT_OFF(x) (sizeof(int) == sizeof(z_off64_t) && (x) > gz_intmax())
 #endif

--- a/zlibWrapper/gzlib.c
+++ b/zlibWrapper/gzlib.c
@@ -19,8 +19,8 @@
 #endif
 
 /* Local functions */
-local void gz_reset OF((gz_statep));
-local gzFile gz_open OF((const void *, int, const char *));
+local void gz_reset _Z_OF((gz_statep));
+local gzFile gz_open _Z_OF((const void *, int, const char *));
 
 #if defined UNDER_CE
 

--- a/zlibWrapper/gzread.c
+++ b/zlibWrapper/gzread.c
@@ -17,13 +17,13 @@
 
 
 /* Local functions */
-local int gz_load OF((gz_statep, unsigned char *, unsigned, unsigned *));
-local int gz_avail OF((gz_statep));
-local int gz_look OF((gz_statep));
-local int gz_decomp OF((gz_statep));
-local int gz_fetch OF((gz_statep));
-local int gz_skip OF((gz_statep, z_off64_t));
-local z_size_t gz_read OF((gz_statep, voidp, z_size_t));
+local int gz_load _Z_OF((gz_statep, unsigned char *, unsigned, unsigned *));
+local int gz_avail _Z_OF((gz_statep));
+local int gz_look _Z_OF((gz_statep));
+local int gz_decomp _Z_OF((gz_statep));
+local int gz_fetch _Z_OF((gz_statep));
+local int gz_skip _Z_OF((gz_statep, z_off64_t));
+local z_size_t gz_read _Z_OF((gz_statep, voidp, z_size_t));
 
 /* Use read() to load a buffer -- return -1 on error, otherwise 0.  Read from
    state.state->fd, and update state.state->eof, state.state->err, and state.state->msg as appropriate.
@@ -464,8 +464,8 @@ z_size_t ZEXPORT gzfread(buf, size, nitems, file)
 #endif
 
 #if ZLIB_VERNUM <= 0x1250
-ZEXTERN int ZEXPORT gzgetc OF((gzFile file));
-ZEXTERN int ZEXPORT gzgetc_ OF((gzFile file));
+ZEXTERN int ZEXPORT gzgetc _Z_OF((gzFile file));
+ZEXTERN int ZEXPORT gzgetc_ _Z_OF((gzFile file));
 #endif
 
 int ZEXPORT gzgetc(file)

--- a/zlibWrapper/gzwrite.c
+++ b/zlibWrapper/gzwrite.c
@@ -11,10 +11,10 @@
 #include "gzguts.h"
 
 /* Local functions */
-local int gz_init OF((gz_statep));
-local int gz_comp OF((gz_statep, int));
-local int gz_zero OF((gz_statep, z_off64_t));
-local z_size_t gz_write OF((gz_statep, voidpc, z_size_t));
+local int gz_init _Z_OF((gz_statep));
+local int gz_comp _Z_OF((gz_statep, int));
+local int gz_zero _Z_OF((gz_statep, z_off64_t));
+local z_size_t gz_write _Z_OF((gz_statep, voidpc, z_size_t));
 
 /* Initialize state for writing a gzip file.  Mark initialization by setting
    state.state->size to non-zero.  Return -1 on a memory allocation failure, or 0 on

--- a/zlibWrapper/zstd_zlibwrapper.c
+++ b/zlibWrapper/zstd_zlibwrapper.c
@@ -101,7 +101,7 @@ ZWRAP_decompress_type ZWRAP_getDecompressionType(void) { return g_ZWRAPdecompres
 
 const char * zstdVersion(void) { return ZSTD_VERSION_STRING; }
 
-ZEXTERN const char * ZEXPORT z_zlibVersion OF((void)) { return zlibVersion();  }
+ZEXTERN const char * ZEXPORT z_zlibVersion _Z_OF((void)) { return zlibVersion();  }
 
 static void* ZWRAP_allocFunction(void* opaque, size_t size)
 {
@@ -260,7 +260,7 @@ static struct internal_state* convert_into_sis(void* ptr)
     return (struct internal_state*) ptr;
 }
 
-ZEXTERN int ZEXPORT z_deflateInit_ OF((z_streamp strm, int level,
+ZEXTERN int ZEXPORT z_deflateInit_ _Z_OF((z_streamp strm, int level,
                                      const char *version, int stream_size))
 {
     ZWRAP_CCtx* zwc;
@@ -287,7 +287,7 @@ ZEXTERN int ZEXPORT z_deflateInit_ OF((z_streamp strm, int level,
 }
 
 
-ZEXTERN int ZEXPORT z_deflateInit2_ OF((z_streamp strm, int level, int method,
+ZEXTERN int ZEXPORT z_deflateInit2_ _Z_OF((z_streamp strm, int level, int method,
                                       int windowBits, int memLevel,
                                       int strategy, const char *version,
                                       int stream_size))
@@ -319,7 +319,7 @@ int ZWRAP_deflateReset_keepDict(z_streamp strm)
 }
 
 
-ZEXTERN int ZEXPORT z_deflateReset OF((z_streamp strm))
+ZEXTERN int ZEXPORT z_deflateReset _Z_OF((z_streamp strm))
 {
     LOG_WRAPPERC("- deflateReset\n");
     if (!g_ZWRAP_useZSTDcompression)
@@ -334,7 +334,7 @@ ZEXTERN int ZEXPORT z_deflateReset OF((z_streamp strm))
 }
 
 
-ZEXTERN int ZEXPORT z_deflateSetDictionary OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_deflateSetDictionary _Z_OF((z_streamp strm,
                                              const Bytef *dictionary,
                                              uInt  dictLength))
 {
@@ -359,7 +359,7 @@ ZEXTERN int ZEXPORT z_deflateSetDictionary OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_deflate OF((z_streamp strm, int flush))
+ZEXTERN int ZEXPORT z_deflate _Z_OF((z_streamp strm, int flush))
 {
     ZWRAP_CCtx* zwc;
 
@@ -465,7 +465,7 @@ ZEXTERN int ZEXPORT z_deflate OF((z_streamp strm, int flush))
 }
 
 
-ZEXTERN int ZEXPORT z_deflateEnd OF((z_streamp strm))
+ZEXTERN int ZEXPORT z_deflateEnd _Z_OF((z_streamp strm))
 {
     if (!g_ZWRAP_useZSTDcompression) {
         LOG_WRAPPERC("- deflateEnd\n");
@@ -483,7 +483,7 @@ ZEXTERN int ZEXPORT z_deflateEnd OF((z_streamp strm))
 }
 
 
-ZEXTERN uLong ZEXPORT z_deflateBound OF((z_streamp strm,
+ZEXTERN uLong ZEXPORT z_deflateBound _Z_OF((z_streamp strm,
                                        uLong sourceLen))
 {
     if (!g_ZWRAP_useZSTDcompression)
@@ -493,7 +493,7 @@ ZEXTERN uLong ZEXPORT z_deflateBound OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_deflateParams OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_deflateParams _Z_OF((z_streamp strm,
                                       int level,
                                       int strategy))
 {
@@ -594,7 +594,7 @@ static int ZWRAPD_finishWithErrorMsg(z_streamp strm, char* message)
 }
 
 
-ZEXTERN int ZEXPORT z_inflateInit_ OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_inflateInit_ _Z_OF((z_streamp strm,
                                      const char* version, int stream_size))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB) {
@@ -623,7 +623,7 @@ ZEXTERN int ZEXPORT z_inflateInit_ OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_inflateInit2_ OF((z_streamp strm, int  windowBits,
+ZEXTERN int ZEXPORT z_inflateInit2_ _Z_OF((z_streamp strm, int  windowBits,
                                       const char *version, int stream_size))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB) {
@@ -660,7 +660,7 @@ int ZWRAP_inflateReset_keepDict(z_streamp strm)
 }
 
 
-ZEXTERN int ZEXPORT z_inflateReset OF((z_streamp strm))
+ZEXTERN int ZEXPORT z_inflateReset _Z_OF((z_streamp strm))
 {
     LOG_WRAPPERD("- inflateReset\n");
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !strm->reserved)
@@ -678,7 +678,7 @@ ZEXTERN int ZEXPORT z_inflateReset OF((z_streamp strm))
 
 
 #if ZLIB_VERNUM >= 0x1240
-ZEXTERN int ZEXPORT z_inflateReset2 OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_inflateReset2 _Z_OF((z_streamp strm,
                                       int windowBits))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !strm->reserved)
@@ -696,7 +696,7 @@ ZEXTERN int ZEXPORT z_inflateReset2 OF((z_streamp strm,
 #endif
 
 
-ZEXTERN int ZEXPORT z_inflateSetDictionary OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_inflateSetDictionary _Z_OF((z_streamp strm,
                                              const Bytef *dictionary,
                                              uInt  dictLength))
 {
@@ -730,7 +730,7 @@ ZEXTERN int ZEXPORT z_inflateSetDictionary OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_inflate OF((z_streamp strm, int flush))
+ZEXTERN int ZEXPORT z_inflate _Z_OF((z_streamp strm, int flush))
 {
     ZWRAP_DCtx* zwd;
 
@@ -926,7 +926,7 @@ error:
 }
 
 
-ZEXTERN int ZEXPORT z_inflateEnd OF((z_streamp strm))
+ZEXTERN int ZEXPORT z_inflateEnd _Z_OF((z_streamp strm))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !strm->reserved)
         return inflateEnd(strm);
@@ -943,7 +943,7 @@ ZEXTERN int ZEXPORT z_inflateEnd OF((z_streamp strm))
 }
 
 
-ZEXTERN int ZEXPORT z_inflateSync OF((z_streamp strm))
+ZEXTERN int ZEXPORT z_inflateSync _Z_OF((z_streamp strm))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !strm->reserved) {
         return inflateSync(strm);
@@ -955,7 +955,7 @@ ZEXTERN int ZEXPORT z_inflateSync OF((z_streamp strm))
 
 
 /* Advanced compression functions */
-ZEXTERN int ZEXPORT z_deflateCopy OF((z_streamp dest,
+ZEXTERN int ZEXPORT z_deflateCopy _Z_OF((z_streamp dest,
                                     z_streamp source))
 {
     if (!g_ZWRAP_useZSTDcompression)
@@ -964,7 +964,7 @@ ZEXTERN int ZEXPORT z_deflateCopy OF((z_streamp dest,
 }
 
 
-ZEXTERN int ZEXPORT z_deflateTune OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_deflateTune _Z_OF((z_streamp strm,
                                     int good_length,
                                     int max_lazy,
                                     int nice_length,
@@ -977,7 +977,7 @@ ZEXTERN int ZEXPORT z_deflateTune OF((z_streamp strm,
 
 
 #if ZLIB_VERNUM >= 0x1260
-ZEXTERN int ZEXPORT z_deflatePending OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_deflatePending _Z_OF((z_streamp strm,
                                        unsigned *pending,
                                        int *bits))
 {
@@ -988,7 +988,7 @@ ZEXTERN int ZEXPORT z_deflatePending OF((z_streamp strm,
 #endif
 
 
-ZEXTERN int ZEXPORT z_deflatePrime OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_deflatePrime _Z_OF((z_streamp strm,
                                      int bits,
                                      int value))
 {
@@ -998,7 +998,7 @@ ZEXTERN int ZEXPORT z_deflatePrime OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_deflateSetHeader OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_deflateSetHeader _Z_OF((z_streamp strm,
                                          gz_headerp head))
 {
     if (!g_ZWRAP_useZSTDcompression)
@@ -1011,7 +1011,7 @@ ZEXTERN int ZEXPORT z_deflateSetHeader OF((z_streamp strm,
 
 /* Advanced decompression functions */
 #if ZLIB_VERNUM >= 0x1280
-ZEXTERN int ZEXPORT z_inflateGetDictionary OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_inflateGetDictionary _Z_OF((z_streamp strm,
                                              Bytef *dictionary,
                                              uInt  *dictLength))
 {
@@ -1022,7 +1022,7 @@ ZEXTERN int ZEXPORT z_inflateGetDictionary OF((z_streamp strm,
 #endif
 
 
-ZEXTERN int ZEXPORT z_inflateCopy OF((z_streamp dest,
+ZEXTERN int ZEXPORT z_inflateCopy _Z_OF((z_streamp dest,
                                     z_streamp source))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !source->reserved)
@@ -1032,7 +1032,7 @@ ZEXTERN int ZEXPORT z_inflateCopy OF((z_streamp dest,
 
 
 #if ZLIB_VERNUM >= 0x1240
-ZEXTERN long ZEXPORT z_inflateMark OF((z_streamp strm))
+ZEXTERN long ZEXPORT z_inflateMark _Z_OF((z_streamp strm))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !strm->reserved)
         return inflateMark(strm);
@@ -1041,7 +1041,7 @@ ZEXTERN long ZEXPORT z_inflateMark OF((z_streamp strm))
 #endif
 
 
-ZEXTERN int ZEXPORT z_inflatePrime OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_inflatePrime _Z_OF((z_streamp strm,
                                      int bits,
                                      int value))
 {
@@ -1051,7 +1051,7 @@ ZEXTERN int ZEXPORT z_inflatePrime OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_inflateGetHeader OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_inflateGetHeader _Z_OF((z_streamp strm,
                                          gz_headerp head))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !strm->reserved)
@@ -1060,7 +1060,7 @@ ZEXTERN int ZEXPORT z_inflateGetHeader OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_inflateBackInit_ OF((z_streamp strm, int windowBits,
+ZEXTERN int ZEXPORT z_inflateBackInit_ _Z_OF((z_streamp strm, int windowBits,
                                          unsigned char FAR *window,
                                          const char *version,
                                          int stream_size))
@@ -1071,7 +1071,7 @@ ZEXTERN int ZEXPORT z_inflateBackInit_ OF((z_streamp strm, int windowBits,
 }
 
 
-ZEXTERN int ZEXPORT z_inflateBack OF((z_streamp strm,
+ZEXTERN int ZEXPORT z_inflateBack _Z_OF((z_streamp strm,
                                     in_func in, void FAR *in_desc,
                                     out_func out, void FAR *out_desc))
 {
@@ -1081,7 +1081,7 @@ ZEXTERN int ZEXPORT z_inflateBack OF((z_streamp strm,
 }
 
 
-ZEXTERN int ZEXPORT z_inflateBackEnd OF((z_streamp strm))
+ZEXTERN int ZEXPORT z_inflateBackEnd _Z_OF((z_streamp strm))
 {
     if (g_ZWRAPdecompressionType == ZWRAP_FORCE_ZLIB || !strm->reserved)
         return inflateBackEnd(strm);
@@ -1089,14 +1089,14 @@ ZEXTERN int ZEXPORT z_inflateBackEnd OF((z_streamp strm))
 }
 
 
-ZEXTERN uLong ZEXPORT z_zlibCompileFlags OF((void)) { return zlibCompileFlags(); }
+ZEXTERN uLong ZEXPORT z_zlibCompileFlags _Z_OF((void)) { return zlibCompileFlags(); }
 
 
 
                     /* ===   utility functions  === */
 #ifndef Z_SOLO
 
-ZEXTERN int ZEXPORT z_compress OF((Bytef *dest,   uLongf *destLen,
+ZEXTERN int ZEXPORT z_compress _Z_OF((Bytef *dest,   uLongf *destLen,
                                  const Bytef *source, uLong sourceLen))
 {
     if (!g_ZWRAP_useZSTDcompression)
@@ -1115,7 +1115,7 @@ ZEXTERN int ZEXPORT z_compress OF((Bytef *dest,   uLongf *destLen,
 }
 
 
-ZEXTERN int ZEXPORT z_compress2 OF((Bytef *dest,   uLongf *destLen,
+ZEXTERN int ZEXPORT z_compress2 _Z_OF((Bytef *dest,   uLongf *destLen,
                                   const Bytef *source, uLong sourceLen,
                                   int level))
 {
@@ -1131,7 +1131,7 @@ ZEXTERN int ZEXPORT z_compress2 OF((Bytef *dest,   uLongf *destLen,
 }
 
 
-ZEXTERN uLong ZEXPORT z_compressBound OF((uLong sourceLen))
+ZEXTERN uLong ZEXPORT z_compressBound _Z_OF((uLong sourceLen))
 {
     if (!g_ZWRAP_useZSTDcompression)
         return compressBound(sourceLen);
@@ -1140,7 +1140,7 @@ ZEXTERN uLong ZEXPORT z_compressBound OF((uLong sourceLen))
 }
 
 
-ZEXTERN int ZEXPORT z_uncompress OF((Bytef *dest,   uLongf *destLen,
+ZEXTERN int ZEXPORT z_uncompress _Z_OF((Bytef *dest,   uLongf *destLen,
                                    const Bytef *source, uLong sourceLen))
 {
     if (!ZSTD_isFrame(source, sourceLen))
@@ -1159,24 +1159,24 @@ ZEXTERN int ZEXPORT z_uncompress OF((Bytef *dest,   uLongf *destLen,
 
                         /* checksum functions */
 
-ZEXTERN uLong ZEXPORT z_adler32 OF((uLong adler, const Bytef *buf, uInt len))
+ZEXTERN uLong ZEXPORT z_adler32 _Z_OF((uLong adler, const Bytef *buf, uInt len))
 {
     return adler32(adler, buf, len);
 }
 
-ZEXTERN uLong ZEXPORT z_crc32   OF((uLong crc, const Bytef *buf, uInt len))
+ZEXTERN uLong ZEXPORT z_crc32   _Z_OF((uLong crc, const Bytef *buf, uInt len))
 {
     return crc32(crc, buf, len);
 }
 
 
 #if ZLIB_VERNUM >= 0x12B0
-ZEXTERN uLong ZEXPORT z_adler32_z OF((uLong adler, const Bytef *buf, z_size_t len))
+ZEXTERN uLong ZEXPORT z_adler32_z _Z_OF((uLong adler, const Bytef *buf, z_size_t len))
 {
     return adler32_z(adler, buf, len);
 }
 
-ZEXTERN uLong ZEXPORT z_crc32_z OF((uLong crc, const Bytef *buf, z_size_t len))
+ZEXTERN uLong ZEXPORT z_crc32_z _Z_OF((uLong crc, const Bytef *buf, z_size_t len))
 {
     return crc32_z(crc, buf, len);
 }
@@ -1184,14 +1184,14 @@ ZEXTERN uLong ZEXPORT z_crc32_z OF((uLong crc, const Bytef *buf, z_size_t len))
 
 
 #if ZLIB_VERNUM >= 0x1270
-ZEXTERN const z_crc_t FAR * ZEXPORT z_get_crc_table    OF((void))
+ZEXTERN const z_crc_t FAR * ZEXPORT z_get_crc_table    _Z_OF((void))
 {
     return get_crc_table();
 }
 #endif
 
                         /* Error function */
-ZEXTERN const char * ZEXPORT z_zError OF((int err))
+ZEXTERN const char * ZEXPORT z_zError _Z_OF((int err))
 {
     /* Just use zlib Error function */
     return zError(err);

--- a/zlibWrapper/zstd_zlibwrapper.h
+++ b/zlibWrapper/zstd_zlibwrapper.h
@@ -25,6 +25,9 @@ extern "C" {
     #define z_const
 #endif
 
+#if !defined(_Z_OF)
+    #define _Z_OF OF
+#endif
 
 /* returns a string with version of zstd library */
 const char * zstdVersion(void);


### PR DESCRIPTION
In zlib `1.2.12` the `OF` macro was changed to `_Z_OF` breaking any project that used zlibWrapper. To fix this the OF has been changed to `_Z_OF` everywhere and `_Z_OF` is defined as `OF` in the case it is not yet defined for zlib `1.2.11` and older.

Fixes: https://github.com/facebook/zstd/issues/3216