### PR TITLE
Fix Permissions on Publish Release Artifacts Job

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -10,8 +10,7 @@ permissions: read-all
 jobs:
   publish-release-artifacts:
     permissions:
-      contents: read # to fetch code (actions/checkout)
-      actions: write # to attach binaries to release artifacts (skx/github-action-publish-binaries)
+      contents: write # to fetch code and upload artifacts
 
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Publishing release artifacts requires the `contents` permission, as documented by: https://docs.github.com/en/rest/overview/permissions-required-for-github-apps.

Tested by authoring a release on my fork.