### PR TITLE
[fix] Add newline when file exceeds 128KB

### DIFF
--- a/programs/dibio.c
+++ b/programs/dibio.c
@@ -298,7 +298,7 @@ static fileStats DiB_fileStats(const char** fileNamesTable, int nbFiles, size_t 
           fs.oneSampleTooLarge |= (fileSize > 2*SAMPLESIZE_MAX);
 
           /* Limit to the first SAMPLESIZE_MAX (128kB) of the file */
-          DISPLAYLEVEL(3, "Sample file '%s' is too large, limiting to %d KB",
+          DISPLAYLEVEL(3, "Sample file '%s' is too large, limiting to %d KB\n",
               fileNamesTable[n], SAMPLESIZE_MAX / (1 KB));
         }
         fs.nbSamples += 1;


### PR DESCRIPTION
Add missing newline in the warning message of the `zstd -v --train` commands when the file size exceeds 128KB.

Addresses https://github.com/facebook/zstd/issues/4052