### PR TITLE
Fix typo found by codespell

### DIFF
--- a/lib/common/huf.h
+++ b/lib/common/huf.h
@@ -204,12 +204,12 @@ typedef enum {
  *  If it uses hufTable it does not modify hufTable or repeat.
  *  If it doesn't, it sets *repeat = HUF_repeat_none, and it sets hufTable to the table used.
  *  If preferRepeat then the old table will always be used if valid.
- *  If suspectUncompressible then some sampling checks will be run to potentially skip huffman coding */
+ *  If suspectIncompressible then some sampling checks will be run to potentially skip huffman coding */
 size_t HUF_compress4X_repeat(void* dst, size_t dstSize,
                        const void* src, size_t srcSize,
                        unsigned maxSymbolValue, unsigned tableLog,
                        void* workSpace, size_t wkspSize,    /**< `workSpace` must be aligned on 4-bytes boundaries, `wkspSize` must be >= HUF_WORKSPACE_SIZE */
-                       HUF_CElt* hufTable, HUF_repeat* repeat, int preferRepeat, int bmi2, unsigned suspectUncompressible);
+                       HUF_CElt* hufTable, HUF_repeat* repeat, int preferRepeat, int bmi2, unsigned suspectIncompressible);
 
 /** HUF_buildCTable_wksp() :
  *  Same as HUF_buildCTable(), but using externally allocated scratch buffer.
@@ -310,12 +310,12 @@ size_t HUF_compress1X_usingCTable_bmi2(void* dst, size_t dstSize, const void* sr
  *  If it uses hufTable it does not modify hufTable or repeat.
  *  If it doesn't, it sets *repeat = HUF_repeat_none, and it sets hufTable to the table used.
  *  If preferRepeat then the old table will always be used if valid.
- *  If suspectUncompressible then some sampling checks will be run to potentially skip huffman coding */
+ *  If suspectIncompressible then some sampling checks will be run to potentially skip huffman coding */
 size_t HUF_compress1X_repeat(void* dst, size_t dstSize,
                        const void* src, size_t srcSize,
                        unsigned maxSymbolValue, unsigned tableLog,
                        void* workSpace, size_t wkspSize,   /**< `workSpace` must be aligned on 4-bytes boundaries, `wkspSize` must be >= HUF_WORKSPACE_SIZE */
-                       HUF_CElt* hufTable, HUF_repeat* repeat, int preferRepeat, int bmi2, unsigned suspectUncompressible);
+                       HUF_CElt* hufTable, HUF_repeat* repeat, int preferRepeat, int bmi2, unsigned suspectIncompressible);
 
 size_t HUF_decompress1X1 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* single-symbol decoder */
 #ifndef HUF_FORCE_DECOMPRESS_X1

--- a/lib/compress/huf_compress.c
+++ b/lib/compress/huf_compress.c
@@ -1214,7 +1214,7 @@ static size_t HUF_compressCTable_internal(
                          HUF_compress1X_usingCTable_internal(op, (size_t)(oend - op), src, srcSize, CTable, bmi2) :
                          HUF_compress4X_usingCTable_internal(op, (size_t)(oend - op), src, srcSize, CTable, bmi2);
     if (HUF_isError(cSize)) { return cSize; }
-    if (cSize==0) { return 0; }   /* uncompressible */
+    if (cSize==0) { return 0; }   /* incompressible */
     op += cSize;
     /* check compressibility */
     assert(op >= ostart);
@@ -1254,7 +1254,7 @@ HUF_compress_internal (void* dst, size_t dstSize,
                        HUF_nbStreams_e nbStreams,
                        void* workSpace, size_t wkspSize,
                        HUF_CElt* oldHufTable, HUF_repeat* repeat, int preferRepeat,
-                 const int bmi2, unsigned suspectUncompressible)
+                 const int bmi2, unsigned suspectIncompressible)
 {
     HUF_compress_tables_t* const table = (HUF_compress_tables_t*)HUF_alignUpWorkspace(workSpace, &wkspSize, ZSTD_ALIGNOF(size_t));
     BYTE* const ostart = (BYTE*)dst;
@@ -1281,9 +1281,9 @@ HUF_compress_internal (void* dst, size_t dstSize,
                                            nbStreams, oldHufTable, bmi2);
     }
 
-    /* If uncompressible data is suspected, do a smaller sampling first */
+    /* If incompressible data is suspected, do a smaller sampling first */
     DEBUG_STATIC_ASSERT(SUSPECT_INCOMPRESSIBLE_SAMPLE_RATIO >= 2);
-    if (suspectUncompressible && srcSize >= (SUSPECT_INCOMPRESSIBLE_SAMPLE_SIZE * SUSPECT_INCOMPRESSIBLE_SAMPLE_RATIO)) {
+    if (suspectIncompressible && srcSize >= (SUSPECT_INCOMPRESSIBLE_SAMPLE_SIZE * SUSPECT_INCOMPRESSIBLE_SAMPLE_RATIO)) {
         size_t largestTotal = 0;
         DEBUGLOG(5, "input suspected incompressible : sampling to check");
         {   unsigned maxSymbolValueBegin = maxSymbolValue;
@@ -1375,13 +1375,13 @@ size_t HUF_compress1X_repeat (void* dst, size_t dstSize,
                       unsigned maxSymbolValue, unsigned huffLog,
                       void* workSpace, size_t wkspSize,
                       HUF_CElt* hufTable, HUF_repeat* repeat, int preferRepeat,
-                      int bmi2, unsigned suspectUncompressible)
+                      int bmi2, unsigned suspectIncompressible)
 {
     DEBUGLOG(5, "HUF_compress1X_repeat (srcSize = %zu)", srcSize);
     return HUF_compress_internal(dst, dstSize, src, srcSize,
                                  maxSymbolValue, huffLog, HUF_singleStream,
                                  workSpace, wkspSize, hufTable,
-                                 repeat, preferRepeat, bmi2, suspectUncompressible);
+                                 repeat, preferRepeat, bmi2, suspectIncompressible);
 }
 
 /* HUF_compress4X_repeat():
@@ -1407,13 +1407,13 @@ size_t HUF_compress4X_repeat (void* dst, size_t dstSize,
                       const void* src, size_t srcSize,
                       unsigned maxSymbolValue, unsigned huffLog,
                       void* workSpace, size_t wkspSize,
-                      HUF_CElt* hufTable, HUF_repeat* repeat, int preferRepeat, int bmi2, unsigned suspectUncompressible)
+                      HUF_CElt* hufTable, HUF_repeat* repeat, int preferRepeat, int bmi2, unsigned suspectIncompressible)
 {
     DEBUGLOG(5, "HUF_compress4X_repeat (srcSize = %zu)", srcSize);
     return HUF_compress_internal(dst, dstSize, src, srcSize,
                                  maxSymbolValue, huffLog, HUF_fourStreams,
                                  workSpace, wkspSize,
-                                 hufTable, repeat, preferRepeat, bmi2, suspectUncompressible);
+                                 hufTable, repeat, preferRepeat, bmi2, suspectIncompressible);
 }
 
 #ifndef ZSTD_NO_UNUSED_FUNCTIONS

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2613,7 +2613,7 @@ ZSTD_buildSequencesStatistics(seqStore_t* seqStorePtr, size_t nbSeq,
  * compresses both literals and sequences
  * Returns compressed size of block, or a zstd error.
  */
-#define SUSPECT_UNCOMPRESSIBLE_LITERAL_RATIO 20
+#define SUSPECT_INCOMPRESSIBLE_LITERAL_RATIO 20
 MEM_STATIC size_t
 ZSTD_entropyCompressSeqStore_internal(seqStore_t* seqStorePtr,
                           const ZSTD_entropyCTables_t* prevEntropy,
@@ -2651,7 +2651,7 @@ ZSTD_entropyCompressSeqStore_internal(seqStore_t* seqStorePtr,
         size_t const numSequences = seqStorePtr->sequences - seqStorePtr->sequencesStart;
         size_t const numLiterals = seqStorePtr->lit - seqStorePtr->litStart;
         /* Base suspicion of uncompressibility on ratio of literals to sequences */
-        unsigned const suspectUncompressible = (numSequences == 0) || (numLiterals / numSequences >= SUSPECT_UNCOMPRESSIBLE_LITERAL_RATIO);
+        unsigned const suspectIncompressible = (numSequences == 0) || (numLiterals / numSequences >= SUSPECT_INCOMPRESSIBLE_LITERAL_RATIO);
         size_t const litSize = (size_t)(seqStorePtr->lit - literals);
         size_t const cSize = ZSTD_compressLiterals(
                                     &prevEntropy->huf, &nextEntropy->huf,
@@ -2660,7 +2660,7 @@ ZSTD_entropyCompressSeqStore_internal(seqStore_t* seqStorePtr,
                                     op, dstCapacity,
                                     literals, litSize,
                                     entropyWorkspace, entropyWkspSize,
-                                    bmi2, suspectUncompressible);
+                                    bmi2, suspectIncompressible);
         FORWARD_IF_ERROR(cSize, "ZSTD_compressLiterals failed");
         assert(cSize <= dstCapacity);
         op += cSize;

--- a/lib/compress/zstd_compress_literals.c
+++ b/lib/compress/zstd_compress_literals.c
@@ -99,7 +99,7 @@ size_t ZSTD_compressLiterals (ZSTD_hufCTables_t const* prevHuf,
                         const void* src, size_t srcSize,
                               void* entropyWorkspace, size_t entropyWorkspaceSize,
                         const int bmi2,
-                        unsigned suspectUncompressible)
+                        unsigned suspectIncompressible)
 {
     size_t const minGain = ZSTD_minGain(srcSize, strategy);
     size_t const lhSize = 3 + (srcSize >= 1 KB) + (srcSize >= 16 KB);
@@ -138,7 +138,7 @@ size_t ZSTD_compressLiterals (ZSTD_hufCTables_t const* prevHuf,
                                 entropyWorkspace, entropyWorkspaceSize,
                                 (HUF_CElt*)nextHuf->CTable,
                                 &repeat, preferRepeat,
-                                bmi2, suspectUncompressible);
+                                bmi2, suspectIncompressible);
         if (repeat != HUF_repeat_none) {
             /* reused the existing table */
             DEBUGLOG(5, "Reusing previous huffman table");

--- a/lib/compress/zstd_compress_literals.h
+++ b/lib/compress/zstd_compress_literals.h
@@ -18,7 +18,7 @@ size_t ZSTD_noCompressLiterals (void* dst, size_t dstCapacity, const void* src, 
 
 size_t ZSTD_compressRleLiteralsBlock (void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 
-/* If suspectUncompressible then some sampling checks will be run to potentially skip huffman coding */
+/* If suspectIncompressible then some sampling checks will be run to potentially skip huffman coding */
 size_t ZSTD_compressLiterals (ZSTD_hufCTables_t const* prevHuf,
                               ZSTD_hufCTables_t* nextHuf,
                               ZSTD_strategy strategy, int disableLiteralCompression,
@@ -26,6 +26,6 @@ size_t ZSTD_compressLiterals (ZSTD_hufCTables_t const* prevHuf,
                         const void* src, size_t srcSize,
                               void* entropyWorkspace, size_t entropyWorkspaceSize,
                         const int bmi2,
-                        unsigned suspectUncompressible);
+                        unsigned suspectIncompressible);
 
 #endif /* ZSTD_COMPRESS_LITERALS_H */

--- a/lib/compress/zstd_compress_superblock.c
+++ b/lib/compress/zstd_compress_superblock.c
@@ -88,7 +88,7 @@ ZSTD_compressSubBlock_literal(const HUF_CElt* hufTable,
         }
         /* If we expand and we aren't writing a header then emit uncompressed */
         if (!writeEntropy && cLitSize >= litSize) {
-            DEBUGLOG(5, "ZSTD_compressSubBlock_literal using raw literal because uncompressible");
+            DEBUGLOG(5, "ZSTD_compressSubBlock_literal using raw literal because incompressible");
             return ZSTD_noCompressLiterals(dst, dstSize, literals, litSize);
         }
         /* If we are writing headers then allow expansion that doesn't change our header size. */

--- a/lib/zdict.h
+++ b/lib/zdict.h
@@ -245,7 +245,7 @@ typedef struct {
  *       instructed to, using notificationLevel>0.
  * NOTE: This function currently may fail in several edge cases including:
  *         * Not enough samples
- *         * Samples are uncompressible
+ *         * Samples are incompressible
  *         * Samples are all exactly the same
  */
 ZDICTLIB_API size_t ZDICT_finalizeDictionary(void* dstDictBuffer, size_t maxDictSize,

--- a/tests/decodecorpus.c
+++ b/tests/decodecorpus.c
@@ -225,7 +225,7 @@ typedef struct {
     frameHeader_t header;
 
     cblockStats_t stats;
-    cblockStats_t oldStats; /* so they can be rolled back if uncompressible */
+    cblockStats_t oldStats; /* so they can be rolled back if incompressible */
 } frame_t;
 
 typedef struct {

--- a/tests/fuzz/huf_round_trip.c
+++ b/tests/fuzz/huf_round_trip.c
@@ -89,7 +89,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
     FUZZ_ZASSERT(tableLog);
     size_t const tableSize = HUF_writeCTable_wksp(cBuf, cBufSize, ct, maxSymbol, tableLog, wksp, wkspSize);
     if (ERR_isError(tableSize)) {
-        /* Errors on uncompressible data or cBufSize too small */
+        /* Errors on incompressible data or cBufSize too small */
         goto _out;
     }
     FUZZ_ZASSERT(tableSize);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -932,7 +932,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
-    DISPLAYLEVEL(3, "test%3i : LDM + opt parser with small uncompressible block ", testNb++);
+    DISPLAYLEVEL(3, "test%3i : LDM + opt parser with small incompressible block ", testNb++);
     {   ZSTD_CCtx* cctx = ZSTD_createCCtx();
         ZSTD_DCtx* dctx = ZSTD_createDCtx();
         size_t const srcSize = 300 KB;
@@ -951,7 +951,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         }
 
         RDG_genBuffer(src, srcSize, 0.5, 0.5, seed);
-        /* Force an LDM to exist that crosses block boundary into uncompressible block */
+        /* Force an LDM to exist that crosses block boundary into incompressible block */
         memcpy(src + 125 KB, src, 3 KB + 5);
 
         /* Enable MT, LDM, and opt parser */
@@ -1069,7 +1069,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();
         ZSTD_DCtx* const dctx = ZSTD_createDCtx();
 
-        /* make dict and src the same uncompressible data */
+        /* make dict and src the same incompressible data */
         RDG_genBuffer(src, size, 0, 0, seed);
         memcpy(dict, src, size);
         assert(!memcmp(dict, src, size));
@@ -1117,7 +1117,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
-    DISPLAYLEVEL(3, "test%3d: superblock uncompressible data, too many nocompress superblocks : ", testNb++);
+    DISPLAYLEVEL(3, "test%3d: superblock incompressible data, too many nocompress superblocks : ", testNb++);
     {
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();
         const BYTE* src = (BYTE*)CNBuffer; BYTE* dst = (BYTE*)compressedBuffer;
@@ -1130,16 +1130,16 @@ static int basicUnitTests(U32 const seed, double compressibility)
         const size_t streamCompressDelta = 1024;
 
         /* The first 1/5 of the buffer is compressible and the last 4/5 is
-         * uncompressible. This is an approximation of the type of data
+         * incompressible. This is an approximation of the type of data
          * the fuzzer generated to catch this bug. Streams like this were making
          * zstd generate noCompress superblocks (which are larger than the src
          * they come from). Do this enough times, and we'll run out of room
          * and throw a dstSize_tooSmall error. */
 
         const size_t compressiblePartSize = srcSize/5;
-        const size_t uncompressiblePartSize = srcSize-compressiblePartSize;
+        const size_t incompressiblePartSize = srcSize-compressiblePartSize;
         RDG_genBuffer(CNBuffer, compressiblePartSize, 0.5, 0.5, seed);
-        RDG_genBuffer((BYTE*)CNBuffer+compressiblePartSize, uncompressiblePartSize, 0, 0, seed);
+        RDG_genBuffer((BYTE*)CNBuffer+compressiblePartSize, incompressiblePartSize, 0, 0, seed);
 
         /* Setting target block size so that superblock is used */
 

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1687,7 +1687,7 @@ static int basicUnitTests(U32 seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
-    DISPLAYLEVEL(3, "test%3i : dictionary + uncompressible block + reusing tables checks offset table validity: ", testNb++);
+    DISPLAYLEVEL(3, "test%3i : dictionary + incompressible block + reusing tables checks offset table validity: ", testNb++);
     {   ZSTD_CDict* const cdict = ZSTD_createCDict_advanced(
             dictionary.start, dictionary.filled,
             ZSTD_dlm_byRef, ZSTD_dct_fullDict,
@@ -1705,7 +1705,7 @@ static int basicUnitTests(U32 seed, double compressibility)
         CHECK(cdict == NULL, "failed to alloc cdict");
         CHECK(inbuf == NULL, "failed to alloc input buffer");
 
-        /* first block is uncompressible */
+        /* first block is incompressible */
         cursegmentlen = 128 * 1024;
         RDG_genBuffer(inbuf + inbufpos, cursegmentlen, 0., 0., seed);
         inbufpos += cursegmentlen;


### PR DESCRIPTION
Although `uncompressible` is not uncommon, most dictionaries do not show it as valid:
* [Cambridge Dictionary](https://dictionary.cambridge.org/dictionary/english/incompressible)
* [Oxford Learner's Dictionaries](https://www.oxfordlearnersdictionaries.com/definition/english/incomprehensible)
* [Merriam-Webster](https://www.merriam-webster.com/dictionary/incompressible)
* [Collins](https://www.collinsdictionary.com/dictionary/english/incompressible)
* [Dictionary.com](https://www.dictionary.com/browse/incompressible)
* [TheFreeDictionary.com](https://www.thefreedictionary.com/incompressible)