### PR TITLE
[huf] Fix bug in fast C decoders

### DIFF
--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -742,7 +742,7 @@ void HUF_decompress4X1_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* 
              */
             for (stream = 1; stream < 4; ++stream) {
                 if (ip[stream] < ip[stream - 1])
-                    break;
+                    goto _out;
             }
         }
 
@@ -774,6 +774,8 @@ void HUF_decompress4X1_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* 
             }
         } while (op[3] < olimit);
     }
+
+_out:
 
     /* Save the final values of each of the state variables back to args. */
     ZSTD_memcpy(&args->bits, &bits, sizeof(bits));
@@ -1535,7 +1537,7 @@ void HUF_decompress4X2_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* 
              */
             for (stream = 1; stream < 4; ++stream) {
                 if (ip[stream] < ip[stream - 1])
-                    break;
+                    goto _out;
             }
         }
 
@@ -1592,6 +1594,8 @@ void HUF_decompress4X2_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* 
             }
         } while (op[3] < olimit);
     }
+
+_out:
 
     /* Save the final values of each of the state variables back to args. */
     ZSTD_memcpy(&args->bits, &bits, sizeof(bits));


### PR DESCRIPTION
The input bounds checks were buggy because they were only breaking from the inner loop, not the outer loop. The fuzzers found this immediately. The fix is to use `goto _out` instead of `break`.

This condition can happen on corrupted inputs.

I've benchmarked before and after on x86-64 and there were small changes in performance, some positive, and some negative, and they end up about balacing out.

Credit to OSS-Fuzz