### PR TITLE
reduce the amount of #include in cover.h

### DIFF
--- a/lib/compress/fse_compress.c
+++ b/lib/compress/fse_compress.c
@@ -25,7 +25,7 @@
 #include "../common/error_private.h"
 #define ZSTD_DEPS_NEED_MALLOC
 #define ZSTD_DEPS_NEED_MATH64
-#include "../common/zstd_deps.h"  /* ZSTD_malloc, ZSTD_free, ZSTD_memcpy, ZSTD_memset */
+#include "../common/zstd_deps.h"  /* ZSTD_memset */
 #include "../common/bits.h" /* ZSTD_highbit32 */
 
 

--- a/lib/dictBuilder/cover.h
+++ b/lib/dictBuilder/cover.h
@@ -12,14 +12,8 @@
 #  define ZDICT_STATIC_LINKING_ONLY
 #endif
 
-#include <stdio.h>  /* fprintf */
-#include <stdlib.h> /* malloc, free, qsort */
-#include <string.h> /* memset */
-#include <time.h>   /* clock */
-#include "../common/mem.h" /* read */
-#include "../common/pool.h"
-#include "../common/threading.h"
-#include "../common/zstd_internal.h" /* includes zstd.h */
+#include "../common/threading.h" /* ZSTD_pthread_mutex_t */
+#include "../common/mem.h"   /* U32, BYTE */
 #include "../zdict.h"
 
 /**


### PR DESCRIPTION
Initially, I was hunting the presence of direct invocations of `malloc()`,
in order to change them into invocations of the user-definable custom allocator,
and discovered that `cover.c` has many such instances.

Unfortunately, this goal will require major code modifications, and this is too much effort or complexity at this point before a release.

But a side effect of this investigation worth merging is a significant reduction in the amount of `#include` within `"cover.h"`, which are then transitively included into any other unit including `cover.h`. It previously included standard headers such as `<stdlib.h>`, `<stdio.h>` or `<time.h>` that we typically _don't_ want to invoke directly nor even just see in any other parts of `libzstd`. The initial list was likely made for the implementation `cover.c`, and is way overkill for the declaration.