### PR TITLE
[zdict] Fix static linking only include guards

### DIFF
--- a/lib/zdict.h
+++ b/lib/zdict.h
@@ -8,13 +8,12 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
-#ifndef DICTBUILDER_H_001
-#define DICTBUILDER_H_001
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
+#ifndef ZSTD_ZDICT_H
+#define ZSTD_ZDICT_H
 
 /*======  Dependencies  ======*/
 #include <stddef.h>  /* size_t */
@@ -260,9 +259,10 @@ ZDICTLIB_API size_t ZDICT_getDictHeaderSize(const void* dictBuffer, size_t dictS
 ZDICTLIB_API unsigned ZDICT_isError(size_t errorCode);
 ZDICTLIB_API const char* ZDICT_getErrorName(size_t errorCode);
 
+#endif   /* ZSTD_ZDICT_H */
 
-
-#ifdef ZDICT_STATIC_LINKING_ONLY
+#if defined(ZDICT_STATIC_LINKING_ONLY) && !defined(ZSTD_ZDICT_H_STATIC)
+#define ZSTD_ZDICT_H_STATIC
 
 /* ====================================================================================
  * The definitions in this section are considered experimental.
@@ -443,10 +443,8 @@ size_t ZDICT_addEntropyTablesFromBuffer(void* dictBuffer, size_t dictContentSize
                                   const void* samplesBuffer, const size_t* samplesSizes, unsigned nbSamples);
 
 
-#endif   /* ZDICT_STATIC_LINKING_ONLY */
+#endif   /* ZSTD_ZDICT_H_STATIC */
 
 #if defined (__cplusplus)
 }
 #endif
-
-#endif   /* DICTBUILDER_H_001 */


### PR DESCRIPTION
Fix `zdict.h` static linking only section so if you include it twice it still exposes the static linking only symbols. E.g. this pattern:

```
#include <zdict.h>
#define ZDICT_STATIC_LINKING_ONLY
#include <zdict.h>
```

This can easily happen when a header you include includes `zdict.h`.

Fixes #3369.