### PR TITLE
faster 32-bit CI tests

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         sudo apt-get -qqq update
         make libc6install
-        CFLAGS="-m32" make test
+        CFLAGS="-m32 -O1" make test V=1
 
   no-intrinsics-fuzztest:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -46,11 +46,12 @@ jobs:
       READFROMBLOCKDEVICE: 1
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
-    - name: make test # note: make -j test seems to break when associated with `-m32`
+    - name: make test # note: `make -j test success` seems to require a clean state
       run: |
         sudo apt-get -qqq update
         make libc6install
-        CFLAGS="-m32 -O2" make test V=1
+        make clean
+        CFLAGS="-m32 -O2" make -j test V=1
 
   no-intrinsics-fuzztest:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -46,11 +46,11 @@ jobs:
       READFROMBLOCKDEVICE: 1
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
-    - name: make test
+    - name: make test # note: make -j test seems to break when associated with `-m32`
       run: |
         sudo apt-get -qqq update
         make libc6install
-        CFLAGS="-m32 -O1" make test V=1
+        CFLAGS="-m32 -O2" make test V=1
 
   no-intrinsics-fuzztest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this is the longest CI test, reaching ~40mn on last PR, so we are waiting CI completion on this one currently.