### PR TITLE
Fix -Wstringop-overflow warning

### DIFF
--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -993,7 +993,7 @@ static void HUF_fillDTableX2Level2(HUF_DEltX2* DTable, U32 targetLog, const U32 
 
 static void HUF_fillDTableX2(HUF_DEltX2* DTable, const U32 targetLog,
                            const sortedSymbol_t* sortedList,
-                           const U32* rankStart, rankVal_t rankValOrigin, const U32 maxWeight,
+                           const U32* rankStart, rankValCol_t* rankValOrigin, const U32 maxWeight,
                            const U32 nbBitsBaseline)
 {
     U32* const rankVal = rankValOrigin[0];


### PR DESCRIPTION
Backported from kernel patch [0].

I wasn't able to reproduce the warning locally, but could repro it in the kernel.

[0] https://lore.kernel.org/lkml/20220330193352.GA119296@embeddedor/