### PR TITLE
[CI] Re-enable versions-test

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -431,18 +431,13 @@ jobs:
           cc -Wall -Wextra -Wpedantic -Werror -o simple examples/simple_compression.c $(pkg-config --cflags --libs libzstd)
           ./simple LICENSE
 
-
-# This test currently fails on Github Actions specifically.
-# Possible reason : TTY emulation.
-# Note that the same test works fine locally and on travisCI.
-# This will have to be fixed before transferring the test to GA.
-#  versions-compatibility:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v3
-#    - name: Versions Compatibility Test
-#      run: |
-#        make -C tests versionsTest
+  versions-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Versions Compatibility Test
+      run: |
+        make -C tests versionsTest
 
 
 # For reference : icc tests


### PR DESCRIPTION
It seems like with the deletion of Travis CI we didn't successfully transfer the version compatibility test. Re-enable the version test.

The version test broke because `v0.5.0` compresses to `stdout` whenever `stdout` is not a TTY. Even if `stdout` is `/dev/null`. Fix the issue by always using zstd compressing from `stdin` to `stdout`.

While I was at it, I also refactored `test-zstd-versions.py` a bit. Mostly to throw an exception when there is a failure, instead of continuing and failing at the end.