### PR TITLE
decompressBound tests and fix

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -785,7 +785,7 @@ static ZSTD_frameSizeInfo ZSTD_findFrameSizeInfo(const void* src, size_t srcSize
         frameSizeInfo.compressedSize = (size_t)(ip - ipstart);
         frameSizeInfo.decompressedBound = (zfh.frameContentSize != ZSTD_CONTENTSIZE_UNKNOWN)
                                         ? zfh.frameContentSize
-                                        : nbBlocks * zfh.blockSizeMax;
+                                        : (unsigned long long)nbBlocks * zfh.blockSizeMax;
         return frameSizeInfo;
     }
 }

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -228,7 +228,7 @@ ZSTDLIB_API size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize)
  * Will produce constant value 0 if srcSize too large.
  */
 #define ZSTD_MAX_INPUT_SIZE ((sizeof(size_t)==8) ? 0xFF00FF00FF00FF00LLU : 0xFF00FF00U)
-#define ZSTD_COMPRESSBOUND(srcSize)   (((size_t)(srcSize) > ZSTD_MAX_INPUT_SIZE) ? 0 : (srcSize) + ((srcSize)>>8) + (((srcSize) < (128<<10)) ? (((128<<10) - (srcSize)) >> 11) /* margin, from 64 to 0 */ : 0))  /* this formula ensures that bound(A) + bound(B) <= bound(A+B) as long as A and B >= 128 KB */
+#define ZSTD_COMPRESSBOUND(srcSize)   (((size_t)(srcSize) >= ZSTD_MAX_INPUT_SIZE) ? 0 : (srcSize) + ((srcSize)>>8) + (((srcSize) < (128<<10)) ? (((128<<10) - (srcSize)) >> 11) /* margin, from 64 to 0 */ : 0))  /* this formula ensures that bound(A) + bound(B) <= bound(A+B) as long as A and B >= 128 KB */
 ZSTDLIB_API size_t ZSTD_compressBound(size_t srcSize); /*!< maximum compressed size in worst case single-pass scenario */
 /* ZSTD_isError() :
  * Most ZSTD_* functions returning a size_t value can be tested for error,

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -494,10 +494,8 @@ static void test_decompressBound(int tnb)
         char cBuffer[ZSTD_COMPRESSBOUND(sizeof(example))];
         size_t const cSize = ZSTD_compress(cBuffer, sizeof(cBuffer), example, sizeof(example), 0);
         CHECK_Z(cSize);
-        {   size_t const dbSize = ZSTD_decompressBound(cBuffer, cSize);
-            CHECK_Z(dbSize);
-            CHECK_EQ(dbSize, sizeof(example));
-    }   }
+        CHECK_EQ(ZSTD_decompressBound(cBuffer, cSize), (unsigned long long)sizeof(example));
+    }
 
     // Simple small compression without size : should provide 1 block size
     {   char cBuffer[ZSTD_COMPRESSBOUND(0)];


### PR DESCRIPTION
This is a complement to #3362 , and finalize fixes for #3323 .

There are additional unit tests to ensure behavior of `ZSTD_decompressBound()`,
including a new "overflow" test which attempts to overflow intermediate results on 32-bit systems
(`ZSTD_decompressBound()` return type is `unsigned long long` which is >= 64-bit , therefore only intermediate calculation results feature overflow risks).

Fixed the detected overflow.