### PR TITLE
fix macos build

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -31,12 +31,12 @@ jobs:
       run: make test
 
   # lasts ~26mn
-  make-test-osx:
+  make-test-macos:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
-    - name: OS-X test
-      run: make test # make -c lib all doesn't work because of the fact that it's not a tty
+    - name: make test on macos
+      run: make test
 
   # lasts ~24mn
   make-test-32bit:

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -305,14 +305,6 @@ else
   PCLIB := $(LDFLAGS_DYNLIB)
 endif
 
-
-ifneq ($(MT),)
-  PCLIB :=
-  PCMTLIB := $(LDFLAGS_DYNLIB)
-else
-  PCLIB := $(LDFLAGS_DYNLIB)
-endif
-
 ifneq (,$(filter FreeBSD NetBSD DragonFly,$(UNAME)))
   PKGCONFIGDIR ?= $(PREFIX)/libdata/pkgconfig
 else

--- a/lib/libzstd.mk
+++ b/lib/libzstd.mk
@@ -206,7 +206,7 @@ endif
 endif
 CPPFLAGS  += -DZSTD_LEGACY_SUPPORT=$(ZSTD_LEGACY_SUPPORT)
 
-UNAME := $(shell sh -c 'MSYSTEM="MSYS" uname') 
+UNAME := $(shell sh -c 'MSYSTEM="MSYS" uname')
 
 ifndef BUILD_DIR
 ifeq ($(UNAME), Darwin)


### PR DESCRIPTION
weird: after replacing the `UNAME` line with an identical one, it does work properly now(??).
Possibly a case of hidden character?

Also: renamed the test `macos`, since it's no longer `OS-X` now