### PR TITLE
Fix cli-tests issues

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -38,6 +38,20 @@ jobs:
     - name: OS-X test
       run: make test # make -c lib all doesn't work because of the fact that it's not a tty
 
+  # lasts ~24mn
+  make-test-32bit:
+    runs-on: ubuntu-latest
+    env:
+      DEVNULLRIGHTS: 1
+      READFROMBLOCKDEVICE: 1
+    steps:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3
+    - name: make test
+      run: |
+        sudo apt-get -qqq update
+        make libc6install
+        CFLAGS="-m32" make test
+
   no-intrinsics-fuzztest:
     runs-on: ubuntu-latest
     steps:

--- a/tests/cli-tests/compression/basic.sh
+++ b/tests/cli-tests/compression/basic.sh
@@ -25,8 +25,10 @@ zstd --stdout file | zstd -t
 println bob | zstd | zstd -t
 
 # Test keeping input file when compressing to stdout in gzip mode
-$ZSTD_SYMLINK_DIR/gzip -c file       | zstd -t ; test -f file
-$ZSTD_SYMLINK_DIR/gzip --stdout file | zstd -t ; test -f file
+if $(command -v $ZSTD_SYMLINK_DIR/gzip); then
+    $ZSTD_SYMLINK_DIR/gzip -c file       | zstd -t ; test -f file
+    $ZSTD_SYMLINK_DIR/gzip --stdout file | zstd -t ; test -f file
+fi
 
 # Test --rm
 cp file file-rm

--- a/tests/cli-tests/compression/gzip-compat.sh
+++ b/tests/cli-tests/compression/gzip-compat.sh
@@ -6,10 +6,12 @@ set -e
 # set -v
 
 # Test gzip specific compression option
-$ZSTD_SYMLINK_DIR/gzip --fast file ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
-$ZSTD_SYMLINK_DIR/gzip --best file ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
+if $(command -v $ZSTD_SYMLINK_DIR/gzip); then
+    $ZSTD_SYMLINK_DIR/gzip --fast file ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
+    $ZSTD_SYMLINK_DIR/gzip --best file ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
 
-# Test -n / --no-name: do not embed original filename in archive
-$ZSTD_SYMLINK_DIR/gzip -n file           ; grep -qv file file.gz  ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
-$ZSTD_SYMLINK_DIR/gzip --no-name file    ; grep -qv file file.gz  ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
-$ZSTD_SYMLINK_DIR/gzip -c --no-name file | grep -qv file
+    # Test -n / --no-name: do not embed original filename in archive
+    $ZSTD_SYMLINK_DIR/gzip -n file           ; grep -qv file file.gz  ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
+    $ZSTD_SYMLINK_DIR/gzip --no-name file    ; grep -qv file file.gz  ; $ZSTD_SYMLINK_DIR/gzip -d file.gz
+    $ZSTD_SYMLINK_DIR/gzip -c --no-name file | grep -qv file
+fi

--- a/tests/cli-tests/compression/window-resize.sh
+++ b/tests/cli-tests/compression/window-resize.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 datagen -g1G > file
-zstd --long=31 -1 --single-thread --no-content-size -f file
+zstd --long=30 -1 --single-thread --no-content-size -f file
 zstd -l -v file.zst
 
 # We want to ignore stderr (its outputting "*** zstd command line interface


### PR DESCRIPTION
Fix for issues #3501 and #3502. 

All tests now seem to pass for `make -C tests test-cli-tests CFLAGS="-O2 -m32"` and `make -C tests test-cli-tests HAVE_ZLIB=0`.