### PR TITLE
Export ZSTD_LEGACY_SUPPORT in tests/Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,6 +21,7 @@
 # ##########################################################################
 
 ZSTD_LEGACY_SUPPORT ?= 5
+export ZSTD_LEGACY_SUPPORT
 
 DEBUGLEVEL ?= 2
 export DEBUGLEVEL  # transmit value to sub-makefiles


### PR DESCRIPTION
This doesn't affect most of the targets, but will help me sleep better at night knowing that future refactors won't break the legacy support.

Should have been included in https://github.com/facebook/zstd/pull/3943 but I noticed after that merged, so putting up a separate PR.