### PR TITLE
Fix building on windows-x86 if clang already includes D101338

### DIFF
--- a/lib/common/cpu.h
+++ b/lib/common/cpu.h
@@ -35,7 +35,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
     U32 f7b = 0;
     U32 f7c = 0;
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
-#if !defined(__clang__)
+#if !defined(__clang__) || __clang_major__ >= 16
     int reg[4];
     __cpuid((int*)reg, 0);
     {


### PR DESCRIPTION
[D101338](https://reviews.llvm.org/D101338) landed in 2021, so clang16 should have it