### PR TITLE
meson: get version up front

### DIFF
--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -23,7 +23,9 @@ project('zstd',
     # so this isn't safe
     #'werror=true'
   ],
-  version: 'DUMMY',
+  version: run_command(
+    find_program('GetZstdLibraryVersion.py'), '../../lib/zstd.h',
+    check: true).stdout().strip(),
   meson_version: '>=0.48.0')
 
 cc = meson.get_compiler('c')
@@ -44,16 +46,6 @@ compiler_clang = 'clang'
 compiler_msvc = 'msvc'
 
 zstd_version = meson.project_version()
-
-zstd_h_file = join_paths(meson.current_source_dir(), '../../lib/zstd.h')
-GetZstdLibraryVersion_py = find_program('GetZstdLibraryVersion.py', native : true)
-r = run_command(GetZstdLibraryVersion_py, zstd_h_file)
-if r.returncode() == 0
-  zstd_version = r.stdout().strip()
-  message('Project version is now: @0@'.format(zstd_version))
-else
-  error('Cannot find project version in @0@'.format(zstd_h_file))
-endif
 
 zstd_libversion = zstd_version
 


### PR DESCRIPTION
Run the scraper command to establish the project version immediately, rather than wait for the build to be configured. This simplifies the code and ensures that project introspection works correctly.