### PR TITLE
fix #3583

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ cli: mmap large dictionaries to save memory, by @daniellerozenblit
 cli: improve speed of --patch-from mode (~+50%) (#3545) by @daniellerozenblit
 cli: improve i/o speed (~+10%) when processing lots of small files (#3479) by @felixhandte
 cli: zstd no longer crashes when requested to write into write-protected directory (#3541) by @felixhandte
-cli: fix decompression into block device using -o (#3584, @Cyan4973) reported by @georgmu
+cli: fix decompression into block device using -o, reported by @georgmu (#3583)
 build: fix zstd CLI compiled with lzma support but not zlib support (#3494) by @Hello71
 build: fix cmake does no longer require 3.18 as minimum version (#3510) by @kou
 build: fix MSVC+ClangCL linking issue (#3569) by @tru

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -604,11 +604,11 @@ FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
 
     isDstRegFile = UTIL_isRegularFile(dstFileName);  /* invoke once */
     if (prefs->sparseFileSupport == 1) {
+        prefs->sparseFileSupport = ZSTD_SPARSE_DEFAULT;
         if (!isDstRegFile) {
             prefs->sparseFileSupport = 0;
             DISPLAYLEVEL(4, "Sparse File Support is disabled when output is not a file \n");
         }
-        prefs->sparseFileSupport = ZSTD_SPARSE_DEFAULT;
     }
 
     if (isDstRegFile) {


### PR DESCRIPTION
As reported by @georgmu,
the previous fix is undone by the later initialization. 
Switch order, so that initialization is adjusted by special case.