### PR TITLE
Block-Level Sequence Producer API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ contrib: lib
 	$(MAKE) -C contrib/seekable_format/examples all
 	$(MAKE) -C contrib/seekable_format/tests test
 	$(MAKE) -C contrib/largeNbDicts all
+	$(MAKE) -C contrib/externalMatchfinder all
 	cd build/single_file_libs/ ; ./build_decoder_test.sh
 	cd build/single_file_libs/ ; ./build_library_test.sh
 
@@ -142,6 +143,7 @@ clean:
 	$(Q)$(MAKE) -C contrib/seekable_format/examples $@ > $(VOID)
 	$(Q)$(MAKE) -C contrib/seekable_format/tests $@ > $(VOID)
 	$(Q)$(MAKE) -C contrib/largeNbDicts $@ > $(VOID)
+	$(Q)$(MAKE) -C contrib/externalMatchfinder $@ > $(VOID)
 	$(Q)$(RM) zstd$(EXT) zstdmt$(EXT) tmp*
 	$(Q)$(RM) -r lz4
 	@echo Cleaning completed

--- a/build/cmake/tests/CMakeLists.txt
+++ b/build/cmake/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ add_test(NAME fuzzer COMMAND fuzzer ${ZSTD_FUZZER_FLAGS})
 #
 # zstreamtest
 #
-add_executable(zstreamtest ${PROGRAMS_DIR}/datagen.c ${PROGRAMS_DIR}/util.c ${PROGRAMS_DIR}/timefn.c ${TESTS_DIR}/seqgen.c ${TESTS_DIR}/zstreamtest.c ${TESTS_DIR}/external_matchfinder.c))
+add_executable(zstreamtest ${PROGRAMS_DIR}/datagen.c ${PROGRAMS_DIR}/util.c ${PROGRAMS_DIR}/timefn.c ${TESTS_DIR}/seqgen.c ${TESTS_DIR}/zstreamtest.c ${TESTS_DIR}/external_matchfinder.c)
 if (NOT MSVC)
     target_compile_options(zstreamtest PRIVATE "-Wno-deprecated-declarations")
 endif()

--- a/build/cmake/tests/CMakeLists.txt
+++ b/build/cmake/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ add_test(NAME fuzzer COMMAND fuzzer ${ZSTD_FUZZER_FLAGS})
 #
 # zstreamtest
 #
-add_executable(zstreamtest ${PROGRAMS_DIR}/datagen.c ${PROGRAMS_DIR}/util.c ${PROGRAMS_DIR}/timefn.c ${TESTS_DIR}/seqgen.c ${TESTS_DIR}/zstreamtest.c)
+add_executable(zstreamtest ${PROGRAMS_DIR}/datagen.c ${PROGRAMS_DIR}/util.c ${PROGRAMS_DIR}/timefn.c ${TESTS_DIR}/seqgen.c ${TESTS_DIR}/zstreamtest.c ${TESTS_DIR}/external_matchfinder.c))
 if (NOT MSVC)
     target_compile_options(zstreamtest PRIVATE "-Wno-deprecated-declarations")
 endif()

--- a/build/meson/tests/meson.build
+++ b/build/meson/tests/meson.build
@@ -65,8 +65,10 @@ fuzzer = executable('fuzzer',
   dependencies: [ testcommon_dep, thread_dep ],
   install: false)
 
-zstreamtest_sources = [join_paths(zstd_rootdir, 'tests/seqgen.c'),
-  join_paths(zstd_rootdir, 'tests/zstreamtest.c')]
+zstreamtest_sources = [
+  join_paths(zstd_rootdir, 'tests/seqgen.c'),
+  join_paths(zstd_rootdir, 'tests/zstreamtest.c'),
+  join_paths(zstd_rootdir, 'tests/external_matchfinder.c')]
 zstreamtest = executable('zstreamtest',
   zstreamtest_sources,
   include_directories: test_includes,

--- a/contrib/externalMatchfinder/.gitignore
+++ b/contrib/externalMatchfinder/.gitignore
@@ -1,0 +1,2 @@
+# build artifacts
+externalMatchfinder

--- a/contrib/externalMatchfinder/Makefile
+++ b/contrib/externalMatchfinder/Makefile
@@ -1,0 +1,40 @@
+# ################################################################
+# Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under both the BSD-style license (found in the
+# LICENSE file in the root directory of this source tree) and the GPLv2 (found
+# in the COPYING file in the root directory of this source tree).
+# ################################################################
+
+PROGDIR = ../../programs
+LIBDIR  = ../../lib
+
+LIBZSTD = $(LIBDIR)/libzstd.a
+
+CPPFLAGS+= -I$(LIBDIR) -I$(LIBDIR)/compress -I$(LIBDIR)/common
+
+CFLAGS  ?= -O3
+CFLAGS  += -std=gnu99
+DEBUGFLAGS= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
+            -Wstrict-aliasing=1 -Wswitch-enum \
+            -Wstrict-prototypes -Wundef -Wpointer-arith \
+            -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings \
+            -Wredundant-decls
+CFLAGS  += $(DEBUGFLAGS) $(MOREFLAGS)
+
+default: externalMatchfinder
+
+all: externalMatchfinder
+
+externalMatchfinder: matchfinder.c main.c $(LIBZSTD)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ $(LDFLAGS) -o $@
+
+.PHONY: $(LIBZSTD)
+$(LIBZSTD):
+	$(MAKE) -C $(LIBDIR) libzstd.a CFLAGS="$(CFLAGS)"
+
+clean:
+	$(RM) *.o
+	$(MAKE) -C $(LIBDIR) clean > /dev/null
+	$(RM) externalMatchfinder

--- a/contrib/externalMatchfinder/Makefile
+++ b/contrib/externalMatchfinder/Makefile
@@ -1,5 +1,5 @@
 # ################################################################
-# Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+# Copyright (c) Yann Collet, Facebook, Inc.
 # All rights reserved.
 #
 # This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/Makefile
+++ b/contrib/externalMatchfinder/Makefile
@@ -1,5 +1,5 @@
 # ################################################################
-# Copyright (c) Yann Collet, Facebook, Inc.
+# Copyright (c) Yann Collet, Meta Platforms, Inc.
 # All rights reserved.
 #
 # This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/README.md
+++ b/contrib/externalMatchfinder/README.md
@@ -1,0 +1,14 @@
+externalMatchfinder
+=====================
+
+`externalMatchfinder` is a test tool for the external matchfinder API.
+It demonstrates how to use the API to perform a simple round-trip test.
+
+A sample matchfinder is provided in matchfinder.c, but the user can swap
+this out with a different one if desired. The sample matchfinder implements
+LZ compression with a 1KB hashtable. Dictionary compression is not currently supported.
+
+Command line :
+```
+externalMatchfinder filename
+```

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
     int simpleExternalMatchState = 0xdeadbeef;
 
     // Here is the crucial bit of code!
-    ZSTD_refExternalMatchFinder(
+    ZSTD_registerExternalMatchFinder(
         zc,
         &simpleExternalMatchState,
         simpleExternalMatchFinder

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -5,7 +5,7 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 #include "zstd_errors.h"
-#include "matchfinder.h" // simpleExternalMatchFinder, simpleExternalMatchStateDestructor
+#include "matchfinder.h" // simpleExternalMatchFinder
 
 int main(int argc, char *argv[]) {
     size_t res;
@@ -35,17 +35,17 @@ int main(int argc, char *argv[]) {
 
     FILE *f = fopen(argv[1], "rb");
     fseek(f, 0, SEEK_END);
-    long srcSize = ftell(f);
+    long const srcSize = ftell(f);
     fseek(f, 0, SEEK_SET);
 
     char *src = malloc(srcSize + 1);
     fread(src, srcSize, 1, f);
     fclose(f);
 
-    size_t dstSize = ZSTD_compressBound(srcSize);
+    size_t const dstSize = ZSTD_compressBound(srcSize);
     char *dst = malloc(dstSize);
 
-    size_t cSize = ZSTD_compress2(zc, dst, dstSize, src, srcSize);
+    size_t const cSize = ZSTD_compress2(zc, dst, dstSize, src, srcSize);
 
     if (ZSTD_isError(cSize)) {
         printf("ERROR: %s\n", ZSTD_getErrorName(cSize));

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -32,6 +32,13 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
+    res = ZSTD_CCtx_setParameter(zc, ZSTD_c_useExternalMatchfinder, 1);
+
+    if (ZSTD_isError(res)) {
+        printf("ERROR: %s\n", ZSTD_getErrorString(res));
+        return 1;
+    }
+
     FILE *f = fopen(argv[1], "rb");
     fseek(f, 0, SEEK_END);
     long srcSize = ftell(f);

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
 
     ZSTD_CCtx* zc = ZSTD_createCCtx();
 
-    int simpleExternalMatchState = 0xdeadbeef; // @nocommit
+    int simpleExternalMatchState = 0xdeadbeef;
 
     // Here is the crucial bit of code!
     ZSTD_refExternalMatchFinder(

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
         simpleExternalMatchFinder
     );
 
-    res = ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchfinderFallback, 1);
+    res = ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchFinderFallback, 1);
 
     if (ZSTD_isError(res)) {
         printf("ERROR: %s\n", ZSTD_getErrorName(res));

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -19,10 +19,12 @@ int main(int argc, char *argv[]) {
 
     ZSTD_CCtx* zc = ZSTD_createCCtx();
 
+    int simpleExternalMatchState = 0xdeadbeef; // @nocommit
+
     // Here is the crucial bit of code!
     res = ZSTD_registerExternalMatchFinder(
         zc,
-        NULL,
+        &simpleExternalMatchState,
         simpleExternalMatchFinder,
         simpleExternalMatchStateDestructor
     );

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd.h"
+#include "matchfinder.h" // simpleExternalMatchfinder
+
+const size_t ZSTD_LEVEL = 1;
+
+int main(int argc, char *argv[]) {
+    ZSTD_CCtx* zc = ZSTD_createCCtx();
+
+    // Here is the crucial bit of code!
+    ZSTD_registerExternalMatchfinder(zc, simpleExternalMatchfinder);
+
+    if (argc != 2) {
+        printf("Usage: exampleMatchfinder <file>\n");
+        return 1;
+    }
+
+    FILE *f = fopen(argv[1], "rb");
+    fseek(f, 0, SEEK_END);
+    long srcSize = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char *src = malloc(srcSize + 1);
+    fread(src, srcSize, 1, f);
+    fclose(f);
+
+    size_t dstSize = ZSTD_compressBound(srcSize);
+    char *dst = malloc(dstSize);
+
+    size_t cSize = ZSTD_compress2(zc, dst, dstSize, src, srcSize);
+
+    if (ZSTD_isError(cSize)) {
+        printf("ERROR: %lu\n", cSize);
+        return 1;
+    }
+
+    char *val = malloc(srcSize);
+    size_t res = ZSTD_decompress(val, srcSize, dst, cSize);
+
+    if (ZSTD_isError(res)) {
+        printf("ERROR: %lu\n", cSize);
+        return 1;
+    }
+
+    if (memcmp(src, val, srcSize) == 0) {
+        printf("Compression and decompression were successful!\n");
+        printf("Original size: %lu\n", srcSize);
+        printf("Compressed size: %lu\n", cSize);
+        return 0;
+    } else {
+        printf("ERROR: input and validation buffers don't match!\n");
+        for (int i = 0; i < srcSize; i++) {
+            if (src[i] != val[i]) {
+                printf("First bad index: %d\n", i);
+                break;
+            }
+        }
+        return 1;
+    }
+}

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -20,24 +20,11 @@ int main(int argc, char *argv[]) {
     int simpleExternalMatchState = 0xdeadbeef; // @nocommit
 
     // Here is the crucial bit of code!
-    res = ZSTD_registerExternalMatchFinder(
+    ZSTD_refExternalMatchFinder(
         zc,
         &simpleExternalMatchState,
-        simpleExternalMatchFinder,
-        simpleExternalMatchStateDestructor
+        simpleExternalMatchFinder
     );
-
-    if (ZSTD_isError(res)) {
-        printf("ERROR: %s\n", ZSTD_getErrorName(res));
-        return 1;
-    }
-
-    res = ZSTD_CCtx_setParameter(zc, ZSTD_c_useExternalMatchfinder, 1);
-
-    if (ZSTD_isError(res)) {
-        printf("ERROR: %s\n", ZSTD_getErrorName(res));
-        return 1;
-    }
 
     res = ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchfinderFallback, 1);
 

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -41,6 +41,13 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
+    res = ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchfinderFallback, 1);
+
+    if (ZSTD_isError(res)) {
+        printf("ERROR: %s\n", ZSTD_getErrorName(res));
+        return 1;
+    }
+
     FILE *f = fopen(argv[1], "rb");
     fseek(f, 0, SEEK_END);
     long srcSize = ftell(f);

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -4,7 +4,8 @@
 
 #define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
-#include "matchfinder.h" // simpleExternalMatchfinder
+#include "zstd_errors.h"
+#include "matchfinder.h" // simpleExternalMatchFinder, simpleExternalMatchStateDestructor
 
 const size_t ZSTD_LEVEL = 1;
 
@@ -12,7 +13,12 @@ int main(int argc, char *argv[]) {
     ZSTD_CCtx* zc = ZSTD_createCCtx();
 
     // Here is the crucial bit of code!
-    ZSTD_registerExternalMatchfinder(zc, simpleExternalMatchfinder);
+    ZSTD_registerExternalMatchfinder(
+        zc,
+        NULL,
+        simpleExternalMatchFinder,
+        simpleExternalMatchStateDestructor
+    );
 
     if (argc != 2) {
         printf("Usage: exampleMatchfinder <file>\n");
@@ -34,7 +40,7 @@ int main(int argc, char *argv[]) {
     size_t cSize = ZSTD_compress2(zc, dst, dstSize, src, srcSize);
 
     if (ZSTD_isError(cSize)) {
-        printf("ERROR: %lu\n", cSize);
+        printf("ERROR: %s\n", ZSTD_getErrorString(cSize));
         return 1;
     }
 
@@ -42,7 +48,7 @@ int main(int argc, char *argv[]) {
     size_t res = ZSTD_decompress(val, srcSize, dst, cSize);
 
     if (ZSTD_isError(res)) {
-        printf("ERROR: %lu\n", cSize);
+        printf("ERROR: %s\n", ZSTD_getErrorString(res));
         return 1;
     }
 

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -28,14 +28,14 @@ int main(int argc, char *argv[]) {
     );
 
     if (ZSTD_isError(res)) {
-        printf("ERROR: %s\n", ZSTD_getErrorString(res));
+        printf("ERROR: %s\n", ZSTD_getErrorName(res));
         return 1;
     }
 
     res = ZSTD_CCtx_setParameter(zc, ZSTD_c_useExternalMatchfinder, 1);
 
     if (ZSTD_isError(res)) {
-        printf("ERROR: %s\n", ZSTD_getErrorString(res));
+        printf("ERROR: %s\n", ZSTD_getErrorName(res));
         return 1;
     }
 
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
     size_t cSize = ZSTD_compress2(zc, dst, dstSize, src, srcSize);
 
     if (ZSTD_isError(cSize)) {
-        printf("ERROR: %s\n", ZSTD_getErrorString(cSize));
+        printf("ERROR: %s\n", ZSTD_getErrorName(cSize));
         return 1;
     }
 
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
     ZSTD_freeCCtx(zc);
 
     if (ZSTD_isError(res)) {
-        printf("ERROR: %s\n", ZSTD_getErrorString(res));
+        printf("ERROR: %s\n", ZSTD_getErrorName(res));
         return 1;
     }
 

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -7,8 +7,6 @@
 #include "zstd_errors.h"
 #include "matchfinder.h" // simpleExternalMatchFinder, simpleExternalMatchStateDestructor
 
-const size_t ZSTD_LEVEL = 1;
-
 int main(int argc, char *argv[]) {
     size_t res;
 

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -10,18 +10,25 @@
 const size_t ZSTD_LEVEL = 1;
 
 int main(int argc, char *argv[]) {
+    size_t res;
+
+    if (argc != 2) {
+        printf("Usage: exampleMatchfinder <file>\n");
+        return 1;
+    }
+
     ZSTD_CCtx* zc = ZSTD_createCCtx();
 
     // Here is the crucial bit of code!
-    ZSTD_registerExternalMatchfinder(
+    res = ZSTD_registerExternalMatchFinder(
         zc,
         NULL,
         simpleExternalMatchFinder,
         simpleExternalMatchStateDestructor
     );
 
-    if (argc != 2) {
-        printf("Usage: exampleMatchfinder <file>\n");
+    if (ZSTD_isError(res)) {
+        printf("ERROR: %s\n", ZSTD_getErrorString(res));
         return 1;
     }
 
@@ -45,7 +52,9 @@ int main(int argc, char *argv[]) {
     }
 
     char *val = malloc(srcSize);
-    size_t res = ZSTD_decompress(val, srcSize, dst, cSize);
+    res = ZSTD_decompress(val, srcSize, dst, cSize);
+
+    ZSTD_freeCCtx(zc);
 
     if (ZSTD_isError(res)) {
         printf("ERROR: %s\n", ZSTD_getErrorString(res));

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -50,13 +50,23 @@ int main(int argc, char *argv[]) {
 
     FILE *f = fopen(argv[1], "rb");
     assert(f);
-    fseek(f, 0, SEEK_END);
-    long const srcSize = ftell(f);
-    fseek(f, 0, SEEK_SET);
+    {
+        int const ret = fseek(f, 0, SEEK_END);
+        assert(ret == 0);
+    }
+    size_t const srcSize = ftell(f);
+    {
+        int const ret = fseek(f, 0, SEEK_SET);
+        assert(ret == 0);
+    }
 
     char* const src = malloc(srcSize + 1);
-    fread(src, srcSize, 1, f);
-    fclose(f);
+    {
+        size_t const ret = fread(src, srcSize, 1, f);
+        assert(ret == 1);
+        int const ret2 = fclose(f);
+        assert(ret2 == 0);
+    }
 
     size_t const dstSize = ZSTD_compressBound(srcSize);
     char* const dst = malloc(dstSize);
@@ -78,9 +88,9 @@ int main(int argc, char *argv[]) {
         printf("Compressed size: %lu\n", cSize);
     } else {
         printf("ERROR: input and validation buffers don't match!\n");
-        for (int i = 0; i < srcSize; i++) {
+        for (size_t i = 0; i < srcSize; i++) {
             if (src[i] != val[i]) {
-                printf("First bad index: %d\n", i);
+                printf("First bad index: %zu\n", i);
                 break;
             }
         }

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -19,7 +19,7 @@
 #include "matchfinder.h" // simpleExternalMatchFinder
 
 #define CHECK(res)                                      \
-do  {                                                   \
+do {                                                    \
     if (ZSTD_isError(res)) {                            \
         printf("ERROR: %s\n", ZSTD_getErrorName(res));  \
         return 1;                                       \
@@ -76,7 +76,6 @@ int main(int argc, char *argv[]) {
         printf("Compression and decompression were successful!\n");
         printf("Original size: %lu\n", srcSize);
         printf("Compressed size: %lu\n", cSize);
-        return 0;
     } else {
         printf("ERROR: input and validation buffers don't match!\n");
         for (int i = 0; i < srcSize; i++) {
@@ -89,4 +88,8 @@ int main(int argc, char *argv[]) {
     }
 
     ZSTD_freeCCtx(zc);
+    free(src);
+    free(dst);
+    free(val);
+    return 0;
 }

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -61,6 +61,7 @@ int main(int argc, char *argv[]) {
     }
 
     char* const src = malloc(srcSize + 1);
+    assert(src);
     {
         size_t const ret = fread(src, srcSize, 1, f);
         assert(ret == 1);
@@ -70,6 +71,7 @@ int main(int argc, char *argv[]) {
 
     size_t const dstSize = ZSTD_compressBound(srcSize);
     char* const dst = malloc(dstSize);
+    assert(dst);
 
     size_t const cSize = ZSTD_compress2(zc, dst, dstSize, src, srcSize);
     CHECK(cSize);

--- a/contrib/externalMatchfinder/main.c
+++ b/contrib/externalMatchfinder/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Meta Platforms, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -1,0 +1,62 @@
+#include "zstd_compress_internal.h"
+#include "matchfinder.h"
+#include <stdio.h>
+
+#define HSIZE 1024
+static U32 const HLOG = 10;
+static U32 const MLS = 4;
+static U32 const BADIDX = (1 << 31);
+
+size_t simpleExternalMatchfinder(
+  void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  const void* src, size_t srcSize, size_t historySize
+) {
+    (void)(externalMatchState);
+    (void)(historySize);
+    (void)(outSeqsCapacity); // @nocommit return an error
+
+    const BYTE* const istart = (const BYTE*)src;
+    const BYTE* const iend = istart + srcSize;
+    const BYTE* ip = istart;
+    const BYTE* anchor = istart;
+
+    size_t seqCount = 0;
+
+    U32 hashTable[HSIZE];
+    for (int i=0; i < HSIZE; i++) {
+        hashTable[i] = BADIDX;
+    }
+
+    while (ip + 4 < iend) {
+        size_t const hash = ZSTD_hashPtr(ip, HLOG, MLS);
+        U32 const matchIndex = hashTable[hash];
+        hashTable[hash] = ip - istart;
+
+        if (matchIndex != BADIDX) {
+            const BYTE* const match = istart + matchIndex;
+            size_t const matchLen = ZSTD_count(ip, match, iend);
+            if (matchLen >= ZSTD_MINMATCH_MIN) {
+                U32 const litLen = ip - anchor;
+                U32 const offset = ip - match;
+                ZSTD_Sequence const seq = {
+                    offset, litLen, matchLen, 0
+                };
+                outSeqs[seqCount++] = seq;
+                ip += matchLen;
+                anchor = ip;
+                continue;
+            }
+        }
+
+        ip++;
+    }
+
+    {
+        ZSTD_Sequence const finalSeq = {
+            0, iend - anchor, 0, 0
+        };
+        outSeqs[seqCount] = finalSeq;
+    }
+
+    return seqCount;
+}

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -11,10 +11,10 @@ size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize, const void* dict, size_t dictSize
 ) {
-    (void)(externalMatchState);
-    (void)(dict);
-    (void)(dictSize);
-    (void)(outSeqsCapacity); // @nocommit return an error
+    (void)externalMatchState;
+    (void)dict;
+    (void)dictSize;
+    (void)outSeqsCapacity; // @nocommit return an error
 
     const BYTE* const istart = (const BYTE*)src;
     const BYTE* const iend = istart + srcSize;

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -7,28 +7,29 @@ static U32 const MLS = 4;
 static U32 const BADIDX = (1 << 31);
 
 size_t simpleExternalMatchFinder(
-  void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  void* externalMatchState,
+  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
   int compressionLevel
 ) {
+    const BYTE* const istart = (const BYTE*)src;
+    const BYTE* const iend = istart + srcSize;
+    const BYTE* ip = istart;
+    const BYTE* anchor = istart;
+    size_t seqCount = 0;
+    U32 hashTable[HSIZE];
+
     (void)externalMatchState;
     (void)dict;
     (void)dictSize;
     (void)outSeqsCapacity;
     (void)compressionLevel;
 
-    const BYTE* const istart = (const BYTE*)src;
-    const BYTE* const iend = istart + srcSize;
-    const BYTE* ip = istart;
-    const BYTE* anchor = istart;
-
-    size_t seqCount = 0;
-
-    U32 hashTable[HSIZE];
-    for (int i=0; i < HSIZE; i++) {
-        hashTable[i] = BADIDX;
-    }
+    {   int i;
+        for (i=0; i < HSIZE; i++) {
+            hashTable[i] = BADIDX;
+    }   }
 
     while (ip + 4 < iend) {
         size_t const hash = ZSTD_hashPtr(ip, HLOG, MLS);
@@ -54,10 +55,11 @@ size_t simpleExternalMatchFinder(
         ip++;
     }
 
-    ZSTD_Sequence const finalSeq = {
-        0, iend - anchor, 0, 0
-    };
-    outSeqs[seqCount++] = finalSeq;
+    {   ZSTD_Sequence const finalSeq = {
+            0, iend - anchor, 0, 0
+        };
+        outSeqs[seqCount++] = finalSeq;
+    }
 
     return seqCount;
 }

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -34,14 +34,14 @@ size_t simpleExternalMatchFinder(
     while (ip + 4 < iend) {
         size_t const hash = ZSTD_hashPtr(ip, HLOG, MLS);
         U32 const matchIndex = hashTable[hash];
-        hashTable[hash] = ip - istart;
+        hashTable[hash] = (U32)(ip - istart);
 
         if (matchIndex != BADIDX) {
             const BYTE* const match = istart + matchIndex;
-            size_t const matchLen = ZSTD_count(ip, match, iend);
+            U32 const matchLen = (U32)ZSTD_count(ip, match, iend);
             if (matchLen >= ZSTD_MINMATCH_MIN) {
-                U32 const litLen = ip - anchor;
-                U32 const offset = ip - match;
+                U32 const litLen = (U32)(ip - anchor);
+                U32 const offset = (U32)(ip - match);
                 ZSTD_Sequence const seq = {
                     offset, litLen, matchLen, 0
                 };
@@ -56,7 +56,7 @@ size_t simpleExternalMatchFinder(
     }
 
     {   ZSTD_Sequence const finalSeq = {
-            0, iend - anchor, 0, 0
+            0, (U32)(iend - anchor), 0, 0
         };
         outSeqs[seqCount++] = finalSeq;
     }

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -7,7 +7,7 @@ static U32 const HLOG = 10;
 static U32 const MLS = 4;
 static U32 const BADIDX = (1 << 31);
 
-ZSTD_externalMatchResult simpleExternalMatchFinder(
+size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize, const void* dict, size_t dictSize
 ) {
@@ -57,10 +57,5 @@ ZSTD_externalMatchResult simpleExternalMatchFinder(
     };
     outSeqs[seqCount] = finalSeq;
 
-    ZSTD_externalMatchResult res = {seqCount, ZSTD_emf_error_none};
-    return res;
-}
-
-void simpleExternalMatchStateDestructor(void* externalMatchState) {
-    (void)externalMatchState;
+     return seqCount;
 }

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -9,10 +9,11 @@ static U32 const BADIDX = (1 << 31);
 
 size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
-  const void* src, size_t srcSize, size_t historySize
+  const void* src, size_t srcSize, const void* dict, size_t dictSize
 ) {
     (void)(externalMatchState);
-    (void)(historySize);
+    (void)(dict);
+    (void)(dictSize);
     (void)(outSeqsCapacity); // @nocommit return an error
 
     const BYTE* const istart = (const BYTE*)src;

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -9,12 +9,15 @@ static U32 const BADIDX = (1 << 31);
 
 size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
-  const void* src, size_t srcSize, const void* dict, size_t dictSize
+  const void* src, size_t srcSize,
+  const void* dict, size_t dictSize,
+  int compressionLevel
 ) {
     (void)externalMatchState;
     (void)dict;
     (void)dictSize;
-    (void)outSeqsCapacity; // @nocommit return an error
+    (void)outSeqsCapacity;
+    (void)compressionLevel;
 
     const BYTE* const istart = (const BYTE*)src;
     const BYTE* const iend = istart + srcSize;

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -7,7 +7,7 @@ static U32 const HLOG = 10;
 static U32 const MLS = 4;
 static U32 const BADIDX = (1 << 31);
 
-size_t simpleExternalMatchFinder(
+ZSTD_externalMatchResult simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize, const void* dict, size_t dictSize
 ) {
@@ -52,14 +52,13 @@ size_t simpleExternalMatchFinder(
         ip++;
     }
 
-    {
-        ZSTD_Sequence const finalSeq = {
-            0, iend - anchor, 0, 0
-        };
-        outSeqs[seqCount] = finalSeq;
-    }
+    ZSTD_Sequence const finalSeq = {
+        0, iend - anchor, 0, 0
+    };
+    outSeqs[seqCount] = finalSeq;
 
-    return seqCount;
+    ZSTD_externalMatchResult res = {seqCount, ZSTD_emf_error_none};
+    return res;
 }
 
 void simpleExternalMatchStateDestructor(void* externalMatchState) {

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -7,7 +7,7 @@ static U32 const HLOG = 10;
 static U32 const MLS = 4;
 static U32 const BADIDX = (1 << 31);
 
-size_t simpleExternalMatchfinder(
+size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize, size_t historySize
 ) {
@@ -59,4 +59,8 @@ size_t simpleExternalMatchfinder(
     }
 
     return seqCount;
+}
+
+void simpleExternalMatchStateDestructor(void* externalMatchState) {
+    (void)externalMatchState;
 }

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
 #include "zstd_compress_internal.h"
 #include "matchfinder.h"
 

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -41,7 +41,7 @@ size_t simpleExternalMatchFinder(
             hashTable[i] = BADIDX;
     }   }
 
-    while (ip + 4 < iend) {
+    while (ip + MLS < iend) {
         size_t const hash = ZSTD_hashPtr(ip, HLOG, MLS);
         U32 const matchIndex = hashTable[hash];
         hashTable[hash] = (U32)(ip - istart);

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -14,7 +14,7 @@
 #define HSIZE 1024
 static U32 const HLOG = 10;
 static U32 const MLS = 4;
-static U32 const BADIDX = (1 << 31);
+static U32 const BADIDX = 0xffffffff;
 
 size_t simpleExternalMatchFinder(
   void* externalMatchState,

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Meta Platforms, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/matchfinder.c
+++ b/contrib/externalMatchfinder/matchfinder.c
@@ -21,7 +21,8 @@ size_t simpleExternalMatchFinder(
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
-  int compressionLevel
+  int compressionLevel,
+  size_t windowSize
 ) {
     const BYTE* const istart = (const BYTE*)src;
     const BYTE* const iend = istart + srcSize;
@@ -55,10 +56,14 @@ size_t simpleExternalMatchFinder(
                 ZSTD_Sequence const seq = {
                     offset, litLen, matchLen, 0
                 };
-                outSeqs[seqCount++] = seq;
-                ip += matchLen;
-                anchor = ip;
-                continue;
+
+                /* Note: it's crucial to stay within the window size! */
+                if (offset <= windowSize) {
+                    outSeqs[seqCount++] = seq;
+                    ip += matchLen;
+                    anchor = ip;
+                    continue;
+                }
             }
         }
 

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -5,7 +5,8 @@
 #include "zstd.h"
 
 size_t simpleExternalMatchFinder(
-  void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  void* externalMatchState,
+  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
   int compressionLevel

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
 #ifndef MATCHFINDER_H
 #define MATCHFINDER_H
 

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -4,7 +4,7 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 
-size_t simpleExternalMatchFinder(
+ZSTD_externalMatchResult simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize, const void* dict, size_t dictSize
 );

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -1,0 +1,12 @@
+#ifndef MATCHFINDER_H
+#define MATCHFINDER_H
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd.h"
+
+size_t simpleExternalMatchfinder(
+  void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  const void* src, size_t srcSize, size_t historySize
+);
+
+#endif

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -4,11 +4,9 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 
-ZSTD_externalMatchResult simpleExternalMatchFinder(
+size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize, const void* dict, size_t dictSize
 );
-
-void simpleExternalMatchStateDestructor(void* matchState);
 
 #endif

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -6,7 +6,7 @@
 
 size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
-  const void* src, size_t srcSize, size_t historySize
+  const void* src, size_t srcSize, const void* dict, size_t dictSize
 );
 
 void simpleExternalMatchStateDestructor(void* matchState);

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -4,9 +4,11 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include "zstd.h"
 
-size_t simpleExternalMatchfinder(
+size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize, size_t historySize
 );
+
+void simpleExternalMatchStateDestructor(void* matchState);
 
 #endif

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -6,7 +6,9 @@
 
 size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
-  const void* src, size_t srcSize, const void* dict, size_t dictSize
+  const void* src, size_t srcSize,
+  const void* dict, size_t dictSize,
+  int compressionLevel
 );
 
 #endif

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Meta Platforms, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/contrib/externalMatchfinder/matchfinder.h
+++ b/contrib/externalMatchfinder/matchfinder.h
@@ -19,7 +19,8 @@ size_t simpleExternalMatchFinder(
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
-  int compressionLevel
+  int compressionLevel,
+  size_t windowSize
 );
 
 #endif

--- a/lib/common/error_private.c
+++ b/lib/common/error_private.c
@@ -51,6 +51,7 @@ const char* ERR_getErrorString(ERR_enum code)
     case PREFIX(seekableIO): return "An I/O error occurred when reading/seeking";
     case PREFIX(dstBuffer_wrong): return "Destination buffer is wrong";
     case PREFIX(srcBuffer_wrong): return "Source buffer is wrong";
+    case PREFIX(externalMatchFinder_failed): return "External matchfinder returned a non-zero error code";
     case PREFIX(maxCode):
     default: return notErrorCode;
     }

--- a/lib/common/error_private.c
+++ b/lib/common/error_private.c
@@ -31,6 +31,7 @@ const char* ERR_getErrorString(ERR_enum code)
     case PREFIX(checksum_wrong): return "Restored data doesn't match checksum";
     case PREFIX(literals_headerWrong): return "Header of Literals' block doesn't respect format specification";
     case PREFIX(parameter_unsupported): return "Unsupported parameter";
+    case PREFIX(parameter_combination_unsupported): return "Unsupported combination of parameters";
     case PREFIX(parameter_outOfBound): return "Parameter is out of bound";
     case PREFIX(init_missing): return "Context should be init first";
     case PREFIX(memory_allocation): return "Allocation error : not enough memory";

--- a/lib/common/error_private.c
+++ b/lib/common/error_private.c
@@ -51,7 +51,7 @@ const char* ERR_getErrorString(ERR_enum code)
     case PREFIX(seekableIO): return "An I/O error occurred when reading/seeking";
     case PREFIX(dstBuffer_wrong): return "Destination buffer is wrong";
     case PREFIX(srcBuffer_wrong): return "Source buffer is wrong";
-    case PREFIX(externalMatchFinder_failed): return "External matchfinder returned a non-zero error code";
+    case PREFIX(externalMatchFinder_failed): return "External matchfinder returned an error code";
     case PREFIX(maxCode):
     default: return notErrorCode;
     }

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1520,7 +1520,7 @@ static size_t ZSTD_estimateCCtxSize_usingCCtxParams_internal(
 {
     size_t const windowSize = (size_t) BOUNDED(1ULL, 1ULL << cParams->windowLog, pledgedSrcSize);
     size_t const blockSize = MIN(ZSTD_BLOCKSIZE_MAX, windowSize);
-    U32    const divider = (cParams->minMatch==3) ? 3 : 4;
+    U32    const divider = (cParams->minMatch==3 || useExternalMatchfinder) ? 3 : 4;
     size_t const maxNbSeq = blockSize / divider;
     size_t const tokenSpace = ZSTD_cwksp_alloc_size(WILDCOPY_OVERLENGTH + blockSize)
                             + ZSTD_cwksp_aligned_alloc_size(maxNbSeq * sizeof(seqDef))
@@ -1914,7 +1914,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 
     {   size_t const windowSize = MAX(1, (size_t)MIN(((U64)1 << params->cParams.windowLog), pledgedSrcSize));
         size_t const blockSize = MIN(ZSTD_BLOCKSIZE_MAX, windowSize);
-        U32    const divider = (params->cParams.minMatch==3) ? 3 : 4;
+        U32    const divider = (params->cParams.minMatch==3 || params->useExternalMatchfinder) ? 3 : 4;
         size_t const maxNbSeq = blockSize / divider;
         size_t const buffOutSize = (zbuff == ZSTDb_buffered && params->outBufferMode == ZSTD_bm_buffered)
                 ? ZSTD_compressBound(blockSize) + 1

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -158,6 +158,13 @@ static void ZSTD_clearAllDicts(ZSTD_CCtx* cctx)
     cctx->cdict = NULL;
 }
 
+/* Clears the external matchfinder, if one has been referenced.
+ * Does not free any resources owned by the external match state! */
+static void ZSTD_clearExternalMatchCtx(ZSTD_CCtx* cctx) {
+    ZSTD_externalMatchCtx nullCtx = {0};
+    cctx->externalMatchCtx = nullCtx;
+}
+
 static size_t ZSTD_sizeof_localDict(ZSTD_localDict dict)
 {
     size_t const bufferSize = dict.dictBuffer != NULL ? dict.dictSize : 0;
@@ -1258,6 +1265,7 @@ size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_ResetDirective reset)
         RETURN_ERROR_IF(cctx->streamStage != zcss_init, stage_wrong,
                         "Can't reset parameters only when not in init stage.");
         ZSTD_clearAllDicts(cctx);
+        ZSTD_clearExternalMatchCtx(cctx);
         return ZSTD_CCtxParams_reset(&cctx->requestedParams);
     }
     return 0;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1533,8 +1533,10 @@ static size_t ZSTD_estimateCCtxSize_usingCCtxParams_internal(
 
     size_t const cctxSpace = isStatic ? ZSTD_cwksp_alloc_size(sizeof(ZSTD_CCtx)) : 0;
 
-    size_t const externalSeqSpace = useExternalMatchFinder ?
-        ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX) * sizeof(ZSTD_Sequence) : 0;
+    size_t const maxNbExternalSeq = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX);
+    size_t const externalSeqSpace = useExternalMatchFinder
+        ? ZSTD_cwksp_alloc_size(maxNbExternalSeq * sizeof(ZSTD_Sequence))
+        : 0;
 
     size_t const neededSpace =
         cctxSpace +

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1533,7 +1533,7 @@ static size_t ZSTD_estimateCCtxSize_usingCCtxParams_internal(
 
     size_t const cctxSpace = isStatic ? ZSTD_cwksp_alloc_size(sizeof(ZSTD_CCtx)) : 0;
 
-    size_t const maxNbExternalSeq = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX);
+    size_t const maxNbExternalSeq = ZSTD_sequenceBound(blockSize);
     size_t const externalSeqSpace = useExternalMatchFinder
         ? ZSTD_cwksp_alloc_size(maxNbExternalSeq * sizeof(ZSTD_Sequence))
         : 0;
@@ -2042,7 +2042,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 
         /* reserve space for block-level external sequences */
         if (params->useExternalMatchFinder) {
-            size_t const maxNbExternalSeq = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX);
+            size_t const maxNbExternalSeq = ZSTD_sequenceBound(blockSize);
             zc->externalMatchCtx.seqBufferCapacity = maxNbExternalSeq;
             zc->externalMatchCtx.seqBuffer =
                 (ZSTD_Sequence*)ZSTD_cwksp_reserve_aligned(ws, maxNbExternalSeq * sizeof(ZSTD_Sequence));

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -591,7 +591,7 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
         bounds.upperBound = (int)ZSTD_ps_disable;
         return bounds;
 
-    case ZSTD_c_enableMatchfinderFallback:
+    case ZSTD_c_enableMatchFinderFallback:
         bounds.lowerBound = 0;
         bounds.upperBound = 1;
         return bounds;
@@ -661,7 +661,7 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     case ZSTD_c_useRowMatchFinder:
     case ZSTD_c_deterministicRefPrefix:
     case ZSTD_c_prefetchCDictTables:
-    case ZSTD_c_enableMatchfinderFallback:
+    case ZSTD_c_enableMatchFinderFallback:
     default:
         return 0;
     }
@@ -718,7 +718,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
     case ZSTD_c_useRowMatchFinder:
     case ZSTD_c_deterministicRefPrefix:
     case ZSTD_c_prefetchCDictTables:
-    case ZSTD_c_enableMatchfinderFallback:
+    case ZSTD_c_enableMatchFinderFallback:
         break;
 
     default: RETURN_ERROR(parameter_unsupported, "unknown parameter");
@@ -951,10 +951,10 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
         CCtxParams->prefetchCDictTables = (ZSTD_paramSwitch_e)value;
         return CCtxParams->prefetchCDictTables;
 
-    case ZSTD_c_enableMatchfinderFallback:
-        BOUNDCHECK(ZSTD_c_enableMatchfinderFallback, value);
-        CCtxParams->enableMatchfinderFallback = value;
-        return CCtxParams->enableMatchfinderFallback;
+    case ZSTD_c_enableMatchFinderFallback:
+        BOUNDCHECK(ZSTD_c_enableMatchFinderFallback, value);
+        CCtxParams->enableMatchFinderFallback = value;
+        return CCtxParams->enableMatchFinderFallback;
 
     default: RETURN_ERROR(parameter_unsupported, "unknown parameter");
     }
@@ -1091,8 +1091,8 @@ size_t ZSTD_CCtxParams_getParameter(
     case ZSTD_c_prefetchCDictTables:
         *value = (int)CCtxParams->prefetchCDictTables;
         break;
-    case ZSTD_c_enableMatchfinderFallback:
-        *value = CCtxParams->enableMatchfinderFallback;
+    case ZSTD_c_enableMatchFinderFallback:
+        *value = CCtxParams->enableMatchFinderFallback;
         break;
     default: RETURN_ERROR(parameter_unsupported, "unknown parameter");
     }
@@ -1516,11 +1516,11 @@ static size_t ZSTD_estimateCCtxSize_usingCCtxParams_internal(
         const size_t buffInSize,
         const size_t buffOutSize,
         const U64 pledgedSrcSize,
-        int useExternalMatchfinder)
+        int useExternalMatchFinder)
 {
     size_t const windowSize = (size_t) BOUNDED(1ULL, 1ULL << cParams->windowLog, pledgedSrcSize);
     size_t const blockSize = MIN(ZSTD_BLOCKSIZE_MAX, windowSize);
-    U32    const divider = (cParams->minMatch==3 || useExternalMatchfinder) ? 3 : 4;
+    U32    const divider = (cParams->minMatch==3 || useExternalMatchFinder) ? 3 : 4;
     size_t const maxNbSeq = blockSize / divider;
     size_t const tokenSpace = ZSTD_cwksp_alloc_size(WILDCOPY_OVERLENGTH + blockSize)
                             + ZSTD_cwksp_aligned_alloc_size(maxNbSeq * sizeof(seqDef))
@@ -1540,7 +1540,7 @@ static size_t ZSTD_estimateCCtxSize_usingCCtxParams_internal(
 
     size_t const cctxSpace = isStatic ? ZSTD_cwksp_alloc_size(sizeof(ZSTD_CCtx)) : 0;
 
-    size_t const externalSeqSpace = useExternalMatchfinder ?
+    size_t const externalSeqSpace = useExternalMatchFinder ?
         ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX) * sizeof(ZSTD_Sequence) : 0;
 
     size_t const neededSpace =
@@ -1570,7 +1570,7 @@ size_t ZSTD_estimateCCtxSize_usingCCtxParams(const ZSTD_CCtx_params* params)
      * be needed. However, we still allocate two 0-sized buffers, which can
      * take space under ASAN. */
     return ZSTD_estimateCCtxSize_usingCCtxParams_internal(
-        &cParams, &params->ldmParams, 1, useRowMatchFinder, 0, 0, ZSTD_CONTENTSIZE_UNKNOWN, params->useExternalMatchfinder);
+        &cParams, &params->ldmParams, 1, useRowMatchFinder, 0, 0, ZSTD_CONTENTSIZE_UNKNOWN, params->useExternalMatchFinder);
 }
 
 size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters cParams)
@@ -1631,7 +1631,7 @@ size_t ZSTD_estimateCStreamSize_usingCCtxParams(const ZSTD_CCtx_params* params)
 
         return ZSTD_estimateCCtxSize_usingCCtxParams_internal(
             &cParams, &params->ldmParams, 1, useRowMatchFinder, inBuffSize, outBuffSize,
-            ZSTD_CONTENTSIZE_UNKNOWN, params->useExternalMatchfinder);
+            ZSTD_CONTENTSIZE_UNKNOWN, params->useExternalMatchFinder);
     }
 }
 
@@ -1914,7 +1914,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 
     {   size_t const windowSize = MAX(1, (size_t)MIN(((U64)1 << params->cParams.windowLog), pledgedSrcSize));
         size_t const blockSize = MIN(ZSTD_BLOCKSIZE_MAX, windowSize);
-        U32    const divider = (params->cParams.minMatch==3 || params->useExternalMatchfinder) ? 3 : 4;
+        U32    const divider = (params->cParams.minMatch==3 || params->useExternalMatchFinder) ? 3 : 4;
         size_t const maxNbSeq = blockSize / divider;
         size_t const buffOutSize = (zbuff == ZSTDb_buffered && params->outBufferMode == ZSTD_bm_buffered)
                 ? ZSTD_compressBound(blockSize) + 1
@@ -1932,7 +1932,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
         size_t const neededSpace =
             ZSTD_estimateCCtxSize_usingCCtxParams_internal(
                 &params->cParams, &params->ldmParams, zc->staticSize != 0, params->useRowMatchFinder,
-                buffInSize, buffOutSize, pledgedSrcSize, params->useExternalMatchfinder);
+                buffInSize, buffOutSize, pledgedSrcSize, params->useExternalMatchFinder);
         int resizeWorkspace;
 
         FORWARD_IF_ERROR(neededSpace, "cctx size estimate failed!");
@@ -2046,7 +2046,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
         }
 
         /* reserve space for block-level external sequences */
-        if (params->useExternalMatchfinder) {
+        if (params->useExternalMatchFinder) {
             size_t const maxNbExternalSeq = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX);
             zc->externalMatchCtx.seqBufferCapacity = maxNbExternalSeq;
             zc->externalMatchCtx.seqBuffer =
@@ -2957,14 +2957,14 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
              * We need to revisit soon and implement it. */
             if (zc->appliedParams.useBlockSplitter == ZSTD_ps_enable) {
                 RETURN_ERROR_IF(
-                    zc->appliedParams.useExternalMatchfinder,
+                    zc->appliedParams.useExternalMatchFinder,
                     parameter_unsupported, // @nocommit Make this a parameter *combination* error?
                     "Block splitting with external matchfinder enabled is not currently supported. "
                     "Note: block splitting is enabled by default at high compression levels."
                 );
             } else {
                 RETURN_ERROR_IF(
-                    zc->appliedParams.useExternalMatchfinder,
+                    zc->appliedParams.useExternalMatchFinder,
                     parameter_unsupported, // @nocommit Make this a parameter *combination* error?
                     "Long-distance matching with external matchfinder enabled is not currently supported."
                 );
@@ -2984,7 +2984,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
             /* External matchfinder + LDM is technically possible, just not implemented yet.
              * We need to revisit soon and implement it. */
             RETURN_ERROR_IF(
-                zc->appliedParams.useExternalMatchfinder,
+                zc->appliedParams.useExternalMatchFinder,
                 parameter_unsupported, // @nocommit Make this a parameter *combination* error?
                 "Long-distance matching with external matchfinder enabled is not currently supported."
             );
@@ -3003,7 +3003,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        zc->appliedParams.useRowMatchFinder,
                                        src, srcSize);
             assert(ldmSeqStore.pos == ldmSeqStore.size);
-        } else if (zc->appliedParams.useExternalMatchfinder) {
+        } else if (zc->appliedParams.useExternalMatchFinder) {
             assert(
                 zc->externalMatchCtx.seqBufferCapacity >= ZSTD_sequenceBound(srcSize)
             );
@@ -3025,7 +3025,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                 ms->ldmSeqStore = NULL;
                 lastLLSize = 0;
             } else {
-                if (zc->appliedParams.enableMatchfinderFallback) {
+                if (zc->appliedParams.enableMatchFinderFallback) {
                     ZSTD_blockCompressor const blockCompressor = ZSTD_selectBlockCompressor(zc->appliedParams.cParams.strategy,
                                                                                             zc->appliedParams.useRowMatchFinder,
                                                                                             dictMode);
@@ -3188,7 +3188,7 @@ static int ZSTD_maybeRLE(seqStore_t const* seqStore, ZSTD_CCtx_params const* app
     size_t const nbSeqs = (size_t)(seqStore->sequences - seqStore->sequencesStart);
     size_t const nbLits = (size_t)(seqStore->lit - seqStore->litStart);
 
-    if (appliedParams->useExternalMatchfinder) {
+    if (appliedParams->useExternalMatchFinder) {
         /* We shouldn't make any assumptions about how an external matchfinder
          * will compress an RLE block. */
         return 1;
@@ -6676,7 +6676,7 @@ void ZSTD_refExternalMatchFinder(
     ZSTD_CCtx* zc, void* mState,
     ZSTD_externalMatchFinder_F* mFinder
 ) {
-    zc->requestedParams.useExternalMatchfinder = 1;
+    zc->requestedParams.useExternalMatchFinder = 1;
     ZSTD_externalMatchCtx emctx = {
         mState,
         mFinder,

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2902,6 +2902,11 @@ size_t ZSTD_registerExternalMatchFinder(
     ZSTD_externalMatchFinder_F* mFinder,
     ZSTD_externalMatchStateDestructor_F* mStateDestructor
 ) {
+    RETURN_ERROR_IF(
+        zc->staticSize, parameter_unsupported,
+        "External matchfinder is not compatible with static alloc"
+    );
+
     ZSTD_clearExternalMatchFinder(zc);
 
     size_t const seqBufferCapacity = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2929,7 +2929,8 @@ static size_t ZSTD_postProcessExternalMatchFinderResult(
 
 #if defined(DEBUGLEVEL) && (DEBUGLEVEL>=2)
     {
-        size_t coveredBytes, idx;
+        size_t coveredBytes = 0;
+        size_t idx = 0;
 
         for (idx = 0; idx < nbExternalSeqs; idx++) {
             /* We already know that nbExternalSeqs <= outSeqsCapacity */

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -281,6 +281,7 @@ static ZSTD_paramSwitch_e ZSTD_resolveEnableLdm(ZSTD_paramSwitch_e mode,
 /* Enables validation for external sequences in debug builds. */
 static int ZSTD_resolveExternalSequenceValidation(int mode) {
 #if defined(DEBUGLEVEL) && (DEBUGLEVEL>=2)
+    (void)mode;
     return 1;
 #else
     return mode;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2907,6 +2907,12 @@ size_t ZSTD_registerExternalMatchFinder(
         "External matchfinder is not compatible with static alloc"
     );
 
+    RETURN_ERROR_IF(
+        (mState && !mStateDestructor) || (!mState && mStateDestructor),
+        GENERIC,
+        "Cannot provide external match state without corresponding destructor, or vice versa!"
+    );
+
     ZSTD_clearExternalMatchFinder(zc);
 
     size_t const seqBufferCapacity = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2964,8 +2964,9 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        src, srcSize);
             assert(ldmSeqStore.pos == ldmSeqStore.size);
         } else if (1 /* @nocommit: change to a cparam */) {
+            // @nocommit document lack of dictionary support in function call
             size_t numSeqsFound = (zc->externalMatchCtx.mFinder)(
-                NULL, zc->externalMatchCtx.seqBuffer, zc->externalMatchCtx.seqBufferCapacity, src, srcSize, 0
+                NULL, zc->externalMatchCtx.seqBuffer, zc->externalMatchCtx.seqBufferCapacity, src, srcSize, NULL, 0
             );
             ZSTD_sequencePosition seqPos = {0,0,0};
             lastLLSize = 0; // @nocommit

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3232,12 +3232,18 @@ static int ZSTD_isRLE(const BYTE* src, size_t length) {
  * This is just a heuristic based on the compressibility.
  * It may return both false positives and false negatives.
  */
-static int ZSTD_maybeRLE(seqStore_t const* seqStore)
+static int ZSTD_maybeRLE(seqStore_t const* seqStore, ZSTD_CCtx_params const* appliedParams)
 {
     size_t const nbSeqs = (size_t)(seqStore->sequences - seqStore->sequencesStart);
     size_t const nbLits = (size_t)(seqStore->lit - seqStore->litStart);
 
-    return nbSeqs < 4 && nbLits < 10;
+    if (appliedParams->useExternalMatchfinder) {
+        /* We shouldn't make any assumptions about how an external matchfinder
+         * will compress an RLE block. */
+        return 1;
+    } else {
+        return nbSeqs < 4 && nbLits < 10;
+    }
 }
 
 static void
@@ -4087,7 +4093,7 @@ static size_t ZSTD_compressBlock_targetCBlockSize_body(ZSTD_CCtx* zc,
             * This is only an issue for zstd <= v1.4.3
             */
             !zc->isFirstBlock &&
-            ZSTD_maybeRLE(&zc->seqStore) &&
+            ZSTD_maybeRLE(&zc->seqStore, &zc->appliedParams) &&
             ZSTD_isRLE((BYTE const*)src, srcSize))
         {
             return ZSTD_rleCompressBlock(dst, dstCapacity, *(BYTE const*)src, srcSize, lastBlock);
@@ -6441,7 +6447,7 @@ ZSTD_compressSequences_internal(ZSTD_CCtx* cctx,
         DEBUGLOG(5, "Compressed sequences size: %zu", compressedSeqsSize);
 
         if (!cctx->isFirstBlock &&
-            ZSTD_maybeRLE(&cctx->seqStore) &&
+            ZSTD_maybeRLE(&cctx->seqStore, &cctx->appliedParams) &&
             ZSTD_isRLE(ip, blockSize)) {
             /* We don't want to emit our first block as a RLE even if it qualifies because
             * doing so will cause the decoder (cli only) to throw a "should consume all input error."

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2880,15 +2880,15 @@ void ZSTD_registerExternalMatchfinder(
     ZSTD_externalMatchStateDestructor_F* mStateDestructor
 ) {
     // @nocommit Call clearExternalMatchContext()
-    size_t const seqBufferSize = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX) * sizeof(ZSTD_Sequence);
-    void* seqBuffer = ZSTD_malloc(seqBufferSize);
+    size_t const seqBufferCapacity = ZSTD_sequenceBound(ZSTD_BLOCKSIZE_MAX);
+    ZSTD_Sequence* seqBuffer = (ZSTD_Sequence*)ZSTD_malloc(seqBufferCapacity * sizeof(ZSTD_Sequence));
 
     ZSTD_externalMatchCtx emctx = {
         mState,
         mFinder,
         mStateDestructor,
         seqBuffer,
-        seqBufferSize
+        seqBufferCapacity
     };
     zc->externalMatchCtx = emctx;
 }
@@ -2965,7 +2965,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
             assert(ldmSeqStore.pos == ldmSeqStore.size);
         } else if (1 /* @nocommit: change to a cparam */) {
             size_t numSeqsFound = (zc->externalMatchCtx.mFinder)(
-                NULL, zc->externalMatchCtx.seqBuffer, zc->externalMatchCtx.seqBufferSize, src, srcSize, 0
+                NULL, zc->externalMatchCtx.seqBuffer, zc->externalMatchCtx.seqBufferCapacity, src, srcSize, 0
             );
             ZSTD_sequencePosition seqPos = {0,0,0};
             lastLLSize = 0; // @nocommit

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -6117,9 +6117,6 @@ static U32 ZSTD_finalizeOffBase(U32 rawOffset, const U32 rep[ZSTD_REP_NUM], U32 
     return offBase;
 }
 
-/* Returns 0 on success, and a ZSTD_error otherwise. This function scans through an array of
- * ZSTD_Sequence, storing the sequences it finds, until it reaches a block delimiter.
- */
 size_t
 ZSTD_copySequencesToSeqStoreExplicitBlockDelim(ZSTD_CCtx* cctx,
                                               ZSTD_sequencePosition* seqPos,
@@ -6174,19 +6171,7 @@ ZSTD_copySequencesToSeqStoreExplicitBlockDelim(ZSTD_CCtx* cctx,
     return 0;
 }
 
-/* Returns the number of bytes to move the current read position back by.
- * Only non-zero if we ended up splitting a sequence.
- * Otherwise, it may return a ZSTD error if something went wrong.
- *
- * This function will attempt to scan through blockSize bytes
- * represented by the sequences in @inSeqs,
- * storing any (partial) sequences.
- *
- * Occasionally, we may want to change the actual number of bytes we consumed from inSeqs to
- * avoid splitting a match, or to avoid splitting a match such that it would produce a match
- * smaller than MINMATCH. In this case, we return the number of bytes that we didn't read from this block.
- */
-static size_t
+size_t
 ZSTD_copySequencesToSeqStoreNoBlockDelim(ZSTD_CCtx* cctx, ZSTD_sequencePosition* seqPos,
                                    const ZSTD_Sequence* const inSeqs, size_t inSeqsSize,
                                    const void* src, size_t blockSize)

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3024,12 +3024,18 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                 );
                 ms->ldmSeqStore = NULL;
                 lastLLSize = 0;
+                DEBUGLOG(5, "Copied %lu sequences from external matchfinder to internal seqStore.", (unsigned long)nbExternalSeqs);
             } else {
                 if (zc->appliedParams.enableMatchFinderFallback) {
                     ZSTD_blockCompressor const blockCompressor = ZSTD_selectBlockCompressor(zc->appliedParams.cParams.strategy,
                                                                                             zc->appliedParams.useRowMatchFinder,
                                                                                             dictMode);
                     ms->ldmSeqStore = NULL;
+                    DEBUGLOG(
+                        5,
+                        "External matchfinder returned error code %lu. Falling back to internal matchfinder.",
+                        (unsigned long)nbExternalSeqs
+                    );
                     lastLLSize = blockCompressor(ms, &zc->seqStore, zc->blockState.nextCBlock->rep, src, srcSize);
                 } else {
                     RETURN_ERROR(

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -3014,7 +3014,8 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                 zc->externalMatchCtx.seqBuffer,
                 zc->externalMatchCtx.seqBufferCapacity,
                 src, srcSize,
-                NULL, 0  /* dict and dictSize, currently not supported */
+                NULL, 0,  /* dict and dictSize, currently not supported */
+                zc->appliedParams.compressionLevel
             );
 
             if (nbExternalSeqs <= zc->externalMatchCtx.seqBufferCapacity) {

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -6731,7 +6731,7 @@ ZSTD_parameters ZSTD_getParams(int compressionLevel, unsigned long long srcSizeH
     return ZSTD_getParams_internal(compressionLevel, srcSizeHint, dictSize, ZSTD_cpm_unknown);
 }
 
-void ZSTD_refExternalMatchFinder(
+void ZSTD_registerExternalMatchFinder(
     ZSTD_CCtx* zc, void* mState,
     ZSTD_externalMatchFinder_F* mFinder
 ) {

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -150,6 +150,18 @@ typedef struct {
   size_t capacity;      /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;
 
+typedef struct {
+    U32 idx;            /* Index in array of ZSTD_Sequence */
+    U32 posInSequence;  /* Position within sequence at idx */
+    size_t posInSrc;    /* Number of bytes given by sequences provided so far */
+} ZSTD_sequencePosition;
+
+size_t
+ZSTD_copySequencesToSeqStoreExplicitBlockDelim(ZSTD_CCtx* cctx,
+                                              ZSTD_sequencePosition* seqPos,
+                                        const ZSTD_Sequence* const inSeqs, size_t inSeqsSize,
+                                        const void* src, size_t blockSize);
+
 UNUSED_ATTR static const rawSeqStore_t kNullRawSeqStore = {NULL, 0, 0, 0, 0};
 
 typedef struct {
@@ -440,6 +452,9 @@ struct ZSTD_CCtx_s {
 
     /* Workspace for block splitter */
     ZSTD_blockSplitCtx blockSplitCtx;
+
+    /* External block matchfinder */
+    ZSTD_externalMatchfinder_F* externalBlockMatchfinder;
 };
 
 typedef enum { ZSTD_dtlm_fast, ZSTD_dtlm_full } ZSTD_dictTableLoadMethod_e;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -389,8 +389,8 @@ typedef struct {
   void* mState;
   ZSTD_externalMatchFinder_F* mFinder;
   ZSTD_externalMatchStateDestructor_F* mStateDestructor;
-  void* seqBuffer; // @nocommit change from void* to ZSTD_Sequence*
-  size_t seqBufferSize;
+  ZSTD_Sequence* seqBuffer;
+  size_t seqBufferCapacity;
 } ZSTD_externalMatchCtx;
 
 struct ZSTD_CCtx_s {

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -353,11 +353,8 @@ struct ZSTD_CCtx_params_s {
     /* Controls prefetching in some dictMatchState matchfinders */
     ZSTD_paramSwitch_e prefetchCDictTables;
 
-    /* Controls block-level sequence compression API */
-    int useExternalMatchfinder;
-
     /* Controls whether zstd will fall back to an internal matchfinder
-     * when the external matchfinder returns a non-zero error code. */
+     * when the external matchfinder returns an error code. */
     int enableMatchfinderFallback;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */
 
@@ -395,7 +392,6 @@ typedef struct {
 typedef struct {
   void* mState;
   ZSTD_externalMatchFinder_F* mFinder;
-  ZSTD_externalMatchStateDestructor_F* mStateDestructor;
   ZSTD_Sequence* seqBuffer;
   size_t seqBufferCapacity;
 } ZSTD_externalMatchCtx;
@@ -470,7 +466,7 @@ struct ZSTD_CCtx_s {
     /* Workspace for block splitter */
     ZSTD_blockSplitCtx blockSplitCtx;
 
-    /* External block matchfinder */
+    /* Workspace for external matchfinder */
     ZSTD_externalMatchCtx externalMatchCtx;
 };
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1439,6 +1439,7 @@ void ZSTD_CCtx_trace(ZSTD_CCtx* cctx, size_t extraCSize);
 
 /* Returns 0 on success, and a ZSTD_error otherwise. This function scans through an array of
  * ZSTD_Sequence, storing the sequences it finds, until it reaches a block delimiter.
+ * Note that the block delimiter must include the last literals of the block.
  */
 size_t
 ZSTD_copySequencesToSeqStoreExplicitBlockDelim(ZSTD_CCtx* cctx,

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -353,7 +353,7 @@ struct ZSTD_CCtx_params_s {
 
     /* Indicates whether an external matchfinder has been referenced.
      * Users can't set this externally.
-     * It is set internally in ZSTD_refExternalMatchFinder(). */
+     * It is set internally in ZSTD_registerExternalMatchFinder(). */
     int useExternalMatchFinder;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -383,6 +383,16 @@ typedef struct {
     ZSTD_entropyCTablesMetadata_t entropyMetadata;
 } ZSTD_blockSplitCtx;
 
+/* Block-level sequence compression API */
+// @nocommit improve docs
+typedef struct {
+  void* mState;
+  ZSTD_externalMatchFinder_F* mFinder;
+  ZSTD_externalMatchStateDestructor_F* mStateDestructor;
+  void* seqBuffer; // @nocommit change from void* to ZSTD_Sequence*
+  size_t seqBufferSize;
+} ZSTD_externalMatchCtx;
+
 struct ZSTD_CCtx_s {
     ZSTD_compressionStage_e stage;
     int cParamsChanged;                  /* == 1 if cParams(except wlog) or compression level are changed in requestedParams. Triggers transmission of new params to ZSTDMT (if available) then reset to 0. */
@@ -454,7 +464,7 @@ struct ZSTD_CCtx_s {
     ZSTD_blockSplitCtx blockSplitCtx;
 
     /* External block matchfinder */
-    ZSTD_externalMatchfinder_F* externalBlockMatchfinder;
+    ZSTD_externalMatchCtx externalMatchCtx;
 };
 
 typedef enum { ZSTD_dtlm_fast, ZSTD_dtlm_full } ZSTD_dictTableLoadMethod_e;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -355,12 +355,12 @@ struct ZSTD_CCtx_params_s {
 
     /* Controls whether zstd will fall back to an internal matchfinder
      * if the external matchfinder returns an error code. */
-    int enableMatchfinderFallback;
+    int enableMatchFinderFallback;
 
     /* Indicates whether an external matchfinder has been referenced.
      * Users can't set this externally.
-     * It is set internally in ZSTD_refExternalMatchfinder(). */
-    int useExternalMatchfinder;
+     * It is set internally in ZSTD_refExternalMatchFinder(). */
+    int useExternalMatchFinder;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */
 
 #define COMPRESS_SEQUENCES_WORKSPACE_SIZE (sizeof(unsigned) * (MaxSeq + 2))

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -354,8 +354,13 @@ struct ZSTD_CCtx_params_s {
     ZSTD_paramSwitch_e prefetchCDictTables;
 
     /* Controls whether zstd will fall back to an internal matchfinder
-     * when the external matchfinder returns an error code. */
+     * if the external matchfinder returns an error code. */
     int enableMatchfinderFallback;
+
+    /* Indicates whether an external matchfinder has been referenced.
+     * Users can't set this externally.
+     * It is set internally in ZSTD_refExternalMatchfinder(). */
+    int useExternalMatchfinder;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */
 
 #define COMPRESS_SEQUENCES_WORKSPACE_SIZE (sizeof(unsigned) * (MaxSeq + 2))

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -392,8 +392,7 @@ typedef struct {
     ZSTD_entropyCTablesMetadata_t entropyMetadata;
 } ZSTD_blockSplitCtx;
 
-/* Block-level sequence compression API */
-// @nocommit improve docs
+/* Context for block-level external matchfinder API */
 typedef struct {
   void* mState;
   ZSTD_externalMatchFinder_F* mFinder;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -355,6 +355,10 @@ struct ZSTD_CCtx_params_s {
 
     /* Controls block-level sequence compression API */
     int useExternalMatchfinder;
+
+    /* Controls whether zstd will fall back to an internal matchfinder
+     * when the external matchfinder returns a non-zero error code. */
+    int enableMatchfinderFallback;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */
 
 #define COMPRESS_SEQUENCES_WORKSPACE_SIZE (sizeof(unsigned) * (MaxSeq + 2))

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -352,6 +352,9 @@ struct ZSTD_CCtx_params_s {
 
     /* Controls prefetching in some dictMatchState matchfinders */
     ZSTD_paramSwitch_e prefetchCDictTables;
+
+    /* Controls block-level sequence compression API */
+    int useExternalMatchfinder;
 };  /* typedef'd to ZSTD_CCtx_params within "zstd.h" */
 
 #define COMPRESS_SEQUENCES_WORKSPACE_SIZE (sizeof(unsigned) * (MaxSeq + 2))

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1510,31 +1510,6 @@ ZSTD_compressSequences( ZSTD_CCtx* cctx, void* dst, size_t dstSize,
                         const ZSTD_Sequence* inSeqs, size_t inSeqsSize,
                         const void* src, size_t srcSize);
 
-/* Block-level sequence compression API */
-/* @nocommit document */
-
-#define ZSTD_EXTERNAL_MATCHFINDER_ERROR ((size_t)(-1))
-
-/* @nocommit document these constraints:
- *     - outSeqsCapacity >= (blockSize / MINMATCH) + 1
- *     - srcSize <= 128 KB
- *     - dictSize is not bounded */
-typedef size_t ZSTD_externalMatchFinder_F (
-  void* externalMatchState,
-  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
-  const void* src, size_t srcSize,
-  const void* dict, size_t dictSize,
-  int compressionLevel,
-  size_t windowSize
-);
-
-ZSTDLIB_STATIC_API void
-ZSTD_registerExternalMatchFinder(
-  ZSTD_CCtx* cctx,
-  void* externalMatchState,
-  ZSTD_externalMatchFinder_F* externalMatchFinder
-);
-
 /****************************************/
 
 /*! ZSTD_writeSkippableFrame() :
@@ -2072,7 +2047,18 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  */
 #define ZSTD_c_prefetchCDictTables ZSTD_c_experimentalParam16
 
-/* @nocommit document */
+/* ZSTD_c_enableMatchFinderFallback
+ * Allowed values are 0 (disable) and 1 (enable). The default setting is 0.
+ *
+ * Controls whether zstd will fall back to an internal matchfinder if an
+ * external matchfinder is registered and returns an error code. This fallback is
+ * block-by-block: the internal matchfinder will only be called for blocks where
+ * the external matchfinder returns an error code. Fallback compression will
+ * follow any other cParam settings, such as compression level, the same as in a
+ * normal (fully-internal) compression operation.
+ *
+ * The user is strongly encouraged to read the full external matchfinder API
+ * documentation (below) before setting this parameter. */
 #define ZSTD_c_enableMatchFinderFallback ZSTD_c_experimentalParam17
 
 /*! ZSTD_CCtx_getParameter() :
@@ -2706,6 +2692,117 @@ ZSTDLIB_STATIC_API size_t ZSTD_compressBlock  (ZSTD_CCtx* cctx, void* dst, size_
 ZSTDLIB_STATIC_API size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 ZSTDLIB_STATIC_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* blockStart, size_t blockSize);  /**< insert uncompressed block into `dctx` history. Useful for multi-blocks decompression. */
 
+
+/* ********************** EXTERNAL MATCHFINDER API **********************
+ *
+ * OVERVIEW
+ * This API allows users to replace the zstd internal block-level matchfinder
+ * with an external matchfinder function. Potential applications of the API
+ * include hardware-accelerated matchfinders and matchfinders specialized to
+ * particular types of data.
+ *
+ * USAGE
+ * The user is responsible for implementing a function of type
+ * ZSTD_externalMatchFinder_F. For each block, zstd will pass the following
+ * arguments to the user-provided function:
+ *
+ *   - externalMatchState: a pointer to a user-managed state for the external
+ *     matchfinder.
+ *
+ *   - outSeqs, outSeqsCapacity: an output buffer for sequences produced by the
+ *     external matchfinder. outSeqsCapacity is guaranteed >=
+ *     ZSTD_sequenceBound(srcSize). The memory backing outSeqs is managed by
+ *     the CCtx.
+ *
+ *   - src, srcSize: an input buffer which the external matchfinder must parse
+ *     into sequences. srcSize is guaranteed to be <= ZSTD_BLOCKSIZE_MAX.
+ *
+ *   - dict, dictSize: a history buffer, which may be empty, which the external
+ *     matchfinder may reference as it produces sequences for the src buffer.
+ *     Currently, zstd will always pass dictSize == 0 into external matchfinders,
+ *     but this will change in the future.
+ *
+ *   - compressionLevel: a signed integer representing the zstd compression level
+ *     set by the user for the current operation. The external matchfinder may
+ *     choose to use this information to change its compression strategy and
+ *     speed/ratio tradeoff. Note: The compression level does not reflect zstd
+ *     parameters set through the advanced API.
+ *
+ *   - windowSize: a size_t representing the maximum allowed offset for external
+ *     sequences. Note that sequence offsets are sometimes allowed to exceed the
+ *     windowSize if a dictionary is present, see doc/zstd_compression_format.md
+ *     for details.
+ *
+ * The user-provided function shall return a size_t representing the number of
+ * sequences written to outSeqs. This return value will be treated as an error
+ * code if it is greater than outSeqsCapacity. The return value must be non-zero
+ * if srcSize is non-zero. The ZSTD_EXTERNAL_MATCHFINDER_ERROR macro is provided
+ * for convenience, but any value greater than outSeqsCapacity will be treated as
+ * an error code.
+ *
+ * If the user-provided function does not return an error code, the sequences
+ * written to outSeqs must be a valid parse of the src buffer. Data corruption may
+ * occur if the parse is not valid. A parse is defined to be valid if the
+ * following conditions hold:
+ *   - The sum of matchLengths and literalLengths is equal to srcSize.
+ *   - All sequences in the parse have matchLength != 0, except for the final
+ *     sequence. matchLength is not constrained for the final sequence.
+ *   - All offsets respect the windowSize parameter as specified in
+ *     doc/zstd_compression_format.md.
+ *
+ * zstd will only validate these conditions (and fail compression if they do not
+ * hold) if the ZSTD_c_validateSequences cParam is enabled. Note that sequence
+ * validation has a performance cost.
+ *
+ * If the user-provided function returns an error, zstd will either fall back
+ * to an internal matchfinder or fail the compression operation. The user can
+ * choose between the two behaviors by setting the
+ * ZSTD_c_enableMatchFinderFallback cParam. Fallback compression will follow any
+ * other cParam settings, such as compression level, the same as in a normal
+ * compression operation.
+ *
+ * The user shall instruct zstd to use a particular ZSTD_externalMatchFinder_F
+ * function by calling ZSTD_refExternalMatchFinder(cctx, externalMatchState,
+ * externalMatchFinder). This setting will persist until the next parameter reset
+ * of the CCtx.
+ *
+ * The externalMatchState must be initialized by the user before calling
+ * ZSTD_refExternalMatchFinder. The user is responsible for destroying the
+ * externalMatchState.
+ *
+ * LIMITATIONS
+ * This API is currently incompatible with long-distance matching. As mentioned
+ * above, history buffers (stream history, dictionaries) are currently not
+ * supported. We plan to remove these limitations in the future.
+ */
+
+#define ZSTD_EXTERNAL_MATCHFINDER_ERROR ((size_t)(-1))
+
+typedef size_t ZSTD_externalMatchFinder_F (
+  void* externalMatchState,
+  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  const void* src, size_t srcSize,
+  const void* dict, size_t dictSize,
+  int compressionLevel,
+  size_t windowSize
+);
+
+/*! ZSTD_registerExternalMatchFinder() :
+ * Instruct zstd to use an external matchfinder function.
+ *
+ * The externalMatchState must be initialized by the caller, and the caller is
+ * responsible for managing its lifetime. This parameter is sticky across
+ * compressions. It will remain set until the user explicitly resets compression
+ * parameters.
+ *
+ * The user is strongly encouraged to read the full API documentation (above)
+ * before calling this function. */
+ZSTDLIB_STATIC_API void
+ZSTD_registerExternalMatchFinder(
+  ZSTD_CCtx* cctx,
+  void* externalMatchState,
+  ZSTD_externalMatchFinder_F* externalMatchFinder
+);
 
 #endif   /* ZSTD_H_ZSTD_STATIC_LINKING_ONLY */
 

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1511,20 +1511,20 @@ ZSTD_compressSequences( ZSTD_CCtx* cctx, void* dst, size_t dstSize,
                         const void* src, size_t srcSize);
 
 /* Block-level sequence compression API */
-// @nocommit improve docs
+/* @nocommit improve docs */
 
 #define ZSTD_EXTERNAL_MATCHFINDER_ERROR ((size_t)(-1))
 
-// @nocommit move bounds comments into docs
+/* @nocommit move bounds comments into docs:
+ * outSeqsCapacity >= blockSize / MINMATCH
+ * srcSize <= 128 KB
+ * dictSize is not bounded */
 typedef size_t ZSTD_externalMatchFinder_F (
   void* externalMatchState,
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
-  // outSeqsCapacity >= blockSize / MINMATCH
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
   int compressionLevel
-  // srcSize <= 128 KB
-  // dictSize is not bounded
 );
 
 ZSTDLIB_STATIC_API void
@@ -2071,7 +2071,7 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  */
 #define ZSTD_c_prefetchCDictTables ZSTD_c_experimentalParam16
 
-// @nocommit document
+/* @nocommit document */
 #define ZSTD_c_enableMatchFinderFallback ZSTD_c_experimentalParam17
 
 /*! ZSTD_CCtx_getParameter() :

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -478,7 +478,7 @@ typedef enum {
      * ZSTD_c_useBlockSplitter
      * ZSTD_c_useRowMatchFinder
      * ZSTD_c_prefetchCDictTables
-     * ZSTD_c_enableMatchfinderFallback
+     * ZSTD_c_enableMatchFinderFallback
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -2071,7 +2071,7 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
 #define ZSTD_c_prefetchCDictTables ZSTD_c_experimentalParam16
 
 // @nocommit document
-#define ZSTD_c_enableMatchfinderFallback ZSTD_c_experimentalParam17
+#define ZSTD_c_enableMatchFinderFallback ZSTD_c_experimentalParam17
 
 /*! ZSTD_CCtx_getParameter() :
  *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1521,7 +1521,8 @@ typedef size_t ZSTD_externalMatchFinder_F (
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   // outSeqsCapacity >= blockSize / MINMATCH
   const void* src, size_t srcSize,
-  const void* dict, size_t dictSize
+  const void* dict, size_t dictSize,
+  int compressionLevel
   // srcSize <= 128 KB
   // dictSize is not bounded
 );

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -2706,7 +2706,6 @@ ZSTDLIB_STATIC_API size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx, void* dst, size_
 ZSTDLIB_STATIC_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* blockStart, size_t blockSize);  /**< insert uncompressed block into `dctx` history. Useful for multi-blocks decompression. */
 
 
-
 #endif   /* ZSTD_H_ZSTD_STATIC_LINKING_ONLY */
 
 #if defined (__cplusplus)

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -562,7 +562,7 @@ typedef enum {
  *                  They will be used to compress next frame.
  *                  Resetting session never fails.
  *  - The parameters : changes all parameters back to "default".
- *                  This removes any reference to any dictionary too. @nocommit mention external matchfinder
+ *                  This also removes any reference to any dictionary or external matchfinder.
  *                  Parameters can only be changed between 2 sessions (i.e. no compression is currently ongoing)
  *                  otherwise the reset fails, and function returns an error value (which can be tested using ZSTD_isError())
  *  - Both : similar to resetting the session, followed by resetting parameters.
@@ -1511,14 +1511,14 @@ ZSTD_compressSequences( ZSTD_CCtx* cctx, void* dst, size_t dstSize,
                         const void* src, size_t srcSize);
 
 /* Block-level sequence compression API */
-/* @nocommit improve docs */
+/* @nocommit document */
 
 #define ZSTD_EXTERNAL_MATCHFINDER_ERROR ((size_t)(-1))
 
-/* @nocommit move bounds comments into docs:
- * outSeqsCapacity >= blockSize / MINMATCH
- * srcSize <= 128 KB
- * dictSize is not bounded */
+/* @nocommit document these constraints:
+ *     - outSeqsCapacity >= (blockSize / MINMATCH) + 1
+ *     - srcSize <= 128 KB
+ *     - dictSize is not bounded */
 typedef size_t ZSTD_externalMatchFinder_F (
   void* externalMatchState,
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -2764,12 +2764,12 @@ ZSTDLIB_STATIC_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* bloc
  * compression operation.
  *
  * The user shall instruct zstd to use a particular ZSTD_externalMatchFinder_F
- * function by calling ZSTD_refExternalMatchFinder(cctx, externalMatchState,
+ * function by calling ZSTD_registerExternalMatchFinder(cctx, externalMatchState,
  * externalMatchFinder). This setting will persist until the next parameter reset
  * of the CCtx.
  *
  * The externalMatchState must be initialized by the user before calling
- * ZSTD_refExternalMatchFinder. The user is responsible for destroying the
+ * ZSTD_registerExternalMatchFinder. The user is responsible for destroying the
  * externalMatchState.
  *
  * LIMITATIONS

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1510,7 +1510,6 @@ ZSTD_compressSequences( ZSTD_CCtx* cctx, void* dst, size_t dstSize,
                         const ZSTD_Sequence* inSeqs, size_t inSeqsSize,
                         const void* src, size_t srcSize);
 
-/****************************************/
 
 /*! ZSTD_writeSkippableFrame() :
  * Generates a zstd skippable frame containing data given by src, and writes it to dst buffer.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -478,7 +478,6 @@ typedef enum {
      * ZSTD_c_useBlockSplitter
      * ZSTD_c_useRowMatchFinder
      * ZSTD_c_prefetchCDictTables
-     * ZSTD_c_useExternalMatchfinder
      * ZSTD_c_enableMatchfinderFallback
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
@@ -500,8 +499,7 @@ typedef enum {
      ZSTD_c_experimentalParam14=1011,
      ZSTD_c_experimentalParam15=1012,
      ZSTD_c_experimentalParam16=1013,
-     ZSTD_c_experimentalParam17=1014,
-     ZSTD_c_experimentalParam18=1015
+     ZSTD_c_experimentalParam17=1014
 } ZSTD_cParameter;
 
 typedef struct {
@@ -564,7 +562,7 @@ typedef enum {
  *                  They will be used to compress next frame.
  *                  Resetting session never fails.
  *  - The parameters : changes all parameters back to "default".
- *                  This removes any reference to any dictionary too.
+ *                  This removes any reference to any dictionary too. @nocommit mention external matchfinder
  *                  Parameters can only be changed between 2 sessions (i.e. no compression is currently ongoing)
  *                  otherwise the reset fails, and function returns an error value (which can be tested using ZSTD_isError())
  *  - Both : similar to resetting the session, followed by resetting parameters.
@@ -1515,22 +1513,10 @@ ZSTD_compressSequences( ZSTD_CCtx* cctx, void* dst, size_t dstSize,
 /* Block-level sequence compression API */
 // @nocommit improve docs
 
-typedef enum {
-  /* External matchfinder successfully compressed the block. */
-  ZSTD_emf_error_none = 0,
-
-  /* External matchfinder hit an unspecified failure condition.
-   * Will fail the overall compression operation. */
-  ZSTD_emf_error_generic= 1,
-} ZSTD_externalMatchFinder_errorCode_e;
-
-typedef struct {
-  size_t nbSeqsFound;
-  ZSTD_externalMatchFinder_errorCode_e errorCode;
-} ZSTD_externalMatchResult;
+#define ZSTD_EXTERNAL_MATCHFINDER_ERROR ((size_t)(-1))
 
 // @nocommit move bounds comments into docs
-typedef ZSTD_externalMatchResult ZSTD_externalMatchFinder_F (
+typedef size_t ZSTD_externalMatchFinder_F (
   void* externalMatchState,
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   // outSeqsCapacity >= blockSize / MINMATCH
@@ -1540,22 +1526,11 @@ typedef ZSTD_externalMatchResult ZSTD_externalMatchFinder_F (
   // dictSize is not bounded
 );
 
-typedef void ZSTD_externalMatchStateDestructor_F (
-  void* externalMatchState
-);
-
-ZSTDLIB_STATIC_API size_t
-ZSTD_registerExternalMatchFinder(
+ZSTDLIB_STATIC_API void
+ZSTD_refExternalMatchFinder(
   ZSTD_CCtx* cctx,
   void* externalMatchState,
-  ZSTD_externalMatchFinder_F* externalMatchFinder,
-  ZSTD_externalMatchStateDestructor_F* externalMatchStateDestructor
-);
-
-/* Note: calls the previously-registered destructor if it is not NULL. */
-ZSTDLIB_STATIC_API void
-ZSTD_clearExternalMatchFinder(
-  ZSTD_CCtx* cctx
+  ZSTD_externalMatchFinder_F* externalMatchFinder
 );
 
 /****************************************/
@@ -2096,10 +2071,7 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
 #define ZSTD_c_prefetchCDictTables ZSTD_c_experimentalParam16
 
 // @nocommit document
-#define ZSTD_c_useExternalMatchfinder ZSTD_c_experimentalParam17
-
-// @nocommit document
-#define ZSTD_c_enableMatchfinderFallback ZSTD_c_experimentalParam18
+#define ZSTD_c_enableMatchfinderFallback ZSTD_c_experimentalParam17
 
 /*! ZSTD_CCtx_getParameter() :
  *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1524,7 +1524,8 @@ typedef size_t ZSTD_externalMatchFinder_F (
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
-  int compressionLevel
+  int compressionLevel,
+  size_t windowSize
 );
 
 ZSTDLIB_STATIC_API void

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1528,7 +1528,7 @@ typedef size_t ZSTD_externalMatchFinder_F (
 );
 
 ZSTDLIB_STATIC_API void
-ZSTD_refExternalMatchFinder(
+ZSTD_registerExternalMatchFinder(
   ZSTD_CCtx* cctx,
   void* externalMatchState,
   ZSTD_externalMatchFinder_F* externalMatchFinder

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1516,7 +1516,8 @@ typedef size_t ZSTD_externalMatchFinder_F (
   void* externalMatchState, // TODO make this an externalMatchState type
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   // outSeqsCapacity >= blockSize / MINMATCH
-  const void* src, size_t srcSize, size_t historySize
+  const void* src, size_t srcSize,
+  const void* dict, size_t dictSize
   // srcSize - historySize <= 128 KB
   // historySize < srcSize ; any size
 );

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1508,6 +1508,24 @@ ZSTD_compressSequences( ZSTD_CCtx* cctx, void* dst, size_t dstSize,
                         const ZSTD_Sequence* inSeqs, size_t inSeqsSize,
                         const void* src, size_t srcSize);
 
+typedef size_t ZSTD_externalMatchfinder_F (
+  void* externalMatchState, // TODO make this an externalMatchState type
+  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  // outSeqsCapacity >= blockSize / MINMATCH
+  const void* src, size_t srcSize, size_t historySize
+  // srcSize - historySize <= 128 KB
+  // historySize < srcSize ; any size
+);
+
+// @nocommit document this
+ZSTDLIB_STATIC_API void
+ZSTD_registerExternalMatchfinder(ZSTD_CCtx* cctx, ZSTD_externalMatchfinder_F* externalBlockMatchfinder);
+
+// @nocommit
+size_t DONT_COMMIT_simpleExternalMatchfinder(
+  void* matchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  const void* src, size_t srcSize, size_t historySize
+);
 
 /*! ZSTD_writeSkippableFrame() :
  * Generates a zstd skippable frame containing data given by src, and writes it to dst buffer.

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -2700,6 +2700,9 @@ ZSTDLIB_STATIC_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* bloc
  * include hardware-accelerated matchfinders and matchfinders specialized to
  * particular types of data.
  *
+ * See contrib/externalMatchfinder for an example program employing the
+ * external matchfinder API.
+ *
  * USAGE
  * The user is responsible for implementing a function of type
  * ZSTD_externalMatchFinder_F. For each block, zstd will pass the following

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1526,13 +1526,19 @@ typedef void ZSTD_externalMatchStateDestructor_F (
   void* externalMatchState
 );
 
-// @nocommit document this
-ZSTDLIB_STATIC_API void
-ZSTD_registerExternalMatchfinder(
+ZSTDLIB_STATIC_API size_t
+ZSTD_registerExternalMatchFinder(
   ZSTD_CCtx* cctx,
   void* externalMatchState,
   ZSTD_externalMatchFinder_F* externalMatchFinder,
   ZSTD_externalMatchStateDestructor_F* externalMatchStateDestructor
+);
+
+/* Note: calls the previously-registered ZSTD_externalMatchStateDestructor_F*
+ * if it is non-NULL. */
+ZSTDLIB_STATIC_API void
+ZSTD_clearExternalMatchFinder(
+  ZSTD_CCtx* cctx
 );
 
 /****************************************/

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -478,6 +478,7 @@ typedef enum {
      * ZSTD_c_useBlockSplitter
      * ZSTD_c_useRowMatchFinder
      * ZSTD_c_prefetchCDictTables
+     * ZSTD_c_useExternalMatchfinder
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -497,7 +498,8 @@ typedef enum {
      ZSTD_c_experimentalParam13=1010,
      ZSTD_c_experimentalParam14=1011,
      ZSTD_c_experimentalParam15=1012,
-     ZSTD_c_experimentalParam16=1013
+     ZSTD_c_experimentalParam16=1013,
+     ZSTD_c_experimentalParam17=1014
 } ZSTD_cParameter;
 
 typedef struct {
@@ -2077,6 +2079,9 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  * Use ZSTD_ps_disable to opt out of prefetching under any circumstances.
  */
 #define ZSTD_c_prefetchCDictTables ZSTD_c_experimentalParam16
+
+// @nocommit document
+#define ZSTD_c_useExternalMatchfinder ZSTD_c_experimentalParam17
 
 /*! ZSTD_CCtx_getParameter() :
  *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1508,7 +1508,11 @@ ZSTD_compressSequences( ZSTD_CCtx* cctx, void* dst, size_t dstSize,
                         const ZSTD_Sequence* inSeqs, size_t inSeqsSize,
                         const void* src, size_t srcSize);
 
-typedef size_t ZSTD_externalMatchfinder_F (
+/* Block-level sequence compression API */
+// @nocommit improve docs
+
+// @nocommit move bounds comments into docs
+typedef size_t ZSTD_externalMatchFinder_F (
   void* externalMatchState, // TODO make this an externalMatchState type
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   // outSeqsCapacity >= blockSize / MINMATCH
@@ -1517,15 +1521,20 @@ typedef size_t ZSTD_externalMatchfinder_F (
   // historySize < srcSize ; any size
 );
 
+typedef void ZSTD_externalMatchStateDestructor_F (
+  void* externalMatchState
+);
+
 // @nocommit document this
 ZSTDLIB_STATIC_API void
-ZSTD_registerExternalMatchfinder(ZSTD_CCtx* cctx, ZSTD_externalMatchfinder_F* externalBlockMatchfinder);
-
-// @nocommit
-size_t DONT_COMMIT_simpleExternalMatchfinder(
-  void* matchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
-  const void* src, size_t srcSize, size_t historySize
+ZSTD_registerExternalMatchfinder(
+  ZSTD_CCtx* cctx,
+  void* externalMatchState,
+  ZSTD_externalMatchFinder_F* externalMatchFinder,
+  ZSTD_externalMatchStateDestructor_F* externalMatchStateDestructor
 );
+
+/****************************************/
 
 /*! ZSTD_writeSkippableFrame() :
  * Generates a zstd skippable frame containing data given by src, and writes it to dst buffer.
@@ -2692,6 +2701,7 @@ ZSTDLIB_STATIC_API size_t ZSTD_getBlockSize   (const ZSTD_CCtx* cctx);
 ZSTDLIB_STATIC_API size_t ZSTD_compressBlock  (ZSTD_CCtx* cctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 ZSTDLIB_STATIC_API size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 ZSTDLIB_STATIC_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* blockStart, size_t blockSize);  /**< insert uncompressed block into `dctx` history. Useful for multi-blocks decompression. */
+
 
 
 #endif   /* ZSTD_H_ZSTD_STATIC_LINKING_ONLY */

--- a/lib/zstd_errors.h
+++ b/lib/zstd_errors.h
@@ -92,6 +92,7 @@ typedef enum {
   ZSTD_error_seekableIO          = 102,
   ZSTD_error_dstBuffer_wrong     = 104,
   ZSTD_error_srcBuffer_wrong     = 105,
+  ZSTD_error_externalMatchFinder_failed = 106,
   ZSTD_error_maxCode = 120  /* never EVER use this value directly, it can change in future versions! Use ZSTD_isError() instead */
 } ZSTD_ErrorCode;
 

--- a/lib/zstd_errors.h
+++ b/lib/zstd_errors.h
@@ -75,6 +75,7 @@ typedef enum {
   ZSTD_error_dictionary_wrong          = 32,
   ZSTD_error_dictionaryCreation_failed = 34,
   ZSTD_error_parameter_unsupported   = 40,
+  ZSTD_error_parameter_combination_unsupported = 41,
   ZSTD_error_parameter_outOfBound    = 42,
   ZSTD_error_tableLog_tooLarge       = 44,
   ZSTD_error_maxSymbolValue_tooLarge = 46,

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -169,7 +169,7 @@ fuzzer-dll : $(ZSTDDIR)/common/xxhash.c $(PRGDIR)/util.c $(PRGDIR)/timefn.c $(PR
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(filter %.c,$^) $(LDFLAGS) -o $@$(EXT)
 
 CLEAN += zstreamtest zstreamtest32
-ZSTREAM_LOCAL_FILES := $(PRGDIR)/datagen.c $(PRGDIR)/util.c $(PRGDIR)/timefn.c seqgen.c zstreamtest.c
+ZSTREAM_LOCAL_FILES := $(PRGDIR)/datagen.c $(PRGDIR)/util.c $(PRGDIR)/timefn.c seqgen.c zstreamtest.c external_matchfinder.c
 ZSTREAM_PROPER_FILES := $(ZDICT_FILES) $(ZSTREAM_LOCAL_FILES)
 ZSTREAMFILES := $(ZSTD_FILES) $(ZSTREAM_PROPER_FILES)
 zstreamtest32 : CFLAGS += -m32

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -1,7 +1,6 @@
 #include "external_matchfinder.h"
 #include <string.h>
 #include "zstd_compress_internal.h"
-#include <stdio.h>
 
 #define HSIZE 1024
 static U32 const HLOG = 10;

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -9,7 +9,8 @@ static U32 const MLS = 4;
 static U32 const BADIDX = (1 << 31);
 
 static size_t simpleExternalMatchFinder(
-  void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  void* externalMatchState,
+  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
   int compressionLevel
@@ -27,9 +28,10 @@ static size_t simpleExternalMatchFinder(
     (void)outSeqsCapacity;
     (void)compressionLevel;
 
-    for (int i=0; i < HSIZE; i++) {
-        hashTable[i] = BADIDX;
-    }
+    {   int i;
+        for (i=0; i < HSIZE; i++) {
+            hashTable[i] = BADIDX;
+    }   }
 
     while (ip + 4 < iend) {
         size_t const hash = ZSTD_hashPtr(ip, HLOG, MLS);

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -36,14 +36,14 @@ static size_t simpleExternalMatchFinder(
     while (ip + 4 < iend) {
         size_t const hash = ZSTD_hashPtr(ip, HLOG, MLS);
         U32 const matchIndex = hashTable[hash];
-        hashTable[hash] = ip - istart;
+        hashTable[hash] = (U32)(ip - istart);
 
         if (matchIndex != BADIDX) {
             const BYTE* const match = istart + matchIndex;
-            size_t const matchLen = ZSTD_count(ip, match, iend);
+            U32 const matchLen = (U32)ZSTD_count(ip, match, iend);
             if (matchLen >= ZSTD_MINMATCH_MIN) {
-                U32 const litLen = ip - anchor;
-                U32 const offset = ip - match;
+                U32 const litLen = (U32)(ip - anchor);
+                U32 const offset = (U32)(ip - match);
                 ZSTD_Sequence const seq = {
                     offset, litLen, matchLen, 0
                 };
@@ -58,7 +58,7 @@ static size_t simpleExternalMatchFinder(
     }
 
     {   ZSTD_Sequence const finalSeq = {
-            0, iend - anchor, 0, 0
+            0, (U32)(iend - anchor), 0, 0
         };
         outSeqs[seqCount++] = finalSeq;
     }
@@ -82,7 +82,7 @@ size_t zstreamExternalMatchFinder(
         case EMF_ONE_BIG_SEQ:
             outSeqs[0].offset = 0;
             outSeqs[0].matchLength = 0;
-            outSeqs[0].litLength = srcSize;
+            outSeqs[0].litLength = (U32)(srcSize);
             return 1;
          case EMF_LOTS_OF_SEQS:
             return simpleExternalMatchFinder(

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -1,31 +1,32 @@
+#include "external_matchfinder.h"
+#include <string.h>
 #include "zstd_compress_internal.h"
-#include "matchfinder.h"
+#include <stdio.h>
 
 #define HSIZE 1024
 static U32 const HLOG = 10;
 static U32 const MLS = 4;
 static U32 const BADIDX = (1 << 31);
 
-size_t simpleExternalMatchFinder(
+static size_t simpleExternalMatchFinder(
   void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
   int compressionLevel
 ) {
+    const BYTE* const istart = (const BYTE*)src;
+    const BYTE* const iend = istart + srcSize;
+    const BYTE* ip = istart;
+    const BYTE* anchor = istart;
+    size_t seqCount = 0;
+    U32 hashTable[HSIZE];
+
     (void)externalMatchState;
     (void)dict;
     (void)dictSize;
     (void)outSeqsCapacity;
     (void)compressionLevel;
 
-    const BYTE* const istart = (const BYTE*)src;
-    const BYTE* const iend = istart + srcSize;
-    const BYTE* ip = istart;
-    const BYTE* anchor = istart;
-
-    size_t seqCount = 0;
-
-    U32 hashTable[HSIZE];
     for (int i=0; i < HSIZE; i++) {
         hashTable[i] = BADIDX;
     }
@@ -54,10 +55,45 @@ size_t simpleExternalMatchFinder(
         ip++;
     }
 
-    ZSTD_Sequence const finalSeq = {
-        0, iend - anchor, 0, 0
-    };
-    outSeqs[seqCount++] = finalSeq;
+    {   ZSTD_Sequence const finalSeq = {
+            0, iend - anchor, 0, 0
+        };
+        outSeqs[seqCount++] = finalSeq;
+    }
 
     return seqCount;
+}
+
+size_t zstreamExternalMatchFinder(
+  void* externalMatchState,
+  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  const void* src, size_t srcSize,
+  const void* dict, size_t dictSize,
+  int compressionLevel
+) {
+    EMF_testCase testCase = *((EMF_testCase*)externalMatchState);
+    memset(outSeqs, 0, outSeqsCapacity);
+
+    switch (testCase) {
+        case EMF_ZERO_SEQS:
+            return 0;
+        case EMF_ONE_BIG_SEQ:
+            outSeqs[0].offset = 0;
+            outSeqs[0].matchLength = 0;
+            outSeqs[0].litLength = srcSize;
+            return 1;
+         case EMF_LOTS_OF_SEQS:
+            return simpleExternalMatchFinder(
+                externalMatchState,
+                outSeqs, outSeqsCapacity,
+                src, srcSize,
+                dict, dictSize,
+                compressionLevel
+            );
+        case EMF_SMALL_ERROR:
+            return outSeqsCapacity + 1;
+        case EMF_BIG_ERROR:
+        default:
+            return ZSTD_EXTERNAL_MATCHFINDER_ERROR;
+    }
 }

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
 #include "external_matchfinder.h"
 #include <string.h>
 #include "zstd_compress_internal.h"

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -73,7 +73,7 @@ size_t zstreamExternalMatchFinder(
   const void* dict, size_t dictSize,
   int compressionLevel
 ) {
-    EMF_testCase testCase = *((EMF_testCase*)externalMatchState);
+    EMF_testCase const testCase = *((EMF_testCase*)externalMatchState);
     memset(outSeqs, 0, outSeqsCapacity);
 
     switch (testCase) {

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Meta Platforms, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -15,7 +15,7 @@
 #define HSIZE 1024
 static U32 const HLOG = 10;
 static U32 const MLS = 4;
-static U32 const BADIDX = (1 << 31);
+static U32 const BADIDX = 0xffffffff;
 
 static size_t simpleExternalMatchFinder(
   void* externalMatchState,

--- a/tests/external_matchfinder.c
+++ b/tests/external_matchfinder.c
@@ -42,7 +42,7 @@ static size_t simpleExternalMatchFinder(
             hashTable[i] = BADIDX;
     }   }
 
-    while (ip + 4 < iend) {
+    while (ip + MLS < iend) {
         size_t const hash = ZSTD_hashPtr(ip, HLOG, MLS);
         U32 const matchIndex = hashTable[hash];
         hashTable[hash] = (U32)(ip - istart);

--- a/tests/external_matchfinder.h
+++ b/tests/external_matchfinder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/external_matchfinder.h
+++ b/tests/external_matchfinder.h
@@ -1,0 +1,23 @@
+#ifndef EXTERNAL_MATCHFINDER
+#define EXTERNAL_MATCHFINDER
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd.h"
+
+/* See external_matchfinder.c for details on each test case */
+typedef enum {
+    EMF_ZERO_SEQS = 0,
+    EMF_ONE_BIG_SEQ = 1,
+    EMF_LOTS_OF_SEQS = 2,
+    EMF_BIG_ERROR = 3,
+    EMF_SMALL_ERROR = 4
+} EMF_testCase;
+
+size_t zstreamExternalMatchFinder(
+  void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  const void* src, size_t srcSize,
+  const void* dict, size_t dictSize,
+  int compressionLevel
+);
+
+#endif // EXTERNAL_MATCHFINDER

--- a/tests/external_matchfinder.h
+++ b/tests/external_matchfinder.h
@@ -14,7 +14,8 @@ typedef enum {
 } EMF_testCase;
 
 size_t zstreamExternalMatchFinder(
-  void* externalMatchState, ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
+  void* externalMatchState,
+  ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
   int compressionLevel

--- a/tests/external_matchfinder.h
+++ b/tests/external_matchfinder.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
 #ifndef EXTERNAL_MATCHFINDER
 #define EXTERNAL_MATCHFINDER
 

--- a/tests/external_matchfinder.h
+++ b/tests/external_matchfinder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Yann Collet, Facebook, Inc.
+ * Copyright (c) Yann Collet, Meta Platforms, Inc.
  * All rights reserved.
  *
  * This source code is licensed under both the BSD-style license (found in the

--- a/tests/external_matchfinder.h
+++ b/tests/external_matchfinder.h
@@ -28,7 +28,8 @@ size_t zstreamExternalMatchFinder(
   ZSTD_Sequence* outSeqs, size_t outSeqsCapacity,
   const void* src, size_t srcSize,
   const void* dict, size_t dictSize,
-  int compressionLevel
+  int compressionLevel,
+  size_t windowSize
 );
 
 #endif // EXTERNAL_MATCHFINDER

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -39,7 +39,7 @@
 #include "seqgen.h"
 #include "util.h"
 #include "timefn.h"       /* UTIL_time_t, UTIL_clockSpanMicro, UTIL_getTime */
-
+#include "external_matchfinder.h"   /* zstreamExternalMatchFinder */
 
 /*-************************************
  *  Constants
@@ -1831,6 +1831,88 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
         CHECK_Z(ZSTD_decompress_usingDict(zd, decodedBuffer, CNBufferSize, out.dst, out.pos, dictionary.start, dictionary.filled));
 
         ZSTD_freeCDict(cdict);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
+    DISPLAYLEVEL(3, "test%3i : External matchfinder API: ", testNb++);
+    {
+        size_t const dstBufSize = ZSTD_compressBound(CNBufferSize);
+        BYTE* dstBuf = (BYTE*)malloc(ZSTD_compressBound(dstBufSize));
+        size_t const checkBufSize = CNBufferSize;
+        BYTE* checkBuf = (BYTE*)malloc(checkBufSize);
+        int enableFallback;
+        size_t res;
+        EMF_testCase externalMatchState;
+
+        ZSTD_CCtx_reset(zc, ZSTD_reset_session_and_parameters);
+
+        /* Reference external matchfinder outside the test loop to
+         * check that the reference is preserved across compressions */
+        ZSTD_refExternalMatchFinder(
+            zc,
+            &externalMatchState,
+            zstreamExternalMatchFinder
+        );
+
+        for (enableFallback = 0; enableFallback < 1; enableFallback++) {
+            size_t testCaseId;
+
+            EMF_testCase const EMF_successCases[] = {
+                EMF_ONE_BIG_SEQ,
+                EMF_LOTS_OF_SEQS,
+            };
+            size_t const EMF_numSuccessCases = 2;
+
+            EMF_testCase const EMF_failureCases[] = {
+                EMF_ZERO_SEQS,
+                EMF_BIG_ERROR,
+                EMF_SMALL_ERROR,
+            };
+            size_t const EMF_numFailureCases = 3;
+
+            /* Test external matchfinder success scenarios */
+            for (testCaseId = 0; testCaseId < EMF_numSuccessCases; testCaseId++) {
+                externalMatchState = EMF_successCases[testCaseId];
+                ZSTD_CCtx_reset(zc, ZSTD_reset_session_only);
+                CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchFinderFallback, enableFallback));
+                res = ZSTD_compress2(zc, dstBuf, dstBufSize, CNBuffer, CNBufferSize);
+                CHECK(ZSTD_isError(res), "EMF: Compression error: %s", ZSTD_getErrorName(res));
+                CHECK_Z(ZSTD_decompress(checkBuf, checkBufSize, dstBuf, res));
+                CHECK(memcmp(CNBuffer, checkBuf, CNBufferSize) != 0, "EMF: Corruption!");
+            }
+
+            /* Test external matchfinder failure scenarios */
+            for (testCaseId = 0; testCaseId < EMF_numFailureCases; testCaseId++) {
+                externalMatchState = EMF_failureCases[testCaseId];
+                ZSTD_CCtx_reset(zc, ZSTD_reset_session_only);
+                CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchFinderFallback, enableFallback));
+                res = ZSTD_compress2(zc, dstBuf, dstBufSize, CNBuffer, CNBufferSize);
+                if (enableFallback) {
+                    CHECK_Z(ZSTD_decompress(checkBuf, checkBufSize, dstBuf, res));
+                    CHECK(memcmp(CNBuffer, checkBuf, CNBufferSize) != 0, "EMF: Corruption!");
+                } else {
+                    CHECK(!ZSTD_isError(res), "EMF: Should have raised an error!");
+                    CHECK(
+                        ZSTD_getErrorCode(res) != ZSTD_error_externalMatchFinder_failed,
+                        "EMF: Wrong error code: %s", ZSTD_getErrorName(res)
+                    );
+                }
+            }
+
+            /* Test compression with external matchfinder + empty src buffer */
+            externalMatchState = EMF_ZERO_SEQS;
+            ZSTD_CCtx_reset(zc, ZSTD_reset_session_only);
+            CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchFinderFallback, enableFallback));
+            res = ZSTD_compress2(zc, dstBuf, dstBufSize, CNBuffer, 0);
+            CHECK(ZSTD_isError(res), "EMF: Compression error: %s", ZSTD_getErrorName(res));
+            CHECK(ZSTD_decompress(checkBuf, checkBufSize, dstBuf, res) != 0, "EMF: Empty src round trip failed!");
+        }
+
+        /* Test that reset clears the external matchfinder */
+        ZSTD_CCtx_reset(zc, ZSTD_reset_session_and_parameters);
+        externalMatchState = EMF_BIG_ERROR; /* ensure zstd will fail if the matchfinder wasn't cleared */
+        CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchFinderFallback, 0));
+        CHECK_Z(ZSTD_compress2(zc, dstBuf, dstBufSize, CNBuffer, CNBufferSize));
     }
     DISPLAYLEVEL(3, "OK \n");
 

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -39,7 +39,7 @@
 #include "seqgen.h"
 #include "util.h"
 #include "timefn.h"       /* UTIL_time_t, UTIL_clockSpanMicro, UTIL_getTime */
-#include "external_matchfinder.h"   /* zstreamExternalMatchFinder */
+#include "external_matchfinder.h"   /* zstreamExternalMatchFinder, EMF_testCase */
 
 /*-************************************
  *  Constants

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1848,7 +1848,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
 
         /* Reference external matchfinder outside the test loop to
          * check that the reference is preserved across compressions */
-        ZSTD_refExternalMatchFinder(
+        ZSTD_registerExternalMatchFinder(
             zc,
             &externalMatchState,
             zstreamExternalMatchFinder

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1913,6 +1913,9 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
         externalMatchState = EMF_BIG_ERROR; /* ensure zstd will fail if the matchfinder wasn't cleared */
         CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_c_enableMatchFinderFallback, 0));
         CHECK_Z(ZSTD_compress2(zc, dstBuf, dstBufSize, CNBuffer, CNBufferSize));
+
+        free(dstBuf);
+        free(checkBuf);
     }
     DISPLAYLEVEL(3, "OK \n");
 

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1837,9 +1837,9 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
     DISPLAYLEVEL(3, "test%3i : External matchfinder API: ", testNb++);
     {
         size_t const dstBufSize = ZSTD_compressBound(CNBufferSize);
-        BYTE* dstBuf = (BYTE*)malloc(ZSTD_compressBound(dstBufSize));
+        BYTE* const dstBuf = (BYTE*)malloc(ZSTD_compressBound(dstBufSize));
         size_t const checkBufSize = CNBufferSize;
-        BYTE* checkBuf = (BYTE*)malloc(checkBufSize);
+        BYTE* const checkBuf = (BYTE*)malloc(checkBufSize);
         int enableFallback;
         EMF_testCase externalMatchState;
 


### PR DESCRIPTION
This PR introduces an API for external block-level sequence producers to plug into zstd. The user provides a function pointer and state object for the external sequence producer, and zstd will call it to generate sequences for each block. Entropy compression of sequences still remains entirely within the library's internal functions.

Potential applications of the API include hardware-accelerated sequence producers and sequence producers specialized to particular types of data.

There are some subtleties around fallback, sequence validation, memory ownership, etc. Users should read all of the documentation added by this PR to zstd.h before using the API. Note: that documentation has been updated in subsequent PRs, so make sure to look at a recent commit.

An example program is provided (see contrib/externalSequenceProducer) which demonstrates how to use the API with a simple LZ parser.

---
Note: the original version of this PR used the term "External Matchfinder API". The above summary has been updated to use the new term "Block-Level Sequence Producer API", but the code in this PR still uses old symbol names. Updated symbol names were introduced to the code in https://github.com/facebook/zstd/pull/3484.