### PR TITLE
Specify offset 0 as invalid and specify required fixup behavior

### DIFF
--- a/doc/decompressor_accepted_invalid_data.md
+++ b/doc/decompressor_accepted_invalid_data.md
@@ -1,0 +1,14 @@
+Decompressor Accepted Invalid Data
+==================================
+
+This document describes the behavior of the reference decompressor in cases
+where it accepts an invalid frame instead of reporting an error.
+
+Zero offsets converted to 1
+---------------------------
+If a sequence is decoded with `literals_length = 0` and `offset_value = 3`
+while `Repeated_Offset_1 = 1`, the computed offset will be `0`, which is
+invalid.
+
+The reference decompressor will process this case as if the computed
+offset was `1`, including inserting `1` into the repeated offset list.

--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -929,7 +929,10 @@ There is an exception though, when current sequence's `literals_length = 0`.
 In this case, repeated offsets are shifted by one,
 so an `offset_value` of 1 means `Repeated_Offset2`,
 an `offset_value` of 2 means `Repeated_Offset3`,
-and an `offset_value` of 3 means `Repeated_Offset1 - 1_byte`.
+and an `offset_value` of 3 means `Repeated_Offset1 - 1`.
+
+In the final case, if `Repeated_Offset1 - 1` evaluates to 0, then the
+data is considered corrupted.
 
 For the first block, the starting offset history is populated with following values :
 `Repeated_Offset1`=1, `Repeated_Offset2`=4, `Repeated_Offset3`=8,


### PR DESCRIPTION
Addresses #3823

Specifies that this case is invalid, but also specifies the fixup behavior.

There have historically been some security issues (not in this project) caused by implementation divergence so I think it is best to specify it, as it is the only case I can find where Zstd doesn't error on invalid data.

This would limit compliant implementations to 2 allowed behaviors: Evaluate as 1, or raise an error.