### PR TITLE
meson: fix broken commit that broke the build

### DIFF
--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -26,7 +26,7 @@ project('zstd',
   version: run_command(
     find_program('GetZstdLibraryVersion.py'), '../../lib/zstd.h',
     check: true).stdout().strip(),
-  meson_version: '>=0.48.0')
+  meson_version: '>=0.50.0')
 
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -51,8 +51,8 @@ endif
 
 export_dynamic_on_windows = false
 # explicit backtrace enable/disable for Linux & Darwin
-execinfo = cc.has_header('execinfo.h', required: use_backtrace)
-if not execinfo.found()
+have_execinfo = cc.has_header('execinfo.h', required: use_backtrace)
+if not have_execinfo
   zstd_c_args += '-DBACKTRACE_ENABLE=0'
 elif use_debug and host_machine_os == os_windows  # MinGW target
   zstd_c_args += '-DBACKTRACE_ENABLE=1'


### PR DESCRIPTION
In commit 031de3c69ccbf3282ed02fb49369b476730aeca8 some code was added that returned a boolean, but was treated as if it returned a dependency object. This wasn't tested and could not work. Moreover, zstd no longer built at all unless the entire programs directory was disabled and not even evaluated.

Fix the return type checking.


Also:
- fix warning for using too-new features
  