### PR TITLE
gen_html: Fix build error with mingw

### DIFF
--- a/contrib/gen_html/Makefile
+++ b/contrib/gen_html/Makefile
@@ -40,7 +40,7 @@ gen_html: gen_html.cpp
 
 $(ZSTDMANUAL): gen_html $(ZSTDAPI)
 	echo "Update zstd manual in /doc"
-	./gen_html $(LIBVER) $(ZSTDAPI) $(ZSTDMANUAL)
+	./gen_html$(EXT) $(LIBVER) $(ZSTDAPI) $(ZSTDMANUAL)
 
 .PHONY: manual
 manual: gen_html $(ZSTDMANUAL)


### PR DESCRIPTION
When building with mingw on Linux, an error occurs when running gen_html without the extension(.exe).

```
make[1]: ./gen_html: No such file or directory
make[1]: *** [Makefile:43: ../../doc/zstd_manual.html] Error 127
make[1]: Leaving directory '/build/zstd/contrib/gen_html'
make: *** [Makefile:112: manual] Error 2
make: *** Waiting for unfinished jobs....
```