### PR TITLE
Fix m68k CI tests on Github Actions

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -275,7 +275,7 @@ jobs:
 
   qemu-consistency:
     name: QEMU ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
       matrix:


### PR DESCRIPTION
The `m68k` CI test started to fail when github migrated `ubuntu-latest` towards Ubuntu 22.04.
It appears that the version of `qemu` shipped with Ubuntu 22.04 has a bug reached in the `m68k` module.
This seems confirmed by multiple bug reports featuring the same symptom in similar scenarios.
Unfortunately, no fix seems confirmed yet.

In any case, as far as `zstd` portability tests are concerned, the better course of action seems to rely on a known working version of `qemu`, aka the one shipped in Ubuntu 20.04.