### PR TITLE
Remove specification text stating that probability overflow is invalid

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1125,8 +1125,6 @@ If it is a 3, another 2-bits repeat flag follows, and so on.
 
 When last symbol reaches cumulated total of `1 << Accuracy_Log`,
 decoding is complete.
-If the last symbol makes cumulated total go above `1 << Accuracy_Log`,
-distribution is considered corrupted.
 If this process results in a non-zero probability for a value outside of the
 valid range of values that the FSE table is defined for, even if that value is
 not used, then the data is considered corrupted.


### PR DESCRIPTION
Due to the FSE probability encoding scheme, the largest possible value that can be decoded is the one that will make the cumulative probability equal the maximum, terminating the loop, so the situation that this text describes isn't possible.