### PR TITLE
meson: make backtrace dependency on execinfo

### DIFF
--- a/build/meson/meson_options.txt
+++ b/build/meson/meson_options.txt
@@ -14,7 +14,7 @@ option('legacy_level', type: 'integer', min: 0, max: 7, value: '5',
   description: 'Support any legacy format: 7 to 1 for v0.7+ to v0.1+')
 option('debug_level', type: 'integer', min: 0, max: 9, value: 1,
   description: 'Enable run-time debug. See lib/common/debug.h')
-option('backtrace', type: 'boolean', value: false,
+option('backtrace', type: 'feature', value: 'disabled',
   description: 'Display a stack backtrace when execution generates a runtime exception')
 option('static_runtime', type: 'boolean', value: false,
   description: 'Link to static run-time libraries on MSVC')

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -42,7 +42,8 @@ endif
 
 export_dynamic_on_windows = false
 # explicit backtrace enable/disable for Linux & Darwin
-if not use_backtrace
+execinfo = cc.has_header('execinfo.h', required: use_backtrace)
+if not execinfo.found()
   zstd_c_args += '-DBACKTRACE_ENABLE=0'
 elif use_debug and host_machine_os == os_windows  # MinGW target
   zstd_c_args += '-DBACKTRACE_ENABLE=1'


### PR DESCRIPTION
musl libc for example has no such header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>