### PR TITLE
[linux-kernel] Fix assert definition

### DIFF
--- a/contrib/linux-kernel/zstd_deps.h
+++ b/contrib/linux-kernel/zstd_deps.h
@@ -84,7 +84,7 @@ static uint64_t ZSTD_div64(uint64_t dividend, uint32_t divisor) {
 
 #include <linux/kernel.h>
 
-#define assert(x) WARN_ON((x))
+#define assert(x) WARN_ON(!(x))
 
 #endif /* ZSTD_DEPS_ASSERT */
 #endif /* ZSTD_DEPS_NEED_ASSERT */


### PR DESCRIPTION
Backport upstream fix of the assert definition. This code is currently unused, and can be enabled for testing, which is why it wasn't caught.

https://lore.kernel.org/lkml/20230129131436.1343228-1-j.neuschaefer@gmx.net/