### PR TITLE
fixed zstd-pgo target for GCC

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -232,17 +232,21 @@ zstd-dll : zstd
 ## zstd-pgo: zstd executable optimized with PGO.
 .PHONY: zstd-pgo
 zstd-pgo :
-	$(MAKE) clean
-	$(MAKE) zstd MOREFLAGS=-fprofile-generate
+	$(MAKE) clean HASH_DIR=$(HASH_DIR)
+	$(MAKE) zstd HASH_DIR=$(HASH_DIR) MOREFLAGS=-fprofile-generate
 	./zstd -b19i1 $(PROFILE_WITH)
 	./zstd -b16i1 $(PROFILE_WITH)
 	./zstd -b9i2 $(PROFILE_WITH)
 	./zstd -b $(PROFILE_WITH)
 	./zstd -b7i2 $(PROFILE_WITH)
 	./zstd -b5 $(PROFILE_WITH)
-	$(RM) zstd *.o
+ifndef BUILD_DIR
+	$(RM) zstd obj/$(HASH_DIR)/*.o
+else
+	$(RM) zstd $(BUILD_DIR)/*.o
+endif
 	case $(CC) in *clang*) if ! [ -e default.profdata ]; then llvm-profdata merge -output=default.profdata default*.profraw; fi ;; esac
-	$(MAKE) zstd MOREFLAGS=-fprofile-use
+	$(MAKE) zstd HASH_DIR=$(HASH_DIR) MOREFLAGS=-fprofile-use
 
 ## zstd-small: minimal target, supporting only zstd compression and decompression. no bench. no legacy. no other format.
 CLEAN += zstd-small zstd-frugal

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -241,9 +241,9 @@ zstd-pgo :
 	./zstd -b7i2 $(PROFILE_WITH)
 	./zstd -b5 $(PROFILE_WITH)
 ifndef BUILD_DIR
-	$(RM) zstd obj/$(HASH_DIR)/*.o
+	$(RM) zstd obj/$(HASH_DIR)/zstd obj/$(HASH_DIR)/*.o
 else
-	$(RM) zstd $(BUILD_DIR)/*.o
+	$(RM) zstd $(BUILD_DIR)/zstd $(BUILD_DIR)/*.o
 endif
 	case $(CC) in *clang*) if ! [ -e default.profdata ]; then llvm-profdata merge -output=default.profdata default*.profraw; fi ;; esac
 	$(MAKE) zstd HASH_DIR=$(HASH_DIR) MOREFLAGS=-fprofile-use


### PR DESCRIPTION
Since your Makefile uses obj/$(HASH_DIR) for object files, this code does not work correctly for GCC. Because profiles are saved in one directory, and are expected in another when reading.

`$(RM) zstd *.o` - this line doesn't delete object files.

Clang stores profiles in the current directory, so the problem doesn't appear when compiling with Clang.

Also this code will work if BUILD_DIR is set.

Additional comment from @ldv-alt:

> Apparently, zstd-pgo target was broken at least for gcc compiler since the commit that introduced BUILD_DIR for programs subdirectory. Starting with [that](https://github.com/facebook/zstd/commit/dd24496951dbce5615b26f2632b4dd9e7e494502) commit, the object directory used for generating profile data is different from the object directory used for producing the result based on that profile data, and this of course does not work with gcc which uses the object directory to store the profile data. Fortunately, gcc detects this and complains by issuing a warning for each object file, e.g.
> 
> `../lib/common/zstd_common.c:83:1: warning: '/path/to/zstd/programs/obj/conf_3da26c95555a8e4d4ab71a33da334472/zstd_common.gcda' profile count data file not found [-Wmissing-profile]`
> 
> Fix this by forwarding HASH_DIR so that the same BUILD_DIR is used both for generating and using profile data.
> 