### PR TITLE
Rename {clean-all,uninstall} targets  -> zstd_{clean-all,uninstall}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ cmakebuild:
 	cd $(BUILDIR)/cmake/build; cmake -DCMAKE_INSTALL_PREFIX:PATH=~/install_test_dir $(CMAKE_PARAMS) ..
 	$(MAKE) -C $(BUILDIR)/cmake/build -j4;
 	$(MAKE) -C $(BUILDIR)/cmake/build install;
-	$(MAKE) -C $(BUILDIR)/cmake/build uninstall;
+	$(MAKE) -C $(BUILDIR)/cmake/build zstd_uninstall;
 	cd $(BUILDIR)/cmake/build; ctest -V -L Medium
 
 c89build: clean

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -168,7 +168,7 @@ endif ()
 #-----------------------------------------------------------------------------
 # Add clean-all target
 #-----------------------------------------------------------------------------
-add_custom_target(clean-all
+add_custom_target(zstd_clean-all
    COMMAND ${CMAKE_BUILD_TOOL} clean
    COMMAND rm -rf ${CMAKE_BINARY_DIR}/
 )

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -164,12 +164,12 @@ install(TARGETS ${library_targets}
     )
 
 # uninstall target
-if (NOT TARGET uninstall)
+if (NOT TARGET zstd_uninstall)
     configure_file(
             "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
             "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
             IMMEDIATE @ONLY)
 
-    add_custom_target(uninstall
+    add_custom_target(zstd_uninstall
             COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 endif ()


### PR DESCRIPTION
This avoids target namespace pollution when including zstd as a sub-project.