### PR TITLE
Fix action error by upgrading Scorecard GHA to 2.0.6 

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # tag=v2.0.3
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # tag=v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
As mentioned in #3308, this change will avoid the scorecard github action from failing.

Closes #3308 

Signed-off-by: Joyce Brum <joycebrum@google.com>