### PR TITLE
Fix for MSVC C4267 warning on ARM64 (which becomes error C2220 with /WX)

### DIFF
--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1078,7 +1078,7 @@ ZSTD_row_getMatchMask(const BYTE* const tagRow, const BYTE tag, const U32 headGr
     }
 # endif /* ZSTD_ARCH_ARM_NEON */
     /* SWAR */
-    {   const size_t chunkSize = sizeof(size_t);
+    {   const int chunkSize = sizeof(size_t);
         const size_t shiftAmount = ((chunkSize * 8) - chunkSize);
         const size_t xFF = ~((size_t)0);
         const size_t x01 = xFF / 0xFF;

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -2123,7 +2123,6 @@ size_t ZSTD_compressBlock_lazy_extDict_row(
 size_t ZSTD_compressBlock_lazy2_extDict_row(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize)
-
 {
     return ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_rowHash, 2);
 }


### PR DESCRIPTION
I've only seen this on the ARM64 toolchain under the new ARM64 version of VS 2022 (running on a shiny new Windows Dev Kit 2023), and didn't see it cross-compiling for ARM64 from x64:
```
warning C4267: '-=': conversion from 'size_t' to 'int', possible loss of data
warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
```
The change is minimal: `i` can't be a `size_t` because it needs to be signed, but changeing `chunkSize` to `int` is fine (it's only ever going to be 32 or 64 (or possibly somewhere between 16 to 128 on the more exotic systems).

(I can't verify the warning on x64 to ARM64 until next week but it's such a minor unintrusive change with known values)