### PR TITLE
ZSTD_decompressStream() fuzz fix

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -2178,23 +2178,23 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
             }
         case zdss_flush:
             {
-            size_t const toFlushSize = zds->outEnd - zds->outStart;
-            size_t const flushedSize = ZSTD_limitCopy(op, (size_t)(oend-op), zds->outBuff + zds->outStart, toFlushSize);
+                size_t const toFlushSize = zds->outEnd - zds->outStart;
+                size_t const flushedSize = ZSTD_limitCopy(op, (size_t)(oend-op), zds->outBuff + zds->outStart, toFlushSize);
 
-            op = op ? op + flushedSize : op;
+                op = op ? op + flushedSize : op;
 
-            zds->outStart += flushedSize;
-            if (flushedSize == toFlushSize) {  /* flush completed */
-                zds->streamStage = zdss_read;
-                if ( (zds->outBuffSize < zds->fParams.frameContentSize)
-                    && (zds->outStart + zds->fParams.blockSizeMax > zds->outBuffSize) ) {
-                    DEBUGLOG(5, "restart filling outBuff from beginning (left:%i, needed:%u)",
-                            (int)(zds->outBuffSize - zds->outStart),
-                            (U32)zds->fParams.blockSizeMax);
-                    zds->outStart = zds->outEnd = 0;
-                }
-                break;
-            } }
+                zds->outStart += flushedSize;
+                if (flushedSize == toFlushSize) {  /* flush completed */
+                    zds->streamStage = zdss_read;
+                    if ( (zds->outBuffSize < zds->fParams.frameContentSize)
+                        && (zds->outStart + zds->fParams.blockSizeMax > zds->outBuffSize) ) {
+                        DEBUGLOG(5, "restart filling outBuff from beginning (left:%i, needed:%u)",
+                                (int)(zds->outBuffSize - zds->outStart),
+                                (U32)zds->fParams.blockSizeMax);
+                        zds->outStart = zds->outEnd = 0;
+                    }
+                    break;
+            }   }
             /* cannot complete flush */
             someMoreWork = 0;
             break;

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -2177,24 +2177,24 @@ size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output, ZSTD_inB
                 break;
             }
         case zdss_flush:
-            if (op != NULL) {
-                size_t const toFlushSize = zds->outEnd - zds->outStart;
-                size_t const flushedSize = ZSTD_limitCopy(op, (size_t)(oend-op), zds->outBuff + zds->outStart, toFlushSize);
+            {
+            size_t const toFlushSize = zds->outEnd - zds->outStart;
+            size_t const flushedSize = ZSTD_limitCopy(op, (size_t)(oend-op), zds->outBuff + zds->outStart, toFlushSize);
 
-                op += flushedSize;
+            op = op ? op + flushedSize : op;
 
-                zds->outStart += flushedSize;
-                if (flushedSize == toFlushSize) {  /* flush completed */
-                    zds->streamStage = zdss_read;
-                    if ( (zds->outBuffSize < zds->fParams.frameContentSize)
+            zds->outStart += flushedSize;
+            if (flushedSize == toFlushSize) {  /* flush completed */
+                zds->streamStage = zdss_read;
+                if ( (zds->outBuffSize < zds->fParams.frameContentSize)
                     && (zds->outStart + zds->fParams.blockSizeMax > zds->outBuffSize) ) {
-                        DEBUGLOG(5, "restart filling outBuff from beginning (left:%i, needed:%u)",
-                                (int)(zds->outBuffSize - zds->outStart),
-                                (U32)zds->fParams.blockSizeMax);
-                        zds->outStart = zds->outEnd = 0;
-                    }
-                    break;
-            }   }
+                    DEBUGLOG(5, "restart filling outBuff from beginning (left:%i, needed:%u)",
+                            (int)(zds->outBuffSize - zds->outStart),
+                            (U32)zds->fParams.blockSizeMax);
+                    zds->outStart = zds->outEnd = 0;
+                }
+                break;
+            } }
             /* cannot complete flush */
             someMoreWork = 0;
             break;


### PR DESCRIPTION
This PR changes some of the logic in a previous PR [(#3258)](https://github.com/facebook/zstd/pull/3258) in response to a failing oss-fuzz test.

In the previous PR, we skip the flush operation in the case of a `op=NULL`. This causes an assertion failure later on when checking for forward progress.

Instead of skipping the entire flush operation, we now simply use a ternary operator to increment `op` when it is non-null.

Note: These were the input and output buffer parameters in ZSTD_decompressStream that caused the test failure.
<img width="365" alt="Screen Shot 2022-09-12 at 6 02 16 PM" src="https://user-images.githubusercontent.com/48103643/189767603-466d9964-b2c8-4e61-a696-521cf708f923.png">