### PR TITLE
Improve dictionary compression speed

### DIFF
--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -597,8 +597,8 @@ size_t ZSTD_compressBlock_fast_dictMatchState_generic(
                 }
             }
 
-            if (matchIndex > prefixStartIndex && MEM_read32(match) == MEM_read32(ip0)) {
-                /* found a regular match */
+            if (ZSTD_match4Found_cmov(ip0, match, matchIndex, prefixStartIndex)) {
+                /* found a regular match of size >= 4 */
                 U32 const offset = (U32) (ip0 - match);
                 mLength = ZSTD_count(ip0 + 4, match + 4, iend) + 4;
                 while (((ip0 > anchor) & (match > prefixStart))

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2450,7 +2450,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
                                                  3742, 3675, 3674, 3665, 3664,
                                                  3663, 3662, 3661, 3660, 3660,
                                                  3660, 3660, 3660 };
-            size_t const target_wdict_cSize[22+1] =  { 2830, 2896, 2893, 2820, 2940,
+            size_t const target_wdict_cSize[22+1] =  { 2830, 2896, 2893, 2840, 2950,
                                                        2950, 2950, 2925, 2900, 2892,
                                                        2910, 2910, 2910, 2780, 2775,
                                                        2765, 2760, 2755, 2754, 2753,


### PR DESCRIPTION
This patch generally improves dictionary compression speed for the `fast` strategy, aka levels 1 & 2, following a method similar to #4165 .

The gains are not uniform, and depend on the shape of the data. Tested on a set of various scenarios, one can observe speed gains as large as +14%, and as low as -2%, with the majority being around +5%. Therefore, this change is mostly positive, and when it's not, it's just by a small amount.

I also tried the same modification for `dfast` strategy, aka levels 3 & 4, but did not observe similar speed gains. That being said, during the investigation process, a few minor modifications were made to the `dfast` dictionary compression code, leading generally to slightly better compression ratios, by favoring longer matches over short ones.