### PR TITLE
Make zstd.h compatible with -Wzero-as-null-pointer-constant

### DIFF
--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1802,7 +1802,11 @@ static
 #ifdef __GNUC__
 __attribute__((__unused__))
 #endif
+// Disable diagnostic for C++ compatibility
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  /**< this constant defers to stdlib's functions */
+#pragma clang diagnostic pop
 
 ZSTDLIB_STATIC_API ZSTD_CCtx*    ZSTD_createCCtx_advanced(ZSTD_customMem customMem);
 ZSTDLIB_STATIC_API ZSTD_CStream* ZSTD_createCStream_advanced(ZSTD_customMem customMem);

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1802,11 +1802,15 @@ static
 #ifdef __GNUC__
 __attribute__((__unused__))
 #endif
-// Disable diagnostic for C++ compatibility
+	
+#if defined(__clang__) && __clang_major__ >= 5
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
 ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  /**< this constant defers to stdlib's functions */
+#if defined(__clang__) && __clang_major__ >= 5
 #pragma clang diagnostic pop
+#endif
 
 ZSTDLIB_STATIC_API ZSTD_CCtx*    ZSTD_createCCtx_advanced(ZSTD_customMem customMem);
 ZSTDLIB_STATIC_API ZSTD_CStream* ZSTD_createCStream_advanced(ZSTD_customMem customMem);


### PR DESCRIPTION
Makes this place nicely when header is used in C++ Files.