### PR TITLE
[fuzz] Turn off -Werror by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,10 +293,10 @@ regressiontest:
 	$(MAKE) -C $(FUZZDIR) regressiontest
 
 uasanregressiontest:
-	$(MAKE) -C $(FUZZDIR) regressiontest CC=clang CXX=clang++ CFLAGS="-O3 -fsanitize=address,undefined" CXXFLAGS="-O3 -fsanitize=address,undefined"
+	$(MAKE) -C $(FUZZDIR) regressiontest CC=clang CXX=clang++ CFLAGS="-O3 -fsanitize=address,undefined -Werror" CXXFLAGS="-O3 -fsanitize=address,undefined -Werror"
 
 msanregressiontest:
-	$(MAKE) -C $(FUZZDIR) regressiontest CC=clang CXX=clang++ CFLAGS="-O3 -fsanitize=memory" CXXFLAGS="-O3 -fsanitize=memory"
+	$(MAKE) -C $(FUZZDIR) regressiontest CC=clang CXX=clang++ CFLAGS="-O3 -fsanitize=memory -Werror" CXXFLAGS="-O3 -fsanitize=memory -Werror"
 
 update_regressionResults : REGRESS_RESULTS_DIR := /tmp/regress_results_dir/
 update_regressionResults:

--- a/tests/fuzz/fuzz.py
+++ b/tests/fuzz/fuzz.py
@@ -408,7 +408,6 @@ def build(args):
     mflags = shlex.split(args.mflags)
     # Flags to be added to both cflags and cxxflags
     common_flags = [
-        '-Werror',
         '-Wno-error=declaration-after-statement',
         '-Wno-error=c++-compat',
         '-Wno-error=deprecated' # C files are sometimes compiled with CXX

--- a/tests/fuzz/sequence_compression_api.c
+++ b/tests/fuzz/sequence_compression_api.c
@@ -127,7 +127,7 @@ static size_t decodeSequences(void* dst, size_t nbSequences,
     FUZZ_ASSERT(litPtr <= litEnd);
     if (mode == ZSTD_sf_noBlockDelimiters) {
         const uint32_t lastLLSize = (uint32_t)(litEnd - litPtr);
-        if (lastLLSize <= oend - op) {
+        if (lastLLSize <= (uint32_t)(oend - op)) {
             memcpy(op, litPtr, lastLLSize);
             generatedSrcBufferSize += lastLLSize;
     }   }


### PR DESCRIPTION
This was causing OSS-Fuzz errors, due to compiler differences.
* Fix the issue
* Also turn off -Werror so we don't fail fuzzer builds for warnings
* Turn on -Werror in our CI