### PR TITLE
Fix Meson-Windows CI test by pulling a more recent version msvc-dev-cmd

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Install packages
         run: pip install --pre meson
       - name: Initialize the MSVC dev command prompt
-        uses: ilammy/msvc-dev-cmd@674ff850cbd739c402260838fa45b7114f750570
+        uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d
       - name: Configure with Meson
         run: |
           meson setup build/meson/ builddir/ -Dbin_tests=true


### PR DESCRIPTION
Recently merge meson-windows CI test fails on a dependency issue.
Updating pinned hash to latest version remedies this issue.