### PR TITLE
Block splitter : minor reformatting

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -118,12 +118,13 @@ typedef struct {
 /** ZSTD_buildBlockEntropyStats() :
  *  Builds entropy for the block.
  *  @return : 0 on success or error code */
-size_t ZSTD_buildBlockEntropyStats(seqStore_t* seqStorePtr,
-                             const ZSTD_entropyCTables_t* prevEntropy,
-                                   ZSTD_entropyCTables_t* nextEntropy,
-                             const ZSTD_CCtx_params* cctxParams,
-                                   ZSTD_entropyCTablesMetadata_t* entropyMetadata,
-                                   void* workspace, size_t wkspSize);
+size_t ZSTD_buildBlockEntropyStats(
+                    const seqStore_t* seqStorePtr,
+                    const ZSTD_entropyCTables_t* prevEntropy,
+                          ZSTD_entropyCTables_t* nextEntropy,
+                    const ZSTD_CCtx_params* cctxParams,
+                          ZSTD_entropyCTablesMetadata_t* entropyMetadata,
+                          void* workspace, size_t wkspSize);
 
 /*********************************
 *  Compression internals structs *


### PR DESCRIPTION
After reading #3204, I wanted to have a look at the block splitter to understand what's going on.
This exercise lead to a (rather large) number of minor changes, which initially were cosmetic only, but eventually added a few correctness updates. They don't change the behavior of the functionality, but hopefully improve maintenance.

List of changes: 
- Shortened many long lines
- Conversion from `offset` to `offbase` was done manually, instead of employing the dedicated macros
- `const` correctness : `seqStore` was passed as a mutable buffer in scenarios where it was read only. The pb ran multiple levels deep, so several functions where controlled and their prototype updated to reflect this property.
- Several variables and pointers could be made `const`, improving the understanding of what happens to them. Some variables could be removed, others could be moved to a more restrictive scope
- Several fixes for `-Wconversion` warning level (note: not activated by default on `zstd` code base)
- Some `assert()` were added, to better document what's the expected state of the system.
- Added a few code comments

Only minor stuff, but I figure it was still valuable enough for maintenance to be merged.
None of these changes impact the behavior of the program. The source code is stricter, but it still does the same thing.

A side effect of this exercise is that I have a better understanding of the block splitter now.

The estimation logic, which judges if a splitting decision is beneficial or not, looks fine and seems generally re-usable.

The splitting decision though is still pretty raw, blindly mechanical.
Hence, that's where improvements could be inserted.

That being said, adding complexity at this stage is also likely going to impact speed.
So it might become desirable to feature multiple "levels" of block splitting.