### PR TITLE
[docs] Add instruction how to install zstd using Conan

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ You can build and install zstd [vcpkg](https://github.com/Microsoft/vcpkg/) depe
 The zstd port in vcpkg is kept up to date by Microsoft team members and community contributors.
 If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+### Conan
+
+You can install pre-built binaries for zstd or build it from source using [Conan](https://conan.io/). Use the following command:
+
+```bash
+conan install --requires="zstd/[*]" --build=missing
+```
+
+The zstd Conan recipe is kept up to date by Conan maintainers and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/conan-io/conan-center-index) on the ConanCenterIndex repository.
+
 ### Visual Studio (Windows)
 
 Going into `build` directory, you will find additional possibilities:


### PR DESCRIPTION
Greetings, fellow Facebook community!

We have just added the latest version of zstd to [Conan Center](https://conan.io/center/recipes/zstd?version=1.5.6) and thought it would be a nice addition to include instructions on how to install libuv via Conan in the README file.

Please let me know if this is okay, or if you would prefer it placed elsewhere.

Regards!