### PR TITLE
Completely overhaul Windows CI

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -204,57 +204,31 @@ jobs:
         make -C tests test-fuzzer-stackmode
 
   mingw-long-test:
-    runs-on: windows-2019
-    strategy:
-      fail-fast: false
-      matrix:
-        include: [
-          { compiler: clang, platform: x64, action: build, script: "MOREFLAGS='--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion -Wno-unused-command-line-argument -Wno-implicit-int-float-conversion' make -j allzstd V=1"},
-          { compiler: gcc, platform: x64, action: test, script: ""},
-        ]
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
-    - name: Mingw long test
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: make
+        update: true
+    # Based on https://ariya.io/2020/07/on-github-actions-with-msys2
+    - name: install mingw gcc
+      run: pacman --noconfirm -S gcc
+    - name: MINGW64 gcc fuzztest
       run: |
-        $env:PATH_ORIGINAL = $env:PATH
-        $env:PATH_MINGW32 = "C:\msys64\mingw32\bin"
-        $env:PATH_MINGW64 = "C:\msys64\mingw64\bin"
-        COPY C:\msys64\usr\bin\make.exe C:\msys64\mingw32\bin\make.exe
-        COPY C:\msys64\usr\bin\make.exe C:\msys64\mingw64\bin\make.exe
-        IF ("${{matrix.platform}}" -eq "x64")
-        {
-            $env:PATH = $env:PATH_MINGW64 + ";" + $env:PATH_ORIGINAL
-        }
-        ELSEIF ("${{matrix.platform}}" -eq "x86")
-        {
-            $env:PATH = $env:PATH_MINGW32 + ";" + $env:PATH_ORIGINAL
-        }
-        IF ("${{matrix.action}}" -eq "build")
-        {
-          make -v
-          sh -c "${{matrix.compiler}} -v"
-          ECHO "Building zlib to static link"
-          $env:CC = "${{matrix.compiler}}"
-          sh -c "cd .. && git clone --depth 1 --branch v1.2.11 https://github.com/madler/zlib"
-          sh -c "cd ../zlib && make -f win32/Makefile.gcc libz.a"
-          ECHO "Building zstd"
-          $env:CPPFLAGS = "-I../../zlib"
-          $env:LDFLAGS = "../../zlib/libz.a"
-          sh -c "${{matrix.script}}"
-        }
-        ELSEIF ("${{matrix.action}}" -eq "test")
-        {
-            ECHO "Testing ${{matrix.compiler}} ${{matrix.platform}}"
-            $env:CC = "gcc"
-            $env:CXX = "g++"
-            MKDIR build\cmake\build
-            CD build\cmake\build
-            $env:FUZZERTEST = "-T2mn"
-            $env:ZSTREAM_TESTTIME = "-T2mn"
-            cmake -G "Visual Studio 14 2015 Win64" ..
-            cd ..\..\..
-            make clean
-        }
+        export CC="gcc"
+        export CXX="g++"
+        export FUZZERTEST="-T2mn"
+        export ZSTREAM_TESTTIME="-T2mn"
+        echo "Testing $CC $CXX MINGW64"
+        make -v
+        $CC --version
+        $CXX --version
+        make -C tests fuzztest
 
   # lasts ~20mn
   oss-fuzz:

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -223,16 +223,25 @@ jobs:
         run: |
           meson install -C builddir --destdir staging/
 
-  cmake-visual-2019:
-    runs-on: windows-2019
+  cmake-visual-studio:
     strategy:
       matrix:
         include:
+          - generator: "Visual Studio 17 2022"
+            flags: "-A x64"
+            runner: "windows-2022"
+          - generator: "Visual Studio 17 2022"
+            flags: "-A Win32"
+            runner: "windows-2022"
           - generator: "Visual Studio 16 2019"
             flags: "-A x64"
+            runner: "windows-2019"
           - generator: "Visual Studio 16 2019"
             flags: "-A Win32"
+            runner: "windows-2019"
           - generator: "MinGW Makefiles"
+            runner: "windows-latest"
+    runs-on: ${{matrix.runner}}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
     - name: Add MSBuild to PATH
@@ -246,40 +255,28 @@ jobs:
         cmake.exe -G "${{matrix.generator}}" ${{matrix.flags}} ..
         cmake.exe --build .
 
-  visual-2019:
-    runs-on: windows-2019
+  msbuild-visual-studio:
     strategy:
       matrix:
-        platform: [x64, Win32]
-        configuration: [Debug, Release]
+        include: [
+          { name: "VS 2022 x64 Debug", platform: x64, configuration: Debug, toolset: v143, runner: "windows-2022"},
+          { name: "VS 2022 Win32 Debug", platform: Win32, configuration: Debug, toolset: v143, runner: "windows-2022"},
+          { name: "VS 2022 x64 Release", platform: x64, configuration: Release, toolset: v143, runner: "windows-2022"},
+          { name: "VS 2022 Win32 Release", platform: Win32, configuration: Release, toolset: v143, runner: "windows-2022"},
+          { name: "VS 2019 x64 Release", platform: Win32, configuration: Release, toolset: v142, runner: "windows-2019"},
+          { name: "VS 2019 Win32 Release", platform: x64, configuration: Release, toolset: v142, runner: "windows-2019"},
+        ]
+    runs-on: ${{matrix.runner}}
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # tag=v1.1.3
+      uses: microsoft/setup-msbuild@v1.3
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: >
-        msbuild "build\VS2010\zstd.sln" /m /verbosity:minimal /property:PlatformToolset=v142
+        msbuild "build\VS2010\zstd.sln" /m /verbosity:minimal /property:PlatformToolset=${{matrix.toolset}}
         /t:Clean,Build /p:Platform=${{matrix.platform}} /p:Configuration=${{matrix.configuration}}
-
-# TODO: fix as part of https://github.com/facebook/zstd/issues/3064
-#  visual-2015:
-#    # only GH actions windows-2016 contains VS 2015
-#    runs-on: windows-2016
-#    strategy:
-#      matrix:
-#        platform: [x64, Win32]
-#        configuration: [Debug, Release]
-#    steps:
-#    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
-#    - name: Add MSBuild to PATH
-#      uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # tag=v1.1.3
-#    - name: Build
-#      working-directory: ${{env.GITHUB_WORKSPACE}}
-#      run: >
-#        msbuild "build\VS2010\zstd.sln" /m /verbosity:minimal /property:PlatformToolset=v140
-#        /t:Clean,Build /p:Platform=${{matrix.platform}} /p:Configuration=${{matrix.configuration}}
 
   # This tests that we don't accidently grow the size too much.
   # If the size grows intentionally, you can raise these numbers.
@@ -394,16 +391,19 @@ jobs:
         LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make clean check
 
   mingw-short-test:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
-      fail-fast: false
       matrix:
         include: [
-          { compiler: gcc, platform: x64, script: "CFLAGS=-Werror make -j allzstd DEBUGLEVEL=2"},
-          { compiler: gcc, platform: x86, script: "CFLAGS=-Werror make -j allzstd"},
-          { compiler: clang, platform: x64, script: "CFLAGS='--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion' make -j allzstd V=1"},
+          { compiler: gcc, msystem: MINGW32, cflags: "-Werror"},
+          { compiler: gcc, msystem: MINGW64, cflags: "-Werror"},
+          { compiler: clang, msystem: MINGW64, cflags: "--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion -Wno-unused-command-line-argument"},
         ]
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
+<<<<<<< HEAD
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
     - name: Mingw short test
       run: |
@@ -421,17 +421,36 @@ jobs:
         {
             $env:PATH = $env:PATH_MINGW32 + ";" + $env:PATH_ORIGINAL
         }
+=======
+    - uses: actions/checkout@v2
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        install: make diffutils
+        update: true
+    # Based on https://ariya.io/2020/07/on-github-actions-with-msys2
+    - name: install mingw gcc
+      if: ${{ matrix.compiler == 'gcc' }}
+      run: pacman --noconfirm -S gcc
+    - name: install mingw clang x86_64
+      if: ${{ (matrix.msystem == 'MINGW64') && (matrix.compiler == 'clang') }}
+      run: pacman --noconfirm -S mingw-w64-x86_64-clang
+    - name: install mingw clang i686
+      if: ${{ (matrix.msystem == 'MINGW32') && (matrix.compiler == 'clang') }}
+      run: pacman --noconfirm -S mingw-w64-i686-clang
+    - name: run mingw tests
+      run: |
+>>>>>>> e16c485f (Overhaul windows CI)
         make -v
-        sh -c "${{matrix.compiler}} -v"
-        $env:CC = "${{matrix.compiler}}"
-        sh -c "${{matrix.script}}"
-        ECHO "Testing ${{matrix.compiler}} ${{matrix.platform}}"
+        export CC=${{ matrix.compiler }}
+        $CC --version
+        CFLAGS="${{ matrix.cflags }}" make -j allzstd
+        echo "Testing $CC ${{ matrix.msystem }}"
         make clean
         make check
 
-
   visual-runtime-tests:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         platform: [x64, Win32]

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -245,7 +245,7 @@ jobs:
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # tag=v1.1.3
+      uses: microsoft/setup-msbuild@v1.3
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
@@ -458,7 +458,7 @@ jobs:
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # tag=v1.1.3
+      uses: microsoft/setup-msbuild@v1.3
     - name: Build and run tests
       working-directory: ${{env.GITHUB_WORKSPACE}}
       env:

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -223,25 +223,16 @@ jobs:
         run: |
           meson install -C builddir --destdir staging/
 
-  cmake-visual-studio:
+  cmake-visual-2022:
     strategy:
       matrix:
         include:
           - generator: "Visual Studio 17 2022"
             flags: "-A x64"
-            runner: "windows-2022"
           - generator: "Visual Studio 17 2022"
             flags: "-A Win32"
-            runner: "windows-2022"
-          - generator: "Visual Studio 16 2019"
-            flags: "-A x64"
-            runner: "windows-2019"
-          - generator: "Visual Studio 16 2019"
-            flags: "-A Win32"
-            runner: "windows-2019"
           - generator: "MinGW Makefiles"
-            runner: "windows-latest"
-    runs-on: ${{matrix.runner}}
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
     - name: Add MSBuild to PATH

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -394,26 +394,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-<<<<<<< HEAD
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
-    - name: Mingw short test
-      run: |
-        ECHO "Building ${{matrix.compiler}} ${{matrix.platform}}"
-        $env:PATH_ORIGINAL = $env:PATH
-        $env:PATH_MINGW32 = "C:\msys64\mingw32\bin"
-        $env:PATH_MINGW64 = "C:\msys64\mingw64\bin"
-        COPY C:\msys64\usr\bin\make.exe C:\msys64\mingw32\bin\make.exe
-        COPY C:\msys64\usr\bin\make.exe C:\msys64\mingw64\bin\make.exe
-        IF ("${{matrix.platform}}" -eq "x64")
-        {
-            $env:PATH = $env:PATH_MINGW64 + ";" + $env:PATH_ORIGINAL
-        }
-        ELSEIF ("${{matrix.platform}}" -eq "x86")
-        {
-            $env:PATH = $env:PATH_MINGW32 + ";" + $env:PATH_ORIGINAL
-        }
-=======
-    - uses: actions/checkout@v2
     - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.msystem }}
@@ -434,7 +415,6 @@ jobs:
       run: pacman --noconfirm -S mingw-w64-i686-clang
     - name: run mingw tests
       run: |
->>>>>>> e16c485f (Overhaul windows CI)
         make -v
         export CC=${{ matrix.compiler }}
         $CC --version

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -421,8 +421,11 @@ jobs:
         update: true
     # Based on https://ariya.io/2020/07/on-github-actions-with-msys2
     - name: install mingw gcc
-      if: ${{ matrix.compiler == 'gcc' }}
-      run: pacman --noconfirm -S gcc
+      if: ${{ (matrix.msystem == 'MINGW32') && (matrix.compiler == 'gcc') }}
+      run: pacman --noconfirm -S mingw-w64-i686-gcc
+    - name: install mingw gcc
+      if: ${{ (matrix.msystem == 'MINGW64') && (matrix.compiler == 'gcc') }}
+      run: pacman --noconfirm -S mingw-w64-x86_64-gcc
     - name: install mingw clang x86_64
       if: ${{ (matrix.msystem == 'MINGW64') && (matrix.compiler == 'clang') }}
       run: pacman --noconfirm -S mingw-w64-x86_64-clang


### PR DESCRIPTION
This PR overhauls our broken Windows tests (cmake, msbuild, and mingw). Fixes https://github.com/facebook/zstd/issues/3064. I'm going to break the summary down into three sections:

### Visual Studio + cmake
* Upgraded from Visual Studio 2019 to Visual Studio 2022.
### Visual Studio + msbuild
*  Deleted Visual Studio 2015 test
*  Kept Visual Studio 2019 test (release build only, to reduce the total number of jobs)
*  Added Visual Studio 2022 test (release + debug)
*  Parameterized the job definition so it can be changed more easily in the future
*  Upgraded the setup-msbuild version from v1.1.3 to v1.3 (future proofing in case v1.1.3 stops working at some point)
### mingw tests
I spent most of my time unbreaking these tests. It took a lot of trial and error: https://github.com/embg/zstd/pull/43

The problem is that GitHub's Windows 2022 image removes some of the msys2 packages that were installed by default in Windows 2019. This is a problem because our mingw jobs were written in PowerShell and replied on certain msys2 packages being installed at certain locations. Using msys2 in GitHub actions from PowerShell is an anti-pattern according to msys2 docs: https://www.msys2.org/docs/ci/

The proper way is to use the `msys2/setup-msys2` GitHub Action to install msys2 and any required packages (such as make and diffutils). I rewrote the mingw jobs to use msys2 properly, fixing the current breakage and preventing future breakages.

Some notes:
* The `mingw-long-test` had a build test which was nearly a duplicate of the build test in `mingw-short-test`. I folded the two build tests together under `mingw-short-test`, so now `mingw-long-test` is solely responsible for fuzzing.
* The PowerShell version of `mingw-short-test` did not fail the overall job in case the build step failed, due to how errors propagage from `sh -c` to PowerShell. This means the CI job wasn't actually validating the build. I checked that the new setup does fail if the build step fails.