### PR TITLE
add line number to debug traces

### DIFF
--- a/lib/common/debug.h
+++ b/lib/common/debug.h
@@ -92,10 +92,14 @@ extern int g_debuglevel; /* the variable is only declared,
         }                                  \
     } while (0)
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define LINE_AS_STRING TOSTRING(__LINE__)
+
 #  define DEBUGLOG(l, ...)                               \
     do {                                                 \
         if (l<=g_debuglevel) {                           \
-            ZSTD_DEBUG_PRINT(__FILE__ ": " __VA_ARGS__); \
+            ZSTD_DEBUG_PRINT(__FILE__ ":" LINE_AS_STRING ": " __VA_ARGS__); \
             ZSTD_DEBUG_PRINT(" \n");                     \
         }                                                \
     } while (0)


### PR DESCRIPTION
`DEBUGLOG()` debug traces currently only prefix the source file name.
Adding the line number to the prefix has proven quite useful during debugging sessions.

Example of new trace format:
```
lib//compress/zstd_compress.c:7041: ZSTD_getCParams_internal selected tableID: 0 row: 3 strat: 2
lib//compress/zstd_compress.c:6224: ZSTD_compressStream2: creating new mtctx for nbWorkers=1
lib//compress/zstdmt_compress.c:939: ZSTDMT_createCCtx_advanced (nbWorkers = 1)
lib//compress/zstd_compress.c:773: ZSTD_CCtxParams_setParameter (400, 1)
lib//compress/zstdmt_compress.c:401: cctxPool created, with 1 workers
lib//compress/zstdmt_compress.c:165: ZSTDMT_setBufferSize: bSize = 0
lib//compress/zstdmt_compress.c:972: mt_cctx created, for 1 threads
lib//compress/zstd_compress.c:6229: call ZSTDMT_initCStream_internal as nbWorkers=1
lib//compress/zstdmt_compress.c:1240: ZSTDMT_initCStream_internal (pledgedSrcSize=3181568, nbWorkers=1, cctxPool=1)
lib//compress/zstdmt_compress.c:1253: ZSTDMT_initCStream_internal: 1 workers
lib//compress/zstdmt_compress.c:1224: overlapLog : 0
lib//compress/zstdmt_compress.c:1225: overlap size : 262144
lib//compress/zstdmt_compress.c:1277: overlapLog=0 => 256 KB
```