### PR TITLE
Replace bitsConsumed with bitsLeft to optimize BitStream

### DIFF
--- a/lib/common/fse.h
+++ b/lib/common/fse.h
@@ -564,7 +564,7 @@ MEM_STATIC BYTE FSE_decodeSymbolFast(FSE_DState_t* DStatePtr, BIT_DStream_t* bit
     FSE_decode_t const DInfo = ((const FSE_decode_t*)(DStatePtr->table))[DStatePtr->state];
     U32 const nbBits = DInfo.nbBits;
     BYTE const symbol = DInfo.symbol;
-    size_t const lowBits = BIT_readBitsFast(bitD, nbBits);
+    size_t const lowBits = BIT_readBits(bitD, nbBits);
 
     DStatePtr->state = DInfo.newState + lowBits;
     return symbol;

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -294,7 +294,7 @@ static size_t HUF_initRemainingDStream(BIT_DStream_t* bit, HUF_DecompressFastArg
     /* Construct the BIT_DStream_t. */
     assert(sizeof(size_t) == 8);
     bit->bitContainer = MEM_readLEST(args->ip[stream]);
-    bit->bitsConsumed = ZSTD_countTrailingZeros64(args->bits[stream]);
+    bit->bitsLeft = sizeof(bit->bitContainer)*8 - ZSTD_countTrailingZeros64(args->bits[stream]);
     bit->start = (const char*)args->ilowest;
     bit->limitPtr = bit->start + sizeof(size_t);
     bit->ptr = (const char*)args->ip[stream];
@@ -1279,11 +1279,11 @@ HUF_decodeLastSymbolX2(void* op, BIT_DStream_t* DStream, const HUF_DEltX2* dt, c
     if (dt[val].length==1) {
         BIT_skipBits(DStream, dt[val].nbBits);
     } else {
-        if (DStream->bitsConsumed < (sizeof(DStream->bitContainer)*8)) {
+        if ((sizeof(DStream->bitContainer)*8 - DStream->bitsLeft) < (sizeof(DStream->bitContainer)*8)) {
             BIT_skipBits(DStream, dt[val].nbBits);
-            if (DStream->bitsConsumed > (sizeof(DStream->bitContainer)*8))
+            if ((sizeof(DStream->bitContainer)*8 - DStream->bitsLeft) > (sizeof(DStream->bitContainer)*8))
                 /* ugly hack; works only because it's the last symbol. Note : can't easily extract nbBits from just this symbol */
-                DStream->bitsConsumed = (sizeof(DStream->bitContainer)*8);
+                DStream->bitsLeft = 0;
         }
     }
     return 1;


### PR DESCRIPTION
This change improves performance for x86 with BMI2 because before we were doing subtraction from 64 to shift but if we move it to bitsLeft, we are going to subtract only once

https://gcc.godbolt.org/z/dMY3j6rEa

Before:

```asm
BIT_readBitsFast(BIT_DStream_t*, unsigned int):  # @BIT_readBitsFast(BIT_DStream_t*, unsigned int)
        movl    8(%rdi), %ecx
        shlxq   %rcx, (%rdi), %rax
        addl    %esi, %ecx
        movl    %esi, %edx
        negb    %dl
        shrxq   %rdx, %rax, %rax
        movl    %ecx, 8(%rdi)
        retq
```

after:

```asm
BIT_readBits(BIT_DStream_t*, unsigned int):      # @BIT_readBits(BIT_DStream_t*, unsigned int)
        movl    8(%rdi), %ecx
        subl    %esi, %ecx
        shrxq   %rcx, (%rdi), %rax
        bzhiq   %rsi, %rax, %rax
        movl    %ecx, 8(%rdi)
        retq
```

Results. On Arm processors I got regression up to 1% but on Intel Xeon I got really nice uplifts. AMD was less sensistive but also got 1-2%. It's much better seen for well compressed data when we change FSE states a lot. clang is clang 16, gcc is gcc 13.2.0.

Intel(R) Xeon(R) CPU @ 2.00GHz (Skylake)

File/Level | -1 | 1 | 5 | 11
-- | -- | -- | -- | --
silesia.tar (clang pr) | 1163.0 MB/s | 937.3 MB/s | 733.7 MB/s | 728.9 MB/s
silesia.tar (clang dev) | 1042.6 MB/s (0.90x) | 902.1 MB/s (0.96x) | 681.3 MB/s (0.93x) | 714.5 MB/s (0.98x)
silesia.tar (gcc pr) | 1112.4 MB/s | 942.0 MB/s | 729.4 MB/s | 742.5 MB/s
silesia.tar (gcc dev) | 1079.2 MB/s (0.97x) | 931.4 MB/s (0.99x) | 714.4 MB/s (0.98x) | 733.5 MB/s (0.99x)
enwik8 (clang pr) | 968.9 MB/s | 830.0 MB/s | 565.9 MB/s | 538.1 MB/s
enwik8 (clang dev) | 902.2 MB/s (0.93x) | 793.8 MB/s (0.96x) | 543.9 MB/s (0.96x) | 514.2 MB/s (0.96x)
enwik8 (gcc pr) | 969.1 MB/s | 845.2 MB/s | 565.9 MB/s | 527.7 MB/s
enwik8 (gcc dev) | 942.1 MB/s (0.97x) | 819.8 MB/s (0.97x) | 554.9 MB/s (0.98x) | 539.6 MB/s (1.02x)

Intel(R) Core(TM) i7-1185G7 @ 3.00GHz

File/Level | -1 | 1 | 5 | 11
-- | -- | -- | -- | --
silesia.tar (clang pr) | 2126.4 MB/s | 1674.5 MB/s | 1471.4 MB/s | 1178.6 MB/s
silesia.tar (clang dev) | 1967.4 MB/s (0.93x) | 1589.7 MB/s (0.95x) | 1334.5 MB/s (0.91x) | 1076.8 MB/s (0.91x)
silesia.tar (gcc pr) | 2031.2 MB/s | 1704.6 MB/s | 1426.7 MB/s | 1161.9 MB/s
silesia.tar (gcc dev) | 2057.1 MB/s (1.01x) | 1605.8 MB/s (0.94x) | 1371.9 MB/s (0.96x) | 1141.6 MB/s (0.98x)
enwik8 (clang pr) | 1748.6 MB/s | 1449.4 MB/s | 1279.0 MB/s | 1356.5 MB/s
enwik8 (clang dev) | 1663.2 MB/s (0.95x) | 1387.6 MB/s (0.96x) | 1174.0 MB/s (0.92x) | 1287.2 MB/s (0.95x)
enwik8 (gcc pr) | 1733.2 MB/s | 1391.6 MB/s | 1195.8 MB/s | 1342.2 MB/s
enwik8 (gcc dev) | 1681.2 MB/s (0.97x) | 1426.4 MB/s (1.02x) | 1137.8 MB/s (0.95x) | 1299.6 MB/s (0.97x)

AMD EPYC 7B13 Zen3

File/Level | -1 | 1 | 5 | 11
-- | -- | -- | -- | --
silesia.tar (clang pr) | 1719.7 MB/s | 1299.1 MB/s | 1189.2 MB/s | 1390.5 MB/s
silesia.tar (clang dev) | 1704.2 MB/s (0.99x) | 1284.9 MB/s (0.99x) | 1183.0 MB/s (0.99x) | 1360.7 MB/s (0.98x)
enwik8 (clang pr) | 1502.0 MB/s | 1143.0 MB/s | 970.1 MB/s | 1131.1 MB/s
enwik8 (clang dev) | 1459.7 MB/s (0.97x) | 1125.9 MB/s (0.99x) | 951.8 MB/s (0.98x) | 1113.2 MB/s (0.98x)


In https://github.com/google/fleetbench where we hand out our production corpora, compression ratios, levels, statistics for our top 10 biggest workloads, we have the following benchmarks (CPU per byte):

Intel Skylake:

```
                                                        old cpu/op   new cpu/op
BM_ZSTD_DECOMPRESS_fleet                                0.59ns ± 3%  0.58ns ± 3%  -1.00%  (p=0.000 n=45+49)
BM_ZSTD_DECOMPRESS_0               [ZSTD_DECOMPRESS_0]  0.47ns ± 3%  0.46ns ± 2%  -0.85%  (p=0.000 n=46+45)
BM_ZSTD_DECOMPRESS_1               [ZSTD_DECOMPRESS_1]  0.65ns ± 2%  0.64ns ± 3%  -1.60%  (p=0.000 n=49+50)
BM_ZSTD_DECOMPRESS_2               [ZSTD_DECOMPRESS_2]  0.72ns ± 2%  0.70ns ± 3%  -1.74%  (p=0.000 n=47+50)
BM_ZSTD_DECOMPRESS_3               [ZSTD_DECOMPRESS_3]  0.93ns ± 2%  0.91ns ± 3%  -2.37%  (p=0.000 n=48+50)
BM_ZSTD_DECOMPRESS_4               [ZSTD_DECOMPRESS_4]  0.63ns ± 3%  0.62ns ± 3%  -0.55%  (p=0.015 n=49+50)
BM_ZSTD_DECOMPRESS_5               [ZSTD_DECOMPRESS_5]  0.88ns ± 2%  0.86ns ± 3%  -2.42%  (p=0.000 n=48+47)
BM_ZSTD_DECOMPRESS_6               [ZSTD_DECOMPRESS_6]  0.48ns ± 3%  0.48ns ± 3%  -0.89%  (p=0.000 n=49+48)
BM_ZSTD_DECOMPRESS_7               [ZSTD_DECOMPRESS_7]  0.72ns ± 2%  0.71ns ± 3%  -1.30%  (p=0.000 n=45+47)
BM_ZSTD_DECOMPRESS_8               [ZSTD_DECOMPRESS_8]  0.56ns ± 3%  0.56ns ± 3%  -0.57%  (p=0.005 n=48+48)
BM_ZSTD_DECOMPRESS_9               [ZSTD_DECOMPRESS_9]  0.66ns ± 3%  0.64ns ± 4%  -1.94%  (p=0.000 n=49+49)
```

AMD Zen3:

```
                                                        old cpu/op   new cpu/op
BM_ZSTD_DECOMPRESS_fleet                                0.60ns ± 2%  0.60ns ± 1%  -0.59%  (p=0.000 n=46+46)
BM_ZSTD_DECOMPRESS_0               [ZSTD_DECOMPRESS_0]  0.46ns ± 1%  0.45ns ± 1%  -0.47%  (p=0.000 n=48+46)
BM_ZSTD_DECOMPRESS_1               [ZSTD_DECOMPRESS_1]  0.68ns ± 2%  0.68ns ± 1%    ~     (p=0.970 n=47+48)
BM_ZSTD_DECOMPRESS_2               [ZSTD_DECOMPRESS_2]  0.74ns ± 2%  0.74ns ± 1%    ~     (p=0.180 n=48+48)
BM_ZSTD_DECOMPRESS_3               [ZSTD_DECOMPRESS_3]  0.95ns ± 1%  0.95ns ± 1%    ~     (p=0.101 n=48+48)
BM_ZSTD_DECOMPRESS_4               [ZSTD_DECOMPRESS_4]  0.63ns ± 1%  0.63ns ± 1%    ~     (p=0.082 n=49+48)
BM_ZSTD_DECOMPRESS_5               [ZSTD_DECOMPRESS_5]  0.91ns ± 2%  0.91ns ± 1%  -0.52%  (p=0.000 n=47+46)
BM_ZSTD_DECOMPRESS_6               [ZSTD_DECOMPRESS_6]  0.48ns ± 2%  0.48ns ± 1%  -0.57%  (p=0.000 n=49+48)
BM_ZSTD_DECOMPRESS_7               [ZSTD_DECOMPRESS_7]  0.75ns ± 1%  0.74ns ± 2%  -0.42%  (p=0.000 n=48+48)
BM_ZSTD_DECOMPRESS_8               [ZSTD_DECOMPRESS_8]  0.56ns ± 1%  0.55ns ± 1%  -0.58%  (p=0.000 n=49+49)
BM_ZSTD_DECOMPRESS_9               [ZSTD_DECOMPRESS_9]  0.67ns ± 1%  0.67ns ± 1%    ~     (p=0.219 n=49+47)
```

Hope you can benchmark on your own and validate that it's better :)