### PR TITLE
Don't require CMake 3.18 or later

### DIFF
--- a/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
+++ b/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
@@ -1,6 +1,15 @@
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
-include(CheckLinkerFlag)
+# VERSION_GREATER_EQUAL requires CMake 3.7 or later.
+# https://cmake.org/cmake/help/latest/command/if.html#version-greater-equal
+if (CMAKE_VERSION VERSION_LESS 3.18)
+    set(ZSTD_HAVE_CHECK_LINKER_FLAG false)
+else ()
+    set(ZSTD_HAVE_CHECK_LINKER_FLAG true)
+endif ()
+if (ZSTD_HAVE_CHECK_LINKER_FLAG)
+    include(CheckLinkerFlag)
+endif()
 
 function(EnableCompilerFlag _flag _C _CXX _LD)
     string(REGEX REPLACE "\\+" "PLUS" varname "${_flag}")
@@ -20,7 +29,15 @@ function(EnableCompilerFlag _flag _C _CXX _LD)
         endif ()
     endif ()
     if (_LD)
-        CHECK_LINKER_FLAG(C ${_flag} LD_FLAG_${varname})
+        # We never add a linker flag with CMake < 3.18. We will
+        # implement CHECK_LINKER_FLAG() like feature for CMake < 3.18
+        # or require CMake >= 3.18 when we need to add a required
+        # linker flag in future.
+        if (ZSTD_HAVE_CHECK_LINKER_FLAG)
+            CHECK_LINKER_FLAG(C ${_flag} LD_FLAG_${varname})
+        else ()
+            set(LD_FLAG_${varname} false)
+        endif ()
         if (LD_FLAG_${varname})
             set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${_flag}" PARENT_SCOPE)
             set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${_flag}" PARENT_SCOPE)


### PR DESCRIPTION
fix #3500

CMake 3.18 or later was required by #3392. Because it uses `CheckLinkerFlag`. But requiring CMake 3.18 or later is a bit aggressive. Because Ubuntu 20.04 LTS still uses CMake 3.16.3: https://packages.ubuntu.com/search?keywords=cmake

This change disables `-z noexecstack` check with old CMake. This will not break any existing users. Because users who need `-z noexecstack` must already use CMake 3.18 or later.