### PR TITLE
Fix a nullptr dereference in ZSTD_createCDict_advanced2()

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -5525,7 +5525,7 @@ ZSTD_CDict* ZSTD_createCDict_advanced2(
                         cctxParams.useRowMatchFinder, cctxParams.enableDedicatedDictSearch,
                         customMem);
 
-    if (ZSTD_isError( ZSTD_initCDict_internal(cdict,
+    if (!cdict || ZSTD_isError( ZSTD_initCDict_internal(cdict,
                                     dict, dictSize,
                                     dictLoadMethod, dictContentType,
                                     cctxParams) )) {


### PR DESCRIPTION
If the relevant allocation returns NULL, ZSTD_createCDict_advanced_internal() will return NULL. But ZSTD_createCDict_advanced2() doesn't check for this and attempts to use the returned pointer anyway, which leads to a segfault.