### PR TITLE
Fix zlibWrapper build

### DIFF
--- a/zlibWrapper/gzwrite.c
+++ b/zlibWrapper/gzwrite.c
@@ -223,7 +223,7 @@ local z_size_t gz_write(gz_statep state, voidpc buf, z_size_t len) {
             z_size_t n = (unsigned)-1;
             if (n > len)
                 n = len;
-            state.state->strm.avail_in = (z_uInt)n;
+            state.state->strm.avail_in = (uInt)n;
             state.state->x.pos += n;
             if (gz_comp(state, Z_NO_FLUSH) == -1)
                 return 0;


### PR DESCRIPTION
Just after a clone I'm getting this:

```
~/zstd/zlibWrapper$ cc -c zstd_zlibwrapper.o gz*.c -lz -lzstd -DSTDC
gzwrite.c: In function ‘gz_write’:
gzwrite.c:226:43: error: ‘z_uInt’ undeclared (first use in this function); did you mean ‘uInt’?
  226 |             state.state->strm.avail_in = (z_uInt)n;
      |                                           ^~~~~~
      |                                           uInt
gzwrite.c:226:43: note: each undeclared identifier is reported only once for each function it appears in
gzwrite.c:226:50: error: expected ‘;’ before ‘n’
  226 |             state.state->strm.avail_in = (z_uInt)n;
      |                                                  ^
      |                                                  ;
```
z_uInt is never used directly, zconf.h redefines uInt to z_uInt under the condition that Z_PREFIX is set. All examples use uInt, and the type of avail_in is also uInt.

In this commit I modify the cast to refer to the same type as the type of lvalue.

Arguably, the real fix here is to handle possible overflows, but that's beyond the scope of this commit.