### PR TITLE
Improve compression speed on small blocks

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -557,6 +557,23 @@ MEM_STATIC int ZSTD_cParam_withinBounds(ZSTD_cParameter cParam, int value)
     return 1;
 }
 
+/* ZSTD_selectAddr:
+ * @return a >= b ? trueAddr : falseAddr,
+ * tries to force branchless codegen. */
+MEM_STATIC const BYTE* ZSTD_selectAddr(U32 a, U32 b, const BYTE* trueAddr, const BYTE* falseAddr) {
+#if defined(__GNUC__) && defined(__x86_64__)
+    __asm__ (
+        "cmp %1, %2\n"
+        "cmova %3, %0\n"
+        : "+r"(trueAddr)
+        : "r"(a), "r"(b), "r"(falseAddr)
+        );
+    return trueAddr;
+#else
+    return a >= b ? trueAddr : falseAddr;
+#endif
+}
+
 /* ZSTD_noCompressBlock() :
  * Writes uncompressed block to dst buffer from given src.
  * Returns the size of the block */

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -558,21 +558,21 @@ MEM_STATIC int ZSTD_cParam_withinBounds(ZSTD_cParameter cParam, int value)
 }
 
 /* ZSTD_selectAddr:
- * @return a >= b ? trueAddr : falseAddr,
+ * @return index >= lowLimit ? candidate : backup,
  * tries to force branchless codegen. */
 MEM_STATIC const BYTE*
-ZSTD_selectAddr(U32 index, U32 lowLimit, const BYTE* trueAddr, const BYTE* falseAddr)
+ZSTD_selectAddr(U32 index, U32 lowLimit, const BYTE* candidate, const BYTE* backup)
 {
 #if defined(__GNUC__) && defined(__x86_64__)
     __asm__ (
         "cmp %1, %2\n"
         "cmova %3, %0\n"
-        : "+r"(trueAddr)
-        : "r"(index), "r"(lowLimit), "r"(falseAddr)
+        : "+r"(candidate)
+        : "r"(index), "r"(lowLimit), "r"(backup)
         );
-    return trueAddr;
+    return candidate;
 #else
-    return a >= b ? trueAddr : falseAddr;
+    return index >= lowLimit ? candidate : backup;
 #endif
 }
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -560,7 +560,9 @@ MEM_STATIC int ZSTD_cParam_withinBounds(ZSTD_cParameter cParam, int value)
 /* ZSTD_selectAddr:
  * @return a >= b ? trueAddr : falseAddr,
  * tries to force branchless codegen. */
-MEM_STATIC const BYTE* ZSTD_selectAddr(U32 a, U32 b, const BYTE* trueAddr, const BYTE* falseAddr) {
+MEM_STATIC const BYTE*
+ZSTD_selectAddr(U32 a, U32 b, const BYTE* trueAddr, const BYTE* falseAddr)
+{
 #if defined(__GNUC__) && defined(__x86_64__)
     __asm__ (
         "cmp %1, %2\n"

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -561,14 +561,14 @@ MEM_STATIC int ZSTD_cParam_withinBounds(ZSTD_cParameter cParam, int value)
  * @return a >= b ? trueAddr : falseAddr,
  * tries to force branchless codegen. */
 MEM_STATIC const BYTE*
-ZSTD_selectAddr(U32 a, U32 b, const BYTE* trueAddr, const BYTE* falseAddr)
+ZSTD_selectAddr(U32 index, U32 lowLimit, const BYTE* trueAddr, const BYTE* falseAddr)
 {
 #if defined(__GNUC__) && defined(__x86_64__)
     __asm__ (
         "cmp %1, %2\n"
         "cmova %3, %0\n"
         : "+r"(trueAddr)
-        : "r"(a), "r"(b), "r"(falseAddr)
+        : "r"(index), "r"(lowLimit), "r"(falseAddr)
         );
     return trueAddr;
 #else

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -201,7 +201,7 @@ size_t ZSTD_compressBlock_doubleFast_noDict_generic(
              * However expression below complies into conditional move. Since
              * match is unlikely and we only *branch* on idxl0 > prefixLowestIndex
              * if there is a match, all branches become predictable. */
-            matchl0_safe = ZSTD_selectAddr(prefixLowestIndex, idxl0, &dummy[0], matchl0);
+            matchl0_safe = ZSTD_selectAddr(idxl0, prefixLowestIndex, matchl0, &dummy[0]);
 
             /* check prefix long match */
             if (MEM_read64(matchl0_safe) == MEM_read64(ip) && matchl0_safe == matchl0) {
@@ -215,7 +215,7 @@ size_t ZSTD_compressBlock_doubleFast_noDict_generic(
             matchl1 = base + idxl1;
 
             /* Same optimization as matchl0 above */
-            matchs0_safe = ZSTD_selectAddr(prefixLowestIndex, idxs0, &dummy[0], matchs0);
+            matchs0_safe = ZSTD_selectAddr(idxs0, prefixLowestIndex, matchs0, &dummy[0]);
 
             /* check prefix short match */
             if(MEM_read32(matchs0_safe) == MEM_read32(ip) && matchs0_safe == matchs0) {
@@ -662,7 +662,7 @@ size_t ZSTD_compressBlock_doubleFast_extDict_generic(
         size_t mLength;
         hashSmall[hSmall] = hashLong[hLong] = curr;   /* update hash table */
 
-        if (((ZSTD_index_overlap_check(prefixStartIndex, repIndex)) 
+        if (((ZSTD_index_overlap_check(prefixStartIndex, repIndex))
             & (offset_1 <= curr+1 - dictStartIndex)) /* note: we are searching at curr+1 */
           && (MEM_read32(repMatch) == MEM_read32(ip+1)) ) {
             const BYTE* repMatchEnd = repIndex < prefixStartIndex ? dictEnd : iend;

--- a/lib/compress/zstd_double_fast.c
+++ b/lib/compress/zstd_double_fast.c
@@ -140,11 +140,17 @@ size_t ZSTD_compressBlock_doubleFast_noDict_generic(
     U32 idxl1; /* the long match index for ip1 */
 
     const BYTE* matchl0; /* the long match for ip */
+    const BYTE* matchl0_safe; /* matchl0 or safe address */
     const BYTE* matchs0; /* the short match for ip */
     const BYTE* matchl1; /* the long match for ip1 */
+    const BYTE* matchs0_safe; /* matchs0 or safe address */
 
     const BYTE* ip = istart; /* the current position */
     const BYTE* ip1; /* the next position */
+    /* Array of ~random data, should have low probability of matching data
+     * we load from here instead of from tables, if matchl0/matchl1 are
+     * invalid indices. Used to avoid unpredictable branches. */
+    const BYTE dummy[] = {0x12,0x34,0x56,0x78,0x9a,0xbc,0xde,0xf0,0xe2,0xb4};
 
     DEBUGLOG(5, "ZSTD_compressBlock_doubleFast_noDict_generic");
 
@@ -191,24 +197,29 @@ size_t ZSTD_compressBlock_doubleFast_noDict_generic(
 
             hl1 = ZSTD_hashPtr(ip1, hBitsL, 8);
 
-            if (idxl0 > prefixLowestIndex) {
-                /* check prefix long match */
-                if (MEM_read64(matchl0) == MEM_read64(ip)) {
-                    mLength = ZSTD_count(ip+8, matchl0+8, iend) + 8;
-                    offset = (U32)(ip-matchl0);
-                    while (((ip>anchor) & (matchl0>prefixLowest)) && (ip[-1] == matchl0[-1])) { ip--; matchl0--; mLength++; } /* catch up */
-                    goto _match_found;
-                }
+            /* idxl0 > prefixLowestIndex is a (somewhat) unpredictable branch.
+             * However expression below complies into conditional move. Since
+             * match is unlikely and we only *branch* on idxl0 > prefixLowestIndex
+             * if there is a match, all branches become predictable. */
+            matchl0_safe = ZSTD_selectAddr(prefixLowestIndex, idxl0, &dummy[0], matchl0);
+
+            /* check prefix long match */
+            if (MEM_read64(matchl0_safe) == MEM_read64(ip) && matchl0_safe == matchl0) {
+                mLength = ZSTD_count(ip+8, matchl0+8, iend) + 8;
+                offset = (U32)(ip-matchl0);
+                while (((ip>anchor) & (matchl0>prefixLowest)) && (ip[-1] == matchl0[-1])) { ip--; matchl0--; mLength++; } /* catch up */
+                goto _match_found;
             }
 
             idxl1 = hashLong[hl1];
             matchl1 = base + idxl1;
 
-            if (idxs0 > prefixLowestIndex) {
-                /* check prefix short match */
-                if (MEM_read32(matchs0) == MEM_read32(ip)) {
-                    goto _search_next_long;
-                }
+            /* Same optimization as matchl0 above */
+            matchs0_safe = ZSTD_selectAddr(prefixLowestIndex, idxs0, &dummy[0], matchs0);
+
+            /* check prefix short match */
+            if(MEM_read32(matchs0_safe) == MEM_read32(ip) && matchs0_safe == matchs0) {
+                  goto _search_next_long;
             }
 
             if (ip1 >= nextStep) {

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -118,7 +118,9 @@ ZSTD_match4Found_cmov(const BYTE* currentPtr, const BYTE* matchAddress, U32 curr
      */
     if (MEM_read32(currentPtr) != MEM_read32(mvalAddr)) return 0;
     /* force ordering of these tests, which matters once the function is inlined, as they become branches */
+#if defined(__GNUC__)
     __asm__("");
+#endif
     return currentIdx >= lowLimit;
 }
 


### PR DESCRIPTION
This is a follow up from #4144 , from @TocarIP .

#4144 improves compression speed on small blocks, by forcing usage of a `cmov` via assembly code (`x64` only).
It works great on small blocks, but since the strategy is applied unconditionally, it's also active for long inputs. In which case, it introduces a speed regression (- 3-6%). 

This PR is a follow up, which attempts to bring the best of both worlds:
instantiate 2 variants, one using `cmov` and the other using a branch,
and select the appropriate variant at runtime.

This PR implements this strategy for the `fast` strategy.

It works fine, on `gcc`.

Initially `clang` didn't like it unfortunately.

Scenario: `silesia.tar`, cut into blocks of 32 KB, i7-9700k (no turbo), Ubuntu 24.04:

| compiler |  `dev` | #4144 | this PR |
| --- | --- | --- | --- |
| gcc-9 | 280 MB/s | 342 MB/s | 343 MB/s |
| clang-16 | 281 MB/s | 342 MB/s | **271 MB/s** |

After investigation, it appears that once the initial formulation `if (test1 && test2) { ... }` is changed into `if (inlined_test(...) { ... }` with `inlined_test() { return test1 && test2; }`, then the order of tests (`test1` _then_ `test2`) is no longer preserved. But, because of inlining, they still generate individual branches ! So `clang` was re-ordering the branches, making the range check branch first, thus negating the benefits of #4144.

One solution, suggested by @terrelln, is to use a memory barrier to force execution in the written order.
This suggestion has worked fine : 

| compiler |  `dev` | #4144 | this PR |
| --- | --- | --- | --- |
| gcc-9 | 280 MB/s | 342 MB/s | 342 MB/s |
| clang-16 | 281 MB/s | 342 MB/s | 342 MB/s |

On the other hand, with this PR, performance on longer inputs is no longer negatively impacted: 

Scenario: `silesia.tar`, entire file, i7-9700k (no turbo), Ubuntu 24.04:

| compiler |  `dev` | #4144 | this PR |
| --- | --- | --- | --- |
| gcc-9 | 386 MB/s | 368 MB/s | 384 MB/s |
| clang-16 | 379 MB/s | 368 MB/s | 386 MB/s |

_edit_ : 
As a good surprise, the current code seems to work fine as is on Apple's M1, without a need for some inline assembly.
It's unclear though if it does generalize well over all `aarch64` architectures and compilers.

Scenario: `silesia.tar`, cut into blocks of 32 KB, M1 Pro, Ubuntu 24.04:

| cpu |  `dev` | #4144 | this PR |
| --- | --- | --- | --- |
| M1 Pro | 410 MB/s | 408 MB/s | 535 MB/s |

_note 2_:
The negative impact of the `cmov` patch on compression speed for long inputs 
is much less pronounced at level 3 than it was at level 1, 
somewhere in the -1/-3% range.
The speed benefits on small data though are well present (> +10% at 32 KB blocks).

Scenario: `silesia.tar`, cut into blocks of 32 KB, level `3`:

| cpu |  `dev` | #4144 | this PR |
| --- | --- | --- | --- |
| i7-9700k | 283 MB/s | 311 MB/s | 317 MB/s | 
| M1 Pro | 336 MB/s | 408 MB/s | 408 MB/s |

Consequently, I believe it's not worth the time and binary size to generate some special `dfast` variant for "long inputs".

Potential follow up:
the current patch applies the new strategy to the `noDict` variants of `fast` and `dfast` _only_.
It seems interesting to also test and eventually adopt this strategy for dictionary compression too.