### PR TITLE
[fix] Add check on failed allocation in legacy/zstd_v06

### DIFF
--- a/lib/legacy/zstd_v06.c
+++ b/lib/legacy/zstd_v06.c
@@ -3919,6 +3919,10 @@ ZBUFFv06_DCtx* ZBUFFv06_createDCtx(void)
     if (zbd==NULL) return NULL;
     memset(zbd, 0, sizeof(*zbd));
     zbd->zd = ZSTDv06_createDCtx();
+    if (zbd->zd==NULL) {
+        ZBUFFv06_freeDCtx(zbd); /* avoid leaking the context */
+        return NULL;
+    }
     zbd->stage = ZBUFFds_init;
     return zbd;
 }


### PR DESCRIPTION
As reported by Ben Hawkes in #4026, a failure to allocate a zstd context would lead to a dereference of a NULL pointer due to a missing check on the returned result of ZSTDv06_createDCtx().

This patch fix the issue by adding a check for valid returned pointer.