### PR TITLE
Disallow 32-bit mode in clang section

### DIFF
--- a/lib/common/cpu.h
+++ b/lib/common/cpu.h
@@ -35,7 +35,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
     U32 f7b = 0;
     U32 f7c = 0;
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
-#if !defined(__clang__) || __clang_major__ >= 16
+#if !defined(_M_X64) || !defined(__clang__) || __clang_major__ >= 16
     int reg[4];
     __cpuid((int*)reg, 0);
     {


### PR DESCRIPTION
Fix register %rbx is only available in 64-bit mode