### PR TITLE
Update FreeBSD VM image to 14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   name: FreeBSD (shortest)
   freebsd_instance:
     matrix:
-      image_family: freebsd-14-0
+      image_family: freebsd-14-1
   install_script: pkg install -y gmake coreutils
   script: |
     MOREFLAGS="-Werror" gmake -j all


### PR DESCRIPTION
FreeBSD 14.0 will reach the end of life on 2024-09-30.
The updated 14.1 is scheduled to end-of-life on 2025-03-31.

ref. https://www.freebsd.org/releases/14.2R/schedule/
