### PR TITLE
Seekable format empty string

### DIFF
--- a/contrib/seekable_format/zstdseek_compress.c
+++ b/contrib/seekable_format/zstdseek_compress.c
@@ -350,7 +350,7 @@ size_t ZSTD_seekable_writeSeekTable(ZSTD_frameLog* fl, ZSTD_outBuffer* output)
 
 size_t ZSTD_seekable_endStream(ZSTD_seekable_CStream* zcs, ZSTD_outBuffer* output)
 {
-    if (!zcs->writingSeekTable && zcs->frameDSize) {
+    if (!zcs->writingSeekTable) {
         const size_t endFrame = ZSTD_seekable_endFrame(zcs, output);
         if (ZSTD_isError(endFrame)) return endFrame;
         /* return an accurate size hint */


### PR DESCRIPTION
This PR is a followup to a [previous PR](https://github.com/facebook/zstd/pull/3058) by @yhoogstrate. The goal of the previous PR was to fix a small bug in `seekable_format` that led to the omission of the ZSTD MAGIC when compressing an empty string.

I have validated the bug fix with the test case provided, but have created this PR to fix some minor issues (forgetting to free malloc'd memory in the test case).

Note that, upon further investigation, it seems that this issue occured whenever `ZSTD_inBuffer.size == 0`, rather than explicitly for an empty string (NULL first char). For example, if we set the size of inBuffer to 255, set the first char to `NULL`, and set `ZSTD_inBuffer.size == sizeof(inBuffer)`, the ZSTD MAGIC was present. On the other hand, if we set `ZSTD_inBuffer.size == strlen(inBuffer)` , the ZSTD MAGIC was omitted.