### PR TITLE
Improved the Bit manipulation of HUF_initFastDStream, Func

### DIFF
--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -153,7 +153,7 @@ static size_t HUF_initFastDStream(BYTE const* ip) {
     size_t const value = MEM_readLEST(ip) | 1;
     assert(bitsConsumed <= 8);
     assert(sizeof(size_t) == 8);
-    return (value << bitsConsumed) | (ip[bitsConsumed >> 3] >> (8 - bitsConsumed & 7));
+    return (value << bitsConsumed) | (ip[bitsConsumed >> 3] >> (8 - (bitsConsumed & 7)));
 }
 
 

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -153,7 +153,7 @@ static size_t HUF_initFastDStream(BYTE const* ip) {
     size_t const value = MEM_readLEST(ip) | 1;
     assert(bitsConsumed <= 8);
     assert(sizeof(size_t) == 8);
-    return value << bitsConsumed;
+    return (value << bitsConsumed) | (ip[bitsConsumed >> 3] >> (8 - bitsConsumed & 7));
 }
 
 


### PR DESCRIPTION
return (value << bitsConsumed) | (ip[bitsConsumed >> 3] >> (8 - bits Consumed & 7));

 Effeciently performing a bitwise operation to combine two values, value and a portion of the ip array. It shifts value left by bitsConsumed bits, then ORs that with the right-shifted portion of ip.