### PR TITLE
Use md5sum rather than gmd5sum for FreeBSD

### DIFF
--- a/lib/libzstd.mk
+++ b/lib/libzstd.mk
@@ -213,8 +213,6 @@ ifeq ($(UNAME), Darwin)
   ifeq ($(shell md5 < /dev/null > /dev/null; echo $$?), 0)
     HASH ?= md5
   endif
-else ifeq ($(UNAME), FreeBSD)
-  HASH ?= gmd5sum
 else ifeq ($(UNAME), NetBSD)
   HASH ?= md5 -n
 else ifeq ($(UNAME), OpenBSD)

--- a/tests/cli-tests/common/platform.sh
+++ b/tests/cli-tests/common/platform.sh
@@ -18,7 +18,6 @@ esac
 
 case "$UNAME" in
   Darwin) MD5SUM="md5 -r" ;;
-  FreeBSD) MD5SUM="gmd5sum" ;;
   NetBSD) MD5SUM="md5 -n" ;;
   OpenBSD) MD5SUM="md5" ;;
   *) MD5SUM="md5sum" ;;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -123,7 +123,6 @@ esac
 
 case "$UNAME" in
   Darwin) MD5SUM="md5 -r" ;;
-  FreeBSD) MD5SUM="gmd5sum" ;;
   NetBSD) MD5SUM="md5 -n" ;;
   OpenBSD) MD5SUM="md5" ;;
   *) MD5SUM="md5sum" ;;


### PR DESCRIPTION
FreeBSD has md5sum in the base system. It also avoids the [hack for gmd5sum](https://github.com/freebsd/freebsd-ports/blob/main/archivers/zstd/Makefile#L22).

Reference:	https://man.freebsd.org/cgi/man.cgi?query=md5sum