### PR TITLE
fix clobbering RBX register in LTO mode within ZSTD_cpuid

### DIFF
--- a/lib/common/cpu.h
+++ b/lib/common/cpu.h
@@ -18,8 +18,12 @@
 
 #include "mem.h"
 
-#ifdef _MSC_VER
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#if defined(_MSC_VER) && !defined(__clang__)
 #include <intrin.h>
+#else
+#include <cpuid.h>
+#endif
 #endif
 
 typedef struct {
@@ -34,67 +38,34 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
     U32 f1d = 0;
     U32 f7b = 0;
     U32 f7c = 0;
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#if defined(_MSC_VER) && !defined(__clang__)
     int reg[4];
     __cpuid((int*)reg, 0);
+#else
+    U32 reg[4];
+    __cpuid(0, reg[0], reg[1], reg[2], reg[3]);
+#endif
     {
-        int const n = reg[0];
+        U32 n = (U32)reg[0];
         if (n >= 1) {
+#if defined(_MSC_VER) && !defined(__clang__)
             __cpuid((int*)reg, 1);
+#else
+            __cpuid(1, reg[0], reg[1], reg[2], reg[3]);
+#endif
             f1c = (U32)reg[2];
             f1d = (U32)reg[3];
         }
         if (n >= 7) {
+#if defined(_MSC_VER) && !defined(__clang__)
             __cpuidex((int*)reg, 7, 0);
+#else
+            __cpuid_count(7, 0, reg[0], reg[1], reg[2], reg[3]);
+#endif
             f7b = (U32)reg[1];
             f7c = (U32)reg[2];
         }
-    }
-#elif defined(__i386__) && defined(__PIC__) && !defined(__clang__) && defined(__GNUC__)
-    /* The following block like the normal cpuid branch below, but gcc
-     * reserves ebx for use of its pic register so we must specially
-     * handle the save and restore to avoid clobbering the register
-     */
-    U32 n;
-    __asm__(
-        "pushl %%ebx\n\t"
-        "cpuid\n\t"
-        "popl %%ebx\n\t"
-        : "=a"(n)
-        : "a"(0)
-        : "ecx", "edx");
-    if (n >= 1) {
-      U32 f1a;
-      __asm__(
-          "pushl %%ebx\n\t"
-          "cpuid\n\t"
-          "popl %%ebx\n\t"
-          : "=a"(f1a), "=c"(f1c), "=d"(f1d)
-          : "a"(1));
-    }
-    if (n >= 7) {
-      __asm__(
-          "pushl %%ebx\n\t"
-          "cpuid\n\t"
-          "movl %%ebx, %%eax\n\t"
-          "popl %%ebx"
-          : "=a"(f7b), "=c"(f7c)
-          : "a"(7), "c"(0)
-          : "edx");
-    }
-#elif defined(__x86_64__) || defined(_M_X64) || defined(__i386__)
-    U32 n;
-    __asm__("cpuid" : "=a"(n) : "a"(0) : "ebx", "ecx", "edx");
-    if (n >= 1) {
-      U32 f1a;
-      __asm__("cpuid" : "=a"(f1a), "=c"(f1c), "=d"(f1d) : "a"(1) : "ebx");
-    }
-    if (n >= 7) {
-      U32 f7a;
-      __asm__("cpuid"
-              : "=a"(f7a), "=b"(f7b), "=c"(f7c)
-              : "a"(7), "c"(0)
-              : "edx");
     }
 #endif
     {


### PR DESCRIPTION
Just rewrite assembly to using std intrinsics for all compilers. It doing right thing by default (e.g. preserving aftermentioned register).

Bug actually was caught on certain Japan's console in LTO mode (PIC is also turned on) but I suspect that same would be true for other platforms as well (e e.g. Linux+PIC+LTO)