### PR TITLE
Remove incorrect docs regarding ZSTD_findFrameCompressedSize()

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -797,10 +797,8 @@ static ZSTD_frameSizeInfo ZSTD_findFrameSizeInfo(const void* src, size_t srcSize
 }
 
 /** ZSTD_findFrameCompressedSize() :
- *  compatible with legacy mode
- *  `src` must point to the start of a ZSTD frame, ZSTD legacy frame, or skippable frame
- *  `srcSize` must be at least as large as the frame contained
- *  @return : the compressed size of the frame starting at `src` */
+ * See docs in zstd.h
+ * Note: compatible with legacy mode */
 size_t ZSTD_findFrameCompressedSize(const void *src, size_t srcSize)
 {
     ZSTD_frameSizeInfo const frameSizeInfo = ZSTD_findFrameSizeInfo(src, srcSize);


### PR DESCRIPTION
The docs for `ZSTD_findFrameCompressedSize()` in `zstd.h` correctly identify that the function may return an error code in case the input is invalid: https://github.com/facebook/zstd/blob/a0a9bc6c95436c85002ffca972ae545f862e1638/lib/zstd.h#L205-L211

However, the nearly-identical docstring in `zstd_decompress.c` omits this detail: https://github.com/facebook/zstd/blob/a0a9bc6c95436c85002ffca972ae545f862e1638/lib/decompress/zstd_decompress.c#L799-L803

This was confusing for me, as I thought for a minute (before reading the code) that the behavior is unspecified in case of an invalid input.

This PR deletes the duplicate docs in `zstd_decompress.c` and directs the reader to `zstd.h`, so that we can have a single and correct source of truth.