### PR TITLE
Specify that decoders may reject non-zero probabilities for larger offset codes than implementation supports

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -1129,7 +1129,10 @@ If the last symbol makes cumulated total go above `1 << Accuracy_Log`,
 distribution is considered corrupted.
 If this process results in a non-zero probability for a value outside of the
 valid range of values that the FSE table is defined for, even if that value is
-not used, then the data is considered corrupted.
+not used, then the data is considered corrupted.  In the case of offset codes,
+a decoder implementation may reject a frame containing a non-zero probability
+for an offset code larger than the largest offset code supported by the decoder
+implementation.
 
 Then the decoder can tell how many bytes were used in this process,
 and how many symbols are present.


### PR DESCRIPTION
This is a somewhat pedantic change, but basically, the current wording states that out-of-range values in an FSE table are invalid.  However, technically offset codes exceeding the decoder's limit are still valid.  This adds some text to allow decoders to reject prob tables with unsupported offset codes.

There is one edge case with this that needs to be figured out though: The current spec states that a decoder may limit the maximum offset code length and the minimum recommended is 22.  However, the predefined table permits offset codes as large as 28.  So, this wording could mean that a decoder is allowed to reject frames using predefined codes, which sounds like something that shouldn't be allowed?

If that's the case, then this text would need to be changed to specify that it only applies to encoded tables, not to the predefined tables, and that predefined tables must be supported.