### PR TITLE
Fix conditional compilation of ZSTD_assertValidSequence and ZSTD_dictionaryIsActive

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -1341,6 +1341,7 @@ ZSTD_decodeSequence(seqState_t* seqState, const ZSTD_longOffset_e longOffsets, c
 }
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#if DEBUGLEVEL >= 1
 MEM_STATIC int ZSTD_dictionaryIsActive(ZSTD_DCtx const* dctx, BYTE const* prefixStart, BYTE const* oLitEnd)
 {
     size_t const windowSize = dctx->fParams.windowSize;
@@ -1355,6 +1356,7 @@ MEM_STATIC int ZSTD_dictionaryIsActive(ZSTD_DCtx const* dctx, BYTE const* prefix
     /* Dictionary is active. */
     return 1;
 }
+#endif
 
 MEM_STATIC void ZSTD_assertValidSequence(
         ZSTD_DCtx const* dctx,

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -1340,7 +1340,7 @@ ZSTD_decodeSequence(seqState_t* seqState, const ZSTD_longOffset_e longOffsets, c
     return seq;
 }
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && defined(FUZZING_ASSERT_VALID_SEQUENCE)
 #if DEBUGLEVEL >= 1
 MEM_STATIC int ZSTD_dictionaryIsActive(ZSTD_DCtx const* dctx, BYTE const* prefixStart, BYTE const* oLitEnd)
 {


### PR DESCRIPTION
ZSTD_assertValidSequence is only called when both
FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION and
FUZZING_ASSERT_VALID_SEQUENCE are defined. Match those conditions for
the function's definition. Additionally, ZSTD_assertValidSequence only
calls ZSTD_dictionaryIsActive when DEBUGLEVEL >= 1, so only define the
function under that condition.