### PR TITLE
Avoid Segfault Caused by Calling `setvbuf()` on Null File Pointer

### DIFF
--- a/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh
+++ b/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# motivated by issue #3523
+
+datagen > file
+mkdir out
+chmod 000 out
+
+zstd file -q --trace-file-stat -o out/file.zst
+zstd -tq out/file.zst
+
+chmod 777 out

--- a/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh.stderr.exact
@@ -1,0 +1,26 @@
+Trace:FileStat: > UTIL_isLink(file)
+Trace:FileStat: < 0
+Trace:FileStat: > UTIL_isConsole(2)
+Trace:FileStat: < 0
+Trace:FileStat: > UTIL_getFileSize(file)
+Trace:FileStat:  > UTIL_stat(-1, file)
+Trace:FileStat:  < 1
+Trace:FileStat: < 65537
+Trace:FileStat: > UTIL_stat(-1, file)
+Trace:FileStat: < 1
+Trace:FileStat: > UTIL_isDirectoryStat()
+Trace:FileStat: < 0
+Trace:FileStat: > UTIL_stat(-1, file)
+Trace:FileStat: < 1
+Trace:FileStat: > UTIL_isSameFile(file, out/file.zst)
+Trace:FileStat:  > UTIL_stat(-1, file)
+Trace:FileStat:  < 1
+Trace:FileStat:  > UTIL_stat(-1, out/file.zst)
+Trace:FileStat:  < 0
+Trace:FileStat: < 0
+Trace:FileStat: > UTIL_isRegularFile(out/file.zst)
+Trace:FileStat:  > UTIL_stat(-1, out/file.zst)
+Trace:FileStat:  < 0
+Trace:FileStat: < 0
+zstd: out/file.zst: Permission denied
+zstd: can't stat out/file.zst : Permission denied -- ignored 

--- a/tests/cli-tests/run.py
+++ b/tests/cli-tests/run.py
@@ -535,7 +535,8 @@ class TestSuite:
             subprocess.run(
                 args=[script],
                 stdin=subprocess.DEVNULL,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 cwd=cwd,
                 env=env,
                 check=True,


### PR DESCRIPTION
Addresses #3523.