### PR TITLE
lib/libzstd.mk: fix typo in the definition of LIB_BINDIR

### DIFF
--- a/lib/libzstd.mk
+++ b/lib/libzstd.mk
@@ -22,7 +22,7 @@ LIBZSTD_MK_INCLUDED := 1
 
 # By default, library's directory is same as this included makefile
 LIB_SRCDIR ?= $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
-LIB_BINDIR ?= $(LIBSRC_DIR)
+LIB_BINDIR ?= $(LIB_SRCDIR)
 
 # ZSTD_LIB_MINIFY is a helper variable that
 # configures a bunch of other variables to space-optimized defaults.


### PR DESCRIPTION
Commit f4dbfce79cb2b82fb496fcd2518ecd3315051b7d ("define LIB_SRCDIR and LIB_BINDIR") significantly reworked the build logic, but in its introduction of LIB_BINDIR a typo was made.

It was introduced as such:

+LIB_SRCDIR ?= $(dir $(realpath $(lastword $(MAKEFILE_LIST)))) +LIB_BINDIR ?= $(LIBSRC_DIR)

But the definition of LIB_BINDIR has a typo: it should use $(LIB_SRCDIR) not $(LIBSRC_DIR).

Due to this, $(LIB_BINDIR) is empty, therefore in programs/Makefile, -L$(LIB_BINDIR) is expanded to just -L, and consequently when trying to link the "zstd" binary with the libzstd library, it cannot find it:

host/lib/gcc/powerpc64-buildroot-linux-gnu/13.3.0/../../../../powerpc64-buildroot-linux-gnu/bin/ld: cannot find -lzstd: No such file or directory

This commit fixes the build by fixing this typo.