### PR TITLE
Clarify that a stream containing too many Huffman weights is invalid

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1353,6 +1353,9 @@ If updating state after decoding a symbol would require more bits than
 remain in the stream, it is assumed that extra bits are 0.  Then,
 symbols for each of the final states are decoded and the process is complete.
 
+If this process would produce more weights than the maximum number of decoded
+weights (255), then the data is considered corrupted.
+
 #### Conversion from weights to Huffman prefix codes
 
 All present symbols shall now have a `Weight` value.


### PR DESCRIPTION
The Huffman weight decoding section specifies how the maximum decoded size is to be calculated but doesn't specify what should happen if that size is exceeded (i.e. if this is a failure condition, or if surplus data should be ignored, or something else).

This clarifies that the expected behavior is to reject the data, matching the behavior of `FSE_decompress_wksp_bmi2`.