### PR TITLE
detect extraneous bytes in the Sequences section

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -720,6 +720,8 @@ size_t ZSTD_decodeSeqHeaders(ZSTD_DCtx* dctx, int* nbSeqPtr,
 
     if (nbSeq == 0) {
         /* No sequence : section ends immediately */
+        RETURN_ERROR_IF(ip != iend, corruption_detected,
+            "extraneous data present in the Sequences section");
         return (size_t)(ip - istart);
     }
 

--- a/tests/cli-tests/decompression/detectErrors.sh
+++ b/tests/cli-tests/decompression/detectErrors.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+GOLDEN_DIR="$ZSTD_REPO_DIR/tests/golden-decompression-errors/"
+
+for file in "$GOLDEN_DIR"/*; do
+    zstd -t $file && die "should have detected an error"
+done
+exit 0
+

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -444,6 +444,11 @@ $DIFF -s tmp1 tmp
 touch tmp_empty
 zstd -d -o tmp2 "$TESTDIR/golden-decompression/empty-block.zst"
 $DIFF -s tmp2 tmp_empty
+
+zstd -t "$TESTDIR/golden-decompression/zeroSeq_2B.zst"
+
+zstd -t "$TESTDIR/golden-decompression-errors/zeroSeq_extraneous.zst" && die "invalid Sequences section should have been detected"
+
 rm -f tmp*
 
 println "\n===>  compress multiple files"


### PR DESCRIPTION
when `nbSeq == 0`,
and added relevant tests.

For this purpose, created a new golden-file directory, for samples which are expected to be detected as errors.

Reported by @ip7z