### PR TITLE
pzstd: use # directly for the test c++ snippet

### DIFF
--- a/contrib/pzstd/Makefile
+++ b/contrib/pzstd/Makefile
@@ -39,7 +39,7 @@ GTEST_INC  = -isystem googletest/googletest/include
 
 # If default C++ version is older than C++11, explicitly set C++11, which is the
 # minimum required by the code.
-ifeq ($(shell echo "\043if __cplusplus < 201103L\n\043error\n\043endif" | $(CXX) -x c++ -Werror -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),0)
+ifeq ($(shell echo "#if __cplusplus < 201103L\n#error\n#endif" | $(CXX) -x c++ -Werror -c - -o /dev/null 2>/dev/null && echo 1 || echo 0),0)
 PZSTD_CXX_STD := -std=c++11
 endif
 


### PR DESCRIPTION
\043 is not portable between shells: dash expands it to #, bash does not. As far as I see, using # works totally fine.