### PR TITLE
Do not truncate file name in verbose mode

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -2441,9 +2441,10 @@ FIO_decompressZstdFrame(FIO_ctx_t* const fCtx, dRess_t* ress,
     U64 frameSize = 0;
     IOJob_t *writeJob = AIO_WritePool_acquireJob(ress->writeCtx);
 
-    /* display last 20 characters only */
+    /* display last 20 characters only when not --verbose */
     {   size_t const srcFileLength = strlen(srcFileName);
-        if (srcFileLength>20) srcFileName += srcFileLength-20;
+        if ((srcFileLength>20) && (g_display_prefs.displayLevel<3))
+            srcFileName += srcFileLength-20;
     }
 
     ZSTD_DCtx_reset(ress->dctx, ZSTD_reset_session_only);


### PR DESCRIPTION
Example:
```
./zstd -d tmp123467890123456789.zst
3467890123456789.zst : Decoding error (36) : Frame requires too much memory for decoding
3467890123456789.zst : Window size larger than maximum : 1000000000 > 134217728
3467890123456789.zst : Use --long=30 or --memory=954MB

./zstd -d -v tmp123467890123456789.zst
tmp123467890123456789.zst : Decoding error (36) : Frame requires too much memory for decoding
tmp123467890123456789.zst : Window size larger than maximum : 1000000000 > 134217728
tmp123467890123456789.zst : Use --long=30 or --memory=954MB
```

fix #3702