### PR TITLE
fix LLU->ULL

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -531,7 +531,7 @@ static void test_decompressBound(unsigned tnb)
             CHECK_EQ( ZSTD_flushStream(cctx, &out), 0 );
         }
         CHECK_EQ( ZSTD_endStream(cctx, &out), 0 );
-        CHECK( ZSTD_decompressBound(outBuffer, out.pos) > 0x100000000LLU /* 4 GB */ );
+        CHECK( ZSTD_decompressBound(outBuffer, out.pos) > 0x100000000ULL /* 4 GB */ );
         ZSTD_freeCCtx(cctx);
         free(outBuffer);
     }


### PR DESCRIPTION
`LLU` is a correct prefix according to `C99` & `C11` standards (but not `C90`). However, older versions of Visual Studio do not work with it. Replace by `ULL`, which doesn't have this issue.

Fixes https://github.com/facebook/zstd/issues/3647