### PR TITLE
Fix CLI Handling of Permissions and Ownership (Again)

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1631,20 +1631,16 @@ static int FIO_compressFilename_dstFile(FIO_ctx_t* const fCtx,
 {
     int closeDstFile = 0;
     int result;
-    stat_t statbuf;
     int transferMTime = 0;
     FILE *dstFile;
-
-    (void)srcFileStat;
 
     assert(AIO_ReadPool_getFile(ress.readCtx) != NULL);
     if (AIO_WritePool_getFile(ress.writeCtx) == NULL) {
         int dstFilePermissions = DEFAULT_FILE_PERMISSIONS;
         if ( strcmp (srcFileName, stdinmark)
           && strcmp (dstFileName, stdoutmark)
-          && UTIL_stat(srcFileName, &statbuf)
-          && UTIL_isRegularFileStat(&statbuf) ) {
-            dstFilePermissions = statbuf.st_mode;
+          && UTIL_isRegularFileStat(srcFileStat) ) {
+            dstFilePermissions = srcFileStat->st_mode;
             transferMTime = 1;
         }
 
@@ -1671,7 +1667,7 @@ static int FIO_compressFilename_dstFile(FIO_ctx_t* const fCtx,
             result=1;
         }
         if (transferMTime) {
-            UTIL_utime(dstFileName, &statbuf);
+            UTIL_utime(dstFileName, srcFileStat);
         }
         if ( (result != 0)  /* operation failure */
           && strcmp(dstFileName, stdoutmark)  /* special case : don't remove() stdout */
@@ -2474,7 +2470,6 @@ static int FIO_decompressDstFile(FIO_ctx_t* const fCtx,
                                  const stat_t* srcFileStat)
 {
     int result;
-    stat_t statbuf;
     int releaseDstFile = 0;
     int transferMTime = 0;
 
@@ -2485,9 +2480,8 @@ static int FIO_decompressDstFile(FIO_ctx_t* const fCtx,
         int dstFilePermissions = DEFAULT_FILE_PERMISSIONS;
         if ( strcmp(srcFileName, stdinmark)   /* special case : don't transfer permissions from stdin */
           && strcmp(dstFileName, stdoutmark)
-          && UTIL_stat(srcFileName, &statbuf)
-          && UTIL_isRegularFileStat(&statbuf) ) {
-            dstFilePermissions = statbuf.st_mode;
+          && UTIL_isRegularFileStat(srcFileStat) ) {
+            dstFilePermissions = srcFileStat->st_mode;
             transferMTime = 1;
         }
 
@@ -2514,7 +2508,7 @@ static int FIO_decompressDstFile(FIO_ctx_t* const fCtx,
         }
 
         if (transferMTime) {
-            UTIL_utime(dstFileName, &statbuf);
+            UTIL_utime(dstFileName, srcFileStat);
         }
 
         if ( (result != 0)  /* operation failure */

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1626,6 +1626,7 @@ static int FIO_compressFilename_dstFile(FIO_ctx_t* const fCtx,
                                         cRess_t ress,
                                         const char* dstFileName,
                                         const char* srcFileName,
+                                        const stat_t* srcFileStat,
                                         int compressionLevel)
 {
     int closeDstFile = 0;
@@ -1633,6 +1634,9 @@ static int FIO_compressFilename_dstFile(FIO_ctx_t* const fCtx,
     stat_t statbuf;
     int transferMTime = 0;
     FILE *dstFile;
+
+    (void)srcFileStat;
+
     assert(AIO_ReadPool_getFile(ress.readCtx) != NULL);
     if (AIO_WritePool_getFile(ress.writeCtx) == NULL) {
         int dstFilePermissions = DEFAULT_FILE_PERMISSIONS;
@@ -1737,7 +1741,10 @@ FIO_compressFilename_srcFile(FIO_ctx_t* const fCtx,
     if (srcFile == NULL) return 1;   /* srcFile could not be opened */
 
     AIO_ReadPool_setFile(ress.readCtx, srcFile);
-    result = FIO_compressFilename_dstFile(fCtx, prefs, ress, dstFileName, srcFileName, compressionLevel);
+    result = FIO_compressFilename_dstFile(
+            fCtx, prefs, ress,
+            dstFileName, srcFileName,
+            &srcFileStat, compressionLevel);
     AIO_ReadPool_closeFile(ress.readCtx);
 
     if ( prefs->removeSrcFile   /* --rm */
@@ -2462,12 +2469,16 @@ static int FIO_decompressFrames(FIO_ctx_t* const fCtx,
 static int FIO_decompressDstFile(FIO_ctx_t* const fCtx,
                                  FIO_prefs_t* const prefs,
                                  dRess_t ress,
-                                 const char* dstFileName, const char* srcFileName)
+                                 const char* dstFileName,
+                                 const char* srcFileName,
+                                 const stat_t* srcFileStat)
 {
     int result;
     stat_t statbuf;
     int releaseDstFile = 0;
     int transferMTime = 0;
+
+    (void)srcFileStat;
 
     if ((AIO_WritePool_getFile(ress.writeCtx) == NULL) && (prefs->testMode == 0)) {
         FILE *dstFile;
@@ -2537,7 +2548,7 @@ static int FIO_decompressSrcFile(FIO_ctx_t* const fCtx, FIO_prefs_t* const prefs
     if (srcFile==NULL) return 1;
     AIO_ReadPool_setFile(ress.readCtx, srcFile);
 
-    result = FIO_decompressDstFile(fCtx, prefs, ress, dstFileName, srcFileName);
+    result = FIO_decompressDstFile(fCtx, prefs, ress, dstFileName, srcFileName, &srcFileStat);
 
     AIO_ReadPool_setFile(ress.readCtx, NULL);
 

--- a/programs/util.c
+++ b/programs/util.c
@@ -185,7 +185,7 @@ int UTIL_isRegularFileStat(const stat_t* statbuf)
 int UTIL_chmod(char const* filename, const stat_t* statbuf, mode_t permissions)
 {
     stat_t localStatBuf;
-    UTIL_TRACE_CALL("UTIL_chmod(%s, %u)", filename, (unsigned)permissions);
+    UTIL_TRACE_CALL("UTIL_chmod(%s, %#4o)", filename, (unsigned)permissions);
     if (statbuf == NULL) {
         if (!UTIL_stat(filename, &localStatBuf)) {
             UTIL_TRACE_RET(0);

--- a/programs/util.h
+++ b/programs/util.h
@@ -171,6 +171,7 @@ int UTIL_chmod(char const* filename, const stat_t* statbuf, mode_t permissions);
 int UTIL_isRegularFile(const char* infilename);
 int UTIL_isDirectory(const char* infilename);
 int UTIL_isSameFile(const char* file1, const char* file2);
+int UTIL_isSameFileStat(const char* file1, const char* file2, const stat_t* file1Stat, const stat_t* file2Stat);
 int UTIL_isCompressedFile(const char* infilename, const char *extensionList[]);
 int UTIL_isLink(const char* infilename);
 int UTIL_isFIFO(const char* infilename);

--- a/tests/cli-tests/file-stat/compress-file-to-file.sh
+++ b/tests/cli-tests/file-stat/compress-file-to-file.sh
@@ -3,6 +3,7 @@
 set -e
 
 datagen > file
+chmod 642 file
 
 zstd file -q --trace-file-stat -o file.zst
 zstd -tq file.zst

--- a/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
@@ -30,5 +30,13 @@ Trace:FileStat: > UTIL_getFileSize(file)
 Trace:FileStat:  > UTIL_stat(file)
 Trace:FileStat:  < 1
 Trace:FileStat: < 65537
-Trace:FileStat: > UTIL_utime(file.zst)
+Trace:FileStat: > UTIL_setFileStat(file.zst)
+Trace:FileStat:  > UTIL_stat(file.zst)
+Trace:FileStat:  < 1
+Trace:FileStat:  > UTIL_utime(file.zst)
+Trace:FileStat:  < 0
+Trace:FileStat:  > UTIL_chmod(file.zst, 420)
+Trace:FileStat:   > chmod
+Trace:FileStat:   < 0
+Trace:FileStat:  < 0
 Trace:FileStat: < 0

--- a/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
@@ -6,9 +6,9 @@ Trace:FileStat: > UTIL_getFileSize(file)
 Trace:FileStat:  > UTIL_stat(file)
 Trace:FileStat:  < 1
 Trace:FileStat: < 65537
-Trace:FileStat: > UTIL_isDirectory(file)
-Trace:FileStat:  > UTIL_stat(file)
-Trace:FileStat:  < 1
+Trace:FileStat: > UTIL_stat(file)
+Trace:FileStat: < 1
+Trace:FileStat: > UTIL_isDirectoryStat()
 Trace:FileStat: < 0
 Trace:FileStat: > UTIL_stat(file)
 Trace:FileStat: < 1

--- a/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
@@ -35,7 +35,7 @@ Trace:FileStat:  > UTIL_stat(file.zst)
 Trace:FileStat:  < 1
 Trace:FileStat:  > UTIL_utime(file.zst)
 Trace:FileStat:  < 0
-Trace:FileStat:  > UTIL_chmod(file.zst, 418)
+Trace:FileStat:  > UTIL_chmod(file.zst, 0642)
 Trace:FileStat:   > chmod
 Trace:FileStat:   < 0
 Trace:FileStat:  < 0

--- a/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
@@ -35,7 +35,7 @@ Trace:FileStat:  > UTIL_stat(file.zst)
 Trace:FileStat:  < 1
 Trace:FileStat:  > UTIL_utime(file.zst)
 Trace:FileStat:  < 0
-Trace:FileStat:  > UTIL_chmod(file.zst, 420)
+Trace:FileStat:  > UTIL_chmod(file.zst, 418)
 Trace:FileStat:   > chmod
 Trace:FileStat:   < 0
 Trace:FileStat:  < 0

--- a/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-file.sh.stderr.exact
@@ -12,8 +12,6 @@ Trace:FileStat:  < 1
 Trace:FileStat: < 0
 Trace:FileStat: > UTIL_stat(file)
 Trace:FileStat: < 1
-Trace:FileStat: > UTIL_stat(file)
-Trace:FileStat: < 1
 Trace:FileStat: > UTIL_isSameFile(file, file.zst)
 Trace:FileStat:  > UTIL_stat(file)
 Trace:FileStat:  < 1

--- a/tests/cli-tests/file-stat/compress-file-to-stdout.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-stdout.sh.stderr.exact
@@ -6,9 +6,9 @@ Trace:FileStat: > UTIL_getFileSize(file)
 Trace:FileStat:  > UTIL_stat(file)
 Trace:FileStat:  < 1
 Trace:FileStat: < 65537
-Trace:FileStat: > UTIL_isDirectory(file)
-Trace:FileStat:  > UTIL_stat(file)
-Trace:FileStat:  < 1
+Trace:FileStat: > UTIL_stat(file)
+Trace:FileStat: < 1
+Trace:FileStat: > UTIL_isDirectoryStat()
 Trace:FileStat: < 0
 Trace:FileStat: > UTIL_stat(file)
 Trace:FileStat: < 1

--- a/tests/cli-tests/file-stat/compress-stdin-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-stdin-to-file.sh.stderr.exact
@@ -6,10 +6,6 @@ Trace:FileStat: > UTIL_getFileSize(/*stdin*\)
 Trace:FileStat:  > UTIL_stat(/*stdin*\)
 Trace:FileStat:  < 0
 Trace:FileStat: < -1
-Trace:FileStat: > UTIL_isDirectory(/*stdin*\)
-Trace:FileStat:  > UTIL_stat(/*stdin*\)
-Trace:FileStat:  < 0
-Trace:FileStat: < 0
 Trace:FileStat: > UTIL_isSameFile(/*stdin*\, file.zst)
 Trace:FileStat:  > UTIL_stat(/*stdin*\)
 Trace:FileStat:  < 0

--- a/tests/cli-tests/file-stat/compress-stdin-to-stdout.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-stdin-to-stdout.sh.stderr.exact
@@ -6,10 +6,6 @@ Trace:FileStat: > UTIL_getFileSize(/*stdin*\)
 Trace:FileStat:  > UTIL_stat(/*stdin*\)
 Trace:FileStat:  < 0
 Trace:FileStat: < -1
-Trace:FileStat: > UTIL_isDirectory(/*stdin*\)
-Trace:FileStat:  > UTIL_stat(/*stdin*\)
-Trace:FileStat:  < 0
-Trace:FileStat: < 0
 Trace:FileStat: > UTIL_isRegularFile(/*stdout*\)
 Trace:FileStat:  > UTIL_stat(/*stdout*\)
 Trace:FileStat:  < 0

--- a/tests/cli-tests/file-stat/decompress-file-to-file.sh
+++ b/tests/cli-tests/file-stat/decompress-file-to-file.sh
@@ -3,5 +3,6 @@
 set -e
 
 datagen | zstd -q > file.zst
+chmod 642 file.zst
 
 zstd -dq --trace-file-stat file.zst

--- a/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
@@ -7,6 +7,8 @@ Trace:FileStat: < 0
 Trace:FileStat: > UTIL_isDirectory(file.zst)
 Trace:FileStat:  > UTIL_stat(file.zst)
 Trace:FileStat:  < 1
+Trace:FileStat:  > UTIL_isDirectoryStat()
+Trace:FileStat:  < 0
 Trace:FileStat: < 0
 Trace:FileStat: > UTIL_stat(file.zst)
 Trace:FileStat: < 1

--- a/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
@@ -31,7 +31,7 @@ Trace:FileStat:  > UTIL_stat(file)
 Trace:FileStat:  < 1
 Trace:FileStat:  > UTIL_utime(file)
 Trace:FileStat:  < 0
-Trace:FileStat:  > UTIL_chmod(file, 418)
+Trace:FileStat:  > UTIL_chmod(file, 0642)
 Trace:FileStat:   > chmod
 Trace:FileStat:   < 0
 Trace:FileStat:  < 0

--- a/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
@@ -31,7 +31,7 @@ Trace:FileStat:  > UTIL_stat(file)
 Trace:FileStat:  < 1
 Trace:FileStat:  > UTIL_utime(file)
 Trace:FileStat:  < 0
-Trace:FileStat:  > UTIL_chmod(file, 420)
+Trace:FileStat:  > UTIL_chmod(file, 418)
 Trace:FileStat:   > chmod
 Trace:FileStat:   < 0
 Trace:FileStat:  < 0

--- a/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
@@ -26,5 +26,13 @@ Trace:FileStat: > UTIL_isRegularFile(file)
 Trace:FileStat:  > UTIL_stat(file)
 Trace:FileStat:  < 1
 Trace:FileStat: < 1
-Trace:FileStat: > UTIL_utime(file)
+Trace:FileStat: > UTIL_setFileStat(file)
+Trace:FileStat:  > UTIL_stat(file)
+Trace:FileStat:  < 1
+Trace:FileStat:  > UTIL_utime(file)
+Trace:FileStat:  < 0
+Trace:FileStat:  > UTIL_chmod(file, 420)
+Trace:FileStat:   > chmod
+Trace:FileStat:   < 0
+Trace:FileStat:  < 0
 Trace:FileStat: < 0

--- a/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/decompress-file-to-file.sh.stderr.exact
@@ -10,8 +10,6 @@ Trace:FileStat:  < 1
 Trace:FileStat: < 0
 Trace:FileStat: > UTIL_stat(file.zst)
 Trace:FileStat: < 1
-Trace:FileStat: > UTIL_stat(file.zst)
-Trace:FileStat: < 1
 Trace:FileStat: > UTIL_isSameFile(file.zst, file)
 Trace:FileStat:  > UTIL_stat(file.zst)
 Trace:FileStat:  < 1

--- a/tests/cli-tests/file-stat/decompress-file-to-stdout.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/decompress-file-to-stdout.sh.stderr.exact
@@ -5,6 +5,8 @@ Trace:FileStat: < 0
 Trace:FileStat: > UTIL_isDirectory(file.zst)
 Trace:FileStat:  > UTIL_stat(file.zst)
 Trace:FileStat:  < 1
+Trace:FileStat:  > UTIL_isDirectoryStat()
+Trace:FileStat:  < 0
 Trace:FileStat: < 0
 Trace:FileStat: > UTIL_stat(file.zst)
 Trace:FileStat: < 1

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -562,18 +562,8 @@ if [ "$isWindows" = false ] ; then
     zstd -f -d tmp1.zst -o tmp1.out
     assertFilePermissions tmp1.out 400
 
-    rm -f tmp1.zst tmp1.out
-
     umask 0666
     chmod 0666 tmp1 tmp2
-
-    println "test : respect umask when copying permissions in file -> file compression "
-    zstd -f tmp1 -o tmp1.zst
-    assertFilePermissions tmp1.zst 0
-    println "test : respect umask when copying permissions in file -> file decompression "
-    chmod 0666 tmp1.zst
-    zstd -f -d tmp1.zst -o tmp1.out
-    assertFilePermissions tmp1.out 0
 
     rm -f tmp1.zst tmp1.out
 


### PR DESCRIPTION
This PR switches the `zstd` CLI's handling of output files' ownership and permissions back (again). This PR brings `zstd`'s behavior back into alignment with `gzip`'s, without introducing any gaps where output files have incorrectly loose permissions.

This PR addresses #2946. Previous issues and PRs on this topic include #2739, #2525, #2491 and #2495, and #1630 and #1644.

When the input is not a regular file, we create the output file with default `0666` permissions (modulated by the `umask`), and then don't change anything at the end of the operation.

When the input *is* a regular file, we create it with `0600` (u+rw) permissions, and then copy the input's ownership, permissions, and timestamps to the output file at the end of the operation. E.g.:

```sh
$ ls -lAh ~/prog/silesia/silesia.tar; \
  ./zstd -q -5 ~/prog/silesia/silesia.tar -o silesia.tar.zst & \
  sleep 1; \
  ls -lAh silesia.tar.zst; \
  wait; \
  ls -lAh silesia.tar.zst
-rw-r----- 1 felixh users 203M Aug 18  2021 /home/felixh/prog/silesia/silesia.tar
[1] 4035425
-rw------- 1 felixh users 25M Jan 18 14:05 silesia.tar.zst
[1]+  Done                    ./zstd -q -5 ~/prog/silesia/silesia.tar -o silesia.tar.zst
-rw-r----- 1 felixh users 61M Aug 18  2021 silesia.tar.zst
```

We also leverage a trick found in `gzip` to avoid a different permissions/ownership race by setting the correct group, then permissions, then user. Otherwise there would be a window of time in which incorrectly lax permissions might be exposed to the wrong user or group. (It's not meaningful for there to be incorrectly lax user permissions exposed to the user that zstd is running as / the file is created as, since an attacker running as that user would already be able to `chmod()` the file to make it user r/w/x-able. But without this 3-step process, it would be possible for incorrectly lax permissions to be applied to the group the file is created as, or the user the file ends up being owned by.)

Finally, this PR refactors how we stat files slightly, to reduce the count of `stat()` calls we make. A further improvement might be to switch to doing `fstat()` calls.

Adding testing for this PR is a challenge. We have reasonably good coverage of checking that timestamps and mode bits are copied over. But it's difficult to extend that to testing that the user and group are copied over correctly. (1) We can't rely on particular other users/groups existing across all the platforms on which we want to test. (2) Zstd will mostly fail to `chown()` the output file anyways:

> Only a privileged process (Linux: one with the `CAP_CHOWN` capability) may change the owner of a file.  The owner of a file may change the group of the file to any group of which that owner is a member.
> \- `chown(2)` man page

I have locally verified that it does correctly propagate ownership when invoked with `sudo`.