### PR TITLE
Exercise ZSTD_findDecompressedSize() in the simple decompression fuzzer

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -1093,6 +1093,15 @@ size_t ZSTD_decompressMultiFrame(ZSTD_DCtx* dctx,
             decodedSize = ZSTD_decompressLegacy(dst, dstCapacity, src, frameSize, dict, dictSize);
             if (ZSTD_isError(decodedSize)) return decodedSize;
 
+            {
+                unsigned long long const expectedSize = ZSTD_getFrameContentSize(src, srcSize);
+                RETURN_ERROR_IF(expectedSize == ZSTD_CONTENTSIZE_ERROR, corruption_detected, "Corrupted frame header!");
+                if (expectedSize != ZSTD_CONTENTSIZE_UNKNOWN) {
+                    RETURN_ERROR_IF(expectedSize != decodedSize, corruption_detected,
+                        "Frame header size does not match decoded size!");
+                }
+            }
+
             assert(decodedSize <= dstCapacity);
             dst = (BYTE*)dst + decodedSize;
             dstCapacity -= decodedSize;

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -2408,6 +2408,15 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : Decoder should reject invalid frame header on legacy frames: ", testNb++);
+    {
+        const unsigned char compressed[] = { 0x26,0xb5,0x2f,0xfd,0x50,0x91,0xfd,0xd8,0xb5 };
+        const size_t compressedSize = 9;
+        size_t const dSize = ZSTD_decompress(NULL, 0, compressed, compressedSize);
+        CHECK(!ZSTD_isError(dSize), "must reject when legacy frame header is invalid");
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
 _end:
     FUZ_freeDictionary(dictionary);
     ZSTD_freeCStream(zc);


### PR DESCRIPTION
If `ZSTD_decompressDCtx()` succeeds on a buffer, then `ZSTD_findDecompressedSize()` should return either `ZSTD_CONTENTSIZE_UNKNOWN` or a matching decompressed size. This PR adds that invariant to the contract fuzzed by `tests/fuzz/simple_decompress.c`.

Adding that invariant to the fuzzer uncovered a bug. On legacy frames, the decoder doesn't reject on frame headers with incorrect sizes, which violates the above invariant. I fixed that bug and added a unit test for one of the bad inputs discovered by the fuzzer.

Without bugfix (fuzzer):
```
simple_decompress.c: 45: Assertion: `(expectedSize == (0ULL - 1) || expectedSize == dSize)' failed. 
==866880== ERROR: libFuzzer: deadly signal
```

Without bugfix (unit test):
```
test 82 : Decoder should reject invalid frame header on legacy frames: Error => must reject when legacy frame header is invalid (seed 3173672436, test nb 83, line 2416)
```

With bugfix (fuzzer): doesn't crash after 5min

With bugfix (unit test):
```
test 82 : Decoder should reject invalid frame header on legacy frames: OK
```
