### PR TITLE
Fix a bug in the CLI tests newline processing, then simplify it further

### DIFF
--- a/tests/cli-tests/run.py
+++ b/tests/cli-tests/run.py
@@ -114,20 +114,12 @@ def pop_line(data: bytes) -> typing.Tuple[typing.Optional[bytes], bytes]:
     if data == b'':
         return (None, data)
 
-    newline_idx = data.find(b"\n")
-    if newline_idx == -1:
-        end_idx = len(data)
-    else:
-        end_idx = newline_idx + 1
+    parts = data.split(NEWLINE, maxsplit=1)
+    line = parts[0] + NEWLINE
+    if len(parts) == 1:
+        return line, b''
 
-    line = data[:end_idx]
-    data = data[end_idx:]
-
-    assert len(line) != 0
-    if not line.endswith(NEWLINE):
-        line += NEWLINE
-
-    return (line, data)
+    return line, parts[1]
 
 
 def glob_line_matches(actual: bytes, expect: bytes) -> bool:

--- a/tests/cli-tests/run.py
+++ b/tests/cli-tests/run.py
@@ -109,7 +109,7 @@ def pop_line(data: bytes) -> typing.Tuple[typing.Optional[bytes], bytes]:
     the first line always ends in a :\n:, even if it is the last line and :data:
     doesn't end in :\n:.
     """
-    NEWLINE = b"\n"[0]
+    NEWLINE = b"\n"
 
     if data == b'':
         return (None, data)
@@ -124,7 +124,7 @@ def pop_line(data: bytes) -> typing.Tuple[typing.Optional[bytes], bytes]:
     data = data[end_idx:]
 
     assert len(line) != 0
-    if line[-1] != NEWLINE:
+    if not line.endswith(NEWLINE):
         line += NEWLINE
 
     return (line, data)


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining zstd!

What do you think about the attached trivial changes? The first one fixes a type mismatch bug: an element of a bytes array is an int value, so it cannot be appended to a bytes array. The second one uses `.split(..., maxsplit=1)` to simplify the line splitting code.

Thanks again, and keep up the great work!

G'luck,
Peter
