### PR TITLE
minor refactoring for timefn

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -28,6 +28,7 @@
 #include <stdio.h>      /* fprintf, open, fdopen, fread, _fileno, stdin, stdout */
 #include <stdlib.h>     /* malloc, free */
 #include <string.h>     /* strcmp, strlen */
+#include <time.h>       /* clock_t, to measure process time */
 #include <fcntl.h>      /* O_WRONLY */
 #include <assert.h>
 #include <errno.h>      /* errno */

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -16,12 +16,6 @@ extern "C" {
 #endif
 
 
-/*-****************************************
-*  Dependencies
-******************************************/
-#include <time.h>         /* clock_t, clock, CLOCKS_PER_SEC */
-
-
 
 /*-****************************************
 *  Local Types
@@ -31,7 +25,7 @@ extern "C" {
 # if defined(_AIX)
 #  include <inttypes.h>
 # else
-#  include <stdint.h> /* intptr_t */
+#  include <stdint.h> /* uint64_t */
 # endif
   typedef uint64_t           PTime;  /* Precise Time */
 #else
@@ -41,8 +35,10 @@ extern "C" {
 
 
 /*-****************************************
-*  Time functions
+*  Time types (note: OS dependent)
 ******************************************/
+#include <time.h>     /* TIME_UTC, then struct timespec and clock_t */
+
 #if defined(_WIN32)   /* Windows */
 
     #include <windows.h>   /* LARGE_INTEGER */
@@ -63,7 +59,7 @@ extern "C" {
     typedef struct timespec UTIL_time_t;
     #define UTIL_TIME_INITIALIZER { 0, 0 }
 
-#else   /* relies on standard C90 (note : clock_t measurements can be wrong when using multi-threading) */
+#else   /* relies on standard C90 (note : clock_t produces wrong measurements for multi-threaded workloads) */
 
     #define UTIL_TIME_USES_C90_CLOCK
     typedef clock_t UTIL_time_t;
@@ -72,15 +68,21 @@ extern "C" {
 #endif
 
 
-UTIL_time_t UTIL_getTime(void);
-PTime UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd);
-PTime UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd);
+/*-****************************************
+*  Time functions
+******************************************/
 
-#define SEC_TO_MICRO ((PTime)1000000)
-PTime UTIL_clockSpanMicro(UTIL_time_t clockStart);
+UTIL_time_t UTIL_getTime(void);
+void UTIL_waitForNextTick(void);
+
+PTime UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd);
 PTime UTIL_clockSpanNano(UTIL_time_t clockStart);
 
-void UTIL_waitForNextTick(void);
+#define SEC_TO_MICRO ((PTime)1000000)
+PTime UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd);
+PTime UTIL_clockSpanMicro(UTIL_time_t clockStart);
+
+
 
 
 #if defined (__cplusplus)

--- a/tests/decodecorpus.c
+++ b/tests/decodecorpus.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>  /* time(), for seed random initialization */
 
 #include "util.h"
 #include "timefn.h"   /* UTIL_clockSpanMicro, SEC_TO_MICRO, UTIL_TIME_INITIALIZER */
@@ -24,7 +25,7 @@
 #include "zdict.h"
 
 /* Direct access to internal compression functions is required */
-#include "zstd_compress.c"
+#include "zstd_compress.c" /* ZSTD_resetSeqStore, ZSTD_storeSeq, *_TO_OFFBASE, HIST_countFast_wksp, HIST_isError */
 
 #define XXH_STATIC_LINKING_ONLY
 #include "xxhash.h"     /* XXH64 */
@@ -165,7 +166,7 @@ static double RAND_exp(U32* seed, double mean)
 /*-*******************************************************
 *  Constants and Structs
 *********************************************************/
-const char *BLOCK_TYPES[] = {"raw", "rle", "compressed"};
+const char* BLOCK_TYPES[] = {"raw", "rle", "compressed"};
 
 #define MAX_DECOMPRESSED_SIZE_LOG 20
 #define MAX_DECOMPRESSED_SIZE (1ULL << MAX_DECOMPRESSED_SIZE_LOG)

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>       /* free */
 #include <stdio.h>        /* fgets, sscanf */
 #include <string.h>       /* strcmp */
+#include <time.h>         /* time_t, time(), to randomize seed */
 #include <assert.h>       /* assert */
 #include "timefn.h"       /* UTIL_time_t, UTIL_getTime */
 #include "mem.h"


### PR DESCRIPTION
`UTIL_getSpanTimeMicro()` can be factored in a generic way, reducing OS-dependent code.