### PR TITLE
drop -E flag in sed

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -298,7 +298,7 @@ INSTALL_DATA    ?= $(INSTALL) -m 644
 
 libzstd.pc: libzstd.pc.in
 	@echo creating pkgconfig
-	@sed $(SED_ERE_OPT) \
+	@sed \
 	        -e 's|@PREFIX@|$(PREFIX)|' \
 	        -e 's|@EXEC_PREFIX@|$(PCEXEC_PREFIX)|' \
 	        -e 's|@INCLUDEDIR@|$(PCINCPREFIX)$(PCINCDIR)|' \

--- a/lib/libzstd.mk
+++ b/lib/libzstd.mk
@@ -124,7 +124,6 @@ ifeq ($HAVE_COLORNEVER, 1)
   GREP_OPTIONS += --color=never
 endif
 GREP = grep $(GREP_OPTIONS)
-SED_ERE_OPT ?= -E
 
 ZSTD_COMMON_FILES := $(sort $(wildcard $(LIBZSTD)/common/*.c))
 ZSTD_COMPRESS_FILES := $(sort $(wildcard $(LIBZSTD)/compress/*.c))


### PR DESCRIPTION
This flag is not universally supported in `sed`, and there's no regex replacement going on anwyays, it's literal text replacement.

`-E` is missing in `sed` version 4.1.5 for example, as found on some ancient centos image I'm working with.