### PR TITLE
fix missing include folder for resource compiler

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -118,7 +118,7 @@ endmacro ()
 
 # Define directories containing the library's public headers
 set(PUBLIC_INCLUDE_DIRS ${LIBRARY_DIR})
-
+set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I ${LIBRARY_DIR}")
 # Split project to static and shared libraries build
 set(library_targets)
 if (ZSTD_BUILD_SHARED)


### PR DESCRIPTION
the cmake build with VS studio 2022 on windows does fail to build because rc does not have the include directory set.
include is now set for rc and build works