### PR TITLE
tcc on windows dosen't support multi thread & intrinsics?

### DIFF
--- a/build/single_file_libs/zstd-in.c
+++ b/build/single_file_libs/zstd-in.c
@@ -47,6 +47,10 @@
 #define ZSTD_MULTITHREAD
 #endif
 #define ZSTD_TRACE 0
+#if defined(__TINYC__) && defined(_WIN32)
+#undef ZSTD_MULTITHREAD
+#define ZSTD_NO_INTRINSICS
+#endif
 /* TODO: Can't amalgamate ASM function */
 #define ZSTD_DISABLE_ASM 1
 

--- a/build/single_file_libs/zstddeclib-in.c
+++ b/build/single_file_libs/zstddeclib-in.c
@@ -43,6 +43,10 @@
 #define ZSTD_LEGACY_SUPPORT 0
 #define ZSTD_STRIP_ERROR_STRINGS
 #define ZSTD_TRACE 0
+#if defined(__TINYC__) && defined(_WIN32)
+#undef ZSTD_MULTITHREAD
+#define ZSTD_NO_INTRINSICS
+#endif
 /* TODO: Can't amalgamate ASM function */
 #define ZSTD_DISABLE_ASM 1
 


### PR DESCRIPTION
As tcc on windows dosen't support multi thread & intrinsics, remove them from the single_file_libs.