### PR TITLE
fullbench with two files 

### DIFF
--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -774,7 +774,9 @@ static int benchFiles(U32 benchNb,
             } else {
                 for (benchNb=0; benchNb<100; benchNb++) {
                     benchMem(benchNb, origBuff, benchedSize, cLevel, cparams);
-            }   }
+                }
+                benchNb = 0;
+            }
 
             free(origBuff);
     }   }


### PR DESCRIPTION
When benchmarking two files with fullbench, the second file will not be benchmarked because the benchNb has not been reset to zero.
![Screenshot 2023-02-20 at 16 55 30](https://user-images.githubusercontent.com/8523411/220152450-32efba7c-7a47-4bd7-9364-a7844eb85b9f.png)
