### PR TITLE
Correct FSE probability bit consumption in specification

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1083,7 +1083,8 @@ It depends on :
   Presuming an `Accuracy_Log` of 8,
   and presuming 100 probabilities points have already been distributed,
   the decoder may read any value from `0` to `256 - 100 + 1 == 157` (inclusive).
-  Therefore, it may read up to `log2sup(157) == 8` bits.
+  Therefore, it may read up to `log2sup(157) == 8` bits, where `log2sup(N)`
+  is the smallest integer `T` that satisfies `(1 << T) > N`.
 
 - Value decoded : small values use 1 less bit :
   __example__ :

--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1083,7 +1083,7 @@ It depends on :
   Presuming an `Accuracy_Log` of 8,
   and presuming 100 probabilities points have already been distributed,
   the decoder may read any value from `0` to `256 - 100 + 1 == 157` (inclusive).
-  Therefore, it must read `log2sup(157) == 8` bits.
+  Therefore, it may read up to `log2sup(157) == 8` bits.
 
 - Value decoded : small values use 1 less bit :
   __example__ :


### PR DESCRIPTION
The current verbiage states that a decoder "must" read the number of bits required for the maximum representable value but it actually may read 1 bit less than that, per the second bullet point.

It does not appear to overconsume bits when it needs fewer than that, which would have implications for decoder behavior if it did.