### PR TITLE
CI Workflow for external compressors dependencies

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -184,6 +184,25 @@ jobs:
           make gcc8install
           CC=gcc-8 CFLAGS="-Werror" make -j all
 
+  make-external-compressors:
+    strategy:
+      matrix:
+        include:
+          - name: "no external compressors"
+            flags: "HAVE_ZLIB=0 HAVE_LZ4=0 HAVE_LZMA=0"
+          - name: "only zlib"
+            flags: "HAVE_ZLIB=1 HAVE_LZ4=0 HAVE_LZMA=0"
+          - name: "only lz4"
+            flags: "HAVE_ZLIB=0 HAVE_LZ4=1 HAVE_LZMA=0"
+          - name: "only lzma"
+            flags: "HAVE_ZLIB=0 HAVE_LZ4=0 HAVE_LZMA=1"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
+      - name: Build with ${{matrix.name}}
+        run: ${{matrix.flags}} make zstd
+
+
   implicit-fall-through:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Implemented CI workflow for testing compilation with external compressors and without them. This serves as a sanity check to avoid any code dependencies on libraries that may not always be present. (Reference: https://github.com/facebook/zstd/pull/3497 for a bug fix related to this issue.)

Note: the new job added here is expected to fail as https://github.com/facebook/zstd/pull/3497 isn't merged yet.
This will give us confirmation that it does find the issue.
After #3497 this will be rebased to make sure the job doesn't fail anymore.