### PR TITLE
Update FreeBSD CI: drop 12.4 (nearly EOL)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,6 @@ task:
   freebsd_instance:
     matrix:
       image_family: freebsd-13-2
-      image_family: freebsd-12-4
   install_script: pkg install -y gmake coreutils
   script: |
     MOREFLAGS="-Werror" gmake -j all


### PR DESCRIPTION
12.4 is EOL as of the end of December 2023, and pkg installation will start failing some time after that so remove those jobs now.