### PR TITLE
changed LLU suffix into ULL for Visual 2012 and lower

### DIFF
--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -228,7 +228,7 @@ ZSTDLIB_API size_t ZSTD_findFrameCompressedSize(const void* src, size_t srcSize)
  * for example to size a static array on stack.
  * Will produce constant value 0 if srcSize too large.
  */
-#define ZSTD_MAX_INPUT_SIZE ((sizeof(size_t)==8) ? 0xFF00FF00FF00FF00LLU : 0xFF00FF00U)
+#define ZSTD_MAX_INPUT_SIZE ((sizeof(size_t)==8) ? 0xFF00FF00FF00FF00ULL : 0xFF00FF00U)
 #define ZSTD_COMPRESSBOUND(srcSize)   (((size_t)(srcSize) >= ZSTD_MAX_INPUT_SIZE) ? 0 : (srcSize) + ((srcSize)>>8) + (((srcSize) < (128<<10)) ? (((128<<10) - (srcSize)) >> 11) /* margin, from 64 to 0 */ : 0))  /* this formula ensures that bound(A) + bound(B) <= bound(A+B) as long as A and B >= 128 KB */
 ZSTDLIB_API size_t ZSTD_compressBound(size_t srcSize); /*!< maximum compressed size in worst case single-pass scenario */
 /* ZSTD_isError() :


### PR DESCRIPTION
both suffixes are supposed to be valid,
but for some reason, Visual 2012 and lower only support `ULL`
(Newer version of Visual work fine with both suffixes).

fix #3663 and #3647 

Note : it's a simple fix.
It would be better if we could deploy a VS2012 test on Github Actions to continue testing this property,
but it's difficult to do, since VS2012 is not supported by Github Actions.