### PR TITLE
Add more prefetching to decompression.

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -40,6 +40,7 @@
 #error "Cannot force the use of the short and the long ZSTD_decompressSequences variants!"
 #endif
 
+#define PREFETCH_DISTANCE (8*CACHELINE_SIZE)
 
 /*_*******************************************************
 *  Memory operations
@@ -1414,6 +1415,8 @@ ZSTD_decompressSequences_bodySplitLitBuffer( ZSTD_DCtx* dctx,
     const BYTE* const prefixStart = (const BYTE*) (dctx->prefixStart);
     const BYTE* const vBase = (const BYTE*) (dctx->virtualStart);
     const BYTE* const dictEnd = (const BYTE*) (dctx->dictEnd);
+    int counter = 0;
+    const int kPrefetchRatio = 16;
     DEBUGLOG(5, "ZSTD_decompressSequences_bodySplitLitBuffer (%i seqs)", nbSeq);
 
     /* Literals are split between internal buffer & output buffer */
@@ -1501,6 +1504,12 @@ ZSTD_decompressSequences_bodySplitLitBuffer( ZSTD_DCtx* dctx,
                 sequence = ZSTD_decodeSequence(&seqState, isLongOffset, nbSeq==1);
                 if (litPtr + sequence.litLength > dctx->litBufferEnd) break;
                 {   size_t const oneSeqSize = ZSTD_execSequenceSplitLitBuffer(op, oend, litPtr + sequence.litLength - WILDCOPY_OVERLENGTH, sequence, &litPtr, litBufferEnd, prefixStart, vBase, dictEnd);
+                    /* Don't prefetch  too often, because it is actually slower */
+                    counter++;
+                    if ((counter / kPrefetchRatio) == 0) {
+                      PREFETCH_L1(op+PREFETCH_DISTANCE);
+                      PREFETCH_L1(litPtr+PREFETCH_DISTANCE);
+                    }
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && defined(FUZZING_ASSERT_VALID_SEQUENCE)
                     assert(!ZSTD_isError(oneSeqSize));
                     ZSTD_assertValidSequence(dctx, op, oend, sequence, prefixStart, vBase);
@@ -1562,6 +1571,8 @@ ZSTD_decompressSequences_bodySplitLitBuffer( ZSTD_DCtx* dctx,
             for ( ; nbSeq ; nbSeq--) {
                 seq_t const sequence = ZSTD_decodeSequence(&seqState, isLongOffset, nbSeq==1);
                 size_t const oneSeqSize = ZSTD_execSequence(op, oend, sequence, &litPtr, litBufferEnd, prefixStart, vBase, dictEnd);
+                PREFETCH_L1(op+PREFETCH_DISTANCE);
+                PREFETCH_L1(litPtr+PREFETCH_DISTANCE);
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && defined(FUZZING_ASSERT_VALID_SEQUENCE)
                 assert(!ZSTD_isError(oneSeqSize));
                 ZSTD_assertValidSequence(dctx, op, oend, sequence, prefixStart, vBase);
@@ -1655,6 +1666,8 @@ ZSTD_decompressSequences_body(ZSTD_DCtx* dctx,
         for ( ; nbSeq ; nbSeq--) {
             seq_t const sequence = ZSTD_decodeSequence(&seqState, isLongOffset, nbSeq==1);
             size_t const oneSeqSize = ZSTD_execSequence(op, oend, sequence, &litPtr, litEnd, prefixStart, vBase, dictEnd);
+            PREFETCH_L1(op+PREFETCH_DISTANCE);
+            PREFETCH_L1(litPtr+PREFETCH_DISTANCE);
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && defined(FUZZING_ASSERT_VALID_SEQUENCE)
             assert(!ZSTD_isError(oneSeqSize));
             ZSTD_assertValidSequence(dctx, op, oend, sequence, prefixStart, vBase);


### PR DESCRIPTION
The benefit is hard to show in benchmarks, but observing the production environment, this change showed single digit improvement on AMD, and nothing but noise on Intel. Closest approximation is benchmarks on AMD machines with disabled hardware prefetching and internal dataset (effect isn't as strong, but directionally correct):

name                                                                                    old time/op  new time/op  delta
BM_DecompressFlat/0/2               [html/level=2]                                      58.5µs ± 2%  57.8µs ± 1%  -1.10%  (p=0.000 n=18+19)
BM_DecompressFlat/1/2               [urls/level=2]                                       621µs ± 1%   623µs ± 1%    ~     (p=0.068 n=20+20)
BM_DecompressFlat/2/2               [jpg/level=2]                                       3.38µs ± 1%  3.36µs ± 1%    ~     (p=0.080 n=19+19)
BM_DecompressFlat/3/2               [jpg_200/level=2]                                   2.81µs ± 1%  2.82µs ± 1%    ~     (p=0.311 n=19+19)
BM_DecompressFlat/4/2               [pdf/level=2]                                       11.8µs ± 1%  11.9µs ± 1%  +0.60%  (p=0.004 n=19+19)
BM_DecompressFlat/5/2               [html4/level=2]                                     66.7µs ± 2%  66.6µs ± 2%    ~     (p=0.512 n=20+20)
BM_DecompressFlat/6/2               [txt1/level=2]                                       194µs ± 1%   190µs ± 1%  -1.97%  (p=0.000 n=19+17)
BM_DecompressFlat/7/2               [txt2/level=2]                                       174µs ± 1%   170µs ± 1%  -1.99%  (p=0.000 n=19+20)
BM_DecompressFlat/8/2               [txt3/level=2]                                       506µs ± 1%   497µs ± 1%  -1.76%  (p=0.000 n=18+19)
BM_DecompressFlat/9/2               [txt4/level=2]                                       632µs ± 1%   621µs ± 1%  -1.71%  (p=0.000 n=18+20)
BM_DecompressFlat/10/2          [pb/level=2]                                            53.7µs ± 2%  52.1µs ± 2%  -3.02%  (p=0.000 n=19+20)
BM_DecompressFlat/11/2          [gaviota/level=2]                                        218µs ± 4%   218µs ± 1%    ~     (p=0.369 n=20+20)
BM_DecompressFlat/12/2          [cp/level=2]                                            28.7µs ± 1%  28.0µs ± 1%  -2.29%  (p=0.000 n=19+19)
BM_DecompressFlat/13/2          [c/level=2]                                             17.8µs ± 1%  17.5µs ± 1%  -1.97%  (p=0.000 n=18+20)
BM_DecompressFlat/14/2          [lsp/level=2]                                           7.15µs ± 1%  7.08µs ± 1%  -0.96%  (p=0.000 n=19+20)
BM_DecompressFlat/15/2          [xls/level=2]                                           1.07ms ± 1%  1.09ms ± 1%  +1.51%  (p=0.000 n=18+18)
BM_DecompressFlat/16/2          [xls_200/level=2]                                       2.21µs ± 1%  2.24µs ± 1%  +1.20%  (p=0.000 n=18+16)
BM_DecompressFlat/17/2          [bin/level=2]                                            281µs ± 2%   286µs ± 1%  +1.80%  (p=0.000 n=19+19)
BM_DecompressFlat/18/2          [bin_200/level=2]                                        268ns ± 3%   265ns ± 2%  -1.09%  (p=0.005 n=19+20)
BM_DecompressFlat/19/2          [sum/level=2]                                           43.4µs ± 1%  41.9µs ± 2%  -3.39%  (p=0.000 n=20+19)
BM_DecompressFlat/20/2          [man/level=2]                                           8.31µs ± 1%  8.17µs ± 2%  -1.78%  (p=0.000 n=20+18)
BM_DecompressFlat/0/3               [html/level=3]                                      55.5µs ± 1%  53.7µs ± 1%  -3.27%  (p=0.000 n=20+19)
BM_DecompressFlat/1/3               [urls/level=3]                                       631µs ± 2%   631µs ± 1%    ~     (p=0.862 n=20+20)
BM_DecompressFlat/2/3               [jpg/level=3]                                       3.38µs ± 2%  3.36µs ± 1%  -0.65%  (p=0.002 n=20+20)
BM_DecompressFlat/3/3               [jpg_200/level=3]                                   2.83µs ± 2%  2.79µs ± 1%  -1.27%  (p=0.000 n=20+19)
BM_DecompressFlat/4/3               [pdf/level=3]                                       11.6µs ± 2%  11.7µs ± 1%  +0.70%  (p=0.000 n=19+19)
BM_DecompressFlat/5/3               [html4/level=3]                                     68.0µs ± 2%  72.1µs ± 3%  +6.06%  (p=0.000 n=20+20)
BM_DecompressFlat/6/3               [txt1/level=3]                                       221µs ± 1%   216µs ± 1%  -2.19%  (p=0.000 n=20+18)
BM_DecompressFlat/7/3               [txt2/level=3]                                       160µs ± 1%   157µs ± 2%  -1.85%  (p=0.000 n=20+20)
BM_DecompressFlat/8/3               [txt3/level=3]                                       509µs ± 2%   496µs ± 1%  -2.47%  (p=0.000 n=20+18)
BM_DecompressFlat/9/3               [txt4/level=3]                                       669µs ± 1%   655µs ± 1%  -2.06%  (p=0.000 n=18+19)
BM_DecompressFlat/10/3          [pb/level=3]                                            51.8µs ± 2%  50.8µs ± 2%  -1.86%  (p=0.000 n=20+20)
BM_DecompressFlat/11/3          [gaviota/level=3]                                        232µs ± 2%   231µs ± 1%    ~     (p=0.879 n=20+19)
BM_DecompressFlat/12/3          [cp/level=3]                                            27.5µs ± 1%  27.0µs ± 2%  -1.67%  (p=0.000 n=18+20)
BM_DecompressFlat/13/3          [c/level=3]                                             15.0µs ± 1%  14.7µs ± 1%  -2.51%  (p=0.000 n=17+19)
BM_DecompressFlat/14/3          [lsp/level=3]                                           6.85µs ± 1%  6.78µs ± 1%  -1.07%  (p=0.000 n=19+20)
BM_DecompressFlat/15/3          [xls/level=3]                                           1.06ms ± 1%  1.07ms ± 1%  +1.32%  (p=0.000 n=20+19)
BM_DecompressFlat/16/3          [xls_200/level=3]                                       2.21µs ± 2%  2.19µs ± 1%  -0.55%  (p=0.033 n=20+20)
BM_DecompressFlat/17/3          [bin/level=3]                                            312µs ± 2%   315µs ± 1%  +1.10%  (p=0.000 n=20+18)
BM_DecompressFlat/18/3          [bin_200/level=3]                                        266ns ± 2%   265ns ± 2%  -0.65%  (p=0.013 n=18+19)
BM_DecompressFlat/19/3          [sum/level=3]                                           42.8µs ± 1%  41.0µs ± 2%  -4.20%  (p=0.000 n=16+20)
BM_DecompressFlat/20/3          [man/level=3]                                           8.01µs ± 1%  7.89µs ± 1%  -1.56%  (p=0.000 n=19+20)
BM_DecompressFlat/0/5               [html/level=5]                                      56.2µs ± 2%  55.7µs ± 1%  -0.88%  (p=0.000 n=20+20)
BM_DecompressFlat/1/5               [urls/level=5]                                       633µs ± 1%   634µs ± 1%    ~     (p=0.947 n=20+20)
BM_DecompressFlat/2/5               [jpg/level=5]                                       3.37µs ± 1%  3.36µs ± 1%    ~     (p=0.114 n=20+20)
BM_DecompressFlat/3/5               [jpg_200/level=5]                                   2.85µs ± 1%  2.82µs ± 1%  -1.22%  (p=0.000 n=20+19)
BM_DecompressFlat/4/5               [pdf/level=5]                                       14.8µs ± 2%  14.8µs ± 1%    ~     (p=0.397 n=19+17)
BM_DecompressFlat/5/5               [html4/level=5]                                     64.4µs ± 3%  67.5µs ± 3%  +4.94%  (p=0.000 n=20+19)
BM_DecompressFlat/6/5               [txt1/level=5]                                       191µs ± 2%   188µs ± 1%  -1.68%  (p=0.000 n=20+19)
BM_DecompressFlat/7/5               [txt2/level=5]                                       196µs ± 1%   192µs ± 2%  -2.24%  (p=0.000 n=20+20)
BM_DecompressFlat/8/5               [txt3/level=5]                                       520µs ± 1%   510µs ± 1%  -1.87%  (p=0.000 n=20+20)
BM_DecompressFlat/9/5               [txt4/level=5]                                       697µs ± 1%   682µs ± 1%  -2.10%  (p=0.000 n=20+19)
BM_DecompressFlat/10/5          [pb/level=5]                                            51.3µs ± 4%  50.2µs ± 2%  -2.15%  (p=0.000 n=20+20)
BM_DecompressFlat/11/5          [gaviota/level=5]                                        216µs ± 2%   218µs ± 1%  +1.02%  (p=0.001 n=20+19)
BM_DecompressFlat/12/5          [cp/level=5]                                            29.9µs ± 2%  29.0µs ± 1%  -3.01%  (p=0.000 n=20+19)
BM_DecompressFlat/13/5          [c/level=5]                                             14.2µs ± 1%  13.9µs ± 1%  -1.97%  (p=0.000 n=20+19)
BM_DecompressFlat/14/5          [lsp/level=5]                                           6.62µs ± 1%  6.60µs ± 1%  -0.43%  (p=0.004 n=18+19)
BM_DecompressFlat/15/5          [xls/level=5]                                           1.07ms ± 1%  1.09ms ± 1%  +1.68%  (p=0.000 n=19+20)
BM_DecompressFlat/16/5          [xls_200/level=5]                                       2.65µs ± 1%  2.64µs ± 1%    ~     (p=0.053 n=18+19)
BM_DecompressFlat/17/5          [bin/level=5]                                            309µs ± 2%   312µs ± 1%  +0.93%  (p=0.004 n=20+20)
BM_DecompressFlat/18/5          [bin_200/level=5]                                        268ns ± 2%   264ns ± 0%  -1.66%  (p=0.000 n=19+16)
BM_DecompressFlat/19/5          [sum/level=5]                                           48.8µs ± 1%  46.8µs ± 2%  -4.21%  (p=0.000 n=19+20)
BM_DecompressFlat/20/5          [man/level=5]                                           7.90µs ± 2%  7.73µs ± 1%  -2.13%  (p=0.000 n=19+20)
BM_DecompressFlat/0/7               [html/level=7]                                      52.2µs ± 2%  51.9µs ± 2%  -0.65%  (p=0.007 n=18+20)
BM_DecompressFlat/1/7               [urls/level=7]                                       605µs ± 2%   604µs ± 1%    ~     (p=0.885 n=19+19)
BM_DecompressFlat/2/7               [jpg/level=7]                                       3.37µs ± 1%  3.36µs ± 1%  -0.38%  (p=0.021 n=20+20)
BM_DecompressFlat/3/7               [jpg_200/level=7]                                   2.85µs ± 1%  2.81µs ± 1%  -1.22%  (p=0.000 n=20+19)
BM_DecompressFlat/4/7               [pdf/level=7]                                       13.2µs ± 1%  13.3µs ± 1%    ~     (p=0.127 n=20+20)
BM_DecompressFlat/5/7               [html4/level=7]                                     61.0µs ± 3%  64.1µs ± 4%  +5.13%  (p=0.000 n=17+20)
BM_DecompressFlat/6/7               [txt1/level=7]                                       205µs ± 1%   202µs ± 1%  -1.55%  (p=0.000 n=18+20)
BM_DecompressFlat/7/7               [txt2/level=7]                                       174µs ± 1%   170µs ± 2%  -1.94%  (p=0.000 n=19+20)
BM_DecompressFlat/8/7               [txt3/level=7]                                       482µs ± 1%   473µs ± 1%  -1.92%  (p=0.000 n=20+20)
BM_DecompressFlat/9/7               [txt4/level=7]                                       642µs ± 1%   631µs ± 1%  -1.83%  (p=0.000 n=18+20)
BM_DecompressFlat/10/7          [pb/level=7]                                            47.1µs ± 2%  45.6µs ± 2%  -3.16%  (p=0.000 n=18+19)
BM_DecompressFlat/11/7          [gaviota/level=7]                                        221µs ± 3%   222µs ± 1%    ~     (p=0.217 n=20+18)
BM_DecompressFlat/12/7          [cp/level=7]                                            28.3µs ± 2%  27.6µs ± 1%  -2.38%  (p=0.000 n=20+18)
BM_DecompressFlat/13/7          [c/level=7]                                             13.5µs ± 2%  13.2µs ± 1%  -2.56%  (p=0.000 n=20+20)
BM_DecompressFlat/14/7          [lsp/level=7]                                           6.54µs ± 1%  6.49µs ± 1%  -0.85%  (p=0.000 n=17+18)
BM_DecompressFlat/15/7          [xls/level=7]                                           1.02ms ± 1%  1.04ms ± 1%  +1.49%  (p=0.000 n=20+19)
BM_DecompressFlat/16/7          [xls_200/level=7]                                       2.65µs ± 1%  2.64µs ± 2%    ~     (p=0.095 n=20+19)
BM_DecompressFlat/17/7          [bin/level=7]                                            276µs ± 3%   280µs ± 3%  +1.50%  (p=0.000 n=19+20)
BM_DecompressFlat/18/7          [bin_200/level=7]                                        267ns ± 1%   264ns ± 2%  -1.13%  (p=0.000 n=18+20)
BM_DecompressFlat/19/7          [sum/level=7]                                           44.9µs ± 1%  43.3µs ± 1%  -3.53%  (p=0.000 n=20+20)
BM_DecompressFlat/20/7          [man/level=7]                                           7.81µs ± 2%  7.63µs ± 1%  -2.40%  (p=0.000 n=19+19)
BM_DecompressFlat/0/9               [html/level=9]                                      50.6µs ± 1%  49.6µs ± 1%  -1.83%  (p=0.000 n=19+20)
BM_DecompressFlat/1/9               [urls/level=9]                                       592µs ± 2%   592µs ± 1%    ~     (p=0.588 n=19+20)
BM_DecompressFlat/2/9               [jpg/level=9]                                       3.37µs ± 1%  3.36µs ± 2%  -0.26%  (p=0.038 n=20+19)
BM_DecompressFlat/3/9               [jpg_200/level=9]                                   2.85µs ± 1%  2.81µs ± 1%  -1.22%  (p=0.000 n=19+18)
BM_DecompressFlat/4/9               [pdf/level=9]                                       12.9µs ± 1%  13.1µs ± 2%  +0.87%  (p=0.001 n=20+19)
BM_DecompressFlat/5/9               [html4/level=9]                                     59.3µs ± 3%  61.4µs ± 2%  +3.55%  (p=0.000 n=20+19)
BM_DecompressFlat/6/9               [txt1/level=9]                                       190µs ± 1%   187µs ± 1%  -1.65%  (p=0.000 n=20+19)
BM_DecompressFlat/7/9               [txt2/level=9]                                       168µs ± 1%   164µs ± 1%  -2.02%  (p=0.000 n=20+20)
BM_DecompressFlat/8/9               [txt3/level=9]                                       462µs ± 1%   454µs ± 1%  -1.74%  (p=0.000 n=20+20)
BM_DecompressFlat/9/9               [txt4/level=9]                                       619µs ± 1%   605µs ± 1%  -2.31%  (p=0.000 n=20+17)
BM_DecompressFlat/10/9          [pb/level=9]                                            45.6µs ± 2%  44.9µs ± 1%  -1.42%  (p=0.000 n=20+20)
BM_DecompressFlat/11/9          [gaviota/level=9]                                        201µs ± 2%   202µs ± 1%    ~     (p=0.192 n=20+20)
BM_DecompressFlat/12/9          [cp/level=9]                                            27.8µs ± 1%  27.1µs ± 1%  -2.55%  (p=0.000 n=19+17)
BM_DecompressFlat/13/9          [c/level=9]                                             13.5µs ± 2%  13.2µs ± 1%  -2.21%  (p=0.000 n=19+18)
BM_DecompressFlat/14/9          [lsp/level=9]                                           6.53µs ± 1%  6.48µs ± 1%  -0.73%  (p=0.000 n=19+18)
BM_DecompressFlat/15/9          [xls/level=9]                                           1.05ms ± 2%  1.06ms ± 1%  +0.75%  (p=0.009 n=20+19)
BM_DecompressFlat/16/9          [xls_200/level=9]                                       2.66µs ± 2%  2.64µs ± 1%  -0.64%  (p=0.005 n=20+19)
BM_DecompressFlat/17/9          [bin/level=9]                                            272µs ± 2%   275µs ± 2%  +0.99%  (p=0.003 n=20+19)
BM_DecompressFlat/18/9          [bin_200/level=9]                                        266ns ± 2%   265ns ± 3%    ~     (p=0.061 n=19+20)
BM_DecompressFlat/19/9          [sum/level=9]                                           44.3µs ± 1%  42.7µs ± 2%  -3.43%  (p=0.000 n=20+18)
BM_DecompressFlat/20/9          [man/level=9]                                           7.79µs ± 1%  7.61µs ± 1%  -2.25%  (p=0.000 n=19+19)
BM_DecompressFlat/0/10          [html/level=10]                                         50.4µs ± 2%  49.3µs ± 2%  -2.13%  (p=0.000 n=16+20)
BM_DecompressFlat/1/10          [urls/level=10]                                          589µs ± 2%   588µs ± 1%    ~     (p=0.258 n=20+19)
BM_DecompressFlat/2/10          [jpg/level=10]                                          3.37µs ± 1%  3.36µs ± 1%  -0.47%  (p=0.030 n=19+17)
BM_DecompressFlat/3/10          [jpg_200/level=10]                                      2.85µs ± 1%  2.82µs ± 1%  -1.00%  (p=0.000 n=19+19)
BM_DecompressFlat/4/10          [pdf/level=10]                                          13.0µs ± 2%  13.0µs ± 1%  +0.42%  (p=0.012 n=19+19)
BM_DecompressFlat/5/10          [html4/level=10]                                        59.0µs ± 1%  62.3µs ± 5%  +5.61%  (p=0.000 n=18+20)
BM_DecompressFlat/6/10          [txt1/level=10]                                          189µs ± 1%   184µs ± 1%  -2.20%  (p=0.000 n=20+17)
BM_DecompressFlat/7/10          [txt2/level=10]                                          166µs ± 1%   163µs ± 1%  -2.12%  (p=0.000 n=18+20)
BM_DecompressFlat/8/10          [txt3/level=10]                                          458µs ± 2%   448µs ± 1%  -2.19%  (p=0.000 n=20+20)
BM_DecompressFlat/9/10          [txt4/level=10]                                          608µs ± 1%   597µs ± 1%  -1.94%  (p=0.000 n=19+19)
BM_DecompressFlat/10/10     [pb/level=10]                                               45.3µs ± 2%  44.8µs ± 1%  -1.16%  (p=0.000 n=20+20)
BM_DecompressFlat/11/10     [gaviota/level=10]                                           193µs ± 1%   194µs ± 1%    ~     (p=0.084 n=20+19)
BM_DecompressFlat/12/10     [cp/level=10]                                               27.7µs ± 2%  27.1µs ± 1%  -2.25%  (p=0.000 n=20+20)
BM_DecompressFlat/13/10     [c/level=10]                                                13.5µs ± 1%  13.2µs ± 2%  -1.98%  (p=0.000 n=20+20)
BM_DecompressFlat/14/10     [lsp/level=10]                                              6.56µs ± 2%  6.50µs ± 1%  -0.94%  (p=0.000 n=20+20)
BM_DecompressFlat/15/10     [xls/level=10]                                              1.05ms ± 3%  1.05ms ± 1%    ~     (p=0.149 n=19+20)
BM_DecompressFlat/16/10     [xls_200/level=10]                                          2.65µs ± 2%  2.64µs ± 1%    ~     (p=0.072 n=20+20)
BM_DecompressFlat/17/10     [bin/level=10]                                               266µs ± 2%   269µs ± 1%  +0.85%  (p=0.001 n=20+18)
BM_DecompressFlat/18/10     [bin_200/level=10]                                           267ns ± 2%   265ns ± 2%  -0.93%  (p=0.005 n=19+20)
BM_DecompressFlat/19/10     [sum/level=10]                                              44.2µs ± 2%  42.5µs ± 1%  -3.97%  (p=0.000 n=20+18)
BM_DecompressFlat/20/10     [man/level=10]                                              7.80µs ± 1%  7.63µs ± 2%  -2.17%  (p=0.000 n=20+19)
BM_DecompressFlat/0/11          [html/level=11]                                         50.1µs ± 1%  49.0µs ± 1%  -2.24%  (p=0.000 n=20+20)
BM_DecompressFlat/1/11          [urls/level=11]                                          586µs ± 3%   585µs ± 1%    ~     (p=0.879 n=20+19)
BM_DecompressFlat/2/11          [jpg/level=11]                                          3.37µs ± 1%  3.36µs ± 1%    ~     (p=0.101 n=20+19)
BM_DecompressFlat/3/11          [jpg_200/level=11]                                      2.85µs ± 1%  2.82µs ± 2%  -1.01%  (p=0.000 n=20+20)
BM_DecompressFlat/4/11          [pdf/level=11]                                          13.0µs ± 1%  13.1µs ± 1%  +0.48%  (p=0.007 n=20+20)
BM_DecompressFlat/5/11          [html4/level=11]                                        58.2µs ± 2%  63.1µs ± 5%  +8.56%  (p=0.000 n=18+20)
BM_DecompressFlat/6/11          [txt1/level=11]                                          188µs ± 2%   184µs ± 1%  -1.97%  (p=0.000 n=20+19)
BM_DecompressFlat/7/11          [txt2/level=11]                                          166µs ± 1%   163µs ± 1%  -1.64%  (p=0.000 n=19+19)
BM_DecompressFlat/8/11          [txt3/level=11]                                          453µs ± 1%   443µs ± 1%  -2.00%  (p=0.000 n=20+20)
BM_DecompressFlat/9/11          [txt4/level=11]                                          604µs ± 1%   591µs ± 1%  -2.14%  (p=0.000 n=20+20)
BM_DecompressFlat/10/11     [pb/level=11]                                               45.1µs ± 2%  44.5µs ± 2%  -1.35%  (p=0.000 n=20+20)
BM_DecompressFlat/11/11     [gaviota/level=11]                                           186µs ± 2%   186µs ± 1%    ~     (p=0.444 n=20+19)
BM_DecompressFlat/12/11     [cp/level=11]                                               27.7µs ± 1%  26.9µs ± 1%  -2.79%  (p=0.000 n=20+19)
BM_DecompressFlat/13/11     [c/level=11]                                                13.9µs ± 1%  13.5µs ± 1%  -2.79%  (p=0.000 n=20+19)
BM_DecompressFlat/14/11     [lsp/level=11]                                              6.61µs ± 2%  6.59µs ± 1%    ~     (p=0.414 n=20+20)
BM_DecompressFlat/15/11     [xls/level=11]                                              1.05ms ± 2%  1.05ms ± 1%    ~     (p=0.411 n=20+19)
BM_DecompressFlat/16/11     [xls_200/level=11]                                          2.68µs ± 2%  2.70µs ± 1%  +0.49%  (p=0.026 n=20+20)
BM_DecompressFlat/17/11     [bin/level=11]                                               265µs ± 2%   267µs ± 1%  +1.00%  (p=0.001 n=20+20)
BM_DecompressFlat/18/11     [bin_200/level=11]                                           266ns ± 2%   265ns ± 2%    ~     (p=0.204 n=19+20)
BM_DecompressFlat/19/11     [sum/level=11]                                              44.3µs ± 1%  42.5µs ± 1%  -4.10%  (p=0.000 n=20+20)
BM_DecompressFlat/20/11     [man/level=11]                                              7.72µs ± 1%  7.60µs ± 2%  -1.52%  (p=0.000 n=19+20)
BM_DecompressSink/0/2               [html/level=2]                                      58.2µs ± 1%  57.8µs ± 1%  -0.75%  (p=0.004 n=20+19)
BM_DecompressSink/1/2               [urls/level=2]                                       652µs ± 2%   648µs ± 1%  -0.64%  (p=0.002 n=20+19)
BM_DecompressSink/2/2               [jpg/level=2]                                       3.43µs ± 1%  3.42µs ± 1%  -0.36%  (p=0.031 n=19+18)
BM_DecompressSink/3/2               [jpg_200/level=2]                                   2.86µs ± 1%  2.89µs ± 1%  +1.08%  (p=0.000 n=20+19)
BM_DecompressSink/4/2               [pdf/level=2]                                       11.9µs ± 1%  11.9µs ± 1%  +0.56%  (p=0.001 n=19+19)
BM_DecompressSink/5/2               [html4/level=2]                                     81.4µs ± 2%  81.1µs ± 2%    ~     (p=0.065 n=20+19)
BM_DecompressSink/6/2               [txt1/level=2]                                       198µs ± 1%   195µs ± 1%  -1.83%  (p=0.000 n=18+20)
BM_DecompressSink/7/2               [txt2/level=2]                                       173µs ± 1%   170µs ± 1%  -1.99%  (p=0.000 n=19+18)
BM_DecompressSink/8/2               [txt3/level=2]                                       526µs ± 1%   514µs ± 1%  -2.18%  (p=0.000 n=20+20)
BM_DecompressSink/9/2               [txt4/level=2]                                       649µs ± 1%   639µs ± 1%  -1.62%  (p=0.000 n=19+20)
BM_DecompressSink/10/2          [pb/level=2]                                            54.0µs ± 1%  52.1µs ± 2%  -3.55%  (p=0.000 n=20+19)
BM_DecompressSink/11/2          [gaviota/level=2]                                        226µs ± 3%   223µs ± 1%  -1.30%  (p=0.000 n=19+18)
BM_DecompressSink/12/2          [cp/level=2]                                            28.8µs ± 1%  28.0µs ± 1%  -2.78%  (p=0.000 n=19+20)
BM_DecompressSink/13/2          [c/level=2]                                             17.9µs ± 1%  17.5µs ± 1%  -2.31%  (p=0.000 n=19+19)
BM_DecompressSink/14/2          [lsp/level=2]                                           7.20µs ± 1%  7.11µs ± 1%  -1.24%  (p=0.000 n=18+19)
BM_DecompressSink/15/2          [xls/level=2]                                           1.11ms ± 2%  1.13ms ± 2%  +1.43%  (p=0.000 n=18+20)
BM_DecompressSink/16/2          [xls_200/level=2]                                       2.26µs ± 1%  2.24µs ± 1%  -0.87%  (p=0.000 n=18+19)
BM_DecompressSink/17/2          [bin/level=2]                                            303µs ± 2%   304µs ± 1%    ~     (p=0.201 n=20+20)
BM_DecompressSink/18/2          [bin_200/level=2]                                        298ns ± 2%   301ns ± 1%  +1.04%  (p=0.000 n=19+20)
BM_DecompressSink/19/2          [sum/level=2]                                           43.4µs ± 1%  41.9µs ± 1%  -3.28%  (p=0.000 n=19+19)
BM_DecompressSink/20/2          [man/level=2]                                           8.35µs ± 1%  8.21µs ± 1%  -1.62%  (p=0.000 n=19+18)
BM_DecompressSink/0/3               [html/level=3]                                      55.3µs ± 2%  53.7µs ± 2%  -2.86%  (p=0.000 n=20+20)
BM_DecompressSink/1/3               [urls/level=3]                                       661µs ± 1%   655µs ± 1%  -0.85%  (p=0.000 n=19+20)
BM_DecompressSink/2/3               [jpg/level=3]                                       3.43µs ± 1%  3.43µs ± 1%    ~     (p=0.558 n=18+19)
BM_DecompressSink/3/3               [jpg_200/level=3]                                   2.88µs ± 1%  2.84µs ± 1%  -1.34%  (p=0.000 n=19+19)
BM_DecompressSink/4/3               [pdf/level=3]                                       11.6µs ± 1%  11.7µs ± 1%  +0.56%  (p=0.001 n=19+20)
BM_DecompressSink/5/3               [html4/level=3]                                     83.0µs ± 1%  86.5µs ± 3%  +4.14%  (p=0.000 n=20+20)
BM_DecompressSink/6/3               [txt1/level=3]                                       226µs ± 1%   221µs ± 1%  -2.02%  (p=0.000 n=19+20)
BM_DecompressSink/7/3               [txt2/level=3]                                       159µs ± 1%   157µs ± 1%  -1.43%  (p=0.000 n=18+19)
BM_DecompressSink/8/3               [txt3/level=3]                                       527µs ± 1%   515µs ± 1%  -2.24%  (p=0.000 n=19+18)
BM_DecompressSink/9/3               [txt4/level=3]                                       686µs ± 0%   674µs ± 1%  -1.69%  (p=0.000 n=18+19)
BM_DecompressSink/10/3          [pb/level=3]                                            51.7µs ± 2%  51.0µs ± 1%  -1.36%  (p=0.000 n=20+18)
BM_DecompressSink/11/3          [gaviota/level=3]                                        238µs ± 1%   237µs ± 1%  -0.69%  (p=0.000 n=17+20)
BM_DecompressSink/12/3          [cp/level=3]                                            27.5µs ± 1%  26.9µs ± 1%  -2.26%  (p=0.000 n=20+19)
BM_DecompressSink/13/3          [c/level=3]                                             15.1µs ± 2%  14.7µs ± 1%  -2.59%  (p=0.000 n=20+19)
BM_DecompressSink/14/3          [lsp/level=3]                                           6.90µs ± 1%  6.84µs ± 2%  -0.95%  (p=0.000 n=20+20)
BM_DecompressSink/15/3          [xls/level=3]                                           1.09ms ± 1%  1.11ms ± 1%  +1.66%  (p=0.000 n=19+19)
BM_DecompressSink/16/3          [xls_200/level=3]                                       2.21µs ± 2%  2.22µs ± 1%  +0.61%  (p=0.008 n=20+19)
BM_DecompressSink/17/3          [bin/level=3]                                            334µs ± 1%   333µs ± 1%    ~     (p=0.224 n=19+20)
BM_DecompressSink/18/3          [bin_200/level=3]                                        298ns ± 1%   301ns ± 2%  +0.95%  (p=0.000 n=19+20)
BM_DecompressSink/19/3          [sum/level=3]                                           42.7µs ± 1%  41.0µs ± 2%  -3.94%  (p=0.000 n=20+20)
BM_DecompressSink/20/3          [man/level=3]                                           8.03µs ± 1%  7.89µs ± 1%  -1.79%  (p=0.000 n=17+19)
BM_DecompressSink/0/5               [html/level=5]                                      56.0µs ± 1%  55.5µs ± 1%  -0.87%  (p=0.000 n=20+19)
BM_DecompressSink/1/5               [urls/level=5]                                       662µs ± 1%   657µs ± 1%  -0.74%  (p=0.000 n=18+18)
BM_DecompressSink/2/5               [jpg/level=5]                                       3.43µs ± 1%  3.43µs ± 1%    ~     (p=0.247 n=20+19)
BM_DecompressSink/3/5               [jpg_200/level=5]                                   2.87µs ± 1%  2.86µs ± 1%  -0.37%  (p=0.020 n=18+19)
BM_DecompressSink/4/5               [pdf/level=5]                                       14.8µs ± 1%  14.9µs ± 1%  +0.48%  (p=0.022 n=19+19)
BM_DecompressSink/5/5               [html4/level=5]                                     79.1µs ± 1%  81.1µs ± 6%  +2.58%  (p=0.002 n=18+20)
BM_DecompressSink/6/5               [txt1/level=5]                                       196µs ± 1%   193µs ± 1%  -1.75%  (p=0.000 n=19+20)
BM_DecompressSink/7/5               [txt2/level=5]                                       196µs ± 1%   191µs ± 1%  -2.23%  (p=0.000 n=20+19)
BM_DecompressSink/8/5               [txt3/level=5]                                       537µs ± 1%   527µs ± 1%  -1.96%  (p=0.000 n=20+19)
BM_DecompressSink/9/5               [txt4/level=5]                                       717µs ± 2%   700µs ± 1%  -2.39%  (p=0.000 n=20+20)
BM_DecompressSink/10/5          [pb/level=5]                                            51.3µs ± 2%  50.1µs ± 2%  -2.35%  (p=0.000 n=19+20)
BM_DecompressSink/11/5          [gaviota/level=5]                                        222µs ± 3%   224µs ± 1%  +0.92%  (p=0.002 n=20+18)
BM_DecompressSink/12/5          [cp/level=5]                                            29.9µs ± 2%  29.0µs ± 1%  -3.02%  (p=0.000 n=20+20)
BM_DecompressSink/13/5          [c/level=5]                                             14.3µs ± 2%  13.9µs ± 0%  -2.54%  (p=0.000 n=18+16)
BM_DecompressSink/14/5          [lsp/level=5]                                           6.68µs ± 2%  6.62µs ± 1%  -0.86%  (p=0.000 n=19+19)
BM_DecompressSink/15/5          [xls/level=5]                                           1.11ms ± 1%  1.12ms ± 1%  +1.05%  (p=0.000 n=20+19)
BM_DecompressSink/16/5          [xls_200/level=5]                                       2.67µs ± 2%  2.66µs ± 1%    ~     (p=0.718 n=20+20)
BM_DecompressSink/17/5          [bin/level=5]                                            330µs ± 2%   330µs ± 1%    ~     (p=0.529 n=20+20)
BM_DecompressSink/18/5          [bin_200/level=5]                                        299ns ± 1%   302ns ± 1%  +1.02%  (p=0.000 n=19+20)
BM_DecompressSink/19/5          [sum/level=5]                                           48.5µs ± 2%  46.6µs ± 1%  -3.94%  (p=0.000 n=18+20)
BM_DecompressSink/20/5          [man/level=5]                                           7.91µs ± 2%  7.73µs ± 1%  -2.27%  (p=0.000 n=20+19)
BM_DecompressSink/0/7               [html/level=7]                                      52.0µs ± 1%  51.5µs ± 1%  -1.10%  (p=0.000 n=19+20)
BM_DecompressSink/1/7               [urls/level=7]                                       632µs ± 1%   628µs ± 1%  -0.71%  (p=0.000 n=20+19)
BM_DecompressSink/2/7               [jpg/level=7]                                       3.43µs ± 1%  3.42µs ± 2%    ~     (p=0.055 n=18+20)
BM_DecompressSink/3/7               [jpg_200/level=7]                                   2.88µs ± 1%  2.86µs ± 1%  -0.60%  (p=0.003 n=18+19)
BM_DecompressSink/4/7               [pdf/level=7]                                       13.2µs ± 1%  13.3µs ± 1%    ~     (p=0.314 n=20+20)
BM_DecompressSink/5/7               [html4/level=7]                                     75.4µs ± 2%  78.1µs ± 3%  +3.63%  (p=0.000 n=19+19)
BM_DecompressSink/6/7               [txt1/level=7]                                       210µs ± 1%   206µs ± 1%  -2.00%  (p=0.000 n=20+20)
BM_DecompressSink/7/7               [txt2/level=7]                                       174µs ± 1%   171µs ± 1%  -1.92%  (p=0.000 n=18+20)
BM_DecompressSink/8/7               [txt3/level=7]                                       501µs ± 1%   492µs ± 1%  -1.98%  (p=0.000 n=20+20)
BM_DecompressSink/9/7               [txt4/level=7]                                       663µs ± 1%   648µs ± 2%  -2.26%  (p=0.000 n=18+20)
BM_DecompressSink/10/7          [pb/level=7]                                            46.9µs ± 2%  45.6µs ± 2%  -2.84%  (p=0.000 n=19+20)
BM_DecompressSink/11/7          [gaviota/level=7]                                        227µs ± 2%   228µs ± 1%    ~     (p=0.435 n=19+19)
BM_DecompressSink/12/7          [cp/level=7]                                            28.4µs ± 1%  27.7µs ± 1%  -2.20%  (p=0.000 n=19+20)
BM_DecompressSink/13/7          [c/level=7]                                             13.5µs ± 1%  13.2µs ± 1%  -2.18%  (p=0.000 n=19+20)
BM_DecompressSink/14/7          [lsp/level=7]                                           6.58µs ± 1%  6.55µs ± 2%  -0.42%  (p=0.019 n=19+20)
BM_DecompressSink/15/7          [xls/level=7]                                           1.05ms ± 1%  1.07ms ± 1%  +1.72%  (p=0.000 n=20+20)
BM_DecompressSink/16/7          [xls_200/level=7]                                       2.66µs ± 1%  2.67µs ± 1%    ~     (p=0.327 n=20+20)
BM_DecompressSink/17/7          [bin/level=7]                                            298µs ± 1%   298µs ± 1%    ~     (p=0.211 n=20+20)
BM_DecompressSink/18/7          [bin_200/level=7]                                        298ns ± 1%   302ns ± 1%  +1.48%  (p=0.000 n=19+19)
BM_DecompressSink/19/7          [sum/level=7]                                           44.7µs ± 1%  43.3µs ± 2%  -3.14%  (p=0.000 n=19+19)
BM_DecompressSink/20/7          [man/level=7]                                           7.80µs ± 1%  7.62µs ± 1%  -2.25%  (p=0.000 n=19+19)
BM_DecompressSink/0/9               [html/level=9]                                      50.6µs ± 1%  49.4µs ± 1%  -2.35%  (p=0.000 n=20+20)
BM_DecompressSink/1/9               [urls/level=9]                                       620µs ± 1%   618µs ± 1%  -0.33%  (p=0.030 n=19+20)
BM_DecompressSink/2/9               [jpg/level=9]                                       3.43µs ± 1%  3.42µs ± 1%    ~     (p=0.199 n=18+19)
BM_DecompressSink/3/9               [jpg_200/level=9]                                   2.88µs ± 1%  2.86µs ± 1%  -0.62%  (p=0.002 n=20+19)
BM_DecompressSink/4/9               [pdf/level=9]                                       13.0µs ± 1%  13.0µs ± 1%    ~     (p=0.196 n=20+18)
BM_DecompressSink/5/9               [html4/level=9]                                     74.0µs ± 4%  76.0µs ± 5%  +2.68%  (p=0.000 n=20+20)
BM_DecompressSink/6/9               [txt1/level=9]                                       196µs ± 2%   192µs ± 1%  -1.99%  (p=0.000 n=20+19)
BM_DecompressSink/7/9               [txt2/level=9]                                       168µs ± 1%   164µs ± 1%  -2.09%  (p=0.000 n=20+18)
BM_DecompressSink/8/9               [txt3/level=9]                                       482µs ± 2%   472µs ± 1%  -2.05%  (p=0.000 n=20+19)
BM_DecompressSink/9/9               [txt4/level=9]                                       640µs ± 1%   624µs ± 1%  -2.46%  (p=0.000 n=20+20)
BM_DecompressSink/10/9          [pb/level=9]                                            45.5µs ± 2%  44.8µs ± 2%  -1.50%  (p=0.000 n=19+20)
BM_DecompressSink/11/9          [gaviota/level=9]                                        206µs ± 2%   207µs ± 2%    ~     (p=0.134 n=19+20)
BM_DecompressSink/12/9          [cp/level=9]                                            27.8µs ± 1%  27.1µs ± 1%  -2.46%  (p=0.000 n=17+19)
BM_DecompressSink/13/9          [c/level=9]                                             13.5µs ± 1%  13.2µs ± 1%  -2.06%  (p=0.000 n=18+18)
BM_DecompressSink/14/9          [lsp/level=9]                                           6.58µs ± 1%  6.55µs ± 1%  -0.51%  (p=0.011 n=20+20)
BM_DecompressSink/15/9          [xls/level=9]                                           1.08ms ± 2%  1.09ms ± 1%  +0.91%  (p=0.004 n=20+18)
BM_DecompressSink/16/9          [xls_200/level=9]                                       2.66µs ± 1%  2.67µs ± 1%    ~     (p=0.061 n=19+19)
BM_DecompressSink/17/9          [bin/level=9]                                            295µs ± 1%   293µs ± 2%  -0.45%  (p=0.017 n=18+20)
BM_DecompressSink/18/9          [bin_200/level=9]                                        298ns ± 1%   301ns ± 1%  +1.04%  (p=0.000 n=19+19)
BM_DecompressSink/19/9          [sum/level=9]                                           44.1µs ± 2%  42.6µs ± 1%  -3.42%  (p=0.000 n=19+19)
BM_DecompressSink/20/9          [man/level=9]                                           7.78µs ± 1%  7.64µs ± 1%  -1.77%  (p=0.000 n=20+20)
BM_DecompressSink/0/10          [html/level=10]                                         49.9µs ± 1%  49.3µs ± 2%  -1.10%  (p=0.000 n=20+19)
BM_DecompressSink/1/10          [urls/level=10]                                          616µs ± 1%   613µs ± 1%  -0.43%  (p=0.013 n=18+19)
BM_DecompressSink/2/10          [jpg/level=10]                                          3.43µs ± 1%  3.44µs ± 2%    ~     (p=0.383 n=20+20)
BM_DecompressSink/3/10          [jpg_200/level=10]                                      2.88µs ± 1%  2.86µs ± 2%  -0.47%  (p=0.028 n=20+20)
BM_DecompressSink/4/10          [pdf/level=10]                                          13.0µs ± 1%  13.0µs ± 2%    ~     (p=1.000 n=20+20)
BM_DecompressSink/5/10          [html4/level=10]                                        73.5µs ± 2%  75.2µs ± 2%  +2.30%  (p=0.000 n=20+19)
BM_DecompressSink/6/10          [txt1/level=10]                                          193µs ± 1%   189µs ± 1%  -1.92%  (p=0.000 n=18+18)
BM_DecompressSink/7/10          [txt2/level=10]                                          166µs ± 1%   162µs ± 1%  -2.10%  (p=0.000 n=19+19)
BM_DecompressSink/8/10          [txt3/level=10]                                          477µs ± 1%   465µs ± 1%  -2.34%  (p=0.000 n=20+18)
BM_DecompressSink/9/10          [txt4/level=10]                                          629µs ± 1%   615µs ± 1%  -2.16%  (p=0.000 n=20+19)
BM_DecompressSink/10/10     [pb/level=10]                                               45.5µs ± 1%  44.9µs ± 2%  -1.32%  (p=0.000 n=20+20)
BM_DecompressSink/11/10     [gaviota/level=10]                                           199µs ± 2%   199µs ± 1%    ~     (p=0.351 n=20+19)
BM_DecompressSink/12/10     [cp/level=10]                                               27.6µs ± 1%  27.1µs ± 2%  -2.11%  (p=0.000 n=19+19)
BM_DecompressSink/13/10     [c/level=10]                                                13.5µs ± 1%  13.3µs ± 2%  -2.11%  (p=0.000 n=19+20)
BM_DecompressSink/14/10     [lsp/level=10]                                              6.58µs ± 1%  6.53µs ± 1%  -0.71%  (p=0.000 n=19+18)
BM_DecompressSink/15/10     [xls/level=10]                                              1.07ms ± 2%  1.09ms ± 1%  +1.73%  (p=0.000 n=19+19)
BM_DecompressSink/16/10     [xls_200/level=10]                                          2.66µs ± 1%  2.67µs ± 1%  +0.43%  (p=0.009 n=18+20)
BM_DecompressSink/17/10     [bin/level=10]                                               288µs ± 1%   287µs ± 1%    ~     (p=0.301 n=20+20)
BM_DecompressSink/18/10     [bin_200/level=10]                                           298ns ± 1%   301ns ± 1%  +1.07%  (p=0.000 n=17+17)
BM_DecompressSink/19/10     [sum/level=10]                                              44.0µs ± 1%  42.6µs ± 1%  -3.24%  (p=0.000 n=20+19)
BM_DecompressSink/20/10     [man/level=10]                                              7.80µs ± 1%  7.64µs ± 1%  -2.08%  (p=0.000 n=19+20)
BM_DecompressSink/0/11          [html/level=11]                                         50.1µs ± 2%  49.0µs ± 2%  -2.18%  (p=0.000 n=20+20)
BM_DecompressSink/1/11          [urls/level=11]                                          613µs ± 1%   612µs ± 1%    ~     (p=0.175 n=19+20)
BM_DecompressSink/2/11          [jpg/level=11]                                          3.43µs ± 1%  3.42µs ± 1%  -0.37%  (p=0.049 n=19+18)
BM_DecompressSink/3/11          [jpg_200/level=11]                                      2.89µs ± 1%  2.88µs ± 1%  -0.43%  (p=0.026 n=20+20)
BM_DecompressSink/4/11          [pdf/level=11]                                          13.0µs ± 1%  13.1µs ± 1%    ~     (p=0.194 n=19+20)
BM_DecompressSink/5/11          [html4/level=11]                                        73.4µs ± 4%  78.0µs ± 1%  +6.27%  (p=0.000 n=20+16)
BM_DecompressSink/6/11          [txt1/level=11]                                          193µs ± 2%   189µs ± 2%  -2.17%  (p=0.000 n=19+20)
BM_DecompressSink/7/11          [txt2/level=11]                                          166µs ± 1%   163µs ± 1%  -1.84%  (p=0.000 n=19+20)
BM_DecompressSink/8/11          [txt3/level=11]                                          471µs ± 1%   462µs ± 1%  -1.90%  (p=0.000 n=20+19)
BM_DecompressSink/9/11          [txt4/level=11]                                          622µs ± 1%   608µs ± 1%  -2.32%  (p=0.000 n=20+19)
BM_DecompressSink/10/11     [pb/level=11]                                               45.0µs ± 2%  44.5µs ± 2%  -1.12%  (p=0.002 n=20+19)
BM_DecompressSink/11/11     [gaviota/level=11]                                           192µs ± 1%   191µs ± 1%  -0.97%  (p=0.000 n=19+18)
BM_DecompressSink/12/11     [cp/level=11]                                               27.7µs ± 3%  27.0µs ± 1%  -2.63%  (p=0.000 n=20+20)
BM_DecompressSink/13/11     [c/level=11]                                                13.9µs ± 2%  13.5µs ± 1%  -2.27%  (p=0.000 n=20+20)
BM_DecompressSink/14/11     [lsp/level=11]                                              6.65µs ± 1%  6.64µs ± 1%    ~     (p=0.309 n=20+19)
BM_DecompressSink/15/11     [xls/level=11]                                              1.07ms ± 2%  1.09ms ± 1%  +1.12%  (p=0.000 n=20+19)
BM_DecompressSink/16/11     [xls_200/level=11]                                          2.72µs ± 1%  2.73µs ± 1%  +0.63%  (p=0.003 n=19+19)
BM_DecompressSink/17/11     [bin/level=11]                                               286µs ± 1%   285µs ± 1%  -0.40%  (p=0.033 n=20+18)
BM_DecompressSink/18/11     [bin_200/level=11]                                           298ns ± 1%   301ns ± 1%  +1.22%  (p=0.000 n=19+20)
BM_DecompressSink/19/11     [sum/level=11]                                              44.1µs ± 1%  42.5µs ± 1%  -3.71%  (p=0.000 n=20+20)
BM_DecompressSink/20/11     [man/level=11]                                              7.74µs ± 1%  7.61µs ± 1%  -1.70%  (p=0.000 n=20+18)