### PR TITLE
Drop support for FreeBSD 13.2 CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,6 @@ task:
   freebsd_instance:
     matrix:
       image_family: freebsd-14-0
-      image_family: freebsd-13-2
   install_script: pkg install -y gmake coreutils
   script: |
     MOREFLAGS="-Werror" gmake -j all


### PR DESCRIPTION
It seems like Cirrus CI doesn't support FreeBSD 13.2 right now. This is causing our CI jobs to fail. This PR drops 13.2 support and keeps support for 14.0, which works fine in CI.

Example failing job: https://github.com/facebook/zstd/runs/25742617625

Example error message:
```
"message": "The resource 'projects/freebsd-org-cloud-dev/global/images/family/freebsd-13-2' was not found",
```