### PR TITLE
Disallow empty string as argument for --output-dir-flat and --output-dir-mirror

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -870,30 +870,30 @@ static const char * trimPath(const char *pathname)
 
 static char* mallocAndJoin2Dir(const char *dir1, const char *dir2)
 {
-    const size_t dir1Size = strlen(dir1);
-    const size_t dir2Size = strlen(dir2);
-    char *outDirBuffer, *buffer, trailingChar;
-
     assert(dir1 != NULL && dir2 != NULL);
-    outDirBuffer = (char *) malloc(dir1Size + dir2Size + 2);
-    CONTROL(outDirBuffer != NULL);
+    {   const size_t dir1Size = strlen(dir1);
+        const size_t dir2Size = strlen(dir2);
+        char *outDirBuffer, *buffer;
 
-    memcpy(outDirBuffer, dir1, dir1Size);
-    outDirBuffer[dir1Size] = '\0';
+        outDirBuffer = (char *) malloc(dir1Size + dir2Size + 2);
+        CONTROL(outDirBuffer != NULL);
 
-    if (dir2[0] == '.')
+        memcpy(outDirBuffer, dir1, dir1Size);
+        outDirBuffer[dir1Size] = '\0';
+
+        if (dir2[0] == '.')
+            return outDirBuffer;
+
+        buffer = outDirBuffer + dir1Size;
+        if (dir1Size > 0 && *(buffer - 1) != PATH_SEP) {
+            *buffer = PATH_SEP;
+            buffer++;
+        }
+        memcpy(buffer, dir2, dir2Size);
+        buffer[dir2Size] = '\0';
+
         return outDirBuffer;
-
-    buffer = outDirBuffer + dir1Size;
-    trailingChar = *(buffer - 1);
-    if (trailingChar != PATH_SEP) {
-        *buffer = PATH_SEP;
-        buffer++;
     }
-    memcpy(buffer, dir2, dir2Size);
-    buffer[dir2Size] = '\0';
-
-    return outDirBuffer;
 }
 
 /* this function will return NULL if input srcFileName is not valid name for mirrored output path */

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1011,7 +1011,14 @@ int main(int argCount, const char* argv[])
                 if (longCommandWArg(&argument, "--stream-size=")) { streamSrcSize = readSizeTFromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--target-compressed-block-size=")) { targetCBlockSize = readSizeTFromChar(&argument); continue; }
                 if (longCommandWArg(&argument, "--size-hint=")) { srcSizeHint = readSizeTFromChar(&argument); continue; }
-                if (longCommandWArg(&argument, "--output-dir-flat")) { NEXT_FIELD(outDirName); continue; }
+                if (longCommandWArg(&argument, "--output-dir-flat")) {
+                    NEXT_FIELD(outDirName);
+                    if (strlen(outDirName) == 0) {
+                        DISPLAY("error: output dir cannot be empty string (did you mean to pass '.' instead?)\n");
+                        CLEAN_RETURN(1);
+                    }
+                    continue;
+                }
                 if (longCommandWArg(&argument, "--auto-threads")) {
                     const char* threadDefault = NULL;
                     NEXT_FIELD(threadDefault);
@@ -1020,7 +1027,14 @@ int main(int argCount, const char* argv[])
                     continue;
                 }
 #ifdef UTIL_HAS_MIRRORFILELIST
-                if (longCommandWArg(&argument, "--output-dir-mirror")) { NEXT_FIELD(outMirroredDirName); continue; }
+                if (longCommandWArg(&argument, "--output-dir-mirror")) {
+                    NEXT_FIELD(outMirroredDirName);
+                    if (strlen(outMirroredDirName) == 0) {
+                        DISPLAY("error: output dir cannot be empty string (did you mean to pass '.' instead?)\n");
+                        CLEAN_RETURN(1);
+                    }
+                    continue;
+                }
 #endif
 #ifndef ZSTD_NOTRACE
                 if (longCommandWArg(&argument, "--trace")) { char const* traceFile; NEXT_FIELD(traceFile); TRACE_enable(traceFile); continue; }

--- a/tests/cli-tests/basic/output_dir.sh
+++ b/tests/cli-tests/basic/output_dir.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+println "+ zstd -r * --output-dir-mirror=\"\""
+zstd -r * --output-dir-mirror="" && die "Should not allow empty output dir!"
+println "+ zstd -r * --output-dir-flat=\"\""
+zstd -r * --output-dir-flat="" && die "Should not allow empty output dir!"
+exit 0

--- a/tests/cli-tests/basic/output_dir.sh.stderr.exact
+++ b/tests/cli-tests/basic/output_dir.sh.stderr.exact
@@ -1,0 +1,2 @@
+error: output dir cannot be empty string (did you mean to pass '.' instead?)
+error: output dir cannot be empty string (did you mean to pass '.' instead?)

--- a/tests/cli-tests/basic/output_dir.sh.stdout.exact
+++ b/tests/cli-tests/basic/output_dir.sh.stdout.exact
@@ -1,0 +1,2 @@
++ zstd -r * --output-dir-mirror=""
++ zstd -r * --output-dir-flat=""


### PR DESCRIPTION
* Move safety checks before strlen calls (better error reporting in debug builds)
* Fix buffer underflow when `dir1 == ""` (fixes https://github.com/facebook/zstd/issues/3200#event-7066815026)

Edit: commit [e1873ad](https://github.com/facebook/zstd/pull/3220/commits/e1873ad576cb478fff0e6e44ad99599cd5fd2846) fixes the buffer underflow, but I realized there is a deeper issue here. The current behavior for `--output-dir-flat=""` and `--output-dir-mirror=""` maps `"" -> "/"`. This is bad. Therefore, in [f9f27de](https://github.com/facebook/zstd/pull/3220/commits/f9f27de91c89d826c6a39c3ef44fb1b02f9a43aa), I disallow empty string as an argument for those flags (and add a test verifying that behavior).