### PR TITLE
[AIX] Fix Compiler Flags and Bugs on AIX to Pass All Tests

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -242,7 +242,7 @@ zstd-pgo :
 	$(MAKE) zstd MOREFLAGS=-fprofile-use
 
 ## zstd-small: minimal target, supporting only zstd compression and decompression. no bench. no legacy. no other format.
-zstd-small: CFLAGS = -Os -s
+zstd-small: CFLAGS = -Os -Wl,-s
 zstd-frugal zstd-small: $(ZSTDLIB_CORE_SRC) zstdcli.c util.c timefn.c fileio.c fileio_asyncio.c
 	$(CC) $(FLAGS) -DZSTD_NOBENCH -DZSTD_NODICT -DZSTD_NOTRACE -UZSTD_LEGACY_SUPPORT -DZSTD_LEGACY_SUPPORT=0 $^ -o $@$(EXT)
 

--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -355,7 +355,7 @@ int DiB_trainFromFiles(const char* dictFileName, size_t maxDictSize,
     }
 
     /* Checks */
-    if ((!sampleSizes) || (!srcBuffer) || (!dictBuffer))
+    if ((fs.nbSamples && !sampleSizes) || (!srcBuffer) || (!dictBuffer))
         EXM_THROW(12, "not enough memory for DiB_trainFiles");   /* should not happen */
     if (fs.oneSampleTooLarge) {
         DISPLAYLEVEL(2, "!  Warning : some sample(s) are very large \n");

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -219,7 +219,7 @@ static void ABRThandler(int sig) {
 }
 #endif
 
-void FIO_addAbortHandler()
+void FIO_addAbortHandler(void)
 {
 #if BACKTRACE_ENABLE
     signal(SIGABRT, ABRThandler);

--- a/programs/util.c
+++ b/programs/util.c
@@ -1378,6 +1378,9 @@ int UTIL_countCores(int logical)
 
 int UTIL_countCores(int logical)
 {
+    /* suppress unused parameter warning */
+    (void)logical;
+
     /* assume 1 */
     return 1;
 }

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -317,7 +317,7 @@ zstd -d -f tmp_corrupt.zst --no-check
 zstd -d -f tmp_corrupt.zst --check --no-check # final flag overrides
 zstd -d -f tmp.zst --no-check
 
-if [ "$isWindows" = false ]; then
+if [ "$isWindows" = false ] && [ "$UNAME" != "AIX" ]; then
   if [ -n "$(which readelf)" ]; then
     println "test: check if binary has executable stack (#2963)"
     readelf -lW "$ZSTD_BIN" | grep 'GNU_STACK .* RW ' || die "zstd binary has executable stack!"


### PR DESCRIPTION
This PR fixes: 

- Code that triggers compiler warnings (unused argument and function prototype warnings)
- The `-s` compiler flag that is no longer supported by newer versions of `clang`. It is replaced by `-Wl,-s`. 
- `malloc` of size zero returns 0 on AIX, causing the `dict-builder/no-inputs.sh` test case to fail. 