### PR TITLE
meson: partial fix for building pzstd on MSVC

### DIFF
--- a/build/meson/contrib/pzstd/meson.build
+++ b/build/meson/contrib/pzstd/meson.build
@@ -18,7 +18,8 @@ pzstd_sources = [join_paths(zstd_rootdir, 'programs/util.c'),
   join_paths(zstd_rootdir, 'contrib/pzstd/SkippableFrame.cpp')]
 pzstd = executable('pzstd',
   pzstd_sources,
-  cpp_args: [ '-DNDEBUG', '-Wno-shadow', '-Wno-deprecated-declarations' ],
+  cpp_args: pzstd_warning_flags,
   include_directories: pzstd_includes,
   dependencies: [ libzstd_dep, thread_dep ],
+  override_options: ['b_ndebug=true'],
   install: true)

--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -104,8 +104,10 @@ use_lz4 = lz4_dep.found()
 
 add_project_arguments('-DXXH_NAMESPACE=ZSTD_', language: ['c'])
 
+pzstd_warning_flags = []
 if [compiler_gcc, compiler_clang].contains(cc_id)
   common_warning_flags = [ '-Wundef', '-Wshadow', '-Wcast-align', '-Wcast-qual' ]
+  pzstd_warning_flags = ['-Wno-shadow', '-Wno-deprecated-declarations']
   if cc_id == compiler_clang
     common_warning_flags += ['-Wconversion', '-Wno-sign-conversion', '-Wdocumentation']
   endif


### PR DESCRIPTION
It uses non-portable compiler options unconditionally. Elsewhere, we check the compiler ID and only add the right ones, globally. Do the same here.

NDEBUG can actually be handled by a core option, so while we are moving things around, do so.

Unfortunately, this doesn't fix things entirely. The remaining issue is not Meson's issue though -- MSVC simply does not like this source code and somehow chokes on innocent code with the inscrutable "syntax error" and "illegal token".