### PR TITLE
Unit test for external sequence producer + static CCtx + streaming

### DIFF
--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -2356,7 +2356,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
     }
     DISPLAYLEVEL(3, "OK \n");
 
-    DISPLAYLEVEL(3, "test%3i : Testing external sequence producer with static CCtx: ", testNb++);
+    DISPLAYLEVEL(3, "test%3i : Testing external sequence producer with static CCtx (one-shot): ", testNb++);
     {
         size_t const dstBufSize = ZSTD_compressBound(CNBufferSize);
         BYTE* const dstBuf = (BYTE*)malloc(dstBufSize);
@@ -2375,7 +2375,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
             size_t const cctxSize = ZSTD_estimateCCtxSize_usingCCtxParams(params);
             cctxBuf = malloc(cctxSize);
             staticCCtx = ZSTD_initStaticCCtx(cctxBuf, cctxSize);
-            ZSTD_CCtx_setParametersUsingCCtxParams(staticCCtx, params);
+            CHECK_Z(ZSTD_CCtx_setParametersUsingCCtxParams(staticCCtx, params));
         }
 
         // Check that compression with external sequence producer succeeds when expected
@@ -2394,6 +2394,65 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
         seqProdState = EMF_BIG_ERROR;
         {
             size_t const cResult = ZSTD_compress2(staticCCtx, dstBuf, dstBufSize, CNBuffer, CNBufferSize);
+            CHECK(!ZSTD_isError(cResult), "EMF: Should have raised an error!");
+            CHECK(
+                ZSTD_getErrorCode(cResult) != ZSTD_error_sequenceProducer_failed,
+                "EMF: Wrong error code: %s", ZSTD_getErrorName(cResult)
+            );
+        }
+
+        free(dstBuf);
+        free(checkBuf);
+        free(cctxBuf);
+        ZSTD_freeCCtxParams(params);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
+    DISPLAYLEVEL(3, "test%3i : Testing external sequence producer with static CCtx (streaming): ", testNb++);
+    {
+        size_t const dstBufSize = ZSTD_compressBound(CNBufferSize);
+        BYTE* const dstBuf = (BYTE*)malloc(dstBufSize);
+        size_t const checkBufSize = CNBufferSize;
+        BYTE* const checkBuf = (BYTE*)malloc(checkBufSize);
+        ZSTD_CCtx_params* params = ZSTD_createCCtxParams();
+        ZSTD_CCtx* staticCCtx;
+        void* cctxBuf;
+        EMF_testCase seqProdState;
+
+        CHECK_Z(ZSTD_CCtxParams_setParameter(params, ZSTD_c_validateSequences, 1));
+        CHECK_Z(ZSTD_CCtxParams_setParameter(params, ZSTD_c_enableSeqProducerFallback, 0));
+        ZSTD_CCtxParams_registerSequenceProducer(params, &seqProdState, zstreamSequenceProducer);
+
+        {
+            size_t const cctxSize = ZSTD_estimateCStreamSize_usingCCtxParams(params);
+            cctxBuf = malloc(cctxSize);
+            staticCCtx = ZSTD_initStaticCCtx(cctxBuf, cctxSize);
+            CHECK_Z(ZSTD_CCtx_setParametersUsingCCtxParams(staticCCtx, params));
+        }
+
+        // Check that compression with external sequence producer succeeds when expected
+        seqProdState = EMF_LOTS_OF_SEQS;
+        {
+            ZSTD_inBuffer inBuf = { CNBuffer, CNBufferSize, 0 };
+            ZSTD_outBuffer outBuf = { dstBuf, dstBufSize, 0 };
+            size_t dResult;
+            CHECK_Z(ZSTD_compressStream(staticCCtx, &outBuf, &inBuf));
+            CHECK_Z(ZSTD_endStream(staticCCtx, &outBuf));
+            CHECK(inBuf.pos != inBuf.size, "EMF: inBuf.pos != inBuf.size");
+            dResult = ZSTD_decompress(checkBuf, checkBufSize, outBuf.dst, outBuf.pos);
+            CHECK(ZSTD_isError(dResult), "EMF: Decompression error: %s", ZSTD_getErrorName(dResult));
+            CHECK(dResult != CNBufferSize, "EMF: Corruption!");
+            CHECK(memcmp(CNBuffer, checkBuf, CNBufferSize) != 0, "EMF: Corruption!");
+        }
+
+        CHECK_Z(ZSTD_CCtx_reset(staticCCtx, ZSTD_reset_session_only));
+
+        // Check that compression with external sequence producer fails when expected
+        seqProdState = EMF_BIG_ERROR;
+        {
+            ZSTD_inBuffer inBuf = { CNBuffer, CNBufferSize, 0 };
+            ZSTD_outBuffer outBuf = { dstBuf, dstBufSize, 0 };
+            size_t const cResult = ZSTD_compressStream(staticCCtx, &outBuf, &inBuf);
             CHECK(!ZSTD_isError(cResult), "EMF: Should have raised an error!");
             CHECK(
                 ZSTD_getErrorCode(cResult) != ZSTD_error_sequenceProducer_failed,


### PR DESCRIPTION
Linux uses [streaming compression](https://github.com/torvalds/linux/blob/c3f38fa61af77b49866b006939479069cd451173/fs/btrfs/zstd.c#L430) in BTRFS, but our existing unit test for the QAT + Linux scenario only covers one-shot compression.

This PR adds a unit test for the streaming scenario. It uses the older `ZSTD_compressStream()` API since that is what Linux uses.