### PR TITLE
Fuzzing and bugfixes for magicless-format decoding

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ lib: accept dictionaries with partial literal tables, by @terrelln
 lib: fix CCtx size estimation with external sequence producer, by @embg
 lib: fix corner case decoder behaviors, by @Cyan4973 and @aimuz
 lib: fix zdict prototype mismatch in static_only mode, by @ldv-alt
+lib: fix several bugs in magicless-format decoding, by @embg
 cli: add common compressed file types to `--exclude-compressed`` by @daniellerozenblit
 cli: fix mixing `-c` and `-o` commands with `--rm`, by @Cyan4973
 cli: fix erroneous exclusion of hidden files with `--output-dir-mirror` by @felixhandte

--- a/doc/decompressor_errata.md
+++ b/doc/decompressor_errata.md
@@ -125,3 +125,24 @@ The total `Block_Content` is `5` bytes, and `Last_Table_Offset` is `2`.
 See the compressor workaround code:
 
 https://github.com/facebook/zstd/blob/8814aa5bfa74f05a86e55e9d508da177a893ceeb/lib/compress/zstd_compress.c#L2667-L2682
+
+Magicless format
+----------------------
+
+**Last affected version**: v1.5.5
+
+**Affected decompressor component(s)**: Library & CLI
+
+**Produced by the reference compressor**: Yes (example: https://gist.github.com/embg/9940726094f4cf2cef162cffe9319232)
+
+**Example Frame**: `27 b5 2f fd 00 03 19 00 00 66 6f 6f 3f ba c4 59`
+
+v1.5.6 fixes several bugs in which the magicless-format decoder rejects valid frames.
+These include but are not limited to:
+* Valid frames that happen to begin with a legacy magic number (little-endian)
+* Valid frames that happen to begin with a skippable magic number (little-endian)
+
+If you are affected by this issue and cannot update to v1.5.6 or later, there is a
+workaround to recover affected data. Simply prepend the ZSTD magic number
+`0xFD2FB528` (little-endian) to your data and decompress using the standard-format
+decoder.

--- a/doc/decompressor_errata.md
+++ b/doc/decompressor_errata.md
@@ -131,7 +131,7 @@ Magicless format
 
 **Last affected version**: v1.5.5
 
-**Affected decompressor component(s)**: Library & CLI
+**Affected decompressor component(s)**: Library
 
 **Produced by the reference compressor**: Yes (example: https://gist.github.com/embg/9940726094f4cf2cef162cffe9319232)
 

--- a/tests/fuzz/Makefile
+++ b/tests/fuzz/Makefile
@@ -124,7 +124,8 @@ FUZZ_TARGETS :=       \
 	sequence_compression_api \
 	seekable_roundtrip \
 	huf_round_trip \
-	huf_decompress
+	huf_decompress \
+	decompress_cross_format
 
 all: libregression.a $(FUZZ_TARGETS)
 
@@ -238,6 +239,9 @@ huf_round_trip: $(FUZZ_HEADERS) $(FUZZ_ROUND_TRIP_OBJ) rt_fuzz_huf_round_trip.o
 
 huf_decompress: $(FUZZ_HEADERS) $(FUZZ_DECOMPRESS_OBJ) d_fuzz_huf_decompress.o
 	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_DECOMPRESS_OBJ) d_fuzz_huf_decompress.o $(LIB_FUZZING_ENGINE) -o $@
+	
+decompress_cross_format: $(FUZZ_HEADERS) $(FUZZ_DECOMPRESS_OBJ) d_fuzz_decompress_cross_format.o
+	$(CXX) $(FUZZ_TARGET_FLAGS) $(FUZZ_DECOMPRESS_OBJ) d_fuzz_decompress_cross_format.o $(LIB_FUZZING_ENGINE) -o $@
 
 libregression.a: $(FUZZ_HEADERS) $(PRGDIR)/util.h $(PRGDIR)/util.c d_fuzz_regression_driver.o
 	$(AR) $(FUZZ_ARFLAGS) $@ d_fuzz_regression_driver.o

--- a/tests/fuzz/decompress_cross_format.c
+++ b/tests/fuzz/decompress_cross_format.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+// This fuzz target validates decompression of magicless-format compressed data.
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "fuzz_helpers.h"
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd.h"
+#include "fuzz_data_producer.h"
+
+static ZSTD_DCtx *dctx = NULL;
+
+int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
+{
+    // Give a random portion of src data to the producer, to use for parameter generation.
+    // The rest will be interpreted as magicless compressed data.
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(src, size);
+    size_t magiclessSize = FUZZ_dataProducer_reserveDataPrefix(producer);
+    const void* const magiclessSrc = src;
+    size_t const dstSize = FUZZ_dataProducer_uint32Range(producer, 0, 10 * size);
+    void* const standardDst = FUZZ_malloc(dstSize);
+    void* const magiclessDst = FUZZ_malloc(dstSize);
+
+    // Create standard-format src from magicless-format src
+    const uint32_t zstd_magic = ZSTD_MAGICNUMBER;
+    size_t standardSize = sizeof(zstd_magic) + magiclessSize;
+    void* const standardSrc = FUZZ_malloc(standardSize);
+    memcpy(standardSrc, &zstd_magic, sizeof(zstd_magic)); // assume fuzzing on little-endian machine
+    memcpy(standardSrc + sizeof(zstd_magic), magiclessSrc, magiclessSize);
+
+    // Truncate to a single frame
+    {
+        const size_t standardFrameCompressedSize = ZSTD_findFrameCompressedSize(standardSrc, standardSize);
+        if (ZSTD_isError(standardFrameCompressedSize)) {
+            goto cleanup_and_return;
+        }
+        standardSize = standardFrameCompressedSize;
+        magiclessSize = standardFrameCompressedSize - sizeof(zstd_magic);
+    }
+
+    // Create DCtx if needed
+    if (!dctx) {
+        dctx = ZSTD_createDCtx();
+        FUZZ_ASSERT(dctx);
+    }
+
+    // Test one-shot decompression
+    {
+        FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1));
+        const size_t standardRet = ZSTD_decompressDCtx(
+                                        dctx, standardDst, dstSize, standardSrc, standardSize);
+
+        FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1_magicless));
+        const size_t magiclessRet = ZSTD_decompressDCtx(
+                                        dctx, magiclessDst, dstSize, magiclessSrc, magiclessSize);
+
+        // Standard accepts => magicless should accept
+        if (!ZSTD_isError(standardRet)) FUZZ_ZASSERT(magiclessRet);
+
+        // Magicless accepts => standard should accept
+        // NOTE: this is nice-to-have, please disable this check if it is difficult to satisfy.
+        if (!ZSTD_isError(magiclessRet)) FUZZ_ZASSERT(standardRet);
+
+        // If both accept, decompressed size and data should match
+        if (!ZSTD_isError(standardRet) && !ZSTD_isError(magiclessRet)) {
+            FUZZ_ASSERT(standardRet == magiclessRet);
+            FUZZ_ASSERT(
+                memcmp(standardDst, magiclessDst, standardRet) == 0
+            );
+        }
+    }
+
+    // Test streaming decompression
+    {
+        ZSTD_inBuffer standardIn = { standardSrc, standardSize, 0 };
+        ZSTD_inBuffer magiclessIn = { magiclessSrc, magiclessSize, 0 };
+        ZSTD_outBuffer standardOut = { standardDst, dstSize, 0 };
+        ZSTD_outBuffer magiclessOut = { magiclessDst, dstSize, 0 };
+
+        FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1));
+        const size_t standardRet = ZSTD_decompressStream(dctx, &standardOut, &standardIn);
+        ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
+
+        FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1_magicless));
+        const size_t magiclessRet = ZSTD_decompressStream(dctx, &magiclessOut, &magiclessIn);
+        ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
+
+        // Standard accepts => magicless should accept
+        if (standardRet == 0) FUZZ_ASSERT(magiclessRet == 0);
+
+        // Magicless accepts => standard should accept
+        // NOTE: this is nice-to-have, please disable this check if it is difficult to satisfy.
+        if (magiclessRet == 0) FUZZ_ASSERT(standardRet == 0);
+
+        // If both accept, decompressed size and data should match
+        if (standardRet == 0 && magiclessRet == 0) {
+            FUZZ_ASSERT(standardOut.pos == magiclessOut.pos);
+            FUZZ_ASSERT(
+                memcmp(standardOut.dst, magiclessOut.dst, standardOut.pos) == 0
+            );
+        }
+    }
+
+cleanup_and_return:
+#ifndef STATEFUL_FUZZING
+    ZSTD_freeDCtx(dctx); dctx = NULL;
+#endif
+    free(standardSrc);
+    free(standardDst);
+    free(magiclessDst);
+    FUZZ_dataProducer_free(producer);
+    return 0;
+}

--- a/tests/fuzz/decompress_cross_format.c
+++ b/tests/fuzz/decompress_cross_format.c
@@ -77,9 +77,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
         // If both accept, decompressed size and data should match
         if (!ZSTD_isError(standardRet) && !ZSTD_isError(magiclessRet)) {
             FUZZ_ASSERT(standardRet == magiclessRet);
-            FUZZ_ASSERT(
-                memcmp(standardDst, magiclessDst, standardRet) == 0
-            );
+            if (standardRet > 0) {
+                FUZZ_ASSERT(
+                    memcmp(standardDst, magiclessDst, standardRet) == 0
+                );
+            }
         }
     }
 
@@ -108,9 +110,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
         // If both accept, decompressed size and data should match
         if (standardRet == 0 && magiclessRet == 0) {
             FUZZ_ASSERT(standardOut.pos == magiclessOut.pos);
-            FUZZ_ASSERT(
-                memcmp(standardOut.dst, magiclessOut.dst, standardOut.pos) == 0
-            );
+            if (standardOut.pos > 0) {
+                FUZZ_ASSERT(
+                    memcmp(standardOut.dst, magiclessOut.dst, standardOut.pos) == 0
+                );
+            }
         }
     }
 

--- a/tests/fuzz/decompress_cross_format.c
+++ b/tests/fuzz/decompress_cross_format.c
@@ -57,10 +57,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
 
     // Test one-shot decompression
     {
+        FUZZ_ZASSERT(ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters));
         FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1));
         const size_t standardRet = ZSTD_decompressDCtx(
                                         dctx, standardDst, dstSize, standardSrc, standardSize);
 
+        FUZZ_ZASSERT(ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters));
         FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1_magicless));
         const size_t magiclessRet = ZSTD_decompressDCtx(
                                         dctx, magiclessDst, dstSize, magiclessSrc, magiclessSize);
@@ -88,13 +90,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *src, size_t size)
         ZSTD_outBuffer standardOut = { standardDst, dstSize, 0 };
         ZSTD_outBuffer magiclessOut = { magiclessDst, dstSize, 0 };
 
+        FUZZ_ZASSERT(ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters));
         FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1));
         const size_t standardRet = ZSTD_decompressStream(dctx, &standardOut, &standardIn);
-        ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
 
+        FUZZ_ZASSERT(ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters));
         FUZZ_ZASSERT(ZSTD_DCtx_setParameter(dctx, ZSTD_d_format, ZSTD_f_zstd1_magicless));
         const size_t magiclessRet = ZSTD_decompressStream(dctx, &magiclessOut, &magiclessIn);
-        ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
 
         // Standard accepts => magicless should accept
         if (standardRet == 0) FUZZ_ASSERT(magiclessRet == 0);

--- a/tests/fuzz/fuzz.py
+++ b/tests/fuzz/fuzz.py
@@ -65,6 +65,7 @@ TARGET_INFO = {
     'seekable_roundtrip': TargetInfo(InputType.RAW_DATA),
     'huf_round_trip': TargetInfo(InputType.RAW_DATA),
     'huf_decompress': TargetInfo(InputType.RAW_DATA),
+    'decompress_cross_format': TargetInfo(InputType.RAW_DATA),
 }
 TARGETS = list(TARGET_INFO.keys())
 ALL_TARGETS = TARGETS + ['all']


### PR DESCRIPTION
### Overview
Follow-up to https://github.com/facebook/zstd/pull/3971.

This PR adds fuzzer coverage for magicless-format decoding. The fuzzers exposed several bugs (instances where the decoder rejects valid frames), which are also fixed in this PR. I constructed an [example](https://gist.github.com/embg/9940726094f4cf2cef162cffe9319232) which proves that the reference encoder can sometimes produce frames that hit these bugs.

*Note that these bugs only affect users of the magicless format. If your code doesn't set parameters `ZSTD_c_format` and `ZSTD_d_format`, you are not affected.*

### Bugfixes
See changes in `zstd_decompress.c`. The bugs fall into three categories:
* Frames that happen to start with legacy magic are rejected
* Frames that happen to start with skippable magic are rejected
* The bug fixed in https://github.com/facebook/zstd/pull/3971, which is entirely separate

### Fuzzing setup
At a high level, the fuzzing setup is as follows:
* Fuzzer picks a random buffer, which we interpret as magicless compressed data
* From the magicless compressed data, we create an equivalent standard-format compressed data by copying to a new buffer and prepending `ZSTD_MAGICNUMBER`.
* We decompress using both the standard-format decoder and the magicless-format decoder.
* We enforce that if the standard decoder accepts, the magicless decoder must also accept.

The idea is that if a frame is valid, then the standard decoder should accept it, in which case we will enforce that the magicless decoder should also accept it.

### Fuzzing limitations
We exercise both one-shot decoding and streaming decoding. One limitation is that we only do a single invocation of `ZSTD_decompressStream()`, which tests the most common *streaming* code path for magicless format: input fits in a single `ZSTD_inBuffer`, output fits in a single `ZSTD_outBuffer`. This is the common case because magicless format is all about tiny data.

A future improvement here could be to test other calling patterns of `ZSTD_decompressStream()`. I spent a bit of time trying to add this, found that it would require non-trivial effort, and decided to leave it out of scope.

Another limitation: the fuzzer can only test exactly one frame at a time. We don't test zero frames or 2+ frames. This would require a completely different approach, and isn't the common case for users of the magicless format.

### Fuzzer coverage checks
I made sure that each of these changes in `zstd_decompress.c` individually cause the fuzzer to crash:
```
-        if (dctx->format == ZSTD_f_zstd1 && ZSTD_isLegacy(src, srcSize)) {
+        if (/*dctx->format == ZSTD_f_zstd1 &&*/ ZSTD_isLegacy(src, srcSize)) {
```
```
-        if (dctx->format == ZSTD_f_zstd1 && srcSize >= 4) {
+        if (/*dctx->format == ZSTD_f_zstd1 &&*/ srcSize >= 4) {
```
```
-                size_t const cSize = ZSTD_findFrameCompressedSize_advanced(istart, (size_t)(iend-istart), zds->format);
+                size_t const cSize = ZSTD_findFrameCompressedSize(istart, (size_t)(iend-istart));
```
```
-            if (zds->format == ZSTD_f_zstd1
-                && (MEM_readLE32(zds->headerBuffer) & ZSTD_MAGIC_SKIPPABLE_MASK) == ZSTD_MAGIC_SKIPPABLE_START) {  /* skippable frame */
+            if ((MEM_readLE32(zds->headerBuffer) & ZSTD_MAGIC_SKIPPABLE_MASK) == ZSTD_MAGIC_SKIPPABLE_START) {  /* skippable frame */
```
