### PR TITLE
[contrib][linux-kernel] Generate SPDX license identifiers

### DIFF
--- a/contrib/linux-kernel/Makefile
+++ b/contrib/linux-kernel/Makefile
@@ -26,6 +26,7 @@ libzstd:
 		--rewrite-include '"(\.\./)?zstd_errors.h"=<linux/zstd_errors.h>' \
 		--sed 's,/\*\*\*,/* *,g' \
 		--sed 's,/\*\*,/*,g' \
+		--spdx \
 		-DZSTD_NO_INTRINSICS \
 		-DZSTD_NO_UNUSED_FUNCTIONS \
 		-DZSTD_LEGACY_SUPPORT=0 \


### PR DESCRIPTION
Add a `--spdx` option to the freestanding script (and use it from the `linux-kernel` `Makefile`) to prefix files with a line like (for `.c` files):

    // SPDX-License-Identifier: GPL-2.0+ OR BSD-3-Clause

or (for `.h` and `.S` files):

    /* SPDX-License-Identifier: GPL-2.0+ OR BSD-3-Clause */

Given the style of the line to be used depends on the extension, a simple `sed` insert command would not work.

It also skips the file if an existing SPDX line is there, as well as raising an error if an unexpected `SPDX-License-Identifier` string appears anywhere else in the file, as well as for unexpected file extensions.

I double-checked that all currently generated files appear to be licensed as expected with:

    grep -LRF 'This source code is licensed under both the BSD-style license (found in the'  linux/lib/zstd
    grep -LRF 'LICENSE file in the root directory of this source tree) and the GPLv2 (found' linux/lib/zstd

but somebody knowledgeable on the licensing of the project should double-check this is the intended case.

Fixes: https://github.com/facebook/zstd/issues/3293
Signed-off-by: Miguel Ojeda <ojeda@kernel.org>