### PR TITLE
[easy] fixed missing include

### DIFF
--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -12,8 +12,9 @@
 #ifndef FILEIO_H_23981798732
 #define FILEIO_H_23981798732
 
-#define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_compressionParameters */
 #include "fileio_types.h"
+#include "util.h"                  /* FileNamesTable */
+#define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_compressionParameters */
 #include "../lib/zstd.h"           /* ZSTD_* */
 
 #if defined (__cplusplus)


### PR DESCRIPTION
Surprisingly, the issue was not detected before
probably because `"fileio.h"` is always included after `"util.h"`.