### PR TITLE
[contrib/pzstd] Select `-std=c++11` When Default is Older

### DIFF
--- a/contrib/pzstd/Makefile
+++ b/contrib/pzstd/Makefile
@@ -37,23 +37,10 @@ CFLAGS   += -Wno-deprecated-declarations
 PZSTD_INC  = -I$(ZSTDDIR) -I$(ZSTDDIR)/common -I$(PROGDIR) -I.
 GTEST_INC  = -isystem googletest/googletest/include
 
-# Select newest C++ standard available, minimum C++11
-ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++23 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
-PZSTD_CXX_STD := -std=c++23
-else
-ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++20 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
-PZSTD_CXX_STD := -std=c++20
-else
-ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++17 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
-PZSTD_CXX_STD := -std=c++17
-else
-ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++14 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
-PZSTD_CXX_STD := -std=c++14
-else
+# If default C++ version is older than C++11, explicitly set C++11, which is the
+# minimum required by the code.
+ifeq ($(shell echo "\043if __cplusplus < 201103L\n\043error\n\043endif" | $(CXX) -x c++ -Werror -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),0)
 PZSTD_CXX_STD := -std=c++11
-endif
-endif
-endif
 endif
 
 PZSTD_CPPFLAGS  = $(PZSTD_INC)

--- a/contrib/pzstd/Makefile
+++ b/contrib/pzstd/Makefile
@@ -37,10 +37,29 @@ CFLAGS   += -Wno-deprecated-declarations
 PZSTD_INC  = -I$(ZSTDDIR) -I$(ZSTDDIR)/common -I$(PROGDIR) -I.
 GTEST_INC  = -isystem googletest/googletest/include
 
+# Select newest C++ standard available, minimum C++11
+ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++23 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
+PZSTD_CXX_STD := -std=c++23
+else
+ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++20 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
+PZSTD_CXX_STD := -std=c++20
+else
+ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++17 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
+PZSTD_CXX_STD := -std=c++17
+else
+ifeq ($(shell echo | $(CXX) -x c++ -Werror -std=c++14 -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),1)
+PZSTD_CXX_STD := -std=c++14
+else
+PZSTD_CXX_STD := -std=c++11
+endif
+endif
+endif
+endif
+
 PZSTD_CPPFLAGS  = $(PZSTD_INC)
 PZSTD_CCXXFLAGS =
 PZSTD_CFLAGS    = $(PZSTD_CCXXFLAGS)
-PZSTD_CXXFLAGS  = $(PZSTD_CCXXFLAGS) -std=c++11
+PZSTD_CXXFLAGS  = $(PZSTD_CCXXFLAGS) $(PZSTD_CXX_STD)
 PZSTD_LDFLAGS   =
 EXTRA_FLAGS     =
 ALL_CFLAGS      = $(EXTRA_FLAGS) $(CPPFLAGS) $(PZSTD_CPPFLAGS) $(CFLAGS)   $(PZSTD_CFLAGS)


### PR DESCRIPTION
Rather than remove the flag entirely, as proposed in #3499, this commit uses the newest C++ standard the compiler supports. This retains the selection of using only standardized features (excluding GNU extensions) and keeps the recency requirements of the codebase explicit.

Tested with various versions of `g++` and `clang++`.