### PR TITLE
Hide ASM symbols on Apple platforms

### DIFF
--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -68,6 +68,8 @@
 /* Mark the internal assembly functions as hidden  */
 #ifdef __ELF__
 # define ZSTD_HIDE_ASM_FUNCTION(func) .hidden func
+#elif defined(__APPLE__)
+# define ZSTD_HIDE_ASM_FUNCTION(func) .private_extern func
 #else
 # define ZSTD_HIDE_ASM_FUNCTION(func)
 #endif


### PR DESCRIPTION
ASM symbols were hidden on platforms using the ELF binary format, but
macOS/iOS uses the Mach-O binary format, not ELF. In addition, the name of
the assembler directive used is different.

This PR hides the ASM symbols on Apple platforms.