### PR TITLE
fix 5921623844651008

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -168,7 +168,7 @@ typedef struct {
 
 typedef enum { zop_dynamic=0, zop_predef } ZSTD_OptPrice_e;
 
-#define ZSTD_OPT_SIZE (ZSTD_OPT_NUM+2)
+#define ZSTD_OPT_SIZE (ZSTD_OPT_NUM+3)
 typedef struct {
     /* All tables are allocated inside cctx->workspace by ZSTD_resetCCtx_internal() */
     unsigned* litFreq;           /* table of literals statistics, of size 256 */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -1196,7 +1196,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
         /* check further positions */
         for (cur = 1; cur <= last_pos; cur++) {
             const BYTE* const inr = ip + cur;
-            assert(cur < ZSTD_OPT_NUM);
+            assert(cur <= ZSTD_OPT_NUM);
             DEBUGLOG(7, "cPos:%zi==rPos:%u", inr-istart, cur);
 
             /* Fix current position with one literal if cheaper */


### PR DESCRIPTION
following #3895, ossfuzz managed to find a scenario which triggers an `assert`. 
This patch fixes it, by providing +1 more space for the backward search pass.