### PR TITLE
Clarify that probability tables must not contain non-zero probabilities for invalid values

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1124,6 +1124,9 @@ When last symbol reaches cumulated total of `1 << Accuracy_Log`,
 decoding is complete.
 If the last symbol makes cumulated total go above `1 << Accuracy_Log`,
 distribution is considered corrupted.
+If this process results in a non-zero probability for a value outside of the
+valid range of values that the FSE table is defined for, even if that value is
+not used, then the data is considered corrupted.
 
 Then the decoder can tell how many bytes were used in this process,
 and how many symbols are present.


### PR DESCRIPTION
The current specification indicates the valid range of values decoded from the FSE entropy coder, but doesn't specify what happens if the probability table declares a non-zero probability for an invalid value but never produces that value.

This adds a specification that a probability table must not contain out-of-range values, even if they are unused, reflecting the behavior of `ZSTD_buildSeqTable`.