### PR TITLE
programs/Makefile: fix zstd-pgo target

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -232,17 +232,21 @@ zstd-dll : zstd
 ## zstd-pgo: zstd executable optimized with PGO.
 .PHONY: zstd-pgo
 zstd-pgo :
-	$(MAKE) clean
-	$(MAKE) zstd MOREFLAGS=-fprofile-generate
+	$(MAKE) clean HASH_DIR=$(HASH_DIR)
+	$(MAKE) zstd HASH_DIR=$(HASH_DIR) MOREFLAGS=-fprofile-generate
 	./zstd -b19i1 $(PROFILE_WITH)
 	./zstd -b16i1 $(PROFILE_WITH)
 	./zstd -b9i2 $(PROFILE_WITH)
 	./zstd -b $(PROFILE_WITH)
 	./zstd -b7i2 $(PROFILE_WITH)
 	./zstd -b5 $(PROFILE_WITH)
-	$(RM) zstd *.o
+ifndef BUILD_DIR
+	$(RM) zstd obj/$(HASH_DIR)/zstd obj/$(HASH_DIR)/*.o
+else
+	$(RM) zstd $(BUILD_DIR)/zstd $(BUILD_DIR)/*.o
+endif
 	case $(CC) in *clang*) if ! [ -e default.profdata ]; then llvm-profdata merge -output=default.profdata default*.profraw; fi ;; esac
-	$(MAKE) zstd MOREFLAGS=-fprofile-use
+	$(MAKE) zstd HASH_DIR=$(HASH_DIR) MOREFLAGS=-fprofile-use
 
 ## zstd-small: minimal target, supporting only zstd compression and decompression. no bench. no legacy. no other format.
 CLEAN += zstd-small zstd-frugal


### PR DESCRIPTION
Apparently, zstd-pgo target was broken at least for gcc compiler since the commit that introduced BUILD_DIR for programs subdirectory. Starting with that commit, the object directory used for generating profile data is different from the object directory used for producing the result based on that profile data, and this of course does not work with gcc which uses the object directory to store the profile data. Fortunately, gcc detects this and complains by issuing a warning for each object file, e.g.

  ../lib/common/zstd_common.c:83:1: warning: '/path/to/zstd/programs/obj/conf_3da26c95555a8e4d4ab71a33da334472/zstd_common.gcda' profile count data file not found [-Wmissing-profile]

Fix this by forwarding HASH_DIR so that the same BUILD_DIR is used both for generating and using profile data.

Fixes: dd2449695 ("programs/zstd also automatically generate object dir per conf")
Co-authored-by: Ilya Kurdyukov <ilyakurdyukov@basealt.ru>