### PR TITLE
ci: test pkg-config file

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -410,6 +410,22 @@ jobs:
       run: |
         sde-external-9.0.0-2021-11-07-lin/sde -cet -cet-raise 0 -cet-endbr-exe -cet-stderr -cet-abort -- ./zstd -b3
 
+  pkg-config:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:testing
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apt -y update
+          apt -y install --no-install-recommends gcc libc6-dev make pkg-config
+      - name: Build and install
+        run: make -C lib install
+      - name: Test pkg-config
+        run: |
+          cc -Wall -Wextra -Wpedantic -Werror -o simple examples/simple_compression.c $(pkg-config --cflags --libs libzstd)
+          ./simple LICENSE
 
 
 # This test currently fails on Github Actions specifically.


### PR DESCRIPTION
As mentioned in https://github.com/facebook/zstd/pull/3252#issuecomment-1251733791, this patch adds a CI job that builds and installs libzstd on the job runner, and then compiles a sample binary linking against the installed library; the needed build flags are passed by invoking pkg-config.