### PR TITLE
Document `pzstd -p`

### DIFF
--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -171,6 +171,12 @@ do not store the original filename and timestamps when compressing a file\. This
 .TP
 \fB\-\-best\fR
 alias to the option \fB\-9\fR\.
+.SS Parallel Zstd OPTIONS
+Additional options for the \fBpzstd\fR utility
+.TP
+\fB\-p\fR, \fB\-\-processes\fR
+ number of threads to use for (de)compression (default:<numcpus>)
+.
 .SS "Environment Variables"
 Employing environment variables to set parameters has security implications\. Therefore, this avenue is intentionally limited\. Only \fBZSTD_CLEVEL\fR and \fBZSTD_NBTHREADS\fR are currently supported\. They set the compression level and number of threads to use during compression, respectively\.
 .P


### PR DESCRIPTION
Document `pzstd -p` in man-page
so that users get at least the same information as from `pzstd --help`