### PR TITLE
Bitstream produces only zeroes after an overflow event

### DIFF
--- a/contrib/linux-kernel/mem.h
+++ b/contrib/linux-kernel/mem.h
@@ -24,6 +24,7 @@
 /*-****************************************
 *  Compiler specifics
 ******************************************/
+#undef MEM_STATIC /* may be already defined from common/compiler.h */
 #define MEM_STATIC static inline
 
 /*-**************************************************************

--- a/lib/common/allocations.h
+++ b/lib/common/allocations.h
@@ -14,7 +14,7 @@
 #define ZSTD_DEPS_NEED_MALLOC
 #include "zstd_deps.h"   /* ZSTD_malloc, ZSTD_calloc, ZSTD_free, ZSTD_memset */
 
-#include "mem.h" /* MEM_STATIC */
+#include "compiler.h" /* MEM_STATIC */
 #define ZSTD_STATIC_LINKING_ONLY
 #include "../zstd.h" /* ZSTD_customMem */
 

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -90,19 +90,20 @@ MEM_STATIC size_t BIT_closeCStream(BIT_CStream_t* bitC);
 /*-********************************************
 *  bitStream decoding API (read backward)
 **********************************************/
+typedef size_t BitContainerType;
 typedef struct {
-    size_t   bitContainer;
+    BitContainerType bitContainer;
     unsigned bitsConsumed;
     const char* ptr;
     const char* start;
     const char* limitPtr;
 } BIT_DStream_t;
 
-typedef enum { BIT_DStream_unfinished = 0,
-               BIT_DStream_endOfBuffer = 1,
-               BIT_DStream_completed = 2,
-               BIT_DStream_overflow = 3 } BIT_DStream_status;  /* result of BIT_reloadDStream() */
-               /* 1,2,4,8 would be better for bitmap combinations, but slows down performance a bit ... :( */
+typedef enum { BIT_DStream_unfinished = 0,  /* fully refilled */
+               BIT_DStream_endOfBuffer = 1, /* still some bits left in bitstream */
+               BIT_DStream_completed = 2,   /* bitstream entirely consumed, bit-exact */
+               BIT_DStream_overflow = 3     /* user requested more bits than present in bitstream */
+    } BIT_DStream_status;  /* result of BIT_reloadDStream() */
 
 MEM_STATIC size_t   BIT_initDStream(BIT_DStream_t* bitD, const void* srcBuffer, size_t srcSize);
 MEM_STATIC size_t   BIT_readBits(BIT_DStream_t* bitD, unsigned nbBits);
@@ -112,7 +113,7 @@ MEM_STATIC unsigned BIT_endOfDStream(const BIT_DStream_t* bitD);
 
 /* Start by invoking BIT_initDStream().
 *  A chunk of the bitStream is then stored into a local register.
-*  Local register size is 64-bits on 64-bits systems, 32-bits on 32-bits systems (size_t).
+*  Local register size is 64-bits on 64-bits systems, 32-bits on 32-bits systems (BitContainerType).
 *  You can then retrieve bitFields stored into the local register, **in reverse order**.
 *  Local register is explicitly reloaded from memory by the BIT_reloadDStream() method.
 *  A reload guarantee a minimum of ((8*sizeof(bitD->bitContainer))-7) bits when its result is BIT_DStream_unfinished.
@@ -162,7 +163,7 @@ MEM_STATIC size_t BIT_initCStream(BIT_CStream_t* bitC,
     return 0;
 }
 
-MEM_STATIC FORCE_INLINE_ATTR size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
+FORCE_INLINE_TEMPLATE size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
 {
 #if defined(STATIC_BMI2) && STATIC_BMI2 == 1 && !defined(ZSTD_NO_INTRINSICS)
     return  _bzhi_u64(bitContainer, nbBits);
@@ -267,22 +268,22 @@ MEM_STATIC size_t BIT_initDStream(BIT_DStream_t* bitD, const void* srcBuffer, si
         bitD->bitContainer = *(const BYTE*)(bitD->start);
         switch(srcSize)
         {
-        case 7: bitD->bitContainer += (size_t)(((const BYTE*)(srcBuffer))[6]) << (sizeof(bitD->bitContainer)*8 - 16);
+        case 7: bitD->bitContainer += (BitContainerType)(((const BYTE*)(srcBuffer))[6]) << (sizeof(bitD->bitContainer)*8 - 16);
                 ZSTD_FALLTHROUGH;
 
-        case 6: bitD->bitContainer += (size_t)(((const BYTE*)(srcBuffer))[5]) << (sizeof(bitD->bitContainer)*8 - 24);
+        case 6: bitD->bitContainer += (BitContainerType)(((const BYTE*)(srcBuffer))[5]) << (sizeof(bitD->bitContainer)*8 - 24);
                 ZSTD_FALLTHROUGH;
 
-        case 5: bitD->bitContainer += (size_t)(((const BYTE*)(srcBuffer))[4]) << (sizeof(bitD->bitContainer)*8 - 32);
+        case 5: bitD->bitContainer += (BitContainerType)(((const BYTE*)(srcBuffer))[4]) << (sizeof(bitD->bitContainer)*8 - 32);
                 ZSTD_FALLTHROUGH;
 
-        case 4: bitD->bitContainer += (size_t)(((const BYTE*)(srcBuffer))[3]) << 24;
+        case 4: bitD->bitContainer += (BitContainerType)(((const BYTE*)(srcBuffer))[3]) << 24;
                 ZSTD_FALLTHROUGH;
 
-        case 3: bitD->bitContainer += (size_t)(((const BYTE*)(srcBuffer))[2]) << 16;
+        case 3: bitD->bitContainer += (BitContainerType)(((const BYTE*)(srcBuffer))[2]) << 16;
                 ZSTD_FALLTHROUGH;
 
-        case 2: bitD->bitContainer += (size_t)(((const BYTE*)(srcBuffer))[1]) <<  8;
+        case 2: bitD->bitContainer += (BitContainerType)(((const BYTE*)(srcBuffer))[1]) <<  8;
                 ZSTD_FALLTHROUGH;
 
         default: break;
@@ -297,12 +298,12 @@ MEM_STATIC size_t BIT_initDStream(BIT_DStream_t* bitD, const void* srcBuffer, si
     return srcSize;
 }
 
-MEM_STATIC FORCE_INLINE_ATTR size_t BIT_getUpperBits(size_t bitContainer, U32 const start)
+FORCE_INLINE_TEMPLATE size_t BIT_getUpperBits(BitContainerType bitContainer, U32 const start)
 {
     return bitContainer >> start;
 }
 
-MEM_STATIC FORCE_INLINE_ATTR size_t BIT_getMiddleBits(size_t bitContainer, U32 const start, U32 const nbBits)
+FORCE_INLINE_TEMPLATE size_t BIT_getMiddleBits(BitContainerType bitContainer, U32 const start, U32 const nbBits)
 {
     U32 const regMask = sizeof(bitContainer)*8 - 1;
     /* if start > regMask, bitstream is corrupted, and result is undefined */
@@ -325,7 +326,7 @@ MEM_STATIC FORCE_INLINE_ATTR size_t BIT_getMiddleBits(size_t bitContainer, U32 c
  *  On 32-bits, maxNbBits==24.
  *  On 64-bits, maxNbBits==56.
  * @return : value extracted */
-MEM_STATIC  FORCE_INLINE_ATTR size_t BIT_lookBits(const BIT_DStream_t*  bitD, U32 nbBits)
+FORCE_INLINE_TEMPLATE size_t BIT_lookBits(const BIT_DStream_t*  bitD, U32 nbBits)
 {
     /* arbitrate between double-shift and shift+mask */
 #if 1
@@ -348,7 +349,7 @@ MEM_STATIC size_t BIT_lookBitsFast(const BIT_DStream_t* bitD, U32 nbBits)
     return (bitD->bitContainer << (bitD->bitsConsumed & regMask)) >> (((regMask+1)-nbBits) & regMask);
 }
 
-MEM_STATIC FORCE_INLINE_ATTR void BIT_skipBits(BIT_DStream_t* bitD, U32 nbBits)
+FORCE_INLINE_TEMPLATE void BIT_skipBits(BIT_DStream_t* bitD, U32 nbBits)
 {
     bitD->bitsConsumed += nbBits;
 }
@@ -357,7 +358,7 @@ MEM_STATIC FORCE_INLINE_ATTR void BIT_skipBits(BIT_DStream_t* bitD, U32 nbBits)
  *  Read (consume) next n bits from local register and update.
  *  Pay attention to not read more than nbBits contained into local register.
  * @return : extracted value. */
-MEM_STATIC FORCE_INLINE_ATTR size_t BIT_readBits(BIT_DStream_t* bitD, unsigned nbBits)
+FORCE_INLINE_TEMPLATE size_t BIT_readBits(BIT_DStream_t* bitD, unsigned nbBits)
 {
     size_t const value = BIT_lookBits(bitD, nbBits);
     BIT_skipBits(bitD, nbBits);
@@ -375,16 +376,16 @@ MEM_STATIC size_t BIT_readBitsFast(BIT_DStream_t* bitD, unsigned nbBits)
 }
 
 /*! BIT_reloadDStreamFast() :
- *  Similar to BIT_reloadDStream(), but with two differences:
- *  1. bitsConsumed <= sizeof(bitD->bitContainer)*8 must hold!
- *  2. Returns BIT_DStream_overflow when bitD->ptr < bitD->limitPtr, at this
- *     point you must use BIT_reloadDStream() to reload.
+ *  Simple variant of BIT_reloadDStream(), with two conditions:
+ *  1. bitsConsumed <= sizeof(bitD->bitContainer)*8
+ *  2. bitD->ptr >= bitD->limitPtr
+ *  These conditions guarantee that bitstream is in a valid state,
+ *  and shifting the position of the look window is safe.
  */
 MEM_STATIC BIT_DStream_status BIT_reloadDStreamFast(BIT_DStream_t* bitD)
 {
-    if (UNLIKELY(bitD->ptr < bitD->limitPtr))
-        return BIT_DStream_overflow;
     assert(bitD->bitsConsumed <= sizeof(bitD->bitContainer)*8);
+    assert(bitD->ptr >= bitD->limitPtr);
     bitD->ptr -= bitD->bitsConsumed >> 3;
     bitD->bitsConsumed &= 7;
     bitD->bitContainer = MEM_readLEST(bitD->ptr);
@@ -393,22 +394,30 @@ MEM_STATIC BIT_DStream_status BIT_reloadDStreamFast(BIT_DStream_t* bitD)
 
 /*! BIT_reloadDStream() :
  *  Refill `bitD` from buffer previously set in BIT_initDStream() .
- *  This function is safe, it guarantees it will not read beyond src buffer.
+ *  This function is safe, it guarantees it will not never beyond src buffer.
  * @return : status of `BIT_DStream_t` internal register.
  *           when status == BIT_DStream_unfinished, internal register is filled with at least 25 or 57 bits */
-MEM_STATIC FORCE_INLINE_ATTR BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD)
+FORCE_INLINE_TEMPLATE BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD)
 {
-    if (bitD->bitsConsumed > (sizeof(bitD->bitContainer)*8))  /* overflow detected, like end of stream */
+    /* note : once in overflow mode, a bitstream remains in this mode until it's reset */
+    if (bitD->bitsConsumed > (sizeof(bitD->bitContainer)*8)) {
+        static const BitContainerType zeroFilled = 0;
+        bitD->ptr = (const char*)&zeroFilled; /* aliasing is allowed for char */
+        /* overflow detected, erroneous scenario or end of stream: no update */
         return BIT_DStream_overflow;
+    }
+
+    assert(bitD->ptr >= bitD->start);
 
     if (bitD->ptr >= bitD->limitPtr) {
         return BIT_reloadDStreamFast(bitD);
     }
     if (bitD->ptr == bitD->start) {
+        /* reached end of bitStream => no update */
         if (bitD->bitsConsumed < sizeof(bitD->bitContainer)*8) return BIT_DStream_endOfBuffer;
         return BIT_DStream_completed;
     }
-    /* start < ptr < limitPtr */
+    /* start < ptr < limitPtr => cautious update */
     {   U32 nbBytes = bitD->bitsConsumed >> 3;
         BIT_DStream_status result = BIT_DStream_unfinished;
         if (bitD->ptr - nbBytes < bitD->start) {

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -51,12 +51,19 @@
 #  define WIN_CDECL
 #endif
 
+/* UNUSED_ATTR tells the compiler it is okay if the function is unused. */
+#if defined(__GNUC__)
+#  define UNUSED_ATTR __attribute__((unused))
+#else
+#  define UNUSED_ATTR
+#endif
+
 /**
  * FORCE_INLINE_TEMPLATE is used to define C "templates", which take constant
  * parameters. They must be inlined for the compiler to eliminate the constant
  * branches.
  */
-#define FORCE_INLINE_TEMPLATE static INLINE_KEYWORD FORCE_INLINE_ATTR
+#define FORCE_INLINE_TEMPLATE static INLINE_KEYWORD FORCE_INLINE_ATTR UNUSED_ATTR
 /**
  * HINT_INLINE is used to help the compiler generate better code. It is *not*
  * used for "templates", so it can be tweaked based on the compilers
@@ -71,14 +78,7 @@
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8 && __GNUC__ < 5
 #  define HINT_INLINE static INLINE_KEYWORD
 #else
-#  define HINT_INLINE static INLINE_KEYWORD FORCE_INLINE_ATTR
-#endif
-
-/* UNUSED_ATTR tells the compiler it is okay if the function is unused. */
-#if defined(__GNUC__)
-#  define UNUSED_ATTR __attribute__((unused))
-#else
-#  define UNUSED_ATTR
+#  define HINT_INLINE FORCE_INLINE_TEMPLATE
 #endif
 
 /* "soft" inline :

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -90,6 +90,7 @@
  * Updating the prefix is probably preferable, but requires a fairly large codemod,
  * since this name is used everywhere.
  */
+#ifndef MEM_STATIC  /* already defined in Linux Kernel mem.h */
 #if defined(__GNUC__)
 #  define MEM_STATIC static __inline UNUSED_ATTR
 #elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
@@ -98,6 +99,7 @@
 #  define MEM_STATIC static __inline
 #else
 #  define MEM_STATIC static  /* this version may generate warnings for unused static functions; disable the relevant warning */
+#endif
 #endif
 
 /* force no inlining */

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -81,6 +81,25 @@
 #  define UNUSED_ATTR
 #endif
 
+/* "soft" inline :
+ * The compiler is free to select if it's a good idea to inline or not.
+ * The main objective is to silence compiler warnings
+ * when a defined function in included but not used.
+ *
+ * Note : this macro is prefixed `MEM_` because it used to be provided by `mem.h` unit.
+ * Updating the prefix is probably preferable, but requires a fairly large codemod,
+ * since this name is used everywhere.
+ */
+#if defined(__GNUC__)
+#  define MEM_STATIC static __inline UNUSED_ATTR
+#elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#  define MEM_STATIC static inline
+#elif defined(_MSC_VER)
+#  define MEM_STATIC static __inline
+#else
+#  define MEM_STATIC static  /* this version may generate warnings for unused static functions; disable the relevant warning */
+#endif
+
 /* force no inlining */
 #ifdef _MSC_VER
 #  define FORCE_NOINLINE static __declspec(noinline)

--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -31,15 +31,6 @@ extern "C" {
 #   include <stdlib.h>  /* _byteswap_ulong */
 #   include <intrin.h>  /* _byteswap_* */
 #endif
-#if defined(__GNUC__)
-#  define MEM_STATIC static __inline __attribute__((unused))
-#elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
-#  define MEM_STATIC static inline
-#elif defined(_MSC_VER)
-#  define MEM_STATIC static __inline
-#else
-#  define MEM_STATIC static  /* this version may generate warnings for unused static functions; disable the relevant warning */
-#endif
 
 /*-**************************************************************
 *  Basic Types

--- a/lib/legacy/zstd_v04.c
+++ b/lib/legacy/zstd_v04.c
@@ -37,15 +37,6 @@ extern "C" {
 #   include <stdlib.h>  /* _byteswap_ulong */
 #   include <intrin.h>  /* _byteswap_* */
 #endif
-#if defined(__GNUC__)
-#  define MEM_STATIC static __attribute__((unused))
-#elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
-#  define MEM_STATIC static inline
-#elif defined(_MSC_VER)
-#  define MEM_STATIC static __inline
-#else
-#  define MEM_STATIC static  /* this version may generate warnings for unused static functions; disable the relevant warning */
-#endif
 
 
 /****************************************************************

--- a/lib/legacy/zstd_v06.c
+++ b/lib/legacy/zstd_v06.c
@@ -67,15 +67,6 @@ extern "C" {
 #   include <stdlib.h>  /* _byteswap_ulong */
 #   include <intrin.h>  /* _byteswap_* */
 #endif
-#if defined(__GNUC__)
-#  define MEM_STATIC static __attribute__((unused))
-#elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
-#  define MEM_STATIC static inline
-#elif defined(_MSC_VER)
-#  define MEM_STATIC static __inline
-#else
-#  define MEM_STATIC static  /* this version may generate warnings for unused static functions; disable the relevant warning */
-#endif
 
 
 /*-**************************************************************

--- a/lib/legacy/zstd_v07.c
+++ b/lib/legacy/zstd_v07.c
@@ -227,15 +227,6 @@ extern "C" {
 #   include <stdlib.h>  /* _byteswap_ulong */
 #   include <intrin.h>  /* _byteswap_* */
 #endif
-#if defined(__GNUC__)
-#  define MEM_STATIC static __attribute__((unused))
-#elif defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
-#  define MEM_STATIC static inline
-#elif defined(_MSC_VER)
-#  define MEM_STATIC static __inline
-#else
-#  define MEM_STATIC static  /* this version may generate warnings for unused static functions; disable the relevant warning */
-#endif
 
 
 /*-**************************************************************


### PR DESCRIPTION
The following modification is focused primarily on the bitstream.
It ensures that, after an `overflow` event, meaning that the calling function has requested more bits than are present in the bitstream, the bitstream object will always return `0` values.

Up to now, the bitstream would simply loop over the content of the last `bitContainer`, which has a `size_t` width, aka 64-bit or 32- bit depending on platforms. As a consequence, after an `overflow` event, the bitstream would produce different bit values, depending on the platform.

This only happen if the frame is invalid. Therefore, the benefit of this patch is mostly to ensure consistency across platforms, ensuring they behave the same on damaged data.

### In term of performance

This is messy. This code modifies (slightly) a very hot loop in the decoder. As a consequence, CPUs which tend to be extremely sensible to random instruction alignment conditions are randomly impacted by code change, in either direction.
This can be seen in the following set of benchmarks, measured on a i7-9700k platform, which compares this commit (left) to `dev` (right) : 

```
compile with gcc-7                                                                 │compile with gcc-7
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  756.0 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  736.8 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  754.4 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  737.7 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  377.3 MB/s, 1230.2 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  373.7 MB/s, 1228.9 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.5 MB/s, 1105.3 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  278.1 MB/s, 1102.5 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  107.5 MB/s, 1053.3 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  108.4 MB/s, 1034.9 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   84.7 MB/s,  853.0 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   84.8 MB/s,  830.2 MB/s
compile with gcc-8                                                                 │compile with gcc-8
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  655.1 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  679.5 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  655.9 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  679.6 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  384.5 MB/s  1198.0 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  383.1 MB/s  1281.0 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  285.5 MB/s, 1058.5 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.6 MB/s, 1139.8 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),   98.8 MB/s, 1014.5 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  104.2 MB/s, 1088.0 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   79.1 MB/s,  810.7 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   82.7 MB/s,  866.7 MB/s
compile with gcc-9                                                                 │compile with gcc-9
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  701.3 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  733.5 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  691.5 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  737.0 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  380.9 MB/s, 1211.0 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  373.5 MB/s, 1299.9 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  282.0 MB/s, 1076.8 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  278.2 MB/s, 1150.1 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  114.3 MB/s,  990.7 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  115.4 MB/s, 1095.8 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   89.6 MB/s,  783.8 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.7 MB/s,  868.2 MB/s
compile with gcc-10                                                                │compile with gcc-10
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  726.6 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  747.6 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  733.1 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  752.5 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  379.7 MB/s, 1313.5 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  385.8 MB/s  1216.4 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  279.7 MB/s, 1166.4 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  284.3 MB/s, 1073.5 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  114.3 MB/s, 1128.1 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  114.8 MB/s, 1051.8 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.0 MB/s,  907.6 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.0 MB/s,  853.8 MB/s
compile with clang-6.0                                                             │compile with clang-6.0
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  752.5 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  759.4 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  753.4 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  754.3 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  391.9 MB/s  1223.4 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  390.6 MB/s  1196.2 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  290.2 MB/s, 1092.1 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  286.2 MB/s, 1058.9 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  119.6 MB/s, 1046.2 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  118.6 MB/s, 1017.3 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   93.7 MB/s,  844.8 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   92.7 MB/s,  810.9 MB/s
compile with clang-7                                                               │compile with clang-7
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  734.5 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  744.5 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  729.0 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  748.4 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  382.3 MB/s  1222.3 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  374.5 MB/s, 1230.9 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  278.3 MB/s, 1093.6 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  275.9 MB/s, 1100.2 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  117.5 MB/s, 1031.9 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  117.7 MB/s, 1038.5 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.3 MB/s,  826.3 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.5 MB/s,  829.0 MB/s
compile with clang-8                                                               │compile with clang-8
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  755.9 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  738.0 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  746.5 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  733.3 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  397.1 MB/s  1217.4 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  399.7 MB/s  1225.3 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  292.6 MB/s, 1085.0 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  294.9 MB/s, 1097.5 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  117.3 MB/s, 1028.1 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  119.0 MB/s, 1034.6 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.4 MB/s,  823.7 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.4 MB/s,  827.1 MB/s
compile with clang-9                                                               │compile with clang-9
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  779.0 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  769.0 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  780.8 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  756.6 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  386.4 MB/s  1247.1 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  382.3 MB/s  1249.3 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  281.6 MB/s, 1111.2 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.0 MB/s, 1109.6 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  116.9 MB/s, 1049.3 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  116.9 MB/s, 1046.2 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.9 MB/s,  836.1 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   92.0 MB/s,  826.1 MB/s
compile with clang-10                                                              │compile with clang-10
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  766.8 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  719.0 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  757.2 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  706.7 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  395.2 MB/s  1245.8 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  395.5 MB/s  1250.6 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  289.7 MB/s, 1103.8 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  292.7 MB/s, 1111.7 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  119.2 MB/s, 1051.4 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  118.6 MB/s, 1048.5 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   92.7 MB/s,  840.8 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   92.0 MB/s,  829.3 MB/s
compile with clang-11                                                              │compile with clang-11
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  721.4 MB/s   │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  793.3 MB/s
 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  726.8 MB/s   │ 3#k9.L22.long30.zst :1000000000 -> 214083365 (x4.671),   0.00 MB/s,  791.0 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  382.1 MB/s  1246.1 MB/s   │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  382.1 MB/s  1213.5 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.9 MB/s, 1106.0 MB/s   │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.9 MB/s, 1080.8 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  118.1 MB/s, 1044.2 MB/s   │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  118.5 MB/s, 1028.6 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.7 MB/s,  832.7 MB/s   │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.7 MB/s,  819.9 MB/s ```
```

Lose some, win some,
I don't even think that it's worthwhile to process an "average" of these variations.

I'm tempted to call it a wash, with the added input of my local M1 laptop, which seems to be less impacted by these instruction alignment issues : on this laptop, performance is simply unchanged, identical between this diff and `dev`.