### PR TITLE
Clarify that the presence of weight value 1 is required, and a lone implied 1 weight is invalid

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1252,7 +1252,9 @@ Number_of_Bits = Weight ? (Max_Number_of_Bits + 1 - Weight) : 0
 ```
 When a literal value is not present, it receives a `Weight` of 0.
 The least frequent symbol receives a `Weight` of 1.
-If no symbol has a `Weight` of 1, then the data is considered corrupted.
+If no literal has a `Weight` of 1, then the data is considered corrupted.
+If there are not at least two literals with non-zero `Weight`, then the data
+is considered corrupted.
 The most frequent symbol receives a `Weight` anywhere between 1 and 11 (max).
 The last symbol's `Weight` is deduced from previously retrieved Weights,
 by completing to the nearest power of 2. It's necessarily non 0.

--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1252,7 +1252,7 @@ Number_of_Bits = Weight ? (Max_Number_of_Bits + 1 - Weight) : 0
 ```
 When a literal value is not present, it receives a `Weight` of 0.
 The least frequent symbol receives a `Weight` of 1.
-Consequently, the `Weight` 1 is necessarily present.
+If no symbol has a `Weight` of 1, then the data is considered corrupted.
 The most frequent symbol receives a `Weight` anywhere between 1 and 11 (max).
 The last symbol's `Weight` is deduced from previously retrieved Weights,
 by completing to the nearest power of 2. It's necessarily non 0.


### PR DESCRIPTION
Adjust the "necessarily present" language to match other language and indicate that the absence of a value of weight 1 is invalid.

While it is possible to produce a valid Huffman table without any values with weight 1, `HUF_readStats_body` will reject it.

`HUF_readStats_body` also enforces that the weight 1 count is even.  Normally, an odd number of 1 weights will result in the resolution of the final weight failing anyway, except for one scenario: All other weights being zero, leaving only the final implied 1 weight.  So, this adds a specification that there must be at least 2 non-zero weights.