### PR TITLE
[lazy] Skip over incompressible data

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1947,6 +1947,7 @@ ZSTD_reset_matchState(ZSTD_matchState_t* ms,
     }
 
     ms->hashLog3 = hashLog3;
+    ms->lazySkipping = 0;
 
     ZSTD_invalidateMatchState(ms);
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -249,6 +249,13 @@ struct ZSTD_matchState_t {
      * This behavior is controlled from the cctx ms.
      * This parameter has no effect in the cdict ms. */
     int prefetchCDictTables;
+
+    /* When == 0, lazy match finders insert every position.
+     * When != 0, lazy match finders only insert positions they search.
+     * This allows them to skip much faster over incompressible data,
+     * at a small cost to compression ratio.
+     */
+    int lazySkipping;
 };
 
 typedef struct {

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -6,10 +6,10 @@ silesia.tar,                        level 0,                            compress
 silesia.tar,                        level 1,                            compress simple,                    5327717
 silesia.tar,                        level 3,                            compress simple,                    4854086
 silesia.tar,                        level 4,                            compress simple,                    4791503
-silesia.tar,                        level 5,                            compress simple,                    4679219
-silesia.tar,                        level 6,                            compress simple,                    4614874
-silesia.tar,                        level 7,                            compress simple,                    4579642
-silesia.tar,                        level 9,                            compress simple,                    4555245
+silesia.tar,                        level 5,                            compress simple,                    4679004
+silesia.tar,                        level 6,                            compress simple,                    4614561
+silesia.tar,                        level 7,                            compress simple,                    4579828
+silesia.tar,                        level 9,                            compress simple,                    4555448
 silesia.tar,                        level 13,                           compress simple,                    4502956
 silesia.tar,                        level 16,                           compress simple,                    4360546
 silesia.tar,                        level 19,                           compress simple,                    4265911
@@ -40,10 +40,10 @@ silesia,                            level 0,                            compress
 silesia,                            level 1,                            compress cctx,                      5306632
 silesia,                            level 3,                            compress cctx,                      4842075
 silesia,                            level 4,                            compress cctx,                      4779186
-silesia,                            level 5,                            compress cctx,                      4667825
-silesia,                            level 6,                            compress cctx,                      4604587
-silesia,                            level 7,                            compress cctx,                      4569976
-silesia,                            level 9,                            compress cctx,                      4545538
+silesia,                            level 5,                            compress cctx,                      4667668
+silesia,                            level 6,                            compress cctx,                      4604351
+silesia,                            level 7,                            compress cctx,                      4570271
+silesia,                            level 9,                            compress cctx,                      4545850
 silesia,                            level 13,                           compress cctx,                      4493990
 silesia,                            level 16,                           compress cctx,                      4360041
 silesia,                            level 19,                           compress cctx,                      4296055
@@ -53,7 +53,7 @@ silesia,                            multithreaded long distance mode,   compress
 silesia,                            small window log,                   compress cctx,                      7082951
 silesia,                            small hash log,                     compress cctx,                      6526141
 silesia,                            small chain log,                    compress cctx,                      4912197
-silesia,                            explicit params,                    compress cctx,                      4794128
+silesia,                            explicit params,                    compress cctx,                      4794318
 silesia,                            uncompressed literals,              compress cctx,                      4842075
 silesia,                            uncompressed literals optimal,      compress cctx,                      4296055
 silesia,                            huffman literals,                   compress cctx,                      6172202
@@ -104,10 +104,10 @@ silesia,                            level 0,                            zstdcli,
 silesia,                            level 1,                            zstdcli,                            5306680
 silesia,                            level 3,                            zstdcli,                            4842123
 silesia,                            level 4,                            zstdcli,                            4779234
-silesia,                            level 5,                            zstdcli,                            4667873
-silesia,                            level 6,                            zstdcli,                            4604635
-silesia,                            level 7,                            zstdcli,                            4570024
-silesia,                            level 9,                            zstdcli,                            4545586
+silesia,                            level 5,                            zstdcli,                            4667716
+silesia,                            level 6,                            zstdcli,                            4604399
+silesia,                            level 7,                            zstdcli,                            4570319
+silesia,                            level 9,                            zstdcli,                            4545898
 silesia,                            level 13,                           zstdcli,                            4494038
 silesia,                            level 16,                           zstdcli,                            4360089
 silesia,                            level 19,                           zstdcli,                            4296103
@@ -117,7 +117,7 @@ silesia,                            multithreaded long distance mode,   zstdcli,
 silesia,                            small window log,                   zstdcli,                            7095048
 silesia,                            small hash log,                     zstdcli,                            6526189
 silesia,                            small chain log,                    zstdcli,                            4912245
-silesia,                            explicit params,                    zstdcli,                            4795654
+silesia,                            explicit params,                    zstdcli,                            4795840
 silesia,                            uncompressed literals,              zstdcli,                            5120614
 silesia,                            uncompressed literals optimal,      zstdcli,                            4319566
 silesia,                            huffman literals,                   zstdcli,                            5321417
@@ -129,10 +129,10 @@ silesia.tar,                        level 0,                            zstdcli,
 silesia.tar,                        level 1,                            zstdcli,                            5329010
 silesia.tar,                        level 3,                            zstdcli,                            4854164
 silesia.tar,                        level 4,                            zstdcli,                            4792352
-silesia.tar,                        level 5,                            zstdcli,                            4680075
-silesia.tar,                        level 6,                            zstdcli,                            4615668
-silesia.tar,                        level 7,                            zstdcli,                            4581604
-silesia.tar,                        level 9,                            zstdcli,                            4555249
+silesia.tar,                        level 5,                            zstdcli,                            4679860
+silesia.tar,                        level 6,                            zstdcli,                            4615355
+silesia.tar,                        level 7,                            zstdcli,                            4581791
+silesia.tar,                        level 9,                            zstdcli,                            4555452
 silesia.tar,                        level 13,                           zstdcli,                            4502960
 silesia.tar,                        level 16,                           zstdcli,                            4360550
 silesia.tar,                        level 19,                           zstdcli,                            4265915
@@ -143,7 +143,7 @@ silesia.tar,                        multithreaded long distance mode,   zstdcli,
 silesia.tar,                        small window log,                   zstdcli,                            7100701
 silesia.tar,                        small hash log,                     zstdcli,                            6529264
 silesia.tar,                        small chain log,                    zstdcli,                            4917022
-silesia.tar,                        explicit params,                    zstdcli,                            4820917
+silesia.tar,                        explicit params,                    zstdcli,                            4821112
 silesia.tar,                        uncompressed literals,              zstdcli,                            5122571
 silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4310145
 silesia.tar,                        huffman literals,                   zstdcli,                            5342074
@@ -235,18 +235,18 @@ silesia,                            level 0,                            advanced
 silesia,                            level 1,                            advanced one pass,                  5306632
 silesia,                            level 3,                            advanced one pass,                  4842075
 silesia,                            level 4,                            advanced one pass,                  4779186
-silesia,                            level 5 row 1,                      advanced one pass,                  4667825
-silesia,                            level 5 row 2,                      advanced one pass,                  4670136
-silesia,                            level 5,                            advanced one pass,                  4667825
-silesia,                            level 6,                            advanced one pass,                  4604587
-silesia,                            level 7 row 1,                      advanced one pass,                  4569976
-silesia,                            level 7 row 2,                      advanced one pass,                  4564868
-silesia,                            level 7,                            advanced one pass,                  4569976
-silesia,                            level 9,                            advanced one pass,                  4545538
-silesia,                            level 11 row 1,                     advanced one pass,                  4505351
-silesia,                            level 11 row 2,                     advanced one pass,                  4503116
-silesia,                            level 12 row 1,                     advanced one pass,                  4505351
-silesia,                            level 12 row 2,                     advanced one pass,                  4503116
+silesia,                            level 5 row 1,                      advanced one pass,                  4667668
+silesia,                            level 5 row 2,                      advanced one pass,                  4670326
+silesia,                            level 5,                            advanced one pass,                  4667668
+silesia,                            level 6,                            advanced one pass,                  4604351
+silesia,                            level 7 row 1,                      advanced one pass,                  4570271
+silesia,                            level 7 row 2,                      advanced one pass,                  4565169
+silesia,                            level 7,                            advanced one pass,                  4570271
+silesia,                            level 9,                            advanced one pass,                  4545850
+silesia,                            level 11 row 1,                     advanced one pass,                  4505658
+silesia,                            level 11 row 2,                     advanced one pass,                  4503429
+silesia,                            level 12 row 1,                     advanced one pass,                  4505658
+silesia,                            level 12 row 2,                     advanced one pass,                  4503429
 silesia,                            level 13,                           advanced one pass,                  4493990
 silesia,                            level 16,                           advanced one pass,                  4360041
 silesia,                            level 19,                           advanced one pass,                  4296055
@@ -257,7 +257,7 @@ silesia,                            multithreaded long distance mode,   advanced
 silesia,                            small window log,                   advanced one pass,                  7095000
 silesia,                            small hash log,                     advanced one pass,                  6526141
 silesia,                            small chain log,                    advanced one pass,                  4912197
-silesia,                            explicit params,                    advanced one pass,                  4795654
+silesia,                            explicit params,                    advanced one pass,                  4795840
 silesia,                            uncompressed literals,              advanced one pass,                  5120566
 silesia,                            uncompressed literals optimal,      advanced one pass,                  4319518
 silesia,                            huffman literals,                   advanced one pass,                  5321369
@@ -269,18 +269,18 @@ silesia.tar,                        level 0,                            advanced
 silesia.tar,                        level 1,                            advanced one pass,                  5327717
 silesia.tar,                        level 3,                            advanced one pass,                  4854086
 silesia.tar,                        level 4,                            advanced one pass,                  4791503
-silesia.tar,                        level 5 row 1,                      advanced one pass,                  4679219
-silesia.tar,                        level 5 row 2,                      advanced one pass,                  4682161
-silesia.tar,                        level 5,                            advanced one pass,                  4679219
-silesia.tar,                        level 6,                            advanced one pass,                  4614874
-silesia.tar,                        level 7 row 1,                      advanced one pass,                  4579642
-silesia.tar,                        level 7 row 2,                      advanced one pass,                  4575393
-silesia.tar,                        level 7,                            advanced one pass,                  4579642
-silesia.tar,                        level 9,                            advanced one pass,                  4555245
-silesia.tar,                        level 11 row 1,                     advanced one pass,                  4514753
-silesia.tar,                        level 11 row 2,                     advanced one pass,                  4513604
-silesia.tar,                        level 12 row 1,                     advanced one pass,                  4514309
-silesia.tar,                        level 12 row 2,                     advanced one pass,                  4513797
+silesia.tar,                        level 5 row 1,                      advanced one pass,                  4679004
+silesia.tar,                        level 5 row 2,                      advanced one pass,                  4682334
+silesia.tar,                        level 5,                            advanced one pass,                  4679004
+silesia.tar,                        level 6,                            advanced one pass,                  4614561
+silesia.tar,                        level 7 row 1,                      advanced one pass,                  4579828
+silesia.tar,                        level 7 row 2,                      advanced one pass,                  4575602
+silesia.tar,                        level 7,                            advanced one pass,                  4579828
+silesia.tar,                        level 9,                            advanced one pass,                  4555448
+silesia.tar,                        level 11 row 1,                     advanced one pass,                  4514962
+silesia.tar,                        level 11 row 2,                     advanced one pass,                  4513816
+silesia.tar,                        level 12 row 1,                     advanced one pass,                  4514517
+silesia.tar,                        level 12 row 2,                     advanced one pass,                  4514007
 silesia.tar,                        level 13,                           advanced one pass,                  4502956
 silesia.tar,                        level 16,                           advanced one pass,                  4360546
 silesia.tar,                        level 19,                           advanced one pass,                  4265911
@@ -291,7 +291,7 @@ silesia.tar,                        multithreaded long distance mode,   advanced
 silesia.tar,                        small window log,                   advanced one pass,                  7100655
 silesia.tar,                        small hash log,                     advanced one pass,                  6529206
 silesia.tar,                        small chain log,                    advanced one pass,                  4917041
-silesia.tar,                        explicit params,                    advanced one pass,                  4807078
+silesia.tar,                        explicit params,                    advanced one pass,                  4807274
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5122473
 silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4310141
 silesia.tar,                        huffman literals,                   advanced one pass,                  5341705
@@ -553,18 +553,18 @@ silesia,                            level 0,                            advanced
 silesia,                            level 1,                            advanced one pass small out,        5306632
 silesia,                            level 3,                            advanced one pass small out,        4842075
 silesia,                            level 4,                            advanced one pass small out,        4779186
-silesia,                            level 5 row 1,                      advanced one pass small out,        4667825
-silesia,                            level 5 row 2,                      advanced one pass small out,        4670136
-silesia,                            level 5,                            advanced one pass small out,        4667825
-silesia,                            level 6,                            advanced one pass small out,        4604587
-silesia,                            level 7 row 1,                      advanced one pass small out,        4569976
-silesia,                            level 7 row 2,                      advanced one pass small out,        4564868
-silesia,                            level 7,                            advanced one pass small out,        4569976
-silesia,                            level 9,                            advanced one pass small out,        4545538
-silesia,                            level 11 row 1,                     advanced one pass small out,        4505351
-silesia,                            level 11 row 2,                     advanced one pass small out,        4503116
-silesia,                            level 12 row 1,                     advanced one pass small out,        4505351
-silesia,                            level 12 row 2,                     advanced one pass small out,        4503116
+silesia,                            level 5 row 1,                      advanced one pass small out,        4667668
+silesia,                            level 5 row 2,                      advanced one pass small out,        4670326
+silesia,                            level 5,                            advanced one pass small out,        4667668
+silesia,                            level 6,                            advanced one pass small out,        4604351
+silesia,                            level 7 row 1,                      advanced one pass small out,        4570271
+silesia,                            level 7 row 2,                      advanced one pass small out,        4565169
+silesia,                            level 7,                            advanced one pass small out,        4570271
+silesia,                            level 9,                            advanced one pass small out,        4545850
+silesia,                            level 11 row 1,                     advanced one pass small out,        4505658
+silesia,                            level 11 row 2,                     advanced one pass small out,        4503429
+silesia,                            level 12 row 1,                     advanced one pass small out,        4505658
+silesia,                            level 12 row 2,                     advanced one pass small out,        4503429
 silesia,                            level 13,                           advanced one pass small out,        4493990
 silesia,                            level 16,                           advanced one pass small out,        4360041
 silesia,                            level 19,                           advanced one pass small out,        4296055
@@ -575,7 +575,7 @@ silesia,                            multithreaded long distance mode,   advanced
 silesia,                            small window log,                   advanced one pass small out,        7095000
 silesia,                            small hash log,                     advanced one pass small out,        6526141
 silesia,                            small chain log,                    advanced one pass small out,        4912197
-silesia,                            explicit params,                    advanced one pass small out,        4795654
+silesia,                            explicit params,                    advanced one pass small out,        4795840
 silesia,                            uncompressed literals,              advanced one pass small out,        5120566
 silesia,                            uncompressed literals optimal,      advanced one pass small out,        4319518
 silesia,                            huffman literals,                   advanced one pass small out,        5321369
@@ -587,18 +587,18 @@ silesia.tar,                        level 0,                            advanced
 silesia.tar,                        level 1,                            advanced one pass small out,        5327717
 silesia.tar,                        level 3,                            advanced one pass small out,        4854086
 silesia.tar,                        level 4,                            advanced one pass small out,        4791503
-silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4679219
-silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4682161
-silesia.tar,                        level 5,                            advanced one pass small out,        4679219
-silesia.tar,                        level 6,                            advanced one pass small out,        4614874
-silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4579642
-silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4575393
-silesia.tar,                        level 7,                            advanced one pass small out,        4579642
-silesia.tar,                        level 9,                            advanced one pass small out,        4555245
-silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4514753
-silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4513604
-silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4514309
-silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4513797
+silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4679004
+silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4682334
+silesia.tar,                        level 5,                            advanced one pass small out,        4679004
+silesia.tar,                        level 6,                            advanced one pass small out,        4614561
+silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4579828
+silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4575602
+silesia.tar,                        level 7,                            advanced one pass small out,        4579828
+silesia.tar,                        level 9,                            advanced one pass small out,        4555448
+silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4514962
+silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4513816
+silesia.tar,                        level 12 row 1,                     advanced one pass small out,        4514517
+silesia.tar,                        level 12 row 2,                     advanced one pass small out,        4514007
 silesia.tar,                        level 13,                           advanced one pass small out,        4502956
 silesia.tar,                        level 16,                           advanced one pass small out,        4360546
 silesia.tar,                        level 19,                           advanced one pass small out,        4265911
@@ -609,7 +609,7 @@ silesia.tar,                        multithreaded long distance mode,   advanced
 silesia.tar,                        small window log,                   advanced one pass small out,        7100655
 silesia.tar,                        small hash log,                     advanced one pass small out,        6529206
 silesia.tar,                        small chain log,                    advanced one pass small out,        4917041
-silesia.tar,                        explicit params,                    advanced one pass small out,        4807078
+silesia.tar,                        explicit params,                    advanced one pass small out,        4807274
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5122473
 silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4310141
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5341705
@@ -871,18 +871,18 @@ silesia,                            level 0,                            advanced
 silesia,                            level 1,                            advanced streaming,                 5306388
 silesia,                            level 3,                            advanced streaming,                 4842075
 silesia,                            level 4,                            advanced streaming,                 4779186
-silesia,                            level 5 row 1,                      advanced streaming,                 4667825
-silesia,                            level 5 row 2,                      advanced streaming,                 4670136
-silesia,                            level 5,                            advanced streaming,                 4667825
-silesia,                            level 6,                            advanced streaming,                 4604587
-silesia,                            level 7 row 1,                      advanced streaming,                 4569976
-silesia,                            level 7 row 2,                      advanced streaming,                 4564868
-silesia,                            level 7,                            advanced streaming,                 4569976
-silesia,                            level 9,                            advanced streaming,                 4545538
-silesia,                            level 11 row 1,                     advanced streaming,                 4505351
-silesia,                            level 11 row 2,                     advanced streaming,                 4503116
-silesia,                            level 12 row 1,                     advanced streaming,                 4505351
-silesia,                            level 12 row 2,                     advanced streaming,                 4503116
+silesia,                            level 5 row 1,                      advanced streaming,                 4667668
+silesia,                            level 5 row 2,                      advanced streaming,                 4670326
+silesia,                            level 5,                            advanced streaming,                 4667668
+silesia,                            level 6,                            advanced streaming,                 4604351
+silesia,                            level 7 row 1,                      advanced streaming,                 4570271
+silesia,                            level 7 row 2,                      advanced streaming,                 4565169
+silesia,                            level 7,                            advanced streaming,                 4570271
+silesia,                            level 9,                            advanced streaming,                 4545850
+silesia,                            level 11 row 1,                     advanced streaming,                 4505658
+silesia,                            level 11 row 2,                     advanced streaming,                 4503429
+silesia,                            level 12 row 1,                     advanced streaming,                 4505658
+silesia,                            level 12 row 2,                     advanced streaming,                 4503429
 silesia,                            level 13,                           advanced streaming,                 4493990
 silesia,                            level 16,                           advanced streaming,                 4360041
 silesia,                            level 19,                           advanced streaming,                 4296055
@@ -893,7 +893,7 @@ silesia,                            multithreaded long distance mode,   advanced
 silesia,                            small window log,                   advanced streaming,                 7111103
 silesia,                            small hash log,                     advanced streaming,                 6526141
 silesia,                            small chain log,                    advanced streaming,                 4912197
-silesia,                            explicit params,                    advanced streaming,                 4795672
+silesia,                            explicit params,                    advanced streaming,                 4795857
 silesia,                            uncompressed literals,              advanced streaming,                 5120566
 silesia,                            uncompressed literals optimal,      advanced streaming,                 4319518
 silesia,                            huffman literals,                   advanced streaming,                 5321370
@@ -905,18 +905,18 @@ silesia.tar,                        level 0,                            advanced
 silesia.tar,                        level 1,                            advanced streaming,                 5327708
 silesia.tar,                        level 3,                            advanced streaming,                 4859271
 silesia.tar,                        level 4,                            advanced streaming,                 4797470
-silesia.tar,                        level 5 row 1,                      advanced streaming,                 4679226
-silesia.tar,                        level 5 row 2,                      advanced streaming,                 4682169
-silesia.tar,                        level 5,                            advanced streaming,                 4679226
-silesia.tar,                        level 6,                            advanced streaming,                 4614873
-silesia.tar,                        level 7 row 1,                      advanced streaming,                 4579641
-silesia.tar,                        level 7 row 2,                      advanced streaming,                 4575394
-silesia.tar,                        level 7,                            advanced streaming,                 4579641
-silesia.tar,                        level 9,                            advanced streaming,                 4555246
-silesia.tar,                        level 11 row 1,                     advanced streaming,                 4514754
-silesia.tar,                        level 11 row 2,                     advanced streaming,                 4513604
-silesia.tar,                        level 12 row 1,                     advanced streaming,                 4514309
-silesia.tar,                        level 12 row 2,                     advanced streaming,                 4513797
+silesia.tar,                        level 5 row 1,                      advanced streaming,                 4679020
+silesia.tar,                        level 5 row 2,                      advanced streaming,                 4682355
+silesia.tar,                        level 5,                            advanced streaming,                 4679020
+silesia.tar,                        level 6,                            advanced streaming,                 4614558
+silesia.tar,                        level 7 row 1,                      advanced streaming,                 4579823
+silesia.tar,                        level 7 row 2,                      advanced streaming,                 4575601
+silesia.tar,                        level 7,                            advanced streaming,                 4579823
+silesia.tar,                        level 9,                            advanced streaming,                 4555445
+silesia.tar,                        level 11 row 1,                     advanced streaming,                 4514959
+silesia.tar,                        level 11 row 2,                     advanced streaming,                 4513810
+silesia.tar,                        level 12 row 1,                     advanced streaming,                 4514514
+silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514003
 silesia.tar,                        level 13,                           advanced streaming,                 4502956
 silesia.tar,                        level 16,                           advanced streaming,                 4360546
 silesia.tar,                        level 19,                           advanced streaming,                 4265911
@@ -927,7 +927,7 @@ silesia.tar,                        multithreaded long distance mode,   advanced
 silesia.tar,                        small window log,                   advanced streaming,                 7117559
 silesia.tar,                        small hash log,                     advanced streaming,                 6529209
 silesia.tar,                        small chain log,                    advanced streaming,                 4917021
-silesia.tar,                        explicit params,                    advanced streaming,                 4807102
+silesia.tar,                        explicit params,                    advanced streaming,                 4807288
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5127423
 silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4310141
 silesia.tar,                        huffman literals,                   advanced streaming,                 5341712
@@ -1189,10 +1189,10 @@ silesia,                            level 0,                            old stre
 silesia,                            level 1,                            old streaming,                      5306388
 silesia,                            level 3,                            old streaming,                      4842075
 silesia,                            level 4,                            old streaming,                      4779186
-silesia,                            level 5,                            old streaming,                      4667825
-silesia,                            level 6,                            old streaming,                      4604587
-silesia,                            level 7,                            old streaming,                      4569976
-silesia,                            level 9,                            old streaming,                      4545538
+silesia,                            level 5,                            old streaming,                      4667668
+silesia,                            level 6,                            old streaming,                      4604351
+silesia,                            level 7,                            old streaming,                      4570271
+silesia,                            level 9,                            old streaming,                      4545850
 silesia,                            level 13,                           old streaming,                      4493990
 silesia,                            level 16,                           old streaming,                      4360041
 silesia,                            level 19,                           old streaming,                      4296055
@@ -1207,10 +1207,10 @@ silesia.tar,                        level 0,                            old stre
 silesia.tar,                        level 1,                            old streaming,                      5327708
 silesia.tar,                        level 3,                            old streaming,                      4859271
 silesia.tar,                        level 4,                            old streaming,                      4797470
-silesia.tar,                        level 5,                            old streaming,                      4679226
-silesia.tar,                        level 6,                            old streaming,                      4614873
-silesia.tar,                        level 7,                            old streaming,                      4579641
-silesia.tar,                        level 9,                            old streaming,                      4555246
+silesia.tar,                        level 5,                            old streaming,                      4679020
+silesia.tar,                        level 6,                            old streaming,                      4614558
+silesia.tar,                        level 7,                            old streaming,                      4579823
+silesia.tar,                        level 9,                            old streaming,                      4555445
 silesia.tar,                        level 13,                           old streaming,                      4502956
 silesia.tar,                        level 16,                           old streaming,                      4360546
 silesia.tar,                        level 19,                           old streaming,                      4265911
@@ -1291,10 +1291,10 @@ silesia,                            level 0,                            old stre
 silesia,                            level 1,                            old streaming advanced,             5306388
 silesia,                            level 3,                            old streaming advanced,             4842075
 silesia,                            level 4,                            old streaming advanced,             4779186
-silesia,                            level 5,                            old streaming advanced,             4667825
-silesia,                            level 6,                            old streaming advanced,             4604587
-silesia,                            level 7,                            old streaming advanced,             4569976
-silesia,                            level 9,                            old streaming advanced,             4545538
+silesia,                            level 5,                            old streaming advanced,             4667668
+silesia,                            level 6,                            old streaming advanced,             4604351
+silesia,                            level 7,                            old streaming advanced,             4570271
+silesia,                            level 9,                            old streaming advanced,             4545850
 silesia,                            level 13,                           old streaming advanced,             4493990
 silesia,                            level 16,                           old streaming advanced,             4360041
 silesia,                            level 19,                           old streaming advanced,             4296055
@@ -1305,7 +1305,7 @@ silesia,                            multithreaded long distance mode,   old stre
 silesia,                            small window log,                   old streaming advanced,             7111103
 silesia,                            small hash log,                     old streaming advanced,             6526141
 silesia,                            small chain log,                    old streaming advanced,             4912197
-silesia,                            explicit params,                    old streaming advanced,             4795672
+silesia,                            explicit params,                    old streaming advanced,             4795857
 silesia,                            uncompressed literals,              old streaming advanced,             4842075
 silesia,                            uncompressed literals optimal,      old streaming advanced,             4296055
 silesia,                            huffman literals,                   old streaming advanced,             6172207
@@ -1317,10 +1317,10 @@ silesia.tar,                        level 0,                            old stre
 silesia.tar,                        level 1,                            old streaming advanced,             5327708
 silesia.tar,                        level 3,                            old streaming advanced,             4859271
 silesia.tar,                        level 4,                            old streaming advanced,             4797470
-silesia.tar,                        level 5,                            old streaming advanced,             4679226
-silesia.tar,                        level 6,                            old streaming advanced,             4614873
-silesia.tar,                        level 7,                            old streaming advanced,             4579641
-silesia.tar,                        level 9,                            old streaming advanced,             4555246
+silesia.tar,                        level 5,                            old streaming advanced,             4679020
+silesia.tar,                        level 6,                            old streaming advanced,             4614558
+silesia.tar,                        level 7,                            old streaming advanced,             4579823
+silesia.tar,                        level 9,                            old streaming advanced,             4555445
 silesia.tar,                        level 13,                           old streaming advanced,             4502956
 silesia.tar,                        level 16,                           old streaming advanced,             4360546
 silesia.tar,                        level 19,                           old streaming advanced,             4265911
@@ -1331,7 +1331,7 @@ silesia.tar,                        multithreaded long distance mode,   old stre
 silesia.tar,                        small window log,                   old streaming advanced,             7117562
 silesia.tar,                        small hash log,                     old streaming advanced,             6529209
 silesia.tar,                        small chain log,                    old streaming advanced,             4917021
-silesia.tar,                        explicit params,                    old streaming advanced,             4807102
+silesia.tar,                        explicit params,                    old streaming advanced,             4807288
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4859271
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4265911
 silesia.tar,                        huffman literals,                   old streaming advanced,             6179056


### PR DESCRIPTION
Every 256 bytes the lazy match finders process without finding a match, they will increase their step size by 1. So for bytes [0, 256) they search every position, for bytes [256, 512) they search every other position, and so on. However, they currently still insert every position into their hash tables. This is different from fast & dfast, which only insert the positions they search.

This PR changes that, so now after we've searched 2KB without finding any matches, at which point we'll only be searching one in 9 positions, we'll stop inserting every position, and only insert the positions we search. The exact cutoff of 2KB isn't terribly important, I've just selected a cutoff that is reasonably large, to minimize the impact on "normal" data.

This PR only adds skipping to greedy, lazy, and lazy2, but does not touch btlazy2.

| Dataset | Level | Compiler     | CSize ∆ | Speed ∆ |
|---------|-------|--------------|---------|---------|
| Random  |     5 | clang-14.0.6 |    0.0% |   +704% |
| Random  |     5 | gcc-12.2.0   |    0.0% |   +670% |
| Random  |     7 | clang-14.0.6 |    0.0% |   +679% |
| Random  |     7 | gcc-12.2.0   |    0.0% |   +657% |
| Random  |    12 | clang-14.0.6 |    0.0% |  +1355% |
| Random  |    12 | gcc-12.2.0   |    0.0% |  +1331% |
| Silesia |     5 | clang-14.0.6 | +0.002% |  +0.35% |
| Silesia |     5 | gcc-12.2.0   | +0.002% |  +2.45% |
| Silesia |     7 | clang-14.0.6 | +0.001% |  -1.40% |
| Silesia |     7 | gcc-12.2.0   | +0.007% |  +0.13% |
| Silesia |    12 | clang-14.0.6 | +0.011% | +22.70% |
| Silesia |    12 | gcc-12.2.0   | +0.011% |  -6.68% |
| Enwik8  |     5 | clang-14.0.6 |    0.0% |  -1.02% |
| Enwik8  |     5 | gcc-12.2.0   |    0.0% |  +0.34% |
| Enwik8  |     7 | clang-14.0.6 |    0.0% |  -1.22% |
| Enwik8  |     7 | gcc-12.2.0   |    0.0% |  -0.72% |
| Enwik8  |    12 | clang-14.0.6 |    0.0% | +26.19% |
| Enwik8  |    12 | gcc-12.2.0   |    0.0% |  -5.70% |

The speed difference for clang at level 12 is real, but is probably caused by some sort of alignment or codegen issues. clang is significantly slower than gcc before this PR, but gets up to parity with it.

I also measured the ratio difference for the HC match finder, and it looks basically the same as the row-based match finder. The speedup on random data looks similar. And performance is about neutral, without the big difference at level 12 for either clang or gcc.

Fixes #3539.