### PR TITLE
[zstd][android] Fix build with NDK r27

### DIFF
--- a/lib/common/zstd_deps.h
+++ b/lib/common/zstd_deps.h
@@ -31,7 +31,7 @@
  */
 #if defined(__linux) || defined(__linux__) || defined(linux) || defined(__gnu_linux__) || \
     defined(__CYGWIN__) || defined(__MSYS__)
-#if !defined(_GNU_SOURCE)
+#if !defined(_GNU_SOURCE) && !defined(__ANDROID__) /* NDK doesn't ship qsort_r(). */
 #define _GNU_SOURCE
 #endif
 #endif

--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -24,7 +24,7 @@
 /* qsort_r is an extension. */
 #if defined(__linux) || defined(__linux__) || defined(linux) || defined(__gnu_linux__) || \
     defined(__CYGWIN__) || defined(__MSYS__)
-#if !defined(_GNU_SOURCE)
+#if !defined(_GNU_SOURCE) && !defined(__ANDROID__) /* NDK doesn't ship qsort_r(). */
 #define _GNU_SOURCE
 #endif
 #endif


### PR DESCRIPTION
The NDK cross compiler declares the target as __linux (which is not technically incorrect), which triggers the enablement of _GNU_SOURCE in the newly added code that requires the presence of qsort_r() used in the COVER dictionary code.

Even though the NDK uses llvm/libc, it doesn't declare qsort_r() in the stdlib.h header.

The build fix is to only activate the _GNU_SOURCE macro if the OS is *not* Android, as then we will fallback to the C90 compliant code.

This patch should solve the reported issue number #4103.