### PR TITLE
Support decompression of compressed blocks of size ZSTD_BLOCKSIZE_MAX

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2770,6 +2770,10 @@ ZSTD_entropyCompressSeqStore(
         if (cSize >= maxCSize) return 0;  /* block not compressed */
     }
     DEBUGLOG(5, "ZSTD_entropyCompressSeqStore() cSize: %zu", cSize);
+    /* libzstd decoder before  > v1.5.4 is not compatible with compressed blocks of size ZSTD_BLOCKSIZE_MAX exactly.
+     * This restriction is indirectly already fulfilled by respecting ZSTD_minGain() condition above.
+     */
+    assert(cSize < ZSTD_BLOCKSIZE_MAX);
     return cSize;
 }
 


### PR DESCRIPTION
The wording of the Zstandard specification
allows valid compressed blocks to be sized exactly `ZSTD_BLOCKSIZE_MAX` bytes (128 KB).
This generally does not happen, since an uncompressed block would have same size but suffer no decompression speed cost.

Starting with this patch, the `libzstd` decoder will now accept decoding a compressed block of size `ZSTD_BLOCKSIZE_MAX` exactly.

Note though that decoders from reference `libzstd` before < `v1.5.4` consider this edge case as an error.

As a consequence, avoid generating compressed blocks of size `ZSTD_BLOCKSIZE_MAX` for broader compatibility with the ecosystem of deployed zstd decoders.
Note that the reference `libzstd` encoder never produces compressed blocks of size `ZSTD_BLOCKSIZE_MAX`, and will continue to do so for the foreseeable future, both to preserve compatibility with older decoders, and because it doesn't make sense to produce compressed blocks of such size (as opposed to uncompressed blocks).

The impact of this modification to the ecosystem is expected to be none. This is mostly meant to respect the letter of the [RFC8878](https://datatracker.ietf.org/doc/html/rfc8878) specification.

Thanks to @SmitaKumar for reporting this issue in #2577