### PR TITLE
meson: always build the zstd binary when tests are enabled

### DIFF
--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -132,7 +132,7 @@ endif
 
 subdir('lib')
 
-if bin_programs
+if bin_programs or bin_tests
   subdir('programs')
 endif
 

--- a/build/meson/programs/meson.build
+++ b/build/meson/programs/meson.build
@@ -72,7 +72,14 @@ zstd = executable('zstd',
   c_args: zstd_c_args,
   dependencies: zstd_deps,
   export_dynamic: export_dynamic_on_windows, # Since Meson 0.45.0
-  install: true)
+  build_by_default: bin_programs,
+  install: bin_programs)
+
+if not bin_programs
+  # we generate rules to build the programs, but don't install anything
+  # so do not continue to installing scripts and manpages
+  subdir_done()
+endif
 
 zstd_frugal_sources = [join_paths(zstd_rootdir, 'programs/zstdcli.c'),
   join_paths(zstd_rootdir, 'programs/timefn.c'),

--- a/build/meson/tests/meson.build
+++ b/build/meson/tests/meson.build
@@ -162,7 +162,7 @@ if host_machine_os != os_windows
       playTests_sh,
       args: opt,
       env: ['ZSTD_BIN=' + zstd.full_path(), 'DATAGEN_BIN=./datagen'],
-      depends: [datagen],
+      depends: [datagen, zstd],
       suite: suite,
       workdir: meson.current_build_dir(),
       timeout: 2800) # Timeout should work on HDD drive


### PR DESCRIPTION
We need to run it for the tests, even if programs are disabled. So if they are disabled, create a build rule for the program, but don't install it. Just make it available for the test itself.

/cc @thesamesam

This allows zstd to build with `-Dbin_programs=false -Dbin_tests=true`, which is useful when you want to build a multilib library for libzstd, but not programs... and yet you also want to test that library.