### PR TITLE
Try to build the contrib directory in Windows CI

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -212,7 +212,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d
       - name: Configure with Meson
         run: |
-          meson setup build/meson/ builddir -Dbin_tests=true -Dbin_programs=true
+          meson setup build/meson/ builddir -Dbin_tests=true -Dbin_programs=true -Dbin_contrib=true
       - name: Build with Meson
         run: |
           ninja -C builddir/

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -212,7 +212,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d
       - name: Configure with Meson
         run: |
-          meson setup build/meson/ builddir/ -Dbin_tests=true
+          meson setup build/meson/ builddir -Dbin_tests=true -Dbin_programs=true
       - name: Build with Meson
         run: |
           ninja -C builddir/


### PR DESCRIPTION
This is just going to fail. PR submitted as a demonstration. The logs look like this:
```
[82/90] Compiling C++ object contrib/pzstd/pzstd.exe.p/.._.._.._.._contrib_pzstd_Pzstd.cpp.obj
FAILED: contrib/pzstd/pzstd.exe.p/.._.._.._.._contrib_pzstd_Pzstd.cpp.obj 
"cl" "-Icontrib\pzstd\pzstd.exe.p" "-Icontrib\pzstd" "-I..\build\meson\contrib\pzstd" "-I..\programs" "-I..\contrib\pzstd" "-I..\lib" "-I..\lib\common" "-I..\lib\compress" "-I..\lib\decompress" "-I..\lib\dictBuilder" "-I..\lib\legacy" "-DNDEBUG" "/MD" "/nologo" "/showIncludes" "/utf-8" "/Zc:__cplusplus" "/W4" "/EHsc" "/std:c++14" "/permissive-" "/O2" "/Gw" "/D_UNICODE" "/DUNICODE" "/MP" "/Fdcontrib\pzstd\pzstd.exe.p\.._.._.._.._contrib_pzstd_Pzstd.cpp.pdb" /Focontrib/pzstd/pzstd.exe.p/.._.._.._.._contrib_pzstd_Pzstd.cpp.obj "/c" ../contrib/pzstd/Pzstd.cpp
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): error C2589: '(': illegal token on right side of '::'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(126): note: see reference to class template instantiation 'pzstd::Range<Iter>' being compiled
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): error C3878: syntax error: unexpected token '(' following 'expression'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): note: error recovery skipped: '( ( identifier'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): error C2760: syntax error: ')' was unexpected here; expected ';'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): error C3878: syntax error: unexpected token ')' following 'jump_statement'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): note: error recovery skipped: ') <'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): error C3878: syntax error: unexpected token ')' following 'expression_statement'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): note: error recovery skipped: ') ?'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): error C2760: syntax error: ':' was unexpected here; expected ';'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): error C3878: syntax error: unexpected token ':' following 'expression_statement'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): note: error recovery skipped: ':'
D:\a\zstd\zstd\contrib\pzstd\utils/Range.h(124): note: error recovery skipped: ') )'
D:\a\zstd\zstd\contrib\pzstd\utils/FileSystem.h(85): warning C4245: 'return': conversion from 'int' to 'uintmax_t', signed/unsigned mismatch
D:\a\zstd\zstd\contrib\pzstd\utils/FileSystem.h(89): warning C4245: 'return': conversion from 'int' to 'uintmax_t', signed/unsigned mismatch
../contrib/pzstd/Pzstd.cpp(366): error C2589: '(': illegal token on right side of '::'
../contrib/pzstd/Pzstd.cpp(366): error C2062: type 'unknown-type' unexpected
../contrib/pzstd/Pzstd.cpp(366): error C2059: syntax error: ')'
../contrib/pzstd/Pzstd.cpp(367): error C3536: 'bytesRead': cannot be used before it is initialized
../contrib/pzstd/Pzstd.cpp(590): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
[83/90] Compiling C object programs/zstd.exe.p/.._.._.._programs_timefn.c.obj
[84/90] Compiling C++ object contrib/gen_html/gen_html.exe.p/.._.._.._.._contrib_gen_html_gen_html.cpp.obj
ninja: build stopped: subcommand failed.
```