### PR TITLE
Make offload API compatible with static CCtx

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -7088,6 +7088,7 @@ void ZSTD_registerSequenceProducer(
     void* extSeqProdState,
     ZSTD_sequenceProducer_F extSeqProdFunc
 ) {
+    assert(zc != NULL);
     ZSTD_CCtxParams_registerSequenceProducer(
         &zc->requestedParams, extSeqProdState, extSeqProdFunc
     );
@@ -7098,6 +7099,7 @@ void ZSTD_CCtxParams_registerSequenceProducer(
   void* extSeqProdState,
   ZSTD_sequenceProducer_F extSeqProdFunc
 ) {
+    assert(params != NULL);
     if (extSeqProdFunc != NULL) {
         params->extSeqProdFunc = extSeqProdFunc;
         params->extSeqProdState = extSeqProdState;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -7084,14 +7084,25 @@ ZSTD_parameters ZSTD_getParams(int compressionLevel, unsigned long long srcSizeH
 }
 
 void ZSTD_registerSequenceProducer(
-    ZSTD_CCtx* zc, void* extSeqProdState,
+    ZSTD_CCtx* zc,
+    void* extSeqProdState,
     ZSTD_sequenceProducer_F extSeqProdFunc
 ) {
+    ZSTD_CCtxParams_registerSequenceProducer(
+        &zc->requestedParams, extSeqProdState, extSeqProdFunc
+    );
+}
+
+void ZSTD_CCtxParams_registerSequenceProducer(
+  ZSTD_CCtx_params* params,
+  void* extSeqProdState,
+  ZSTD_sequenceProducer_F extSeqProdFunc
+) {
     if (extSeqProdFunc != NULL) {
-        zc->requestedParams.extSeqProdFunc = extSeqProdFunc;
-        zc->requestedParams.extSeqProdState = extSeqProdState;
+        params->extSeqProdFunc = extSeqProdFunc;
+        params->extSeqProdState = extSeqProdState;
     } else {
-        zc->requestedParams.extSeqProdFunc = NULL;
-        zc->requestedParams.extSeqProdState = NULL;
+        params->extSeqProdFunc = NULL;
+        params->extSeqProdState = NULL;
     }
 }

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -2830,7 +2830,8 @@ ZSTD_registerSequenceProducer(
  * is required, then this function is for you. Otherwise, you probably don't need it.
  *
  * See tests/zstreamtest.c for example usage. */
-void ZSTD_CCtxParams_registerSequenceProducer(
+ZSTDLIB_STATIC_API void
+ZSTD_CCtxParams_registerSequenceProducer(
   ZSTD_CCtx_params* params,
   void* sequenceProducerState,
   ZSTD_sequenceProducer_F sequenceProducer

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -2824,6 +2824,12 @@ ZSTD_registerSequenceProducer(
   ZSTD_sequenceProducer_F sequenceProducer
 );
 
+void ZSTD_CCtxParams_registerSequenceProducer(
+  ZSTD_CCtx_params* params,
+  void* sequenceProducerState,
+  ZSTD_sequenceProducer_F sequenceProducer
+);
+
 
 /*********************************************************************
 *  Buffer-less and synchronous inner streaming functions (DEPRECATED)

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1665,9 +1665,6 @@ ZSTDLIB_API unsigned ZSTD_isSkippableFrame(const void* buffer, size_t size);
  *
  *  Note : only single-threaded compression is supported.
  *  ZSTD_estimateCCtxSize_usingCCtxParams() will return an error code if ZSTD_c_nbWorkers is >= 1.
- *
- *  Note 2 : ZSTD_estimateCCtxSize* functions are not compatible with the Block-Level Sequence Producer API at this time.
- *  Size estimates assume that no external sequence producer is registered.
  */
 ZSTDLIB_STATIC_API size_t ZSTD_estimateCCtxSize(int maxCompressionLevel);
 ZSTDLIB_STATIC_API size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters cParams);
@@ -2824,6 +2821,15 @@ ZSTD_registerSequenceProducer(
   ZSTD_sequenceProducer_F sequenceProducer
 );
 
+/*! ZSTD_CCtxParams_registerSequenceProducer() :
+ * Same as ZSTD_registerSequenceProducer(), but operates on ZSTD_CCtx_params.
+ * This is used for accurate size estimation with ZSTD_estimateCCtxSize_usingCCtxParams(),
+ * which is needed when creating a ZSTD_CCtx with ZSTD_initStaticCCtx().
+ *
+ * If you are using the external sequence producer API in a scenario where ZSTD_initStaticCCtx()
+ * is required, then this function is for you. Otherwise, you probably don't need it.
+ *
+ * See tests/zstreamtest.c for example usage. */
 void ZSTD_CCtxParams_registerSequenceProducer(
   ZSTD_CCtx_params* params,
   void* sequenceProducerState,


### PR DESCRIPTION
Currently our CCtx size estimation functions don't account for memory used by the block-level external sequence producer API, so it is impossible to use that API together with `ZSTD_initStaticCCtx()` (which requires a correctly-sized buffer). This is a problem in particular for the Linux kernel, which uses `ZSTD_initStaticCCtx()` and also wants to use the offload API.

This PR adds a function `ZSTD_CCtxParams_registerSequenceProducer()` to the public API, which makes it possible to accurately estimate the size of a CCtx for the offload scenario. Simply call the newly-added function on a `ZSTD_CCtx_params` object and then compute a size estimate with `ZSTD_estimateCCtxSize_usingCCtxParams()`.

I added a unit test to demonstrate that compression offload works properly with a static CCtx.

Note: this is a follow-up to https://github.com/facebook/zstd/pull/3839