### PR TITLE
Fix zstd-pgo run error

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -232,7 +232,7 @@ zstd-dll : zstd
 .PHONY: zstd-pgo
 zstd-pgo : LLVM_PROFDATA?=llvm-profdata
 zstd-pgo : PROF_GENERATE_FLAGS=-fprofile-generate $(if $(findstring gcc,$(CC)),-fprofile-dir=.)
-zstd-pgo : PROF_USE_FLAGS=-fprofile-use $(if $(findstring gcc,$(CC)),-fprofile-dir=. -Werror=missing-profile -Wno-error=coverage-mismatch)
+zstd-pgo : PROF_USE_FLAGS=-fprofile-use $(if $(findstring gcc,$(CC)),-fprofile-dir=. -Wno-error=missing-profile -Wno-error=coverage-mismatch)
 zstd-pgo :
 	$(MAKE) clean HASH_DIR=$(HASH_DIR)
 	$(MAKE) zstd HASH_DIR=$(HASH_DIR) MOREFLAGS="$(PROF_GENERATE_FLAGS)"


### PR DESCRIPTION
The -Werror=missing-profile caused thread/zlib/lzma/lz4 detection failure when build with profile-use, thus caused ZSTD_MULTITHREAD etc. is not defined for profile-use, then there will be many profile mismatch information in output and the final binary reports run error sometimes as below:

Error : ZSTD_CCtx_setParameter(ctx, ZSTD_c_nbWorkers, adv->nbWorkers) failed : Unsupported parameter