### PR TITLE
Changed the decoding loop to detect more invalid cases of corruption sooner

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -411,7 +411,7 @@ MEM_STATIC BIT_DStream_status BIT_reloadDStreamFast(BIT_DStream_t* bitD)
 FORCE_INLINE_TEMPLATE BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD)
 {
     /* note : once in overflow mode, a bitstream remains in this mode until it's reset */
-    if (bitD->bitsConsumed > (sizeof(bitD->bitContainer)*8)) {
+    if (UNLIKELY(bitD->bitsConsumed > (sizeof(bitD->bitContainer)*8))) {
         static const BitContainerType zeroFilled = 0;
         bitD->ptr = (const char*)&zeroFilled; /* aliasing is allowed for char */
         /* overflow detected, erroneous scenario or end of stream: no update */

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -1429,7 +1429,7 @@ ZSTD_decompressSequences_bodySplitLitBuffer( ZSTD_DCtx* dctx,
                 BIT_DStream_completed < BIT_DStream_overflow);
 
         /* decompress without overrunning litPtr begins */
-        {   seq_t sequence;
+        {   seq_t sequence = {0,0,0};  /* some static analyzer believe that @sequence is not initialized (it necessarily is, since for(;;) loop as at least one interation) */
             /* Align the decompression loop to 32 + 16 bytes.
                 *
                 * zstd compiled with gcc-9 on an Intel i9-9900k shows 10% decompression

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -1215,128 +1215,6 @@ ZSTD_updateFseStateWithDInfo(ZSTD_fseState* DStatePtr, BIT_DStream_t* bitD, U16 
 typedef enum { ZSTD_lo_isRegularOffset, ZSTD_lo_isLongOffset=1 } ZSTD_longOffset_e;
 
 /**
- * ZSTD_decodeSequence_old():
- * @p longOffsets : tells the decoder to reload more bit while decoding large offsets
- *                  only used in 32-bit mode
- * @return : Sequence (litL + matchL + offset)
- */
-FORCE_INLINE_TEMPLATE seq_t
-ZSTD_decodeSequence_old(seqState_t* seqState, const ZSTD_longOffset_e longOffsets)
-{
-    seq_t seq;
-    /*
-     * ZSTD_seqSymbol is a 64 bits wide structure.
-     * It can be loaded in one operation
-     * and its fields extracted by simply shifting or bit-extracting on aarch64.
-     * GCC doesn't recognize this and generates more unnecessary ldr/ldrb/ldrh
-     * operations that cause performance drop. This can be avoided by using this
-     * ZSTD_memcpy hack.
-     */
-#if defined(__aarch64__) && (defined(__GNUC__) && !defined(__clang__))
-    ZSTD_seqSymbol llDInfoS, mlDInfoS, ofDInfoS;
-    ZSTD_seqSymbol* const llDInfo = &llDInfoS;
-    ZSTD_seqSymbol* const mlDInfo = &mlDInfoS;
-    ZSTD_seqSymbol* const ofDInfo = &ofDInfoS;
-    ZSTD_memcpy(llDInfo, seqState->stateLL.table + seqState->stateLL.state, sizeof(ZSTD_seqSymbol));
-    ZSTD_memcpy(mlDInfo, seqState->stateML.table + seqState->stateML.state, sizeof(ZSTD_seqSymbol));
-    ZSTD_memcpy(ofDInfo, seqState->stateOffb.table + seqState->stateOffb.state, sizeof(ZSTD_seqSymbol));
-#else
-    const ZSTD_seqSymbol* const llDInfo = seqState->stateLL.table + seqState->stateLL.state;
-    const ZSTD_seqSymbol* const mlDInfo = seqState->stateML.table + seqState->stateML.state;
-    const ZSTD_seqSymbol* const ofDInfo = seqState->stateOffb.table + seqState->stateOffb.state;
-#endif
-    seq.matchLength = mlDInfo->baseValue;
-    seq.litLength = llDInfo->baseValue;
-    {   U32 const ofBase = ofDInfo->baseValue;
-        BYTE const llBits = llDInfo->nbAdditionalBits;
-        BYTE const mlBits = mlDInfo->nbAdditionalBits;
-        BYTE const ofBits = ofDInfo->nbAdditionalBits;
-        BYTE const totalBits = llBits+mlBits+ofBits;
-
-        U16 const llNext = llDInfo->nextState;
-        U16 const mlNext = mlDInfo->nextState;
-        U16 const ofNext = ofDInfo->nextState;
-        U32 const llnbBits = llDInfo->nbBits;
-        U32 const mlnbBits = mlDInfo->nbBits;
-        U32 const ofnbBits = ofDInfo->nbBits;
-
-        assert(llBits <= MaxLLBits);
-        assert(mlBits <= MaxMLBits);
-        assert(ofBits <= MaxOff);
-        /*
-         * As gcc has better branch and block analyzers, sometimes it is only
-         * valuable to mark likeliness for clang, it gives around 3-4% of
-         * performance.
-         */
-
-        /* sequence */
-        {   size_t offset;
-            if (ofBits > 1) {
-                ZSTD_STATIC_ASSERT(ZSTD_lo_isLongOffset == 1);
-                ZSTD_STATIC_ASSERT(LONG_OFFSETS_MAX_EXTRA_BITS_32 == 5);
-                ZSTD_STATIC_ASSERT(STREAM_ACCUMULATOR_MIN_32 > LONG_OFFSETS_MAX_EXTRA_BITS_32);
-                ZSTD_STATIC_ASSERT(STREAM_ACCUMULATOR_MIN_32 - LONG_OFFSETS_MAX_EXTRA_BITS_32 >= MaxMLBits);
-                if (MEM_32bits() && longOffsets && (ofBits >= STREAM_ACCUMULATOR_MIN_32)) {
-                    /* Always read extra bits, this keeps the logic simple,
-                     * avoids branches, and avoids accidentally reading 0 bits.
-                     */
-                    U32 const extraBits = LONG_OFFSETS_MAX_EXTRA_BITS_32;
-                    offset = ofBase + (BIT_readBitsFast(&seqState->DStream, ofBits - extraBits) << extraBits);
-                    BIT_reloadDStream(&seqState->DStream);
-                    offset += BIT_readBitsFast(&seqState->DStream, extraBits);
-                } else {
-                    offset = ofBase + BIT_readBitsFast(&seqState->DStream, ofBits/*>0*/);   /* <=  (ZSTD_WINDOWLOG_MAX-1) bits */
-                    if (MEM_32bits()) BIT_reloadDStream(&seqState->DStream);
-                }
-                seqState->prevOffset[2] = seqState->prevOffset[1];
-                seqState->prevOffset[1] = seqState->prevOffset[0];
-                seqState->prevOffset[0] = offset;
-            } else {
-                U32 const ll0 = (llDInfo->baseValue == 0);
-                if (LIKELY((ofBits == 0))) {
-                    offset = seqState->prevOffset[ll0];
-                    seqState->prevOffset[1] = seqState->prevOffset[!ll0];
-                    seqState->prevOffset[0] = offset;
-                } else {
-                    offset = ofBase + ll0 + BIT_readBitsFast(&seqState->DStream, 1);
-                    {   size_t temp = (offset==3) ? seqState->prevOffset[0] - 1 : seqState->prevOffset[offset];
-                        temp += !temp;   /* 0 is not valid; input is corrupted; force offset to 1 */
-                        if (offset != 1) seqState->prevOffset[2] = seqState->prevOffset[1];
-                        seqState->prevOffset[1] = seqState->prevOffset[0];
-                        seqState->prevOffset[0] = offset = temp;
-            }   }   }
-            seq.offset = offset;
-        }
-
-        if (mlBits > 0)
-            seq.matchLength += BIT_readBitsFast(&seqState->DStream, mlBits/*>0*/);
-
-        if (MEM_32bits() && (mlBits+llBits >= STREAM_ACCUMULATOR_MIN_32-LONG_OFFSETS_MAX_EXTRA_BITS_32))
-            BIT_reloadDStream(&seqState->DStream);
-        if (MEM_64bits() && UNLIKELY(totalBits >= STREAM_ACCUMULATOR_MIN_64-(LLFSELog+MLFSELog+OffFSELog)))
-            BIT_reloadDStream(&seqState->DStream);
-        /* Ensure there are enough bits to read the rest of data in 64-bit mode. */
-        ZSTD_STATIC_ASSERT(16+LLFSELog+MLFSELog+OffFSELog < STREAM_ACCUMULATOR_MIN_64);
-
-        if (llBits > 0)
-            seq.litLength += BIT_readBitsFast(&seqState->DStream, llBits/*>0*/);
-
-        if (MEM_32bits())
-            BIT_reloadDStream(&seqState->DStream);
-
-        DEBUGLOG(6, "seq: litL=%u, matchL=%u, offset=%u",
-                    (U32)seq.litLength, (U32)seq.matchLength, (U32)seq.offset);
-
-        ZSTD_updateFseStateWithDInfo(&seqState->stateLL, &seqState->DStream, llNext, llnbBits);    /* <=  9 bits */
-        ZSTD_updateFseStateWithDInfo(&seqState->stateML, &seqState->DStream, mlNext, mlnbBits);    /* <=  9 bits */
-        if (MEM_32bits()) BIT_reloadDStream(&seqState->DStream);    /* <= 18 bits */
-        ZSTD_updateFseStateWithDInfo(&seqState->stateOffb, &seqState->DStream, ofNext, ofnbBits);  /* <=  8 bits */
-    }
-
-    return seq;
-}
-
-/**
  * ZSTD_decodeSequence():
  * @p longOffsets : tells the decoder to reload more bit while decoding large offsets
  *                  only used in 32-bit mode
@@ -1754,11 +1632,6 @@ ZSTD_decompressSequences_body(ZSTD_DCtx* dctx,
         ZSTD_initFseState(&seqState.stateML, &seqState.DStream, dctx->MLTptr);
         assert(dst != NULL);
 
-        ZSTD_STATIC_ASSERT(
-            BIT_DStream_unfinished < BIT_DStream_completed &&
-            BIT_DStream_endOfBuffer < BIT_DStream_completed &&
-            BIT_DStream_completed < BIT_DStream_overflow);
-
 #if defined(__GNUC__) && defined(__x86_64__)
             __asm__(".p2align 6");
             __asm__("nop");
@@ -1787,9 +1660,7 @@ ZSTD_decompressSequences_body(ZSTD_DCtx* dctx,
         }
 
         /* check if reached exact end */
-        DEBUGLOG(5, "ZSTD_decompressSequences_body: after decode loop, remaining nbSeq : %i", nbSeq);
-        RETURN_ERROR_IF(nbSeq, corruption_detected, "");
-        DEBUGLOG(5, "bitStream : start=%p, ptr=%p, bitsConsumed=%u", seqState.DStream.start, seqState.DStream.ptr, seqState.DStream.bitsConsumed);
+        assert(nbSeq == 0);
         RETURN_ERROR_IF(!BIT_endOfDStream(&seqState.DStream), corruption_detected, "");
         /* save reps for next block */
         { U32 i; for (i=0; i<ZSTD_REP_NUM; i++) dctx->entropy.rep[i] = (U32)(seqState.prevOffset[i]); }
@@ -1801,8 +1672,7 @@ ZSTD_decompressSequences_body(ZSTD_DCtx* dctx,
         if (op != NULL) {
             ZSTD_memcpy(op, litPtr, lastLLSize);
             op += lastLLSize;
-        }
-    }
+    }   }
 
     return op-ostart;
 }
@@ -1886,20 +1756,17 @@ ZSTD_decompressSequencesLong_body(
         ZSTD_initFseState(&seqState.stateML, &seqState.DStream, dctx->MLTptr);
 
         /* prepare in advance */
-        for (seqNb=0; (BIT_reloadDStream(&seqState.DStream) <= BIT_DStream_completed) && (seqNb<seqAdvance); seqNb++) {
-            seq_t const sequence = ZSTD_decodeSequence_old(&seqState, isLongOffset);
+        for (seqNb=0; seqNb<seqAdvance; seqNb++) {
+            seq_t const sequence = ZSTD_decodeSequence(&seqState, isLongOffset, seqNb == nbSeq-1);
             prefetchPos = ZSTD_prefetchMatch(prefetchPos, sequence, prefixStart, dictEnd);
             sequences[seqNb] = sequence;
         }
-        RETURN_ERROR_IF(seqNb<seqAdvance, corruption_detected, "");
 
         /* decompress without stomping litBuffer */
-        for (; (BIT_reloadDStream(&(seqState.DStream)) <= BIT_DStream_completed) && (seqNb < nbSeq); seqNb++) {
-            seq_t sequence = ZSTD_decodeSequence_old(&seqState, isLongOffset);
-            size_t oneSeqSize;
+        for (; seqNb < nbSeq; seqNb++) {
+            seq_t sequence = ZSTD_decodeSequence(&seqState, isLongOffset, seqNb == nbSeq-1);
 
-            if (dctx->litBufferLocation == ZSTD_split && litPtr + sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK].litLength > dctx->litBufferEnd)
-            {
+            if (dctx->litBufferLocation == ZSTD_split && litPtr + sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK].litLength > dctx->litBufferEnd) {
                 /* lit buffer is reaching split point, empty out the first buffer and transition to litExtraBuffer */
                 const size_t leftoverLit = dctx->litBufferEnd - litPtr;
                 if (leftoverLit)
@@ -1912,21 +1779,21 @@ ZSTD_decompressSequencesLong_body(
                 litPtr = dctx->litExtraBuffer;
                 litBufferEnd = dctx->litExtraBuffer + ZSTD_LITBUFFEREXTRASIZE;
                 dctx->litBufferLocation = ZSTD_not_in_dst;
-                oneSeqSize = ZSTD_execSequence(op, oend, sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK], &litPtr, litBufferEnd, prefixStart, dictStart, dictEnd);
+                {   size_t const oneSeqSize = ZSTD_execSequence(op, oend, sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK], &litPtr, litBufferEnd, prefixStart, dictStart, dictEnd);
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && defined(FUZZING_ASSERT_VALID_SEQUENCE)
-                assert(!ZSTD_isError(oneSeqSize));
-                ZSTD_assertValidSequence(dctx, op, oend, sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK], prefixStart, dictStart);
+                    assert(!ZSTD_isError(oneSeqSize));
+                    ZSTD_assertValidSequence(dctx, op, oend, sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK], prefixStart, dictStart);
 #endif
-                if (ZSTD_isError(oneSeqSize)) return oneSeqSize;
+                    if (ZSTD_isError(oneSeqSize)) return oneSeqSize;
 
-                prefetchPos = ZSTD_prefetchMatch(prefetchPos, sequence, prefixStart, dictEnd);
-                sequences[seqNb & STORED_SEQS_MASK] = sequence;
-                op += oneSeqSize;
-            }
+                    prefetchPos = ZSTD_prefetchMatch(prefetchPos, sequence, prefixStart, dictEnd);
+                    sequences[seqNb & STORED_SEQS_MASK] = sequence;
+                    op += oneSeqSize;
+            }   }
             else
             {
                 /* lit buffer is either wholly contained in first or second split, or not split at all*/
-                oneSeqSize = dctx->litBufferLocation == ZSTD_split ?
+                size_t const oneSeqSize = dctx->litBufferLocation == ZSTD_split ?
                     ZSTD_execSequenceSplitLitBuffer(op, oend, litPtr + sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK].litLength - WILDCOPY_OVERLENGTH, sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK], &litPtr, litBufferEnd, prefixStart, dictStart, dictEnd) :
                     ZSTD_execSequence(op, oend, sequences[(seqNb - ADVANCED_SEQS) & STORED_SEQS_MASK], &litPtr, litBufferEnd, prefixStart, dictStart, dictEnd);
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && defined(FUZZING_ASSERT_VALID_SEQUENCE)
@@ -1940,17 +1807,15 @@ ZSTD_decompressSequencesLong_body(
                 op += oneSeqSize;
             }
         }
-        RETURN_ERROR_IF(seqNb<nbSeq, corruption_detected, "");
+        RETURN_ERROR_IF(!BIT_endOfDStream(&seqState.DStream), corruption_detected, "");
 
         /* finish queue */
         seqNb -= seqAdvance;
         for ( ; seqNb<nbSeq ; seqNb++) {
             seq_t *sequence = &(sequences[seqNb&STORED_SEQS_MASK]);
-            if (dctx->litBufferLocation == ZSTD_split && litPtr + sequence->litLength > dctx->litBufferEnd)
-            {
+            if (dctx->litBufferLocation == ZSTD_split && litPtr + sequence->litLength > dctx->litBufferEnd) {
                 const size_t leftoverLit = dctx->litBufferEnd - litPtr;
-                if (leftoverLit)
-                {
+                if (leftoverLit) {
                     RETURN_ERROR_IF(leftoverLit > (size_t)(oend - op), dstSize_tooSmall, "remaining lit must fit within dstBuffer");
                     ZSTD_safecopyDstBeforeSrc(op, litPtr, leftoverLit);
                     sequence->litLength -= leftoverLit;
@@ -1959,8 +1824,7 @@ ZSTD_decompressSequencesLong_body(
                 litPtr = dctx->litExtraBuffer;
                 litBufferEnd = dctx->litExtraBuffer + ZSTD_LITBUFFEREXTRASIZE;
                 dctx->litBufferLocation = ZSTD_not_in_dst;
-                {
-                    size_t const oneSeqSize = ZSTD_execSequence(op, oend, *sequence, &litPtr, litBufferEnd, prefixStart, dictStart, dictEnd);
+                {   size_t const oneSeqSize = ZSTD_execSequence(op, oend, *sequence, &litPtr, litBufferEnd, prefixStart, dictStart, dictEnd);
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && defined(FUZZING_ASSERT_VALID_SEQUENCE)
                     assert(!ZSTD_isError(oneSeqSize));
                     ZSTD_assertValidSequence(dctx, op, oend, sequences[seqNb&STORED_SEQS_MASK], prefixStart, dictStart);
@@ -1988,8 +1852,7 @@ ZSTD_decompressSequencesLong_body(
     }
 
     /* last literal segment */
-    if (dctx->litBufferLocation == ZSTD_split)  /* first deplete literal buffer in dst, then copy litExtraBuffer */
-    {
+    if (dctx->litBufferLocation == ZSTD_split) { /* first deplete literal buffer in dst, then copy litExtraBuffer */
         size_t const lastLLSize = litBufferEnd - litPtr;
         RETURN_ERROR_IF(lastLLSize > (size_t)(oend - op), dstSize_tooSmall, "");
         if (op != NULL) {


### PR DESCRIPTION
The main objective of this PR is to detect an additional invalid case of corruption without reliance on the checksum.
For the record, many cases of corruption are possible, of several of them are undetectable, except by the final checksum.
Even for those which are theoretically detectable, such detection must remain practical, i.e. not cost a lot of performance nor increase complexity too much.

This is one of them. Prior attempts to add this one corruption case to the list of early-detected ones were unsuccessful, as they lead to more complex code on top of slower decompression speed. Upon discussion with @ip7z, I decided to have another look at the topic.

The newly proposed change fixes the issue, *and* imho makes the code better (i.e. more readable) for maintenance. To achieve this, I had to modify the main decoding loop, impacting the scope and interface of `decodeSequence` function. All decoding loops were impacted, though the changes are more pronounced for the `splitLitBuffer` variant .

In term of performance, the outcome is mixed.
As expected, modifying the hottest loop in the code is bound to impact performance measurably, even if the generated assembly is modified in a minor way. We also know that this code is incredibly sensitive to Instruction Alignments side-effects, which are essentially random, so we expect fairly large swings in either direction.

To verify this, the decompression speed of this patch was benched on a `i7-9700k` workstation with several different compilers and versions. Here is the detailed outcome, comparing this commit (left) with `dev` branch (right) :

```
compile with gcc-7                                                                │compile with gcc-7
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  722.6 MB/s/s│ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  746.2 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  885.4 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  946.8 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  379.6 MB/s, 1169.1 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  370.7 MB/s, 1227.4 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  285.8 MB/s, 1036.2 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  279.1 MB/s, 1101.8 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  212.6 MB/s, 1010.5 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  209.6 MB/s, 1071.1 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  151.9 MB/s,  818.0 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  150.3 MB/s,  872.7 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  109.6 MB/s,  984.4 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  109.5 MB/s, 1055.1 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   86.0 MB/s,  784.6 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   85.9 MB/s,  850.8 MB/s
compile with gcc-8                                                                │compile with gcc-8
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  742.5 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  655.9 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  886.1 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  917.9 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  374.5 MB/s, 1124.9 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  379.7 MB/s, 1197.5 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  278.4 MB/s,  982.2 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  283.9 MB/s, 1058.7 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  211.5 MB/s,  982.4 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  206.0 MB/s, 1037.2 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  150.1 MB/s,  799.9 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  147.2 MB/s,  842.3 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  103.2 MB/s,  954.5 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),   98.7 MB/s, 1009.6 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   82.2 MB/s,  761.1 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   79.0 MB/s,  806.1 MB/s
compile with gcc-9                                                                │compile with gcc-9
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  731.4 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  693.0 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  917.2 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  878.8 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  375.4 MB/s, 1176.1 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  377.6 MB/s, 1206.9 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  277.3 MB/s, 1021.5 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  279.4 MB/s, 1073.8 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  207.7 MB/s, 1017.5 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  212.0 MB/s, 1034.7 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  149.3 MB/s,  809.0 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  151.7 MB/s,  836.5 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  115.8 MB/s, 1003.9 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  115.1 MB/s,  999.9 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.1 MB/s,  791.1 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.6 MB/s,  795.1 MB/s
compile with gcc-10                                                               │compile with gcc-10
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  754.4 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  730.1 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  939.2 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s, 1010.1 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  379.9 MB/s, 1204.2 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  373.3 MB/s, 1311.9 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.1 MB/s, 1073.0 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  278.9 MB/s, 1164.2 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  213.2 MB/s, 1059.2 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  217.5 MB/s, 1146.1 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  152.1 MB/s,  878.8 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  155.7 MB/s,  933.5 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  114.3 MB/s, 1039.8 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  114.7 MB/s, 1125.0 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.0 MB/s,  847.2 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.2 MB/s,  904.5 MB/s
compile with gcc-11                                                               │compile with gcc-11
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  717.4 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  724.5 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  916.3 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  936.8 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  375.7 MB/s, 1181.5 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  375.9 MB/s, 1186.7 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  282.8 MB/s, 1034.4 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.2 MB/s, 1036.7 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  210.8 MB/s, 1039.3 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  207.0 MB/s, 1037.7 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  151.1 MB/s,  852.7 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  148.1 MB/s,  842.6 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  112.9 MB/s, 1011.4 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  113.6 MB/s, 1026.5 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   88.1 MB/s,  813.6 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   89.2 MB/s,  821.1 MB/s
compile with clang-6.0                                                            │compile with clang-6.0
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  693.0 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  756.6 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  897.2 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  932.8 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  386.3 MB/s  1164.7 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  387.4 MB/s  1222.4 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  285.5 MB/s, 1031.7 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  287.7 MB/s, 1091.3 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  212.4 MB/s, 1016.3 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  207.3 MB/s, 1058.9 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  153.0 MB/s,  828.7 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  150.4 MB/s,  863.9 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  115.8 MB/s,  981.2 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  119.6 MB/s, 1044.5 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.5 MB/s,  783.4 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   93.7 MB/s,  842.5 MB/s
 compile with clang-7                                                              │compile with clang-7
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  763.9 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  739.3 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  919.2 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  932.8 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  369.8 MB/s, 1187.8 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  377.3 MB/s, 1222.3 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  272.3 MB/s, 1057.4 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  279.8 MB/s, 1092.8 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  215.1 MB/s, 1034.8 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  214.3 MB/s, 1067.4 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  154.0 MB/s,  843.7 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  152.9 MB/s,  874.0 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  118.0 MB/s, 1002.5 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  116.4 MB/s, 1031.5 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.7 MB/s,  800.6 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.9 MB/s,  827.3 MB/s
compile with clang-8                                                              │compile with clang-8
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  683.5 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  754.2 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  962.9 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  927.6 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  393.3 MB/s  1253.5 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  393.7 MB/s  1217.8 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  286.4 MB/s, 1104.6 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  291.3 MB/s, 1086.0 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  207.4 MB/s, 1085.2 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  205.8 MB/s, 1054.2 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  149.9 MB/s,  874.1 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  148.4 MB/s,  856.8 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  118.4 MB/s, 1066.3 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  118.3 MB/s, 1033.3 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   90.8 MB/s,  848.4 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   91.3 MB/s,  829.8 MB/s
compile with clang-9                                                              │compile with clang-9
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  751.9 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  784.2 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  927.2 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  932.0 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  373.3 MB/s, 1209.4 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  370.7 MB/s, 1245.0 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  275.8 MB/s, 1063.2 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  280.4 MB/s, 1108.9 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  204.8 MB/s, 1055.4 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  204.6 MB/s, 1069.6 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  147.3 MB/s,  854.0 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  147.2 MB/s,  863.5 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  117.4 MB/s, 1035.9 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  116.9 MB/s, 1043.7 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   92.6 MB/s,  828.0 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   92.0 MB/s,  830.1 MB/s
compile with clang-10                                                             │compile with clang-10
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  747.2 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  759.1 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  935.8 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  941.3 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  387.5 MB/s  1211.0 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  387.7 MB/s  1240.6 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  286.6 MB/s, 1064.7 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  288.4 MB/s, 1098.9 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  211.1 MB/s, 1068.7 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  204.6 MB/s, 1071.4 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  153.1 MB/s,  870.8 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  149.3 MB/s,  868.8 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  120.1 MB/s, 1039.7 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  120.0 MB/s, 1056.2 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   93.5 MB/s,  830.2 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   93.3 MB/s,  846.2 MB/s
compile with clang-11                                                             │compile with clang-11
 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  752.5 MB/s  │ 3#enwik9.L22.zst    :1000000000 -> 215031773 (x4.650),   0.00 MB/s,  726.7 MB/s
 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  959.2 MB/s  │ 3#lesia.tar.L19.zst : 211957760 ->  52990423 (x4.000),   0.00 MB/s,  944.2 MB/s
 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  377.4 MB/s, 1261.9 MB/s  │ 1#silesia.tar       : 211957760 ->  73422067 (x2.887),  372.3 MB/s, 1242.9 MB/s
 1#enwik8            : 100000000 ->  40667563 (x2.459),  278.4 MB/s, 1109.6 MB/s  │ 1#enwik8            : 100000000 ->  40667563 (x2.459),  279.0 MB/s, 1102.7 MB/s
 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  206.2 MB/s, 1096.7 MB/s  │ 3#silesia.tar       : 211957760 ->  66523984 (x3.186),  210.1 MB/s, 1081.9 MB/s
 3#enwik8            : 100000000 ->  35461800 (x2.820),  149.8 MB/s,  883.3 MB/s  │ 3#enwik8            : 100000000 ->  35461800 (x2.820),  152.4 MB/s,  882.3 MB/s
 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  119.6 MB/s, 1079.4 MB/s  │ 5#silesia.tar       : 211957760 ->  63040521 (x3.362),  119.2 MB/s, 1058.2 MB/s
 5#enwik8            : 100000000 ->  33702880 (x2.967),   93.2 MB/s,  859.7 MB/s  │ 5#enwik8            : 100000000 ->  33702880 (x2.967),   92.5 MB/s,  848.4 MB/s
```

As expected, performance changes were essentially random, depending on compiler version. One could say they are rather more favorable and more stable for `gcc`, and rather defavorable for `clang`, mostly due to 2 bad versions. But this is just because the starting point of these comparisons (`dev` branch) was also randomly impacted by instruction alignments, and was a bit more detrimental to `gcc` baseline, and more advantageous to `clang`.

So far, no surprise, nothing conclusive. It's just a pity that such a setup doesn't allow us to detect small changes (~1% range) with confidence due to the much larger random impact of instruction alignment.

To complete the picture, I'm adding tests for the M1 Pro platform. As the cpu architecture is radically different, I was hoping that issues such as random instruction alignments impact would not be present there.

I was too optimistic.
The effect of this change is pretty positive when compiling with default system compiler (`Apple clang version 14.0.3 (clang-1403.0.22.14.1)`) : 
```
./zstd -b1e6i5 ~/dev/bench/silesia.tar            │
 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  610.8 MB/s, 1530.8 MB/s │ 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  609.9 MB/s, 1480.5 MB/s
 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  461.2 MB/s, 1419.2 MB/s │ 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  468.2 MB/s, 1361.7 MB/s
 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  383.3 MB/s  1413.0 MB/s │ 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  383.0 MB/s  1340.1 MB/s
 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  351.6 MB/s, 1412.6 MB/s │ 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  350.6 MB/s, 1334.0 MB/s
 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  183.1 MB/s, 1409.6 MB/s │ 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  182.8 MB/s, 1329.0 MB/s
 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  128.5 MB/s, 1502.9 MB/s │ 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  128.3 MB/s, 1419.3 MB/s
```
This is a non-negligible +4-5% decompression speed performance across the board, not bad !

Unfortunately, the trend reverses when using `gcc`, provided by `brew` : 
```
compile with gcc-11                                                              │compile with gcc-11
 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  609.2 MB/s, 1538.9 MB/s │ 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  602.1 MB/s, 1723.6 MB/s
 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  470.1 MB/s, 1439.7 MB/s │ 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  467.1 MB/s, 1676.9 MB/s
 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  378.4 MB/s, 1431.7 MB/s │ 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  374.9 MB/s, 1699.0 MB/s
 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  347.4 MB/s, 1431.6 MB/s │ 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  344.6 MB/s, 1720.1 MB/s
 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  187.6 MB/s, 1427.0 MB/s │ 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  187.7 MB/s, 1720.1 MB/s
 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  133.8 MB/s, 1522.5 MB/s │ 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  133.9 MB/s, 1823.1 MB/s

compile with gcc-12                                                              │compile with gcc-12
 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  613.7 MB/s, 1552.4 MB/s │ 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  613.2 MB/s, 1710.3 MB/s
 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  472.3 MB/s, 1454.3 MB/s │ 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  472.2 MB/s, 1664.2 MB/s
 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  377.9 MB/s, 1445.8 MB/s │ 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  377.5 MB/s, 1680.0 MB/s
 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  347.7 MB/s, 1448.7 MB/s │ 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  346.8 MB/s, 1700.7 MB/s
 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  184.5 MB/s, 1444.7 MB/s │ 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  184.3 MB/s, 1696.3 MB/s
 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  129.4 MB/s, 1541.2 MB/s │ 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  129.5 MB/s, 1798.0 MB/s

compile with gcc-13                                                              │compile with gcc-13
 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  617.4 MB/s, 1550.3 MB/s │ 1#silesia.tar       : 211972608 ->  73422432 (x2.887),  617.0 MB/s, 1713.0 MB/s
 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  477.0 MB/s, 1454.3 MB/s │ 2#silesia.tar       : 211972608 ->  69499071 (x3.050),  476.1 MB/s, 1663.7 MB/s
 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  379.6 MB/s, 1446.0 MB/s │ 3#silesia.tar       : 211972608 ->  66523575 (x3.186),  379.0 MB/s, 1682.8 MB/s
 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  349.6 MB/s, 1449.9 MB/s │ 4#silesia.tar       : 211972608 ->  65324711 (x3.245),  348.6 MB/s, 1700.3 MB/s
 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  184.4 MB/s, 1445.7 MB/s │ 5#silesia.tar       : 211972608 ->  63045668 (x3.362),  183.7 MB/s, 1697.9 MB/s
 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  129.3 MB/s, 1539.8 MB/s │ 6#silesia.tar       : 211972608 ->  61547760 (x3.444),  129.2 MB/s, 1800.4 MB/s
```

Now we are talking a pretty severe 10-12% decompression speed drop compared to `dev` !
This is a pretty large drop.

Yet, there are a few considerations.
To begin with, the performance of `gcc` on `dev` branch is exceptionally stellar. We are talking about a ~+20% performance advantage over `clang` ! This is impressive.
Even after the change, were `clang` gains +4-5% while `gcc` loses `-10-12%`, `gcc` is still in the lead, though by a reduced margin of `+2-3%`. 
This makes me wonder where does the exceptional performance of `gcc` on `dev` branch comes from.

This could be due to one or a combination of effects. Come to mind : 
1) M1 Pro is actually not immune to random instruction alignment side-effects, or other cpu architecture side-effects that are effectively uncontrollable from `C`.  `gcc` was simply "lucky" when generating the `dev` binary, and no longer after the change.
2) `gcc` might have performance heuristics that happen to work well with previous decoding loop, but do no longer get triggered properly after the change introduced by this patch.

Given that all 3 `gcc` versions tested have the same behavior, the explanation 2) feels a bit more likely. In which case, it would be interesting to understand why, and find a mitigation which allows `gcc` to shine again. But this is difficult to investigate. There is no equivalent to `perf` counter on `macos`. I presume understanding the performance profile of the generated binary implies better proficiency with `Xcode` tooling, and `Xcode` might be tied to `clang`.

Now, to be fair, on `macos` M1 Pro, I would also expect `clang` to be a more common compiler that `gcc`, making `clang` results a bit more important for this platform.

To summarize, if we ignore performance results or consider them non-conclusive, I am in favor of this PR, because : 
1) It achieves the objective (add an additional corruption case that can be detected without checksum)
2) It makes the decoding loop code (slightly) easier to read and maintain

I believe that both of these properties are desirable.