### PR TITLE
Fix MSYS2 symlink issues in CI

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -384,6 +384,7 @@ jobs:
   mingw-short-test:
     runs-on: windows-latest
     strategy:
+      fail-fast: false  # 'false' means Don't stop matrix workflows even if some matrix failed.
       matrix:
         include: [
           { compiler: gcc, msystem: MINGW32, cflags: "-Werror"},
@@ -401,18 +402,18 @@ jobs:
         install: make diffutils
         update: true
     # Based on https://ariya.io/2020/07/on-github-actions-with-msys2
-    - name: install mingw gcc
+    - name: install mingw gcc i686
       if: ${{ (matrix.msystem == 'MINGW32') && (matrix.compiler == 'gcc') }}
       run: pacman --noconfirm -S mingw-w64-i686-gcc
-    - name: install mingw gcc
+    - name: install mingw gcc x86_64
       if: ${{ (matrix.msystem == 'MINGW64') && (matrix.compiler == 'gcc') }}
       run: pacman --noconfirm -S mingw-w64-x86_64-gcc
-    - name: install mingw clang x86_64
-      if: ${{ (matrix.msystem == 'MINGW64') && (matrix.compiler == 'clang') }}
-      run: pacman --noconfirm -S mingw-w64-x86_64-clang
     - name: install mingw clang i686
       if: ${{ (matrix.msystem == 'MINGW32') && (matrix.compiler == 'clang') }}
       run: pacman --noconfirm -S mingw-w64-i686-clang
+    - name: install mingw clang x86_64
+      if: ${{ (matrix.msystem == 'MINGW64') && (matrix.compiler == 'clang') }}
+      run: pacman --noconfirm -S mingw-w64-x86_64-clang
     - name: run mingw tests
       run: |
         make -v
@@ -421,7 +422,7 @@ jobs:
         CFLAGS="${{ matrix.cflags }}" make -j allzstd
         echo "Testing $CC ${{ matrix.msystem }}"
         make clean
-        make check
+        MSYS="" make check
 
   visual-runtime-tests:
     runs-on: windows-latest


### PR DESCRIPTION
Recently [some mingw jobs](https://github.com/embg/zstd/actions/runs/3915429703/jobs/6693598399#step:7:4) have failed because they are running with 
```
env:
    MSYS: winsymlinks:nativestrict
```
I'm not sure which upstream dependency is inserting `winsymlinks:nativestrict`, since it's not in our job spec. But it breaks `make check`, because it instructs MSYS2 to emulate symlinks in a way that only works when running as Administrator, or if Window's "developer mode" has been enabled. Our script runs with a lower privilege level and can't open those symlinks, which causes `make check` to fail.

This PR has a couple cosmetic changes, but the functional change is
```
-   make check
+   MSYS="" make check
```
Setting `MSYS=""` instructs MSYS2 to replace symlinks with file copies. That is, `ln -s` becomes `cp`. This is the default on MSYS2 and all our jobs ran with `MSYS=""` prior to the recent change coming from upstream.

If we want to test "real" symlinks, we would need to run the job as Administrator, or enable "developer mode". I have [reached out](https://github.com/orgs/community/discussions/44268) to see if this is possible, but for now I think `MSYS=""` is an acceptable trade-off.

More information on MSYS2 symlink support: https://dev.to/hakonhagland/handling-of-symlinks-on-windows-perl-msys2-cygwin-52h3

Closes https://github.com/facebook/zstd/issues/3420