### PR TITLE
Add sequenceBound(srcSize) method

### DIFF
--- a/contrib/seqBench/seqBench.c
+++ b/contrib/seqBench/seqBench.c
@@ -22,9 +22,7 @@ int main(int argc, char *argv[]) {
     fread(inBuf, inBufSize, 1, f);
     fclose(f);
 
-    // Should work fine for this benchmark, but we really need
-    // a function like ZSTD_compressBound() for sequences
-    size_t seqsSize = 2 * (inBufSize / sizeof(ZSTD_Sequence));
+    size_t seqsSize = ZSTD_sequenceBound(inBufSize);
     ZSTD_Sequence *seqs = (ZSTD_Sequence*)malloc(seqsSize * sizeof(ZSTD_Sequence));
     char *outBuf = malloc(ZSTD_compressBound(inBufSize));
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3003,6 +3003,10 @@ static void ZSTD_copyBlockSequences(ZSTD_CCtx* zc)
     zc->seqCollector.seqIndex += seqStoreSeqSize;
 }
 
+size_t ZSTD_sequenceBound(size_t srcSize) {
+    return (srcSize / ZSTD_MINMATCH_MIN) + 1;
+}
+
 size_t ZSTD_generateSequences(ZSTD_CCtx* zc, ZSTD_Sequence* outSeqs,
                               size_t outSeqsSize, const void* src, size_t srcSize)
 {

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1396,6 +1396,15 @@ typedef enum {
   ZSTD_sf_explicitBlockDelimiters = 1    /* Representation of ZSTD_Sequence contains explicit block delimiters */
 } ZSTD_sequenceFormat_e;
 
+/*! ZSTD_sequenceBound() :
+ * `srcSize` : size of the input buffer
+ *  @return : upper-bound for the number of sequences that can be generated
+ *            from a buffer of srcSize bytes
+ *
+ *  note : returns number of sequences - to get bytes, multiply by sizeof(ZSTD_Sequence).
+ */
+ZSTDLIB_STATIC_API size_t ZSTD_sequenceBound(size_t srcSize);
+
 /*! ZSTD_generateSequences() :
  * Generate sequences using ZSTD_compress2(), given a source buffer.
  *


### PR DESCRIPTION
This PR adds a new method `ZSTD_sequenceBound(size_t srcSize)` which returns the upper bound of the number of sequences that can be generated from a buffer of `srcSize` bytes.

Note that this is calculated using `ZSTD_MINMATCH_MIN`, which is the minimum possible length of a match. It may be more accurate to get the minimum match length from the CCtx, but this is the safest option. Consider a scenario where someone calls ZSTD_sequenceBound(cctx, srcSize), change minMatch, and then call generateSequences –– in this case, the output buffer might be too small and overflow.