### PR TITLE
Make ZSTD_getDictID_fromDDict() Read DictID from DDict

### DIFF
--- a/lib/decompress/zstd_ddict.c
+++ b/lib/decompress/zstd_ddict.c
@@ -240,5 +240,5 @@ size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict)
 unsigned ZSTD_getDictID_fromDDict(const ZSTD_DDict* ddict)
 {
     if (ddict==NULL) return 0;
-    return ZSTD_getDictID_fromDict(ddict->dictContent, ddict->dictSize);
+    return ddict->dictID;
 }


### PR DESCRIPTION
Currently this function actually reads the dict ID from the dictionary's header, via `ZSTD_getDictID_fromDict()`. But during decompression the decompressor actually compares the dict ID in the frame header with the dict ID in the DDict. Now of course the dict ID in the dictionary contents and the dict ID in the DDict struct *should* be the same. But in cases of memory corruption, where they can drift out of sync, it's misleading for this function to read it again from the dict buffer rather then return the dict ID that will actually be used.

Also doing it this way avoids rechecking the magic and so on and so it is a tiny bit more efficient.