### PR TITLE
Starting state: Sequences

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -819,8 +819,8 @@ each using the required number of bits in their respective _accuracy_,
 decoded previously from their normalized distribution.
 
 It starts by `Literals_Length_State`,
-followed by `Offset_State`,
-and finally `Match_Length_State`.
+followed by `Match_Length_State`,
+and finally `Offset_State`.
 
 Reminder : always keep in mind that all values are read _backward_,
 so the 'start' of the bitstream is at the highest position in memory,


### PR DESCRIPTION
While initialising the FSE state in the Sequences section, we follow the interleaves order:
```
[..., offset, match_length, literal_length, literal_length, match_length, offset, ...]
```

This suggests there might have been a mismatch in the document?

Please close PR if I misunderstood.