### PR TITLE
Fix #3719 : mixing -c, -o and --rm

### DIFF
--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -234,8 +234,8 @@ the last one takes effect.
     write to standard output (even if it is the console); keep original files (disable `--rm`).
 * `-o FILE`:
     save result into `FILE`.
-    This command is in conflict with `-c`.
-    If both are present on the command line, the last expressed one wins.
+    Note that this operation is in conflict with `-c`.
+    If both operations are present on the command line, the last expressed one wins.
 * `--[no-]sparse`:
     enable / disable sparse FS support,
     to make files with many zeroes smaller on disk.

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -225,15 +225,17 @@ the last one takes effect.
     This parameter defines a loose target: compressed blocks will target this size "on average", but individual blocks can still be larger or smaller.
     Enabling this feature can decrease compression speed by up to ~10% at level 1.
     Higher levels will see smaller relative speed regression, becoming invisible at higher settings.
-* `-o FILE`:
-    save result into `FILE`.
 * `-f`, `--force`:
     disable input and output checks. Allows overwriting existing files, input
     from console, output to stdout, operating on links, block devices, etc.
     During decompression and when the output destination is stdout, pass-through
     unrecognized formats as-is.
 * `-c`, `--stdout`:
-    write to standard output (even if it is the console); keep original files unchanged.
+    write to standard output (even if it is the console); keep original files (disable `--rm`).
+* `-o FILE`:
+    save result into `FILE`.
+    This command is in conflict with `-c`.
+    If both are present on the command line, the last expressed one wins.
 * `--[no-]sparse`:
     enable / disable sparse FS support,
     to make files with many zeroes smaller on disk.

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1176,7 +1176,10 @@ int main(int argCount, const char* argv[])
                         operation=zom_decompress; argument++; break;
 
                     /* Force stdout, even if stdout==console */
-                case 'c': forceStdout=1; outFileName=stdoutmark; removeSrcFile=0; argument++; break;
+                case 'c': forceStdout=1; outFileName=stdoutmark; argument++; break;
+
+                    /* destination file name */
+                case 'o': argument++; NEXT_FIELD(outFileName); break;
 
                     /* do not store filename - gzip compatibility - nothing to do */
                 case 'n': argument++; break;
@@ -1201,9 +1204,6 @@ int main(int argCount, const char* argv[])
 
                     /* test compressed file */
                 case 't': operation=zom_test; argument++; break;
-
-                    /* destination file name */
-                case 'o': argument++; NEXT_FIELD(outFileName); break;
 
                     /* limit memory */
                 case 'M':
@@ -1365,6 +1365,14 @@ int main(int argCount, const char* argv[])
         DISPLAYLEVEL(1, "file information is not supported \n");
         CLEAN_RETURN(1);
 #endif
+    }
+
+    /* disable --rm when writing to stdout */
+    if (!strcmp(outFileName, stdoutmark)) {
+        if (removeSrcFile) {
+            DISPLAYLEVEL(2, "warning: source not removed when writing to stdout \n");
+            removeSrcFile = 0;
+        }
     }
 
     /* Check if benchmark is selected */

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -962,7 +962,7 @@ int main(int argCount, const char* argv[])
                 if (!strcmp(argument, "--help")) { usageAdvanced(programName); CLEAN_RETURN(0); }
                 if (!strcmp(argument, "--verbose")) { g_displayLevel++; continue; }
                 if (!strcmp(argument, "--quiet")) { g_displayLevel--; continue; }
-                if (!strcmp(argument, "--stdout")) { forceStdout=1; outFileName=stdoutmark; removeSrcFile=0; continue; }
+                if (!strcmp(argument, "--stdout")) { forceStdout=1; outFileName=stdoutmark; continue; }
                 if (!strcmp(argument, "--ultra")) { ultra=1; continue; }
                 if (!strcmp(argument, "--check")) { FIO_setChecksumFlag(prefs, 2); continue; }
                 if (!strcmp(argument, "--no-check")) { FIO_setChecksumFlag(prefs, 0); continue; }
@@ -1365,14 +1365,6 @@ int main(int argCount, const char* argv[])
         DISPLAYLEVEL(1, "file information is not supported \n");
         CLEAN_RETURN(1);
 #endif
-    }
-
-    /* disable --rm when writing to stdout */
-    if (!strcmp(outFileName, stdoutmark)) {
-        if (removeSrcFile) {
-            DISPLAYLEVEL(2, "warning: source not removed when writing to stdout \n");
-            removeSrcFile = 0;
-        }
     }
 
     /* Check if benchmark is selected */


### PR DESCRIPTION
`-c` disables `--rm`, but only if it's selected.
In situations where `-o` is in the same command and happens to be present after `-c`, `-o` ends up being the selected one, and the different rules of `-o` become applicable (essentially `-o` respects `--rm` if there is only 1 input file).

fix #3719