### PR TITLE
add makefile entry to build fat binary on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,15 @@ uninstall:
 travis-install:
 	$(MAKE) install PREFIX=~/install_test_dir
 
+.PHONY: clangbuild-darwin-fat
+clangbuild-darwin-fat: clean
+	clang -v
+	CXX=clang++ CC=clang CFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation -arch arm64" $(MAKE) zstd-release
+	mv programs/zstd programs/zstd_arm64
+	CXX=clang++ CC=clang CFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation -arch x86_64" $(MAKE) zstd-release
+	mv programs/zstd programs/zstd_x64
+	lipo -create programs/zstd_x64 programs/zstd_arm64 -output programs/zstd
+
 .PHONY: gcc5build gcc6build gcc7build clangbuild m32build armbuild aarch64build ppcbuild ppc64build
 gcc5build: clean
 	gcc-5 -v

--- a/programs/.gitignore
+++ b/programs/.gitignore
@@ -9,6 +9,8 @@ zstd-small
 zstd-nolegacy
 zstd-dictBuilder
 zstd-dll
+zstd_arm64
+zstd_x64
 
 # Object files
 *.o


### PR DESCRIPTION
I had the need for a cli binary that runs on both Intel and ARM Macs. I figured I'd contribute my success back to the main project in hopes that it'll help someone else too.

I admit I have little familiarity with makefiles, so if there are any changes needed for style or anything, I'm happy to oblige. All I can say is that it works and I feel like I got close to what would be desired for makefile style presented.