### PR TITLE
Increase tests timeout

### DIFF
--- a/tests/cli-tests/run.py
+++ b/tests/cli-tests/run.py
@@ -647,7 +647,7 @@ if __name__ == "__main__":
         help="Preserve the scratch directory TEST_DIR/scratch/ for debugging purposes."
     )
     parser.add_argument("--verbose", action="store_true", help="Verbose test output.")
-    parser.add_argument("--timeout", default=60, type=int, help="Test case timeout in seconds. Set to 0 to disable timeouts.")
+    parser.add_argument("--timeout", default=200, type=int, help="Test case timeout in seconds. Set to 0 to disable timeouts.")
     parser.add_argument(
         "--exec-prefix",
         default=None,


### PR DESCRIPTION
    Current timeout is too small for some slower machines, e.g. most modern riscv64 boards,
    where tests fail with the following diagnostics:

    	Traceback (most recent call last):
    	  File "/usr/src/RPM/BUILD/zstd-1.5.4-alt2/tests/./cli-tests/run.py", line 734, in <module>
    	    success = run_tests(tests, opts)
    	  File "/usr/src/RPM/BUILD/zstd-1.5.4-alt2/tests/./cli-tests/run.py", line 601, in run_tests
    	    tests[test_case.name] = test_case.run()
    	  File "/usr/src/RPM/BUILD/zstd-1.5.4-alt2/tests/./cli-tests/run.py", line 285, in run
    	    return self.analyze()
    	  File "/usr/src/RPM/BUILD/zstd-1.5.4-alt2/tests/./cli-tests/run.py", line 275, in analyze
    	    self._join_test()
    	  File "/usr/src/RPM/BUILD/zstd-1.5.4-alt2/tests/./cli-tests/run.py", line 330, in _join_test
    	    (stdout, stderr) = self._test_process.communicate(timeout=self._opts.timeout)
    	  File "/usr/lib64/python3.10/subprocess.py", line 1154, in communicate
    	    stdout, stderr = self._communicate(input, endtime, timeout)
    	  File "/usr/lib64/python3.10/subprocess.py", line 2006, in _communicate
    	    self._check_timeout(endtime, orig_timeout, stdout, stderr)
    	  File "/usr/lib64/python3.10/subprocess.py", line 1198, in _check_timeout
    	    raise TimeoutExpired(
    	subprocess.TimeoutExpired: Command '['/usr/src/RPM/BUILD/zstd-1.5.4-alt2/tests/cli-tests/compression/window-resize.sh']' timed out after 60 seconds