### PR TITLE
decompress: add -DZSTD_DISABLE_FAST_C_LOOP to disable fast C loops

### DIFF
--- a/doc/zstd_manual.html
+++ b/doc/zstd_manual.html
@@ -513,6 +513,8 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);  </b>/* accept NULL pointer */<b>
      * ZSTD_d_forceIgnoreChecksum
      * ZSTD_d_refMultipleDDicts
      * ZSTD_d_disableHuffmanAssembly
+     * ZSTD_d_maxBlockSize
+     * ZSTD_d_disableFastCLoops
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
@@ -520,7 +522,9 @@ size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);  </b>/* accept NULL pointer */<b>
      ZSTD_d_experimentalParam2=1001,
      ZSTD_d_experimentalParam3=1002,
      ZSTD_d_experimentalParam4=1003,
-     ZSTD_d_experimentalParam5=1004
+     ZSTD_d_experimentalParam5=1004,
+     ZSTD_d_experimentalParam6=1005,
+     ZSTD_d_experimentalParam7=1006,
 
 } ZSTD_dParameter;
 </b></pre><BR>

--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -136,6 +136,15 @@
 # define ZSTD_ENABLE_ASM_X86_64_BMI2 0
 #endif
 
+/**
+ * 
+*/
+#if !defined(ZSTD_DISABLE_FAST_C_LOOP)
+# define ZSTD_ENABLE_FAST_C_LOOP 1
+#else
+# define ZSTD_ENABLE_FAST_C_LOOP 0
+#endif
+
 /*
  * For x86 ELF targets, add .note.gnu.property section for Intel CET in
  * assembly sources when CET is enabled.

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -684,6 +684,7 @@ HUF_ASM_DECL void HUF_decompress4X1_usingDTable_internal_fast_asm_loop(HUF_Decom
 
 #endif
 
+#if ZSTD_ENABLE_FAST_C_LOOP
 static HUF_FAST_BMI2_ATTRS
 void HUF_decompress4X1_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* args)
 {
@@ -782,6 +783,7 @@ _out:
     ZSTD_memcpy((void*)(&args->ip), &ip, sizeof(ip));
     ZSTD_memcpy(&args->op, &op, sizeof(op));
 }
+#endif
 
 /**
  * @returns @p dstSize on success (>= 6)
@@ -847,7 +849,12 @@ static size_t HUF_decompress4X1_usingDTable_internal(void* dst, size_t dstSize, 
                     size_t cSrcSize, HUF_DTable const* DTable, int flags)
 {
     HUF_DecompressUsingDTableFn fallbackFn = HUF_decompress4X1_usingDTable_internal_default;
-    HUF_DecompressFastLoopFn loopFn = HUF_decompress4X1_usingDTable_internal_fast_c_loop;
+    HUF_DecompressFastLoopFn loopFn = NULL;
+    
+#if ZSTD_ENABLE_FAST_C_LOOP
+    loopFn = HUF_decompress4X1_usingDTable_internal_fast_c_loop;
+    #warning "ZSTD_ENABLE_FAST_C_LOOP is enabled, this is not recommended for production use"
+#endif
 
 #if DYNAMIC_BMI2
     if (flags & HUF_flags_bmi2) {
@@ -868,7 +875,7 @@ static size_t HUF_decompress4X1_usingDTable_internal(void* dst, size_t dstSize, 
     }
 #endif
 
-    if (!(flags & HUF_flags_disableFast)) {
+    if (loopFn && !(flags & HUF_flags_disableFast)) {
         size_t const ret = HUF_decompress4X1_usingDTable_internal_fast(dst, dstSize, cSrc, cSrcSize, DTable, loopFn);
         if (ret != 0)
             return ret;
@@ -1464,6 +1471,7 @@ HUF_ASM_DECL void HUF_decompress4X2_usingDTable_internal_fast_asm_loop(HUF_Decom
 
 #endif
 
+#if ZSTD_ENABLE_FAST_C_LOOP
 static HUF_FAST_BMI2_ATTRS
 void HUF_decompress4X2_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* args)
 {
@@ -1602,7 +1610,7 @@ _out:
     ZSTD_memcpy((void*)(&args->ip), &ip, sizeof(ip));
     ZSTD_memcpy(&args->op, &op, sizeof(op));
 }
-
+#endif
 
 static HUF_FAST_BMI2_ATTRS size_t
 HUF_decompress4X2_usingDTable_internal_fast(
@@ -1658,7 +1666,11 @@ static size_t HUF_decompress4X2_usingDTable_internal(void* dst, size_t dstSize, 
                     size_t cSrcSize, HUF_DTable const* DTable, int flags)
 {
     HUF_DecompressUsingDTableFn fallbackFn = HUF_decompress4X2_usingDTable_internal_default;
-    HUF_DecompressFastLoopFn loopFn = HUF_decompress4X2_usingDTable_internal_fast_c_loop;
+    HUF_DecompressFastLoopFn loopFn = NULL;
+    
+#if ZSTD_ENABLE_FAST_C_LOOP
+    loopFn = HUF_decompress4X2_usingDTable_internal_fast_c_loop;
+#endif
 
 #if DYNAMIC_BMI2
     if (flags & HUF_flags_bmi2) {
@@ -1679,7 +1691,7 @@ static size_t HUF_decompress4X2_usingDTable_internal(void* dst, size_t dstSize, 
     }
 #endif
 
-    if (!(flags & HUF_flags_disableFast)) {
+    if (loopFn && !(flags & HUF_flags_disableFast)) {
         size_t const ret = HUF_decompress4X2_usingDTable_internal_fast(dst, dstSize, cSrc, cSrcSize, DTable, loopFn);
         if (ret != 0)
             return ret;

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -853,7 +853,6 @@ static size_t HUF_decompress4X1_usingDTable_internal(void* dst, size_t dstSize, 
     
 #if ZSTD_ENABLE_FAST_C_LOOP
     loopFn = HUF_decompress4X1_usingDTable_internal_fast_c_loop;
-    #warning "ZSTD_ENABLE_FAST_C_LOOP is enabled, this is not recommended for production use"
 #endif
 
 #if DYNAMIC_BMI2

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -245,6 +245,7 @@ static void ZSTD_DCtx_resetParameters(ZSTD_DCtx* dctx)
     dctx->forceIgnoreChecksum = ZSTD_d_validateChecksum;
     dctx->refMultipleDDicts = ZSTD_rmd_refSingleDDict;
     dctx->disableHufAsm = 0;
+    dctx->disableHufFastCLoops = 0;
     dctx->maxBlockSizeParam = 0;
 }
 
@@ -1831,6 +1832,7 @@ ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam)
             bounds.upperBound = (int)ZSTD_rmd_refMultipleDDicts;
             return bounds;
         case ZSTD_d_disableHuffmanAssembly:
+        case ZSTD_d_disableHuffmanFastCLoops:
             bounds.lowerBound = 0;
             bounds.upperBound = 1;
             return bounds;
@@ -1882,6 +1884,9 @@ size_t ZSTD_DCtx_getParameter(ZSTD_DCtx* dctx, ZSTD_dParameter param, int* value
         case ZSTD_d_disableHuffmanAssembly:
             *value = (int)dctx->disableHufAsm;
             return 0;
+        case ZSTD_d_disableHuffmanFastCLoops:
+            *value = (int)dctx->disableHufFastCLoops;
+            return 0;
         case ZSTD_d_maxBlockSize:
             *value = dctx->maxBlockSizeParam;
             return 0;
@@ -1921,6 +1926,10 @@ size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter dParam, int value
         case ZSTD_d_disableHuffmanAssembly:
             CHECK_DBOUNDS(ZSTD_d_disableHuffmanAssembly, value);
             dctx->disableHufAsm = value != 0;
+            return 0;
+        case ZSTD_d_disableHuffmanFastCLoops:
+            CHECK_DBOUNDS(ZSTD_d_disableHuffmanFastCLoops, value);
+            dctx->disableHufFastCLoops = value != 0;
             return 0;
         case ZSTD_d_maxBlockSize:
             if (value != 0) CHECK_DBOUNDS(ZSTD_d_maxBlockSize, value);

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -159,7 +159,8 @@ static size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
                 size_t expectedWriteSize = MIN(blockSizeMax, dstCapacity);
                 int const flags = 0
                     | (ZSTD_DCtx_get_bmi2(dctx) ? HUF_flags_bmi2 : 0)
-                    | (dctx->disableHufAsm ? HUF_flags_disableAsm : 0);
+                    | (dctx->disableHufAsm ? HUF_flags_disableAsm : 0)
+                    | (dctx->disableHufFastCLoops ? HUF_flags_disableFast : 0);
                 switch(lhlCode)
                 {
                 case 0: case 1: default:   /* note : default is impossible, since lhlCode into [0..3] */

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -167,6 +167,7 @@ struct ZSTD_DCtx_s
     ZSTD_DDictHashSet* ddictSet;                    /* Hash set for multiple ddicts */
     ZSTD_refMultipleDDicts_e refMultipleDDicts;     /* User specified: if == 1, will allow references to multiple DDicts. Default == 0 (disabled) */
     int disableHufAsm;
+    int disableHufFastCLoops;
     int maxBlockSizeParam;
 
     /* streaming */

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -619,6 +619,7 @@ typedef enum {
      * ZSTD_d_refMultipleDDicts
      * ZSTD_d_disableHuffmanAssembly
      * ZSTD_d_maxBlockSize
+     * ZSTD_d_disableHuffmanFastCLoops
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly
      */
@@ -627,7 +628,8 @@ typedef enum {
      ZSTD_d_experimentalParam3=1002,
      ZSTD_d_experimentalParam4=1003,
      ZSTD_d_experimentalParam5=1004,
-     ZSTD_d_experimentalParam6=1005
+     ZSTD_d_experimentalParam6=1005,
+     ZSTD_d_experimentalParam7=1006,
 
 } ZSTD_dParameter;
 
@@ -2453,6 +2455,18 @@ ZSTDLIB_STATIC_API size_t ZSTD_DCtx_getParameter(ZSTD_DCtx* dctx, ZSTD_dParamete
  * that have block sizes larger than the configured maxBlockSize.
  */
 #define ZSTD_d_maxBlockSize ZSTD_d_experimentalParam6
+
+
+/* ZSTD_d_disableHuffmanFastCLoops
+ * Set to 1 to disable the generic C fast compression loops.
+  * The default value is 0, which allows zstd to use the generic C fast
+  * compression loops.
+  * 
+  * This parameter can be used to disable the generic C fast compression loops
+  * at runtime. If you want to disable them at compile time you can define the
+  * macro ZSTD_DISABLE_FAST_C_LOOP.
+  */
+#define ZSTD_d_disableHuffmanFastCLoops ZSTD_d_experimentalParam7
 
 
 /*! ZSTD_DCtx_setFormat() :

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -629,7 +629,7 @@ typedef enum {
      ZSTD_d_experimentalParam4=1003,
      ZSTD_d_experimentalParam5=1004,
      ZSTD_d_experimentalParam6=1005,
-     ZSTD_d_experimentalParam7=1006,
+     ZSTD_d_experimentalParam7=1006
 
 } ZSTD_dParameter;
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -695,6 +695,17 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : decompress %u bytes with fast C Loops disabled : ", testNb++, (unsigned)CNBuffSize);
+    {
+        ZSTD_DCtx* dctx = ZSTD_createDCtx();
+        size_t r;
+        CHECK_Z(ZSTD_DCtx_setParameter(dctx, ZSTD_d_disableHuffmanFastCLoops, 1));
+        r = ZSTD_decompress(decodedBuffer, CNBuffSize, compressedBuffer, cSize);
+        if (r != CNBuffSize || memcmp(decodedBuffer, CNBuffer, CNBuffSize)) goto _output_error;
+        ZSTD_freeDCtx(dctx);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     DISPLAYLEVEL(3, "test%3i : check decompressed result : ", testNb++);
     {   size_t u;
         for (u=0; u<CNBuffSize; u++) {

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -3045,6 +3045,9 @@ static int fuzzerTests_newAPI(U32 seed, int nbTests, int startTest,
             CHECK_Z(ZSTD_DCtx_setParameter(zd, ZSTD_d_disableHuffmanAssembly, FUZ_rand(&lseed) & 1));
         }
         if (FUZ_rand(&lseed) & 1) {
+            CHECK_Z(ZSTD_DCtx_setParameter(zd, ZSTD_d_disableHuffmanFastCLoops, FUZ_rand(&lseed) & 1));
+        }
+        if (FUZ_rand(&lseed) & 1) {
             int maxBlockSize;
             CHECK_Z(ZSTD_CCtx_getParameter(zc, ZSTD_c_maxBlockSize, &maxBlockSize));
             CHECK_Z(ZSTD_DCtx_setParameter(zd, ZSTD_d_maxBlockSize, maxBlockSize));
@@ -3099,6 +3102,9 @@ static int fuzzerTests_newAPI(U32 seed, int nbTests, int startTest,
         }
         if (FUZ_rand(&lseed) & 1) {
             CHECK_Z(ZSTD_DCtx_setParameter(zd_noise, ZSTD_d_disableHuffmanAssembly, FUZ_rand(&lseed) & 1));
+        }
+        if (FUZ_rand(&lseed) & 1) {
+            CHECK_Z(ZSTD_DCtx_setParameter(zd_noise, ZSTD_d_disableHuffmanFastCLoops, FUZ_rand(&lseed) & 1));
         }
         {   ZSTD_inBuffer  inBuff = { cBuffer, cSize, 0 };
             ZSTD_outBuffer outBuff= { dstBuffer, dstBufferSize, 0 };


### PR DESCRIPTION
https://github.com/facebook/zstd/issues/3762 seems to show that it doesn't perform as well as we though it would in many cases. It makes sense to at least allow users to disable them at buildtime and runtime.

