### PR TITLE
Clean up a false error message in the LDM debug log

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4609,19 +4609,15 @@ size_t ZSTD_writeLastEmptyBlock(void* dst, size_t dstCapacity)
     }
 }
 
-size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSeq)
+void ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSeq)
 {
-    RETURN_ERROR_IF(cctx->stage != ZSTDcs_init, stage_wrong,
-                    "wrong cctx stage");
-    RETURN_ERROR_IF(cctx->appliedParams.ldmParams.enableLdm == ZSTD_ps_enable,
-                    parameter_unsupported,
-                    "incompatible with ldm");
+    assert(cctx->stage == ZSTDcs_init);
+    assert(nbSeq == 0 || cctx->appliedParams.ldmParams.enableLdm != ZSTD_ps_enable);
     cctx->externSeqStore.seq = seq;
     cctx->externSeqStore.size = nbSeq;
     cctx->externSeqStore.capacity = nbSeq;
     cctx->externSeqStore.pos = 0;
     cctx->externSeqStore.posInSequence = 0;
-    return 0;
 }
 
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1467,11 +1467,10 @@ size_t ZSTD_writeLastEmptyBlock(void* dst, size_t dstCapacity);
  * This cannot be used when long range matching is enabled.
  * Zstd will use these sequences, and pass the literals to a secondary block
  * compressor.
- * @return : An error code on failure.
  * NOTE: seqs are not verified! Invalid sequences can cause out-of-bounds memory
  * access and data corruption.
  */
-size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSeq);
+void ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSeq);
 
 /** ZSTD_cycleLog() :
  *  condition for correct operation : hashLog > 1 */

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -601,11 +601,8 @@ static void ZSTDMT_serialState_update(serialState_t* serialState,
     ZSTD_pthread_mutex_unlock(&serialState->mutex);
 
     if (seqStore.size > 0) {
-        size_t const err = ZSTD_referenceExternalSequences(
-            jobCCtx, seqStore.seq, seqStore.size);
+        ZSTD_referenceExternalSequences(jobCCtx, seqStore.seq, seqStore.size);
         assert(serialState->params.ldmParams.enableLdm == ZSTD_ps_enable);
-        assert(!ZSTD_isError(err));
-        (void)err;
     }
 }
 


### PR DESCRIPTION
While investigating a fuzzer issue I got side-tracked by this error message, which delayed my investigation:
```
$ DEBUGLEVEL=5 make -j
$ ./zstd  foo.txt --long 2>&1 | grep ERROR
../lib/compress/zstd_compress.c:4618: ERROR!: check cctx->appliedParams.ldmParams.enableLdm == ZSTD_ps_enable failed, returning ERROR(parameter_unsupported): incompatible with ldm
```
The error is generated by [this call](https://github.com/facebook/zstd/blob/e4aeaebc201ba49fec50b087aeb15343c63712e5/lib/compress/zstd_compress.c#L2253) to `ZSTD_referenceExternalSequences()`. It is complaining that we should not reference external sequences in the top-level CCtx while in LDM mode. But in the linked callsite we are clearing the `externSeqStore`, not referencing external sequences. So the error is incorrect.

I suppressed the error when `nbSeq == 0`. Additionally, I converted the errors to asserts, because the return value of `ZSTD_referenceExternalSequences()` is never checked in release builds of the library:
```
$ rg ZSTD_referenceExternalSequences -A 3
lib/compress/zstd_compress_internal.h
1464:/* ZSTD_referenceExternalSequences() :
1465- * Must be called before starting a compression operation.
1466- * seqs must parse a prefix of the source.
1467- * This cannot be used when long range matching is enabled.
--
1474:size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSeq);
1475-
1476-/** ZSTD_cycleLog() :
1477- *  condition for correct operation : hashLog > 1 */

lib/compress/zstdmt_compress.c
604:        size_t const err = ZSTD_referenceExternalSequences(
605-            jobCCtx, seqStore.seq, seqStore.size);
606-        assert(serialState->params.ldmParams.enableLdm == ZSTD_ps_enable);
607-        assert(!ZSTD_isError(err));

lib/compress/zstd_compress.c
2253:        ZSTD_referenceExternalSequences(zc, NULL, 0);
2254-        zc->seqStore.maxNbSeq = maxNbSeq;
2255-        zc->seqStore.llCode = ZSTD_cwksp_reserve_buffer(ws, maxNbSeq * sizeof(BYTE));
2256-        zc->seqStore.mlCode = ZSTD_cwksp_reserve_buffer(ws, maxNbSeq * sizeof(BYTE));
--
4612:size_t ZSTD_referenceExternalSequences(ZSTD_CCtx* cctx, rawSeq* seq, size_t nbSeq)
4613-{
4614-    RETURN_ERROR_IF(cctx->stage != ZSTDcs_init, stage_wrong,
4615-                    "wrong cctx stage");
```