### PR TITLE
fix x32 tests on Github CI

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -38,7 +38,7 @@ jobs:
         CFLAGS="-m32 -O1 -fstack-protector" make check V=1
 
   check-x32:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  # ubuntu-latest == ubuntu-22.04 have issues currently with x32
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # tag=v3
     - name: make check on x32 ABI # https://en.wikipedia.org/wiki/X32_ABI


### PR DESCRIPTION
ubuntu-22.04 seems to have problems with x32 recently:
https://github.com/actions/runner-images/issues/8397

switching to ubuntu-20.04 which seems to work fine so far
