### PR TITLE
Added faster block splitter variants for levels 3-7

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4507,8 +4507,10 @@ static size_t ZSTD_optimalBlockSize(ZSTD_CCtx* cctx, const void* src, size_t src
     /* dynamic splitting has a cpu cost for analysis,
      * due to that cost it's only used for higher levels */
     if (strat >= ZSTD_btopt)
-        return ZSTD_splitBlock(src, srcSize, blockSizeMax, split_lvl2, cctx->tmpWorkspace, cctx->tmpWkspSize);
+        return ZSTD_splitBlock(src, srcSize, blockSizeMax, split_lvl3, cctx->tmpWorkspace, cctx->tmpWkspSize);
     if (strat >= ZSTD_lazy2)
+        return ZSTD_splitBlock(src, srcSize, blockSizeMax, split_lvl2, cctx->tmpWorkspace, cctx->tmpWkspSize);
+    if (strat >= ZSTD_greedy)
         return ZSTD_splitBlock(src, srcSize, blockSizeMax, split_lvl1, cctx->tmpWorkspace, cctx->tmpWkspSize);
     /* blind split strategy
      * heuristic value, tested as being "generally better".

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4507,11 +4507,11 @@ static size_t ZSTD_optimalBlockSize(ZSTD_CCtx* cctx, const void* src, size_t src
     /* dynamic splitting has a cpu cost for analysis,
      * due to that cost it's only used for higher levels */
     if (strat >= ZSTD_btopt)
-        return ZSTD_splitBlock(src, srcSize, blockSizeMax, split_lvl3, cctx->tmpWorkspace, cctx->tmpWkspSize);
+        return ZSTD_splitBlock(src, blockSizeMax, split_lvl3, cctx->tmpWorkspace, cctx->tmpWkspSize);
     if (strat >= ZSTD_lazy2)
-        return ZSTD_splitBlock(src, srcSize, blockSizeMax, split_lvl2, cctx->tmpWorkspace, cctx->tmpWkspSize);
+        return ZSTD_splitBlock(src, blockSizeMax, split_lvl2, cctx->tmpWorkspace, cctx->tmpWkspSize);
     if (strat >= ZSTD_greedy)
-        return ZSTD_splitBlock(src, srcSize, blockSizeMax, split_lvl1, cctx->tmpWorkspace, cctx->tmpWkspSize);
+        return ZSTD_splitBlock(src, blockSizeMax, split_lvl1, cctx->tmpWorkspace, cctx->tmpWkspSize);
     /* blind split strategy
      * heuristic value, tested as being "generally better".
      * no cpu cost, but can over-split homegeneous data.

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4507,11 +4507,13 @@ static size_t ZSTD_optimalBlockSize(ZSTD_CCtx* cctx, const void* src, size_t src
     /* dynamic splitting has a cpu cost for analysis,
      * due to that cost it's only used for higher levels */
     if (strat >= ZSTD_btopt)
-        return ZSTD_splitBlock(src, blockSizeMax, split_lvl3, cctx->tmpWorkspace, cctx->tmpWkspSize);
+        return ZSTD_splitBlock(src, blockSizeMax, 3, cctx->tmpWorkspace, cctx->tmpWkspSize);
     if (strat >= ZSTD_lazy2)
-        return ZSTD_splitBlock(src, blockSizeMax, split_lvl2, cctx->tmpWorkspace, cctx->tmpWkspSize);
+        return ZSTD_splitBlock(src, blockSizeMax, 2, cctx->tmpWorkspace, cctx->tmpWkspSize);
     if (strat >= ZSTD_greedy)
-        return ZSTD_splitBlock(src, blockSizeMax, split_lvl1, cctx->tmpWorkspace, cctx->tmpWkspSize);
+        return ZSTD_splitBlock(src, blockSizeMax, 1, cctx->tmpWorkspace, cctx->tmpWkspSize);
+    if (strat >= ZSTD_dfast)
+        return ZSTD_splitBlock(src, blockSizeMax, 0, cctx->tmpWorkspace, cctx->tmpWkspSize);
     /* blind split strategy
      * heuristic value, tested as being "generally better".
      * no cpu cost, but can over-split homegeneous data.

--- a/lib/compress/zstd_preSplit.c
+++ b/lib/compress/zstd_preSplit.c
@@ -68,6 +68,7 @@ FORCE_INLINE_TEMPLATE void addEvents_generic(Fingerprint* fp, const void* src, s
 
 ZSTD_GEN_ADDEVENTS_SAMPLE(1)
 ZSTD_GEN_ADDEVENTS_SAMPLE(5)
+ZSTD_GEN_ADDEVENTS_SAMPLE(11)
 
 
 typedef void (*addEvents_f)(Fingerprint* fp, const void* src, size_t srcSize);
@@ -173,9 +174,12 @@ size_t ZSTD_splitBlock(const void* src, size_t srcSize,
                     size_t blockSizeMax, ZSTD_SplitBlock_strategy_e splitStrat,
                     void* workspace, size_t wkspSize)
 {
-    if (splitStrat == split_lvl2)
+    if (splitStrat == split_lvl3)
         return ZSTD_splitBlock_byChunks(src, srcSize, blockSizeMax, ADDEVENTS_RATE(1), workspace, wkspSize);
 
+    if (splitStrat == split_lvl2)
+        return ZSTD_splitBlock_byChunks(src, srcSize, blockSizeMax, ADDEVENTS_RATE(5), workspace, wkspSize);
+
     assert(splitStrat == split_lvl1);
-    return ZSTD_splitBlock_byChunks(src, srcSize, blockSizeMax, ADDEVENTS_RATE(5), workspace, wkspSize);
+    return ZSTD_splitBlock_byChunks(src, srcSize, blockSizeMax, ADDEVENTS_RATE(11), workspace, wkspSize);
 }

--- a/lib/compress/zstd_preSplit.c
+++ b/lib/compress/zstd_preSplit.c
@@ -63,7 +63,7 @@ addEvents_generic(Fingerprint* fp, const void* src, size_t srcSize, size_t sampl
 FORCE_INLINE_TEMPLATE void
 recordFingerprint_generic(Fingerprint* fp, const void* src, size_t srcSize, size_t samplingRate, unsigned hashLog)
 {
-    ZSTD_memset(fp, 0, sizeof(unsigned) * (1 << hashLog));
+    ZSTD_memset(fp, 0, sizeof(unsigned) * ((size_t)1 << hashLog));
     fp->nbEvents = 0;
     addEvents_generic(fp, src, srcSize, samplingRate, hashLog);
 }

--- a/lib/compress/zstd_preSplit.h
+++ b/lib/compress/zstd_preSplit.h
@@ -17,11 +17,10 @@
 extern "C" {
 #endif
 
-typedef enum { split_lvl1, split_lvl2, split_lvl3 } ZSTD_SplitBlock_strategy_e;
-
 #define ZSTD_SLIPBLOCK_WORKSPACESIZE 8208
 
-/* note:
+/* @level must be a value between 0 and 3.
+ *        higher levels spend more energy to find block boundaries
  * @workspace must be aligned on 8-bytes boundaries
  * @wkspSize must be at least >= ZSTD_SLIPBLOCK_WORKSPACESIZE
  * note2:
@@ -30,7 +29,7 @@ typedef enum { split_lvl1, split_lvl2, split_lvl3 } ZSTD_SplitBlock_strategy_e;
  * This could be extended to smaller sizes in the future.
  */
 size_t ZSTD_splitBlock(const void* blockStart, size_t blockSize,
-                    ZSTD_SplitBlock_strategy_e splitStrat,
+                    int level,
                     void* workspace, size_t wkspSize);
 
 #if defined (__cplusplus)

--- a/lib/compress/zstd_preSplit.h
+++ b/lib/compress/zstd_preSplit.h
@@ -29,8 +29,8 @@ typedef enum { split_lvl1, split_lvl2, split_lvl3 } ZSTD_SplitBlock_strategy_e;
  * therefore @blockSizeMax must be == 128 KB.
  * This could be extended to smaller sizes in the future.
  */
-size_t ZSTD_splitBlock(const void* src, size_t srcSize,
-                    size_t blockSizeMax, ZSTD_SplitBlock_strategy_e splitStrat,
+size_t ZSTD_splitBlock(const void* blockStart, size_t blockSize,
+                    ZSTD_SplitBlock_strategy_e splitStrat,
                     void* workspace, size_t wkspSize);
 
 #if defined (__cplusplus)

--- a/lib/compress/zstd_preSplit.h
+++ b/lib/compress/zstd_preSplit.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-typedef enum { split_lvl1, split_lvl2 } ZSTD_SplitBlock_strategy_e;
+typedef enum { split_lvl1, split_lvl2, split_lvl3 } ZSTD_SplitBlock_strategy_e;
 
 #define ZSTD_SLIPBLOCK_WORKSPACESIZE 8208
 

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -2,10 +2,10 @@ Data,                               Config,                             Method, 
 silesia.tar,                        level -5,                           compress simple,                    6860782
 silesia.tar,                        level -3,                           compress simple,                    6507448
 silesia.tar,                        level -1,                           compress simple,                    6175582
-silesia.tar,                        level 0,                            compress simple,                    4843429
+silesia.tar,                        level 0,                            compress simple,                    4829268
 silesia.tar,                        level 1,                            compress simple,                    5316794
-silesia.tar,                        level 3,                            compress simple,                    4843429
-silesia.tar,                        level 4,                            compress simple,                    4780657
+silesia.tar,                        level 3,                            compress simple,                    4829268
+silesia.tar,                        level 4,                            compress simple,                    4767074
 silesia.tar,                        level 5,                            compress simple,                    4662847
 silesia.tar,                        level 6,                            compress simple,                    4597877
 silesia.tar,                        level 7,                            compress simple,                    4563998
@@ -13,16 +13,16 @@ silesia.tar,                        level 9,                            compress
 silesia.tar,                        level 13,                           compress simple,                    4484732
 silesia.tar,                        level 16,                           compress simple,                    4355572
 silesia.tar,                        level 19,                           compress simple,                    4257629
-silesia.tar,                        uncompressed literals,              compress simple,                    4843429
+silesia.tar,                        uncompressed literals,              compress simple,                    4829268
 silesia.tar,                        uncompressed literals optimal,      compress simple,                    4257629
 silesia.tar,                        huffman literals,                   compress simple,                    6175582
 github.tar,                         level -5,                           compress simple,                    52320
 github.tar,                         level -3,                           compress simple,                    45823
 github.tar,                         level -1,                           compress simple,                    42740
-github.tar,                         level 0,                            compress simple,                    39073
+github.tar,                         level 0,                            compress simple,                    38884
 github.tar,                         level 1,                            compress simple,                    39444
-github.tar,                         level 3,                            compress simple,                    39073
-github.tar,                         level 4,                            compress simple,                    39068
+github.tar,                         level 3,                            compress simple,                    38884
+github.tar,                         level 4,                            compress simple,                    38880
 github.tar,                         level 5,                            compress simple,                    39651
 github.tar,                         level 6,                            compress simple,                    39282
 github.tar,                         level 7,                            compress simple,                    38005
@@ -30,16 +30,16 @@ github.tar,                         level 9,                            compress
 github.tar,                         level 13,                           compress simple,                    35501
 github.tar,                         level 16,                           compress simple,                    40466
 github.tar,                         level 19,                           compress simple,                    32262
-github.tar,                         uncompressed literals,              compress simple,                    39073
+github.tar,                         uncompressed literals,              compress simple,                    38884
 github.tar,                         uncompressed literals optimal,      compress simple,                    32262
 github.tar,                         huffman literals,                   compress simple,                    42740
 silesia,                            level -5,                           compress cctx,                      6857776
 silesia,                            level -3,                           compress cctx,                      6504756
 silesia,                            level -1,                           compress cctx,                      6174127
-silesia,                            level 0,                            compress cctx,                      4838417
+silesia,                            level 0,                            compress cctx,                      4832054
 silesia,                            level 1,                            compress cctx,                      5306931
-silesia,                            level 3,                            compress cctx,                      4838417
-silesia,                            level 4,                            compress cctx,                      4775359
+silesia,                            level 3,                            compress cctx,                      4832054
+silesia,                            level 4,                            compress cctx,                      4768799
 silesia,                            level 5,                            compress cctx,                      4663718
 silesia,                            level 6,                            compress cctx,                      4600034
 silesia,                            level 7,                            compress cctx,                      4566069
@@ -47,17 +47,17 @@ silesia,                            level 9,                            compress
 silesia,                            level 13,                           compress cctx,                      4488969
 silesia,                            level 16,                           compress cctx,                      4356799
 silesia,                            level 19,                           compress cctx,                      4265851
-silesia,                            long distance mode,                 compress cctx,                      4838417
-silesia,                            multithreaded,                      compress cctx,                      4838417
-silesia,                            multithreaded long distance mode,   compress cctx,                      4838417
+silesia,                            long distance mode,                 compress cctx,                      4832054
+silesia,                            multithreaded,                      compress cctx,                      4832054
+silesia,                            multithreaded long distance mode,   compress cctx,                      4832054
 silesia,                            small window log,                   compress cctx,                      7082907
 silesia,                            small hash log,                     compress cctx,                      6525510
 silesia,                            small chain log,                    compress cctx,                      4912248
 silesia,                            explicit params,                    compress cctx,                      4789676
-silesia,                            uncompressed literals,              compress cctx,                      4838417
+silesia,                            uncompressed literals,              compress cctx,                      4832054
 silesia,                            uncompressed literals optimal,      compress cctx,                      4265851
 silesia,                            huffman literals,                   compress cctx,                      6174127
-silesia,                            multithreaded with advanced params, compress cctx,                      4838417
+silesia,                            multithreaded with advanced params, compress cctx,                      4832054
 github,                             level -5,                           compress cctx,                      204407
 github,                             level -5 with dict,                 compress cctx,                      47581
 github,                             level -3,                           compress cctx,                      193253
@@ -100,10 +100,10 @@ github,                             multithreaded with advanced params, compress
 silesia,                            level -5,                           zstdcli,                            6856073
 silesia,                            level -3,                           zstdcli,                            6505580
 silesia,                            level -1,                           zstdcli,                            6172649
-silesia,                            level 0,                            zstdcli,                            4838997
+silesia,                            level 0,                            zstdcli,                            4833113
 silesia,                            level 1,                            zstdcli,                            5306179
-silesia,                            level 3,                            zstdcli,                            4838997
-silesia,                            level 4,                            zstdcli,                            4775769
+silesia,                            level 3,                            zstdcli,                            4833113
+silesia,                            level 4,                            zstdcli,                            4770061
 silesia,                            level 5,                            zstdcli,                            4663332
 silesia,                            level 6,                            zstdcli,                            4599601
 silesia,                            level 7,                            zstdcli,                            4565601
@@ -111,24 +111,24 @@ silesia,                            level 9,                            zstdcli,
 silesia,                            level 13,                           zstdcli,                            4488438
 silesia,                            level 16,                           zstdcli,                            4358150
 silesia,                            level 19,                           zstdcli,                            4265929
-silesia,                            long distance mode,                 zstdcli,                            4830467
-silesia,                            multithreaded,                      zstdcli,                            4838997
-silesia,                            multithreaded long distance mode,   zstdcli,                            4830467
+silesia,                            long distance mode,                 zstdcli,                            4824875
+silesia,                            multithreaded,                      zstdcli,                            4833113
+silesia,                            multithreaded long distance mode,   zstdcli,                            4824875
 silesia,                            small window log,                   zstdcli,                            7094528
 silesia,                            small hash log,                     zstdcli,                            6527214
 silesia,                            small chain log,                    zstdcli,                            4911647
 silesia,                            explicit params,                    zstdcli,                            4790803
-silesia,                            uncompressed literals,              zstdcli,                            5117843
+silesia,                            uncompressed literals,              zstdcli,                            5118235
 silesia,                            uncompressed literals optimal,      zstdcli,                            4316761
 silesia,                            huffman literals,                   zstdcli,                            5320793
-silesia,                            multithreaded with advanced params, zstdcli,                            5117843
+silesia,                            multithreaded with advanced params, zstdcli,                            5118235
 silesia.tar,                        level -5,                           zstdcli,                            6860173
 silesia.tar,                        level -3,                           zstdcli,                            6507196
 silesia.tar,                        level -1,                           zstdcli,                            6177719
-silesia.tar,                        level 0,                            zstdcli,                            4841906
+silesia.tar,                        level 0,                            zstdcli,                            4836004
 silesia.tar,                        level 1,                            zstdcli,                            5313917
-silesia.tar,                        level 3,                            zstdcli,                            4841906
-silesia.tar,                        level 4,                            zstdcli,                            4780121
+silesia.tar,                        level 3,                            zstdcli,                            4836004
+silesia.tar,                        level 4,                            zstdcli,                            4774061
 silesia.tar,                        level 5,                            zstdcli,                            4667310
 silesia.tar,                        level 6,                            zstdcli,                            4602398
 silesia.tar,                        level 7,                            zstdcli,                            4568891
@@ -136,18 +136,18 @@ silesia.tar,                        level 9,                            zstdcli,
 silesia.tar,                        level 13,                           zstdcli,                            4488484
 silesia.tar,                        level 16,                           zstdcli,                            4357018
 silesia.tar,                        level 19,                           zstdcli,                            4259593
-silesia.tar,                        no source size,                     zstdcli,                            4841902
-silesia.tar,                        long distance mode,                 zstdcli,                            4834266
-silesia.tar,                        multithreaded,                      zstdcli,                            4841906
-silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4834266
+silesia.tar,                        no source size,                     zstdcli,                            4836000
+silesia.tar,                        long distance mode,                 zstdcli,                            4828171
+silesia.tar,                        multithreaded,                      zstdcli,                            4836004
+silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4828171
 silesia.tar,                        small window log,                   zstdcli,                            7100110
 silesia.tar,                        small hash log,                     zstdcli,                            6530127
 silesia.tar,                        small chain log,                    zstdcli,                            4915865
 silesia.tar,                        explicit params,                    zstdcli,                            4808370
-silesia.tar,                        uncompressed literals,              zstdcli,                            5116446
+silesia.tar,                        uncompressed literals,              zstdcli,                            5116583
 silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4306520
 silesia.tar,                        huffman literals,                   zstdcli,                            5326463
-silesia.tar,                        multithreaded with advanced params, zstdcli,                            5116446
+silesia.tar,                        multithreaded with advanced params, zstdcli,                            5116583
 github,                             level -5,                           zstdcli,                            206407
 github,                             level -5 with dict,                 zstdcli,                            47832
 github,                             level -3,                           zstdcli,                            195253
@@ -193,14 +193,14 @@ github.tar,                         level -3,                           zstdcli,
 github.tar,                         level -3 with dict,                 zstdcli,                            44883
 github.tar,                         level -1,                           zstdcli,                            42688
 github.tar,                         level -1 with dict,                 zstdcli,                            41510
-github.tar,                         level 0,                            zstdcli,                            39071
-github.tar,                         level 0 with dict,                  zstdcli,                            38140
+github.tar,                         level 0,                            zstdcli,                            38888
+github.tar,                         level 0 with dict,                  zstdcli,                            37999
 github.tar,                         level 1,                            zstdcli,                            39404
 github.tar,                         level 1 with dict,                  zstdcli,                            38320
-github.tar,                         level 3,                            zstdcli,                            39071
-github.tar,                         level 3 with dict,                  zstdcli,                            38140
-github.tar,                         level 4,                            zstdcli,                            39067
-github.tar,                         level 4 with dict,                  zstdcli,                            38082
+github.tar,                         level 3,                            zstdcli,                            38888
+github.tar,                         level 3 with dict,                  zstdcli,                            37999
+github.tar,                         level 4,                            zstdcli,                            38884
+github.tar,                         level 4 with dict,                  zstdcli,                            37952
 github.tar,                         level 5,                            zstdcli,                            39655
 github.tar,                         level 5 with dict,                  zstdcli,                            39073
 github.tar,                         level 6,                            zstdcli,                            39286
@@ -215,26 +215,26 @@ github.tar,                         level 16,                           zstdcli,
 github.tar,                         level 16 with dict,                 zstdcli,                            33379
 github.tar,                         level 19,                           zstdcli,                            32266
 github.tar,                         level 19 with dict,                 zstdcli,                            32705
-github.tar,                         no source size,                     zstdcli,                            39068
-github.tar,                         no source size with dict,           zstdcli,                            38274
-github.tar,                         long distance mode,                 zstdcli,                            40381
-github.tar,                         multithreaded,                      zstdcli,                            39071
-github.tar,                         multithreaded long distance mode,   zstdcli,                            40381
+github.tar,                         no source size,                     zstdcli,                            38885
+github.tar,                         no source size with dict,           zstdcli,                            38115
+github.tar,                         long distance mode,                 zstdcli,                            40227
+github.tar,                         multithreaded,                      zstdcli,                            38888
+github.tar,                         multithreaded long distance mode,   zstdcli,                            40227
 github.tar,                         small window log,                   zstdcli,                            198539
 github.tar,                         small hash log,                     zstdcli,                            129874
 github.tar,                         small chain log,                    zstdcli,                            41673
 github.tar,                         explicit params,                    zstdcli,                            41385
-github.tar,                         uncompressed literals,              zstdcli,                            41704
+github.tar,                         uncompressed literals,              zstdcli,                            41566
 github.tar,                         uncompressed literals optimal,      zstdcli,                            35360
 github.tar,                         huffman literals,                   zstdcli,                            39046
-github.tar,                         multithreaded with advanced params, zstdcli,                            41704
+github.tar,                         multithreaded with advanced params, zstdcli,                            41566
 silesia,                            level -5,                           advanced one pass,                  6857776
 silesia,                            level -3,                           advanced one pass,                  6504756
 silesia,                            level -1,                           advanced one pass,                  6174127
-silesia,                            level 0,                            advanced one pass,                  4838417
+silesia,                            level 0,                            advanced one pass,                  4832054
 silesia,                            level 1,                            advanced one pass,                  5306931
-silesia,                            level 3,                            advanced one pass,                  4838417
-silesia,                            level 4,                            advanced one pass,                  4775359
+silesia,                            level 3,                            advanced one pass,                  4832054
+silesia,                            level 4,                            advanced one pass,                  4768799
 silesia,                            level 5 row 1,                      advanced one pass,                  4663718
 silesia,                            level 5 row 2,                      advanced one pass,                  4666272
 silesia,                            level 5,                            advanced one pass,                  4663718
@@ -250,25 +250,25 @@ silesia,                            level 12 row 2,                     advanced
 silesia,                            level 13,                           advanced one pass,                  4488969
 silesia,                            level 16,                           advanced one pass,                  4356799
 silesia,                            level 19,                           advanced one pass,                  4265851
-silesia,                            no source size,                     advanced one pass,                  4838417
-silesia,                            long distance mode,                 advanced one pass,                  4830097
-silesia,                            multithreaded,                      advanced one pass,                  4838949
-silesia,                            multithreaded long distance mode,   advanced one pass,                  4830419
+silesia,                            no source size,                     advanced one pass,                  4832054
+silesia,                            long distance mode,                 advanced one pass,                  4823833
+silesia,                            multithreaded,                      advanced one pass,                  4833065
+silesia,                            multithreaded long distance mode,   advanced one pass,                  4824827
 silesia,                            small window log,                   advanced one pass,                  7094480
 silesia,                            small hash log,                     advanced one pass,                  6525510
 silesia,                            small chain log,                    advanced one pass,                  4912248
 silesia,                            explicit params,                    advanced one pass,                  4791219
-silesia,                            uncompressed literals,              advanced one pass,                  5117482
+silesia,                            uncompressed literals,              advanced one pass,                  5117526
 silesia,                            uncompressed literals optimal,      advanced one pass,                  4316644
 silesia,                            huffman literals,                   advanced one pass,                  5321686
-silesia,                            multithreaded with advanced params, advanced one pass,                  5117795
+silesia,                            multithreaded with advanced params, advanced one pass,                  5118187
 silesia.tar,                        level -5,                           advanced one pass,                  6860782
 silesia.tar,                        level -3,                           advanced one pass,                  6507448
 silesia.tar,                        level -1,                           advanced one pass,                  6175582
-silesia.tar,                        level 0,                            advanced one pass,                  4843429
+silesia.tar,                        level 0,                            advanced one pass,                  4829268
 silesia.tar,                        level 1,                            advanced one pass,                  5316794
-silesia.tar,                        level 3,                            advanced one pass,                  4843429
-silesia.tar,                        level 4,                            advanced one pass,                  4780657
+silesia.tar,                        level 3,                            advanced one pass,                  4829268
+silesia.tar,                        level 4,                            advanced one pass,                  4767074
 silesia.tar,                        level 5 row 1,                      advanced one pass,                  4662847
 silesia.tar,                        level 5 row 2,                      advanced one pass,                  4666825
 silesia.tar,                        level 5,                            advanced one pass,                  4662847
@@ -284,18 +284,18 @@ silesia.tar,                        level 12 row 2,                     advanced
 silesia.tar,                        level 13,                           advanced one pass,                  4484732
 silesia.tar,                        level 16,                           advanced one pass,                  4355572
 silesia.tar,                        level 19,                           advanced one pass,                  4257629
-silesia.tar,                        no source size,                     advanced one pass,                  4843429
-silesia.tar,                        long distance mode,                 advanced one pass,                  4830453
-silesia.tar,                        multithreaded,                      advanced one pass,                  4841902
-silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4834262
+silesia.tar,                        no source size,                     advanced one pass,                  4829268
+silesia.tar,                        long distance mode,                 advanced one pass,                  4816169
+silesia.tar,                        multithreaded,                      advanced one pass,                  4836000
+silesia.tar,                        multithreaded long distance mode,   advanced one pass,                  4828167
 silesia.tar,                        small window log,                   advanced one pass,                  7100064
 silesia.tar,                        small hash log,                     advanced one pass,                  6530222
 silesia.tar,                        small chain log,                    advanced one pass,                  4915689
 silesia.tar,                        explicit params,                    advanced one pass,                  4790421
-silesia.tar,                        uncompressed literals,              advanced one pass,                  5116329
+silesia.tar,                        uncompressed literals,              advanced one pass,                  5114702
 silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4306289
 silesia.tar,                        huffman literals,                   advanced one pass,                  5331382
-silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5116442
+silesia.tar,                        multithreaded with advanced params, advanced one pass,                  5116579
 github,                             level -5,                           advanced one pass,                  204407
 github,                             level -5 with dict,                 advanced one pass,                  45832
 github,                             level -3,                           advanced one pass,                  193253
@@ -427,30 +427,30 @@ github.tar,                         level -3,                           advanced
 github.tar,                         level -3 with dict,                 advanced one pass,                  44882
 github.tar,                         level -1,                           advanced one pass,                  42740
 github.tar,                         level -1 with dict,                 advanced one pass,                  41506
-github.tar,                         level 0,                            advanced one pass,                  39073
-github.tar,                         level 0 with dict,                  advanced one pass,                  38146
-github.tar,                         level 0 with dict dms,              advanced one pass,                  38262
-github.tar,                         level 0 with dict dds,              advanced one pass,                  38262
-github.tar,                         level 0 with dict copy,             advanced one pass,                  38146
-github.tar,                         level 0 with dict load,             advanced one pass,                  38107
+github.tar,                         level 0,                            advanced one pass,                  38884
+github.tar,                         level 0 with dict,                  advanced one pass,                  37995
+github.tar,                         level 0 with dict dms,              advanced one pass,                  38114
+github.tar,                         level 0 with dict dds,              advanced one pass,                  38114
+github.tar,                         level 0 with dict copy,             advanced one pass,                  37995
+github.tar,                         level 0 with dict load,             advanced one pass,                  37956
 github.tar,                         level 1,                            advanced one pass,                  39444
 github.tar,                         level 1 with dict,                  advanced one pass,                  38338
 github.tar,                         level 1 with dict dms,              advanced one pass,                  38641
 github.tar,                         level 1 with dict dds,              advanced one pass,                  38641
 github.tar,                         level 1 with dict copy,             advanced one pass,                  38338
 github.tar,                         level 1 with dict load,             advanced one pass,                  38592
-github.tar,                         level 3,                            advanced one pass,                  39073
-github.tar,                         level 3 with dict,                  advanced one pass,                  38146
-github.tar,                         level 3 with dict dms,              advanced one pass,                  38262
-github.tar,                         level 3 with dict dds,              advanced one pass,                  38262
-github.tar,                         level 3 with dict copy,             advanced one pass,                  38146
-github.tar,                         level 3 with dict load,             advanced one pass,                  38107
-github.tar,                         level 4,                            advanced one pass,                  39068
-github.tar,                         level 4 with dict,                  advanced one pass,                  38081
-github.tar,                         level 4 with dict dms,              advanced one pass,                  38135
-github.tar,                         level 4 with dict dds,              advanced one pass,                  38135
-github.tar,                         level 4 with dict copy,             advanced one pass,                  38081
-github.tar,                         level 4 with dict load,             advanced one pass,                  38088
+github.tar,                         level 3,                            advanced one pass,                  38884
+github.tar,                         level 3 with dict,                  advanced one pass,                  37995
+github.tar,                         level 3 with dict dms,              advanced one pass,                  38114
+github.tar,                         level 3 with dict dds,              advanced one pass,                  38114
+github.tar,                         level 3 with dict copy,             advanced one pass,                  37995
+github.tar,                         level 3 with dict load,             advanced one pass,                  37956
+github.tar,                         level 4,                            advanced one pass,                  38880
+github.tar,                         level 4 with dict,                  advanced one pass,                  37948
+github.tar,                         level 4 with dict dms,              advanced one pass,                  37995
+github.tar,                         level 4 with dict dds,              advanced one pass,                  37995
+github.tar,                         level 4 with dict copy,             advanced one pass,                  37948
+github.tar,                         level 4 with dict load,             advanced one pass,                  37927
 github.tar,                         level 5 row 1,                      advanced one pass,                  39651
 github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39043
 github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39069
@@ -533,26 +533,26 @@ github.tar,                         level 19 with dict dms,             advanced
 github.tar,                         level 19 with dict dds,             advanced one pass,                  32565
 github.tar,                         level 19 with dict copy,            advanced one pass,                  32701
 github.tar,                         level 19 with dict load,            advanced one pass,                  32428
-github.tar,                         no source size,                     advanced one pass,                  39073
-github.tar,                         no source size with dict,           advanced one pass,                  38146
-github.tar,                         long distance mode,                 advanced one pass,                  40402
-github.tar,                         multithreaded,                      advanced one pass,                  39067
-github.tar,                         multithreaded long distance mode,   advanced one pass,                  40377
+github.tar,                         no source size,                     advanced one pass,                  38884
+github.tar,                         no source size with dict,           advanced one pass,                  37995
+github.tar,                         long distance mode,                 advanced one pass,                  40242
+github.tar,                         multithreaded,                      advanced one pass,                  38884
+github.tar,                         multithreaded long distance mode,   advanced one pass,                  40223
 github.tar,                         small window log,                   advanced one pass,                  198535
 github.tar,                         small hash log,                     advanced one pass,                  129870
 github.tar,                         small chain log,                    advanced one pass,                  41669
 github.tar,                         explicit params,                    advanced one pass,                  41385
-github.tar,                         uncompressed literals,              advanced one pass,                  41709
+github.tar,                         uncompressed literals,              advanced one pass,                  41562
 github.tar,                         uncompressed literals optimal,      advanced one pass,                  35356
 github.tar,                         huffman literals,                   advanced one pass,                  39099
-github.tar,                         multithreaded with advanced params, advanced one pass,                  41700
+github.tar,                         multithreaded with advanced params, advanced one pass,                  41562
 silesia,                            level -5,                           advanced one pass small out,        6857776
 silesia,                            level -3,                           advanced one pass small out,        6504756
 silesia,                            level -1,                           advanced one pass small out,        6174127
-silesia,                            level 0,                            advanced one pass small out,        4838417
+silesia,                            level 0,                            advanced one pass small out,        4832054
 silesia,                            level 1,                            advanced one pass small out,        5306931
-silesia,                            level 3,                            advanced one pass small out,        4838417
-silesia,                            level 4,                            advanced one pass small out,        4775359
+silesia,                            level 3,                            advanced one pass small out,        4832054
+silesia,                            level 4,                            advanced one pass small out,        4768799
 silesia,                            level 5 row 1,                      advanced one pass small out,        4663718
 silesia,                            level 5 row 2,                      advanced one pass small out,        4666272
 silesia,                            level 5,                            advanced one pass small out,        4663718
@@ -568,25 +568,25 @@ silesia,                            level 12 row 2,                     advanced
 silesia,                            level 13,                           advanced one pass small out,        4488969
 silesia,                            level 16,                           advanced one pass small out,        4356799
 silesia,                            level 19,                           advanced one pass small out,        4265851
-silesia,                            no source size,                     advanced one pass small out,        4838417
-silesia,                            long distance mode,                 advanced one pass small out,        4830097
-silesia,                            multithreaded,                      advanced one pass small out,        4838949
-silesia,                            multithreaded long distance mode,   advanced one pass small out,        4830419
+silesia,                            no source size,                     advanced one pass small out,        4832054
+silesia,                            long distance mode,                 advanced one pass small out,        4823833
+silesia,                            multithreaded,                      advanced one pass small out,        4833065
+silesia,                            multithreaded long distance mode,   advanced one pass small out,        4824827
 silesia,                            small window log,                   advanced one pass small out,        7094480
 silesia,                            small hash log,                     advanced one pass small out,        6525510
 silesia,                            small chain log,                    advanced one pass small out,        4912248
 silesia,                            explicit params,                    advanced one pass small out,        4791219
-silesia,                            uncompressed literals,              advanced one pass small out,        5117482
+silesia,                            uncompressed literals,              advanced one pass small out,        5117526
 silesia,                            uncompressed literals optimal,      advanced one pass small out,        4316644
 silesia,                            huffman literals,                   advanced one pass small out,        5321686
-silesia,                            multithreaded with advanced params, advanced one pass small out,        5117795
+silesia,                            multithreaded with advanced params, advanced one pass small out,        5118187
 silesia.tar,                        level -5,                           advanced one pass small out,        6860782
 silesia.tar,                        level -3,                           advanced one pass small out,        6507448
 silesia.tar,                        level -1,                           advanced one pass small out,        6175582
-silesia.tar,                        level 0,                            advanced one pass small out,        4843429
+silesia.tar,                        level 0,                            advanced one pass small out,        4829268
 silesia.tar,                        level 1,                            advanced one pass small out,        5316794
-silesia.tar,                        level 3,                            advanced one pass small out,        4843429
-silesia.tar,                        level 4,                            advanced one pass small out,        4780657
+silesia.tar,                        level 3,                            advanced one pass small out,        4829268
+silesia.tar,                        level 4,                            advanced one pass small out,        4767074
 silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4662847
 silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4666825
 silesia.tar,                        level 5,                            advanced one pass small out,        4662847
@@ -602,18 +602,18 @@ silesia.tar,                        level 12 row 2,                     advanced
 silesia.tar,                        level 13,                           advanced one pass small out,        4484732
 silesia.tar,                        level 16,                           advanced one pass small out,        4355572
 silesia.tar,                        level 19,                           advanced one pass small out,        4257629
-silesia.tar,                        no source size,                     advanced one pass small out,        4843429
-silesia.tar,                        long distance mode,                 advanced one pass small out,        4830453
-silesia.tar,                        multithreaded,                      advanced one pass small out,        4841902
-silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4834262
+silesia.tar,                        no source size,                     advanced one pass small out,        4829268
+silesia.tar,                        long distance mode,                 advanced one pass small out,        4816169
+silesia.tar,                        multithreaded,                      advanced one pass small out,        4836000
+silesia.tar,                        multithreaded long distance mode,   advanced one pass small out,        4828167
 silesia.tar,                        small window log,                   advanced one pass small out,        7100064
 silesia.tar,                        small hash log,                     advanced one pass small out,        6530222
 silesia.tar,                        small chain log,                    advanced one pass small out,        4915689
 silesia.tar,                        explicit params,                    advanced one pass small out,        4790421
-silesia.tar,                        uncompressed literals,              advanced one pass small out,        5116329
+silesia.tar,                        uncompressed literals,              advanced one pass small out,        5114702
 silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4306289
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5331382
-silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5116442
+silesia.tar,                        multithreaded with advanced params, advanced one pass small out,        5116579
 github,                             level -5,                           advanced one pass small out,        204407
 github,                             level -5 with dict,                 advanced one pass small out,        45832
 github,                             level -3,                           advanced one pass small out,        193253
@@ -745,30 +745,30 @@ github.tar,                         level -3,                           advanced
 github.tar,                         level -3 with dict,                 advanced one pass small out,        44882
 github.tar,                         level -1,                           advanced one pass small out,        42740
 github.tar,                         level -1 with dict,                 advanced one pass small out,        41506
-github.tar,                         level 0,                            advanced one pass small out,        39073
-github.tar,                         level 0 with dict,                  advanced one pass small out,        38146
-github.tar,                         level 0 with dict dms,              advanced one pass small out,        38262
-github.tar,                         level 0 with dict dds,              advanced one pass small out,        38262
-github.tar,                         level 0 with dict copy,             advanced one pass small out,        38146
-github.tar,                         level 0 with dict load,             advanced one pass small out,        38107
+github.tar,                         level 0,                            advanced one pass small out,        38884
+github.tar,                         level 0 with dict,                  advanced one pass small out,        37995
+github.tar,                         level 0 with dict dms,              advanced one pass small out,        38114
+github.tar,                         level 0 with dict dds,              advanced one pass small out,        38114
+github.tar,                         level 0 with dict copy,             advanced one pass small out,        37995
+github.tar,                         level 0 with dict load,             advanced one pass small out,        37956
 github.tar,                         level 1,                            advanced one pass small out,        39444
 github.tar,                         level 1 with dict,                  advanced one pass small out,        38338
 github.tar,                         level 1 with dict dms,              advanced one pass small out,        38641
 github.tar,                         level 1 with dict dds,              advanced one pass small out,        38641
 github.tar,                         level 1 with dict copy,             advanced one pass small out,        38338
 github.tar,                         level 1 with dict load,             advanced one pass small out,        38592
-github.tar,                         level 3,                            advanced one pass small out,        39073
-github.tar,                         level 3 with dict,                  advanced one pass small out,        38146
-github.tar,                         level 3 with dict dms,              advanced one pass small out,        38262
-github.tar,                         level 3 with dict dds,              advanced one pass small out,        38262
-github.tar,                         level 3 with dict copy,             advanced one pass small out,        38146
-github.tar,                         level 3 with dict load,             advanced one pass small out,        38107
-github.tar,                         level 4,                            advanced one pass small out,        39068
-github.tar,                         level 4 with dict,                  advanced one pass small out,        38081
-github.tar,                         level 4 with dict dms,              advanced one pass small out,        38135
-github.tar,                         level 4 with dict dds,              advanced one pass small out,        38135
-github.tar,                         level 4 with dict copy,             advanced one pass small out,        38081
-github.tar,                         level 4 with dict load,             advanced one pass small out,        38088
+github.tar,                         level 3,                            advanced one pass small out,        38884
+github.tar,                         level 3 with dict,                  advanced one pass small out,        37995
+github.tar,                         level 3 with dict dms,              advanced one pass small out,        38114
+github.tar,                         level 3 with dict dds,              advanced one pass small out,        38114
+github.tar,                         level 3 with dict copy,             advanced one pass small out,        37995
+github.tar,                         level 3 with dict load,             advanced one pass small out,        37956
+github.tar,                         level 4,                            advanced one pass small out,        38880
+github.tar,                         level 4 with dict,                  advanced one pass small out,        37948
+github.tar,                         level 4 with dict dms,              advanced one pass small out,        37995
+github.tar,                         level 4 with dict dds,              advanced one pass small out,        37995
+github.tar,                         level 4 with dict copy,             advanced one pass small out,        37948
+github.tar,                         level 4 with dict load,             advanced one pass small out,        37927
 github.tar,                         level 5 row 1,                      advanced one pass small out,        39651
 github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39043
 github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39069
@@ -851,26 +851,26 @@ github.tar,                         level 19 with dict dms,             advanced
 github.tar,                         level 19 with dict dds,             advanced one pass small out,        32565
 github.tar,                         level 19 with dict copy,            advanced one pass small out,        32701
 github.tar,                         level 19 with dict load,            advanced one pass small out,        32428
-github.tar,                         no source size,                     advanced one pass small out,        39073
-github.tar,                         no source size with dict,           advanced one pass small out,        38146
-github.tar,                         long distance mode,                 advanced one pass small out,        40402
-github.tar,                         multithreaded,                      advanced one pass small out,        39067
-github.tar,                         multithreaded long distance mode,   advanced one pass small out,        40377
+github.tar,                         no source size,                     advanced one pass small out,        38884
+github.tar,                         no source size with dict,           advanced one pass small out,        37995
+github.tar,                         long distance mode,                 advanced one pass small out,        40242
+github.tar,                         multithreaded,                      advanced one pass small out,        38884
+github.tar,                         multithreaded long distance mode,   advanced one pass small out,        40223
 github.tar,                         small window log,                   advanced one pass small out,        198535
 github.tar,                         small hash log,                     advanced one pass small out,        129870
 github.tar,                         small chain log,                    advanced one pass small out,        41669
 github.tar,                         explicit params,                    advanced one pass small out,        41385
-github.tar,                         uncompressed literals,              advanced one pass small out,        41709
+github.tar,                         uncompressed literals,              advanced one pass small out,        41562
 github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35356
 github.tar,                         huffman literals,                   advanced one pass small out,        39099
-github.tar,                         multithreaded with advanced params, advanced one pass small out,        41700
+github.tar,                         multithreaded with advanced params, advanced one pass small out,        41562
 silesia,                            level -5,                           advanced streaming,                 6856699
 silesia,                            level -3,                           advanced streaming,                 6505694
 silesia,                            level -1,                           advanced streaming,                 6174139
-silesia,                            level 0,                            advanced streaming,                 4839173
+silesia,                            level 0,                            advanced streaming,                 4835804
 silesia,                            level 1,                            advanced streaming,                 5305682
-silesia,                            level 3,                            advanced streaming,                 4839173
-silesia,                            level 4,                            advanced streaming,                 4776074
+silesia,                            level 3,                            advanced streaming,                 4835804
+silesia,                            level 4,                            advanced streaming,                 4773049
 silesia,                            level 5 row 1,                      advanced streaming,                 4664679
 silesia,                            level 5 row 2,                      advanced streaming,                 4667307
 silesia,                            level 5,                            advanced streaming,                 4664679
@@ -886,25 +886,25 @@ silesia,                            level 12 row 2,                     advanced
 silesia,                            level 13,                           advanced streaming,                 4490650
 silesia,                            level 16,                           advanced streaming,                 4358094
 silesia,                            level 19,                           advanced streaming,                 4265908
-silesia,                            no source size,                     advanced streaming,                 4839137
-silesia,                            long distance mode,                 advanced streaming,                 4831125
-silesia,                            multithreaded,                      advanced streaming,                 4838949
-silesia,                            multithreaded long distance mode,   advanced streaming,                 4830419
+silesia,                            no source size,                     advanced streaming,                 4835768
+silesia,                            long distance mode,                 advanced streaming,                 4827592
+silesia,                            multithreaded,                      advanced streaming,                 4833065
+silesia,                            multithreaded long distance mode,   advanced streaming,                 4824827
 silesia,                            small window log,                   advanced streaming,                 7110591
 silesia,                            small hash log,                     advanced streaming,                 6525259
 silesia,                            small chain log,                    advanced streaming,                 4911577
 silesia,                            explicit params,                    advanced streaming,                 4792505
-silesia,                            uncompressed literals,              advanced streaming,                 5117625
+silesia,                            uncompressed literals,              advanced streaming,                 5116404
 silesia,                            uncompressed literals optimal,      advanced streaming,                 4316533
 silesia,                            huffman literals,                   advanced streaming,                 5321812
-silesia,                            multithreaded with advanced params, advanced streaming,                 5117795
+silesia,                            multithreaded with advanced params, advanced streaming,                 5118187
 silesia.tar,                        level -5,                           advanced streaming,                 6857458
 silesia.tar,                        level -3,                           advanced streaming,                 6508562
 silesia.tar,                        level -1,                           advanced streaming,                 6178057
-silesia.tar,                        level 0,                            advanced streaming,                 4849720
+silesia.tar,                        level 0,                            advanced streaming,                 4846783
 silesia.tar,                        level 1,                            advanced streaming,                 5311452
-silesia.tar,                        level 3,                            advanced streaming,                 4849720
-silesia.tar,                        level 4,                            advanced streaming,                 4787534
+silesia.tar,                        level 3,                            advanced streaming,                 4846783
+silesia.tar,                        level 4,                            advanced streaming,                 4785332
 silesia.tar,                        level 5 row 1,                      advanced streaming,                 4664523
 silesia.tar,                        level 5 row 2,                      advanced streaming,                 4668292
 silesia.tar,                        level 5,                            advanced streaming,                 4664523
@@ -920,18 +920,18 @@ silesia.tar,                        level 12 row 2,                     advanced
 silesia.tar,                        level 13,                           advanced streaming,                 4486652
 silesia.tar,                        level 16,                           advanced streaming,                 4358029
 silesia.tar,                        level 19,                           advanced streaming,                 4258228
-silesia.tar,                        no source size,                     advanced streaming,                 4849716
-silesia.tar,                        long distance mode,                 advanced streaming,                 4829339
-silesia.tar,                        multithreaded,                      advanced streaming,                 4841902
-silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4834262
+silesia.tar,                        no source size,                     advanced streaming,                 4846779
+silesia.tar,                        long distance mode,                 advanced streaming,                 4826177
+silesia.tar,                        multithreaded,                      advanced streaming,                 4836000
+silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4828167
 silesia.tar,                        small window log,                   advanced streaming,                 7117024
 silesia.tar,                        small hash log,                     advanced streaming,                 6529503
 silesia.tar,                        small chain log,                    advanced streaming,                 4915956
 silesia.tar,                        explicit params,                    advanced streaming,                 4791739
-silesia.tar,                        uncompressed literals,              advanced streaming,                 5124811
+silesia.tar,                        uncompressed literals,              advanced streaming,                 5123274
 silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4306968
 silesia.tar,                        huffman literals,                   advanced streaming,                 5326278
-silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5116442
+silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5116579
 github,                             level -5,                           advanced streaming,                 204407
 github,                             level -5 with dict,                 advanced streaming,                 45832
 github,                             level -3,                           advanced streaming,                 193253
@@ -1063,30 +1063,30 @@ github.tar,                         level -3,                           advanced
 github.tar,                         level -3 with dict,                 advanced streaming,                 44973
 github.tar,                         level -1,                           advanced streaming,                 42777
 github.tar,                         level -1 with dict,                 advanced streaming,                 41603
-github.tar,                         level 0,                            advanced streaming,                 39249
-github.tar,                         level 0 with dict,                  advanced streaming,                 38309
-github.tar,                         level 0 with dict dms,              advanced streaming,                 38445
-github.tar,                         level 0 with dict dds,              advanced streaming,                 38445
-github.tar,                         level 0 with dict copy,             advanced streaming,                 38309
-github.tar,                         level 0 with dict load,             advanced streaming,                 38281
+github.tar,                         level 0,                            advanced streaming,                 38884
+github.tar,                         level 0 with dict,                  advanced streaming,                 37995
+github.tar,                         level 0 with dict dms,              advanced streaming,                 38114
+github.tar,                         level 0 with dict dds,              advanced streaming,                 38114
+github.tar,                         level 0 with dict copy,             advanced streaming,                 37995
+github.tar,                         level 0 with dict load,             advanced streaming,                 37956
 github.tar,                         level 1,                            advanced streaming,                 39550
 github.tar,                         level 1 with dict,                  advanced streaming,                 38502
 github.tar,                         level 1 with dict dms,              advanced streaming,                 38770
 github.tar,                         level 1 with dict dds,              advanced streaming,                 38770
 github.tar,                         level 1 with dict copy,             advanced streaming,                 38502
 github.tar,                         level 1 with dict load,             advanced streaming,                 38716
-github.tar,                         level 3,                            advanced streaming,                 39249
-github.tar,                         level 3 with dict,                  advanced streaming,                 38309
-github.tar,                         level 3 with dict dms,              advanced streaming,                 38445
-github.tar,                         level 3 with dict dds,              advanced streaming,                 38445
-github.tar,                         level 3 with dict copy,             advanced streaming,                 38309
-github.tar,                         level 3 with dict load,             advanced streaming,                 38281
-github.tar,                         level 4,                            advanced streaming,                 39247
-github.tar,                         level 4 with dict,                  advanced streaming,                 38270
-github.tar,                         level 4 with dict dms,              advanced streaming,                 38317
-github.tar,                         level 4 with dict dds,              advanced streaming,                 38317
-github.tar,                         level 4 with dict copy,             advanced streaming,                 38270
-github.tar,                         level 4 with dict load,             advanced streaming,                 38259
+github.tar,                         level 3,                            advanced streaming,                 38884
+github.tar,                         level 3 with dict,                  advanced streaming,                 37995
+github.tar,                         level 3 with dict dms,              advanced streaming,                 38114
+github.tar,                         level 3 with dict dds,              advanced streaming,                 38114
+github.tar,                         level 3 with dict copy,             advanced streaming,                 37995
+github.tar,                         level 3 with dict load,             advanced streaming,                 37956
+github.tar,                         level 4,                            advanced streaming,                 38880
+github.tar,                         level 4 with dict,                  advanced streaming,                 37948
+github.tar,                         level 4 with dict dms,              advanced streaming,                 37995
+github.tar,                         level 4 with dict dds,              advanced streaming,                 37995
+github.tar,                         level 4 with dict copy,             advanced streaming,                 37948
+github.tar,                         level 4 with dict load,             advanced streaming,                 37927
 github.tar,                         level 5 row 1,                      advanced streaming,                 39651
 github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39043
 github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39069
@@ -1169,26 +1169,26 @@ github.tar,                         level 19 with dict dms,             advanced
 github.tar,                         level 19 with dict dds,             advanced streaming,                 32565
 github.tar,                         level 19 with dict copy,            advanced streaming,                 32701
 github.tar,                         level 19 with dict load,            advanced streaming,                 32428
-github.tar,                         no source size,                     advanced streaming,                 39246
-github.tar,                         no source size with dict,           advanced streaming,                 38442
-github.tar,                         long distance mode,                 advanced streaming,                 40569
-github.tar,                         multithreaded,                      advanced streaming,                 39067
-github.tar,                         multithreaded long distance mode,   advanced streaming,                 40377
+github.tar,                         no source size,                     advanced streaming,                 38881
+github.tar,                         no source size with dict,           advanced streaming,                 38111
+github.tar,                         long distance mode,                 advanced streaming,                 40242
+github.tar,                         multithreaded,                      advanced streaming,                 38884
+github.tar,                         multithreaded long distance mode,   advanced streaming,                 40223
 github.tar,                         small window log,                   advanced streaming,                 199553
 github.tar,                         small hash log,                     advanced streaming,                 129870
 github.tar,                         small chain log,                    advanced streaming,                 41669
 github.tar,                         explicit params,                    advanced streaming,                 41385
-github.tar,                         uncompressed literals,              advanced streaming,                 41784
+github.tar,                         uncompressed literals,              advanced streaming,                 41562
 github.tar,                         uncompressed literals optimal,      advanced streaming,                 35356
 github.tar,                         huffman literals,                   advanced streaming,                 39226
-github.tar,                         multithreaded with advanced params, advanced streaming,                 41700
+github.tar,                         multithreaded with advanced params, advanced streaming,                 41562
 silesia,                            level -5,                           old streaming,                      6856699
 silesia,                            level -3,                           old streaming,                      6505694
 silesia,                            level -1,                           old streaming,                      6174139
-silesia,                            level 0,                            old streaming,                      4839173
+silesia,                            level 0,                            old streaming,                      4835804
 silesia,                            level 1,                            old streaming,                      5305682
-silesia,                            level 3,                            old streaming,                      4839173
-silesia,                            level 4,                            old streaming,                      4776074
+silesia,                            level 3,                            old streaming,                      4835804
+silesia,                            level 4,                            old streaming,                      4773049
 silesia,                            level 5,                            old streaming,                      4664679
 silesia,                            level 6,                            old streaming,                      4601116
 silesia,                            level 7,                            old streaming,                      4567082
@@ -1196,17 +1196,17 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming,                      4490650
 silesia,                            level 16,                           old streaming,                      4358094
 silesia,                            level 19,                           old streaming,                      4265908
-silesia,                            no source size,                     old streaming,                      4839137
-silesia,                            uncompressed literals,              old streaming,                      4839173
+silesia,                            no source size,                     old streaming,                      4835768
+silesia,                            uncompressed literals,              old streaming,                      4835804
 silesia,                            uncompressed literals optimal,      old streaming,                      4265908
 silesia,                            huffman literals,                   old streaming,                      6174139
 silesia.tar,                        level -5,                           old streaming,                      6857458
 silesia.tar,                        level -3,                           old streaming,                      6508562
 silesia.tar,                        level -1,                           old streaming,                      6178057
-silesia.tar,                        level 0,                            old streaming,                      4849720
+silesia.tar,                        level 0,                            old streaming,                      4846783
 silesia.tar,                        level 1,                            old streaming,                      5311452
-silesia.tar,                        level 3,                            old streaming,                      4849720
-silesia.tar,                        level 4,                            old streaming,                      4787534
+silesia.tar,                        level 3,                            old streaming,                      4846783
+silesia.tar,                        level 4,                            old streaming,                      4785332
 silesia.tar,                        level 5,                            old streaming,                      4664523
 silesia.tar,                        level 6,                            old streaming,                      4599420
 silesia.tar,                        level 7,                            old streaming,                      4565332
@@ -1214,8 +1214,8 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming,                      4486652
 silesia.tar,                        level 16,                           old streaming,                      4358029
 silesia.tar,                        level 19,                           old streaming,                      4258228
-silesia.tar,                        no source size,                     old streaming,                      4849716
-silesia.tar,                        uncompressed literals,              old streaming,                      4849720
+silesia.tar,                        no source size,                     old streaming,                      4846779
+silesia.tar,                        uncompressed literals,              old streaming,                      4846783
 silesia.tar,                        uncompressed literals optimal,      old streaming,                      4258228
 silesia.tar,                        huffman literals,                   old streaming,                      6178057
 github,                             level -5,                           old streaming,                      204407
@@ -1257,14 +1257,14 @@ github.tar,                         level -3,                           old stre
 github.tar,                         level -3 with dict,                 old streaming,                      44973
 github.tar,                         level -1,                           old streaming,                      42777
 github.tar,                         level -1 with dict,                 old streaming,                      41603
-github.tar,                         level 0,                            old streaming,                      39249
-github.tar,                         level 0 with dict,                  old streaming,                      38309
+github.tar,                         level 0,                            old streaming,                      38884
+github.tar,                         level 0 with dict,                  old streaming,                      37995
 github.tar,                         level 1,                            old streaming,                      39550
 github.tar,                         level 1 with dict,                  old streaming,                      38502
-github.tar,                         level 3,                            old streaming,                      39249
-github.tar,                         level 3 with dict,                  old streaming,                      38309
-github.tar,                         level 4,                            old streaming,                      39247
-github.tar,                         level 4 with dict,                  old streaming,                      38270
+github.tar,                         level 3,                            old streaming,                      38884
+github.tar,                         level 3 with dict,                  old streaming,                      37995
+github.tar,                         level 4,                            old streaming,                      38880
+github.tar,                         level 4 with dict,                  old streaming,                      37948
 github.tar,                         level 5,                            old streaming,                      39651
 github.tar,                         level 5 with dict,                  old streaming,                      39145
 github.tar,                         level 6,                            old streaming,                      39282
@@ -1279,18 +1279,18 @@ github.tar,                         level 16,                           old stre
 github.tar,                         level 16 with dict,                 old streaming,                      33375
 github.tar,                         level 19,                           old streaming,                      32262
 github.tar,                         level 19 with dict,                 old streaming,                      32701
-github.tar,                         no source size,                     old streaming,                      39246
-github.tar,                         no source size with dict,           old streaming,                      38442
-github.tar,                         uncompressed literals,              old streaming,                      39249
+github.tar,                         no source size,                     old streaming,                      38881
+github.tar,                         no source size with dict,           old streaming,                      38111
+github.tar,                         uncompressed literals,              old streaming,                      38884
 github.tar,                         uncompressed literals optimal,      old streaming,                      32262
 github.tar,                         huffman literals,                   old streaming,                      42777
 silesia,                            level -5,                           old streaming advanced,             6856699
 silesia,                            level -3,                           old streaming advanced,             6505694
 silesia,                            level -1,                           old streaming advanced,             6174139
-silesia,                            level 0,                            old streaming advanced,             4839173
+silesia,                            level 0,                            old streaming advanced,             4835804
 silesia,                            level 1,                            old streaming advanced,             5305682
-silesia,                            level 3,                            old streaming advanced,             4839173
-silesia,                            level 4,                            old streaming advanced,             4776074
+silesia,                            level 3,                            old streaming advanced,             4835804
+silesia,                            level 4,                            old streaming advanced,             4773049
 silesia,                            level 5,                            old streaming advanced,             4664679
 silesia,                            level 6,                            old streaming advanced,             4601116
 silesia,                            level 7,                            old streaming advanced,             4567082
@@ -1298,25 +1298,25 @@ silesia,                            level 9,                            old stre
 silesia,                            level 13,                           old streaming advanced,             4490650
 silesia,                            level 16,                           old streaming advanced,             4358094
 silesia,                            level 19,                           old streaming advanced,             4265908
-silesia,                            no source size,                     old streaming advanced,             4839137
-silesia,                            long distance mode,                 old streaming advanced,             4839173
-silesia,                            multithreaded,                      old streaming advanced,             4839173
-silesia,                            multithreaded long distance mode,   old streaming advanced,             4839173
+silesia,                            no source size,                     old streaming advanced,             4835768
+silesia,                            long distance mode,                 old streaming advanced,             4835804
+silesia,                            multithreaded,                      old streaming advanced,             4835804
+silesia,                            multithreaded long distance mode,   old streaming advanced,             4835804
 silesia,                            small window log,                   old streaming advanced,             7110591
 silesia,                            small hash log,                     old streaming advanced,             6525259
 silesia,                            small chain log,                    old streaming advanced,             4911577
 silesia,                            explicit params,                    old streaming advanced,             4792505
-silesia,                            uncompressed literals,              old streaming advanced,             4839173
+silesia,                            uncompressed literals,              old streaming advanced,             4835804
 silesia,                            uncompressed literals optimal,      old streaming advanced,             4265908
 silesia,                            huffman literals,                   old streaming advanced,             6174139
-silesia,                            multithreaded with advanced params, old streaming advanced,             4839173
+silesia,                            multithreaded with advanced params, old streaming advanced,             4835804
 silesia.tar,                        level -5,                           old streaming advanced,             6857458
 silesia.tar,                        level -3,                           old streaming advanced,             6508562
 silesia.tar,                        level -1,                           old streaming advanced,             6178057
-silesia.tar,                        level 0,                            old streaming advanced,             4849720
+silesia.tar,                        level 0,                            old streaming advanced,             4846783
 silesia.tar,                        level 1,                            old streaming advanced,             5311452
-silesia.tar,                        level 3,                            old streaming advanced,             4849720
-silesia.tar,                        level 4,                            old streaming advanced,             4787534
+silesia.tar,                        level 3,                            old streaming advanced,             4846783
+silesia.tar,                        level 4,                            old streaming advanced,             4785332
 silesia.tar,                        level 5,                            old streaming advanced,             4664523
 silesia.tar,                        level 6,                            old streaming advanced,             4599420
 silesia.tar,                        level 7,                            old streaming advanced,             4565332
@@ -1324,18 +1324,18 @@ silesia.tar,                        level 9,                            old stre
 silesia.tar,                        level 13,                           old streaming advanced,             4486652
 silesia.tar,                        level 16,                           old streaming advanced,             4358029
 silesia.tar,                        level 19,                           old streaming advanced,             4258228
-silesia.tar,                        no source size,                     old streaming advanced,             4849716
-silesia.tar,                        long distance mode,                 old streaming advanced,             4849720
-silesia.tar,                        multithreaded,                      old streaming advanced,             4849720
-silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4849720
+silesia.tar,                        no source size,                     old streaming advanced,             4846779
+silesia.tar,                        long distance mode,                 old streaming advanced,             4846783
+silesia.tar,                        multithreaded,                      old streaming advanced,             4846783
+silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4846783
 silesia.tar,                        small window log,                   old streaming advanced,             7117027
 silesia.tar,                        small hash log,                     old streaming advanced,             6529503
 silesia.tar,                        small chain log,                    old streaming advanced,             4915956
 silesia.tar,                        explicit params,                    old streaming advanced,             4791739
-silesia.tar,                        uncompressed literals,              old streaming advanced,             4849720
+silesia.tar,                        uncompressed literals,              old streaming advanced,             4846783
 silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4258228
 silesia.tar,                        huffman literals,                   old streaming advanced,             6178057
-silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4849720
+silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4846783
 github,                             level -5,                           old streaming advanced,             213265
 github,                             level -5 with dict,                 old streaming advanced,             46708
 github,                             level -3,                           old streaming advanced,             196126
@@ -1383,14 +1383,14 @@ github.tar,                         level -3,                           old stre
 github.tar,                         level -3 with dict,                 old streaming advanced,             45211
 github.tar,                         level -1,                           old streaming advanced,             42777
 github.tar,                         level -1 with dict,                 old streaming advanced,             41865
-github.tar,                         level 0,                            old streaming advanced,             39249
-github.tar,                         level 0 with dict,                  old streaming advanced,             38327
+github.tar,                         level 0,                            old streaming advanced,             38884
+github.tar,                         level 0 with dict,                  old streaming advanced,             38013
 github.tar,                         level 1,                            old streaming advanced,             39550
 github.tar,                         level 1 with dict,                  old streaming advanced,             38714
-github.tar,                         level 3,                            old streaming advanced,             39249
-github.tar,                         level 3 with dict,                  old streaming advanced,             38327
-github.tar,                         level 4,                            old streaming advanced,             39247
-github.tar,                         level 4 with dict,                  old streaming advanced,             38382
+github.tar,                         level 3,                            old streaming advanced,             38884
+github.tar,                         level 3 with dict,                  old streaming advanced,             38013
+github.tar,                         level 4,                            old streaming advanced,             38880
+github.tar,                         level 4 with dict,                  old streaming advanced,             38063
 github.tar,                         level 5,                            old streaming advanced,             39651
 github.tar,                         level 5 with dict,                  old streaming advanced,             39018
 github.tar,                         level 6,                            old streaming advanced,             39282
@@ -1405,19 +1405,19 @@ github.tar,                         level 16,                           old stre
 github.tar,                         level 16 with dict,                 old streaming advanced,             38578
 github.tar,                         level 19,                           old streaming advanced,             32262
 github.tar,                         level 19 with dict,                 old streaming advanced,             32678
-github.tar,                         no source size,                     old streaming advanced,             39246
-github.tar,                         no source size with dict,           old streaming advanced,             38399
-github.tar,                         long distance mode,                 old streaming advanced,             39249
-github.tar,                         multithreaded,                      old streaming advanced,             39249
-github.tar,                         multithreaded long distance mode,   old streaming advanced,             39249
+github.tar,                         no source size,                     old streaming advanced,             38881
+github.tar,                         no source size with dict,           old streaming advanced,             38076
+github.tar,                         long distance mode,                 old streaming advanced,             38884
+github.tar,                         multithreaded,                      old streaming advanced,             38884
+github.tar,                         multithreaded long distance mode,   old streaming advanced,             38884
 github.tar,                         small window log,                   old streaming advanced,             199556
 github.tar,                         small hash log,                     old streaming advanced,             129870
 github.tar,                         small chain log,                    old streaming advanced,             41669
 github.tar,                         explicit params,                    old streaming advanced,             41385
-github.tar,                         uncompressed literals,              old streaming advanced,             39249
+github.tar,                         uncompressed literals,              old streaming advanced,             38884
 github.tar,                         uncompressed literals optimal,      old streaming advanced,             32262
 github.tar,                         huffman literals,                   old streaming advanced,             42777
-github.tar,                         multithreaded with advanced params, old streaming advanced,             39249
+github.tar,                         multithreaded with advanced params, old streaming advanced,             38884
 github,                             level -5 with dict,                 old streaming cdict,                45832
 github,                             level -3 with dict,                 old streaming cdict,                44671
 github,                             level -1 with dict,                 old streaming cdict,                41825
@@ -1436,10 +1436,10 @@ github,                             no source size with dict,           old stre
 github.tar,                         level -5 with dict,                 old streaming cdict,                51512
 github.tar,                         level -3 with dict,                 old streaming cdict,                45379
 github.tar,                         level -1 with dict,                 old streaming cdict,                42084
-github.tar,                         level 0 with dict,                  old streaming cdict,                38281
+github.tar,                         level 0 with dict,                  old streaming cdict,                37956
 github.tar,                         level 1 with dict,                  old streaming cdict,                38716
-github.tar,                         level 3 with dict,                  old streaming cdict,                38281
-github.tar,                         level 4 with dict,                  old streaming cdict,                38259
+github.tar,                         level 3 with dict,                  old streaming cdict,                37956
+github.tar,                         level 4 with dict,                  old streaming cdict,                37927
 github.tar,                         level 5 with dict,                  old streaming cdict,                39000
 github.tar,                         level 6 with dict,                  old streaming cdict,                38647
 github.tar,                         level 7 with dict,                  old streaming cdict,                37286
@@ -1447,7 +1447,7 @@ github.tar,                         level 9 with dict,                  old stre
 github.tar,                         level 13 with dict,                 old streaming cdict,                36010
 github.tar,                         level 16 with dict,                 old streaming cdict,                39081
 github.tar,                         level 19 with dict,                 old streaming cdict,                32428
-github.tar,                         no source size with dict,           old streaming cdict,                38442
+github.tar,                         no source size with dict,           old streaming cdict,                38111
 github,                             level -5 with dict,                 old streaming advanced cdict,       46708
 github,                             level -3 with dict,                 old streaming advanced cdict,       45476
 github,                             level -1 with dict,                 old streaming advanced cdict,       42060
@@ -1466,10 +1466,10 @@ github,                             no source size with dict,           old stre
 github.tar,                         level -5 with dict,                 old streaming advanced cdict,       51019
 github.tar,                         level -3 with dict,                 old streaming advanced cdict,       45149
 github.tar,                         level -1 with dict,                 old streaming advanced cdict,       41694
-github.tar,                         level 0 with dict,                  old streaming advanced cdict,       38327
+github.tar,                         level 0 with dict,                  old streaming advanced cdict,       38013
 github.tar,                         level 1 with dict,                  old streaming advanced cdict,       38513
-github.tar,                         level 3 with dict,                  old streaming advanced cdict,       38327
-github.tar,                         level 4 with dict,                  old streaming advanced cdict,       38382
+github.tar,                         level 3 with dict,                  old streaming advanced cdict,       38013
+github.tar,                         level 4 with dict,                  old streaming advanced cdict,       38063
 github.tar,                         level 5 with dict,                  old streaming advanced cdict,       39018
 github.tar,                         level 6 with dict,                  old streaming advanced cdict,       38635
 github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37264
@@ -1477,4 +1477,4 @@ github.tar,                         level 9 with dict,                  old stre
 github.tar,                         level 13 with dict,                 old streaming advanced cdict,       35807
 github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38578
 github.tar,                         level 19 with dict,                 old streaming advanced cdict,       32678
-github.tar,                         no source size with dict,           old streaming advanced cdict,       38399
+github.tar,                         no source size with dict,           old streaming advanced cdict,       38076

--- a/tests/regression/results.csv
+++ b/tests/regression/results.csv
@@ -6,9 +6,9 @@ silesia.tar,                        level 0,                            compress
 silesia.tar,                        level 1,                            compress simple,                    5316794
 silesia.tar,                        level 3,                            compress simple,                    4843429
 silesia.tar,                        level 4,                            compress simple,                    4780657
-silesia.tar,                        level 5,                            compress simple,                    4669650
-silesia.tar,                        level 6,                            compress simple,                    4604925
-silesia.tar,                        level 7,                            compress simple,                    4570873
+silesia.tar,                        level 5,                            compress simple,                    4662847
+silesia.tar,                        level 6,                            compress simple,                    4597877
+silesia.tar,                        level 7,                            compress simple,                    4563998
 silesia.tar,                        level 9,                            compress simple,                    4537558
 silesia.tar,                        level 13,                           compress simple,                    4484732
 silesia.tar,                        level 16,                           compress simple,                    4355572
@@ -23,9 +23,9 @@ github.tar,                         level 0,                            compress
 github.tar,                         level 1,                            compress simple,                    39444
 github.tar,                         level 3,                            compress simple,                    39073
 github.tar,                         level 4,                            compress simple,                    39068
-github.tar,                         level 5,                            compress simple,                    39808
-github.tar,                         level 6,                            compress simple,                    39455
-github.tar,                         level 7,                            compress simple,                    38168
+github.tar,                         level 5,                            compress simple,                    39651
+github.tar,                         level 6,                            compress simple,                    39282
+github.tar,                         level 7,                            compress simple,                    38005
 github.tar,                         level 9,                            compress simple,                    36723
 github.tar,                         level 13,                           compress simple,                    35501
 github.tar,                         level 16,                           compress simple,                    40466
@@ -40,9 +40,9 @@ silesia,                            level 0,                            compress
 silesia,                            level 1,                            compress cctx,                      5306931
 silesia,                            level 3,                            compress cctx,                      4838417
 silesia,                            level 4,                            compress cctx,                      4775359
-silesia,                            level 5,                            compress cctx,                      4666524
-silesia,                            level 6,                            compress cctx,                      4602031
-silesia,                            level 7,                            compress cctx,                      4567954
+silesia,                            level 5,                            compress cctx,                      4663718
+silesia,                            level 6,                            compress cctx,                      4600034
+silesia,                            level 7,                            compress cctx,                      4566069
 silesia,                            level 9,                            compress cctx,                      4540520
 silesia,                            level 13,                           compress cctx,                      4488969
 silesia,                            level 16,                           compress cctx,                      4356799
@@ -53,7 +53,7 @@ silesia,                            multithreaded long distance mode,   compress
 silesia,                            small window log,                   compress cctx,                      7082907
 silesia,                            small hash log,                     compress cctx,                      6525510
 silesia,                            small chain log,                    compress cctx,                      4912248
-silesia,                            explicit params,                    compress cctx,                      4792640
+silesia,                            explicit params,                    compress cctx,                      4789676
 silesia,                            uncompressed literals,              compress cctx,                      4838417
 silesia,                            uncompressed literals optimal,      compress cctx,                      4265851
 silesia,                            huffman literals,                   compress cctx,                      6174127
@@ -104,11 +104,11 @@ silesia,                            level 0,                            zstdcli,
 silesia,                            level 1,                            zstdcli,                            5306179
 silesia,                            level 3,                            zstdcli,                            4838997
 silesia,                            level 4,                            zstdcli,                            4775769
-silesia,                            level 5,                            zstdcli,                            4666931
-silesia,                            level 6,                            zstdcli,                            4602509
-silesia,                            level 7,                            zstdcli,                            4568265
-silesia,                            level 9,                            zstdcli,                            4540123
-silesia,                            level 13,                           zstdcli,                            4488478
+silesia,                            level 5,                            zstdcli,                            4663332
+silesia,                            level 6,                            zstdcli,                            4599601
+silesia,                            level 7,                            zstdcli,                            4565601
+silesia,                            level 9,                            zstdcli,                            4540082
+silesia,                            level 13,                           zstdcli,                            4488438
 silesia,                            level 16,                           zstdcli,                            4358150
 silesia,                            level 19,                           zstdcli,                            4265929
 silesia,                            long distance mode,                 zstdcli,                            4830467
@@ -117,7 +117,7 @@ silesia,                            multithreaded long distance mode,   zstdcli,
 silesia,                            small window log,                   zstdcli,                            7094528
 silesia,                            small hash log,                     zstdcli,                            6527214
 silesia,                            small chain log,                    zstdcli,                            4911647
-silesia,                            explicit params,                    zstdcli,                            4794378
+silesia,                            explicit params,                    zstdcli,                            4790803
 silesia,                            uncompressed literals,              zstdcli,                            5117843
 silesia,                            uncompressed literals optimal,      zstdcli,                            4316761
 silesia,                            huffman literals,                   zstdcli,                            5320793
@@ -129,23 +129,23 @@ silesia.tar,                        level 0,                            zstdcli,
 silesia.tar,                        level 1,                            zstdcli,                            5313917
 silesia.tar,                        level 3,                            zstdcli,                            4841906
 silesia.tar,                        level 4,                            zstdcli,                            4780121
-silesia.tar,                        level 5,                            zstdcli,                            4671144
-silesia.tar,                        level 6,                            zstdcli,                            4606407
-silesia.tar,                        level 7,                            zstdcli,                            4572666
-silesia.tar,                        level 9,                            zstdcli,                            4542599
-silesia.tar,                        level 13,                           zstdcli,                            4489976
-silesia.tar,                        level 16,                           zstdcli,                            4356959
-silesia.tar,                        level 19,                           zstdcli,                            4259787
+silesia.tar,                        level 5,                            zstdcli,                            4667310
+silesia.tar,                        level 6,                            zstdcli,                            4602398
+silesia.tar,                        level 7,                            zstdcli,                            4568891
+silesia.tar,                        level 9,                            zstdcli,                            4541098
+silesia.tar,                        level 13,                           zstdcli,                            4488484
+silesia.tar,                        level 16,                           zstdcli,                            4357018
+silesia.tar,                        level 19,                           zstdcli,                            4259593
 silesia.tar,                        no source size,                     zstdcli,                            4841902
 silesia.tar,                        long distance mode,                 zstdcli,                            4834266
 silesia.tar,                        multithreaded,                      zstdcli,                            4841906
 silesia.tar,                        multithreaded long distance mode,   zstdcli,                            4834266
 silesia.tar,                        small window log,                   zstdcli,                            7100110
-silesia.tar,                        small hash log,                     zstdcli,                            6530007
-silesia.tar,                        small chain log,                    zstdcli,                            4916091
-silesia.tar,                        explicit params,                    zstdcli,                            4809323
+silesia.tar,                        small hash log,                     zstdcli,                            6530127
+silesia.tar,                        small chain log,                    zstdcli,                            4915865
+silesia.tar,                        explicit params,                    zstdcli,                            4808370
 silesia.tar,                        uncompressed literals,              zstdcli,                            5116446
-silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4306844
+silesia.tar,                        uncompressed literals optimal,      zstdcli,                            4306520
 silesia.tar,                        huffman literals,                   zstdcli,                            5326463
 silesia.tar,                        multithreaded with advanced params, zstdcli,                            5116446
 github,                             level -5,                           zstdcli,                            206407
@@ -201,11 +201,11 @@ github.tar,                         level 3,                            zstdcli,
 github.tar,                         level 3 with dict,                  zstdcli,                            38140
 github.tar,                         level 4,                            zstdcli,                            39067
 github.tar,                         level 4 with dict,                  zstdcli,                            38082
-github.tar,                         level 5,                            zstdcli,                            39815
-github.tar,                         level 5 with dict,                  zstdcli,                            39221
-github.tar,                         level 6,                            zstdcli,                            39455
-github.tar,                         level 6 with dict,                  zstdcli,                            38787
-github.tar,                         level 7,                            zstdcli,                            38177
+github.tar,                         level 5,                            zstdcli,                            39655
+github.tar,                         level 5 with dict,                  zstdcli,                            39073
+github.tar,                         level 6,                            zstdcli,                            39286
+github.tar,                         level 6 with dict,                  zstdcli,                            38647
+github.tar,                         level 7,                            zstdcli,                            38009
 github.tar,                         level 7 with dict,                  zstdcli,                            37861
 github.tar,                         level 9,                            zstdcli,                            36727
 github.tar,                         level 9 with dict,                  zstdcli,                            36686
@@ -223,7 +223,7 @@ github.tar,                         multithreaded long distance mode,   zstdcli,
 github.tar,                         small window log,                   zstdcli,                            198539
 github.tar,                         small hash log,                     zstdcli,                            129874
 github.tar,                         small chain log,                    zstdcli,                            41673
-github.tar,                         explicit params,                    zstdcli,                            41588
+github.tar,                         explicit params,                    zstdcli,                            41385
 github.tar,                         uncompressed literals,              zstdcli,                            41704
 github.tar,                         uncompressed literals optimal,      zstdcli,                            35360
 github.tar,                         huffman literals,                   zstdcli,                            39046
@@ -235,13 +235,13 @@ silesia,                            level 0,                            advanced
 silesia,                            level 1,                            advanced one pass,                  5306931
 silesia,                            level 3,                            advanced one pass,                  4838417
 silesia,                            level 4,                            advanced one pass,                  4775359
-silesia,                            level 5 row 1,                      advanced one pass,                  4666524
-silesia,                            level 5 row 2,                      advanced one pass,                  4668976
-silesia,                            level 5,                            advanced one pass,                  4666524
-silesia,                            level 6,                            advanced one pass,                  4602031
-silesia,                            level 7 row 1,                      advanced one pass,                  4567954
-silesia,                            level 7 row 2,                      advanced one pass,                  4562774
-silesia,                            level 7,                            advanced one pass,                  4567954
+silesia,                            level 5 row 1,                      advanced one pass,                  4663718
+silesia,                            level 5 row 2,                      advanced one pass,                  4666272
+silesia,                            level 5,                            advanced one pass,                  4663718
+silesia,                            level 6,                            advanced one pass,                  4600034
+silesia,                            level 7 row 1,                      advanced one pass,                  4566069
+silesia,                            level 7 row 2,                      advanced one pass,                  4560893
+silesia,                            level 7,                            advanced one pass,                  4566069
 silesia,                            level 9,                            advanced one pass,                  4540520
 silesia,                            level 11 row 1,                     advanced one pass,                  4500472
 silesia,                            level 11 row 2,                     advanced one pass,                  4498174
@@ -257,7 +257,7 @@ silesia,                            multithreaded long distance mode,   advanced
 silesia,                            small window log,                   advanced one pass,                  7094480
 silesia,                            small hash log,                     advanced one pass,                  6525510
 silesia,                            small chain log,                    advanced one pass,                  4912248
-silesia,                            explicit params,                    advanced one pass,                  4794219
+silesia,                            explicit params,                    advanced one pass,                  4791219
 silesia,                            uncompressed literals,              advanced one pass,                  5117482
 silesia,                            uncompressed literals optimal,      advanced one pass,                  4316644
 silesia,                            huffman literals,                   advanced one pass,                  5321686
@@ -269,13 +269,13 @@ silesia.tar,                        level 0,                            advanced
 silesia.tar,                        level 1,                            advanced one pass,                  5316794
 silesia.tar,                        level 3,                            advanced one pass,                  4843429
 silesia.tar,                        level 4,                            advanced one pass,                  4780657
-silesia.tar,                        level 5 row 1,                      advanced one pass,                  4669650
-silesia.tar,                        level 5 row 2,                      advanced one pass,                  4673119
-silesia.tar,                        level 5,                            advanced one pass,                  4669650
-silesia.tar,                        level 6,                            advanced one pass,                  4604925
-silesia.tar,                        level 7 row 1,                      advanced one pass,                  4570873
-silesia.tar,                        level 7 row 2,                      advanced one pass,                  4566314
-silesia.tar,                        level 7,                            advanced one pass,                  4570873
+silesia.tar,                        level 5 row 1,                      advanced one pass,                  4662847
+silesia.tar,                        level 5 row 2,                      advanced one pass,                  4666825
+silesia.tar,                        level 5,                            advanced one pass,                  4662847
+silesia.tar,                        level 6,                            advanced one pass,                  4597877
+silesia.tar,                        level 7 row 1,                      advanced one pass,                  4563998
+silesia.tar,                        level 7 row 2,                      advanced one pass,                  4559520
+silesia.tar,                        level 7,                            advanced one pass,                  4563998
 silesia.tar,                        level 9,                            advanced one pass,                  4537558
 silesia.tar,                        level 11 row 1,                     advanced one pass,                  4496590
 silesia.tar,                        level 11 row 2,                     advanced one pass,                  4495225
@@ -291,7 +291,7 @@ silesia.tar,                        multithreaded long distance mode,   advanced
 silesia.tar,                        small window log,                   advanced one pass,                  7100064
 silesia.tar,                        small hash log,                     advanced one pass,                  6530222
 silesia.tar,                        small chain log,                    advanced one pass,                  4915689
-silesia.tar,                        explicit params,                    advanced one pass,                  4797958
+silesia.tar,                        explicit params,                    advanced one pass,                  4790421
 silesia.tar,                        uncompressed literals,              advanced one pass,                  5116329
 silesia.tar,                        uncompressed literals optimal,      advanced one pass,                  4306289
 silesia.tar,                        huffman literals,                   advanced one pass,                  5331382
@@ -451,44 +451,44 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass,                  38135
 github.tar,                         level 4 with dict copy,             advanced one pass,                  38081
 github.tar,                         level 4 with dict load,             advanced one pass,                  38088
-github.tar,                         level 5 row 1,                      advanced one pass,                  39808
-github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39185
-github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39213
-github.tar,                         level 5 row 1 with dict copy,       advanced one pass,                  39284
-github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  39155
-github.tar,                         level 5 row 2,                      advanced one pass,                  39851
-github.tar,                         level 5 row 2 with dict dms,        advanced one pass,                  39498
-github.tar,                         level 5 row 2 with dict dds,        advanced one pass,                  39364
-github.tar,                         level 5 row 2 with dict copy,       advanced one pass,                  39843
-github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  39312
-github.tar,                         level 5,                            advanced one pass,                  39808
-github.tar,                         level 5 with dict,                  advanced one pass,                  39284
-github.tar,                         level 5 with dict dms,              advanced one pass,                  39185
-github.tar,                         level 5 with dict dds,              advanced one pass,                  39213
-github.tar,                         level 5 with dict copy,             advanced one pass,                  39284
-github.tar,                         level 5 with dict load,             advanced one pass,                  39155
-github.tar,                         level 6,                            advanced one pass,                  39455
-github.tar,                         level 6 with dict,                  advanced one pass,                  38808
-github.tar,                         level 6 with dict dms,              advanced one pass,                  38792
-github.tar,                         level 6 with dict dds,              advanced one pass,                  38790
-github.tar,                         level 6 with dict copy,             advanced one pass,                  38808
-github.tar,                         level 6 with dict load,             advanced one pass,                  38796
-github.tar,                         level 7 row 1,                      advanced one pass,                  38168
+github.tar,                         level 5 row 1,                      advanced one pass,                  39651
+github.tar,                         level 5 row 1 with dict dms,        advanced one pass,                  39043
+github.tar,                         level 5 row 1 with dict dds,        advanced one pass,                  39069
+github.tar,                         level 5 row 1 with dict copy,       advanced one pass,                  39145
+github.tar,                         level 5 row 1 with dict load,       advanced one pass,                  39000
+github.tar,                         level 5 row 2,                      advanced one pass,                  39701
+github.tar,                         level 5 row 2 with dict dms,        advanced one pass,                  39365
+github.tar,                         level 5 row 2 with dict dds,        advanced one pass,                  39233
+github.tar,                         level 5 row 2 with dict copy,       advanced one pass,                  39715
+github.tar,                         level 5 row 2 with dict load,       advanced one pass,                  39158
+github.tar,                         level 5,                            advanced one pass,                  39651
+github.tar,                         level 5 with dict,                  advanced one pass,                  39145
+github.tar,                         level 5 with dict dms,              advanced one pass,                  39043
+github.tar,                         level 5 with dict dds,              advanced one pass,                  39069
+github.tar,                         level 5 with dict copy,             advanced one pass,                  39145
+github.tar,                         level 5 with dict load,             advanced one pass,                  39000
+github.tar,                         level 6,                            advanced one pass,                  39282
+github.tar,                         level 6 with dict,                  advanced one pass,                  38656
+github.tar,                         level 6 with dict dms,              advanced one pass,                  38640
+github.tar,                         level 6 with dict dds,              advanced one pass,                  38643
+github.tar,                         level 6 with dict copy,             advanced one pass,                  38656
+github.tar,                         level 6 with dict load,             advanced one pass,                  38647
+github.tar,                         level 7 row 1,                      advanced one pass,                  38005
 github.tar,                         level 7 row 1 with dict dms,        advanced one pass,                  37832
 github.tar,                         level 7 row 1 with dict dds,        advanced one pass,                  37857
 github.tar,                         level 7 row 1 with dict copy,       advanced one pass,                  37839
-github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  37445
-github.tar,                         level 7 row 2,                      advanced one pass,                  38235
+github.tar,                         level 7 row 1 with dict load,       advanced one pass,                  37286
+github.tar,                         level 7 row 2,                      advanced one pass,                  38077
 github.tar,                         level 7 row 2 with dict dms,        advanced one pass,                  38012
 github.tar,                         level 7 row 2 with dict dds,        advanced one pass,                  38014
 github.tar,                         level 7 row 2 with dict copy,       advanced one pass,                  38101
-github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  37552
-github.tar,                         level 7,                            advanced one pass,                  38168
+github.tar,                         level 7 row 2 with dict load,       advanced one pass,                  37402
+github.tar,                         level 7,                            advanced one pass,                  38005
 github.tar,                         level 7 with dict,                  advanced one pass,                  37839
 github.tar,                         level 7 with dict dms,              advanced one pass,                  37832
 github.tar,                         level 7 with dict dds,              advanced one pass,                  37857
 github.tar,                         level 7 with dict copy,             advanced one pass,                  37839
-github.tar,                         level 7 with dict load,             advanced one pass,                  37445
+github.tar,                         level 7 with dict load,             advanced one pass,                  37286
 github.tar,                         level 9,                            advanced one pass,                  36723
 github.tar,                         level 9 with dict,                  advanced one pass,                  36531
 github.tar,                         level 9 with dict dms,              advanced one pass,                  36615
@@ -541,7 +541,7 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced one pass,                  198535
 github.tar,                         small hash log,                     advanced one pass,                  129870
 github.tar,                         small chain log,                    advanced one pass,                  41669
-github.tar,                         explicit params,                    advanced one pass,                  41605
+github.tar,                         explicit params,                    advanced one pass,                  41385
 github.tar,                         uncompressed literals,              advanced one pass,                  41709
 github.tar,                         uncompressed literals optimal,      advanced one pass,                  35356
 github.tar,                         huffman literals,                   advanced one pass,                  39099
@@ -553,13 +553,13 @@ silesia,                            level 0,                            advanced
 silesia,                            level 1,                            advanced one pass small out,        5306931
 silesia,                            level 3,                            advanced one pass small out,        4838417
 silesia,                            level 4,                            advanced one pass small out,        4775359
-silesia,                            level 5 row 1,                      advanced one pass small out,        4666524
-silesia,                            level 5 row 2,                      advanced one pass small out,        4668976
-silesia,                            level 5,                            advanced one pass small out,        4666524
-silesia,                            level 6,                            advanced one pass small out,        4602031
-silesia,                            level 7 row 1,                      advanced one pass small out,        4567954
-silesia,                            level 7 row 2,                      advanced one pass small out,        4562774
-silesia,                            level 7,                            advanced one pass small out,        4567954
+silesia,                            level 5 row 1,                      advanced one pass small out,        4663718
+silesia,                            level 5 row 2,                      advanced one pass small out,        4666272
+silesia,                            level 5,                            advanced one pass small out,        4663718
+silesia,                            level 6,                            advanced one pass small out,        4600034
+silesia,                            level 7 row 1,                      advanced one pass small out,        4566069
+silesia,                            level 7 row 2,                      advanced one pass small out,        4560893
+silesia,                            level 7,                            advanced one pass small out,        4566069
 silesia,                            level 9,                            advanced one pass small out,        4540520
 silesia,                            level 11 row 1,                     advanced one pass small out,        4500472
 silesia,                            level 11 row 2,                     advanced one pass small out,        4498174
@@ -575,7 +575,7 @@ silesia,                            multithreaded long distance mode,   advanced
 silesia,                            small window log,                   advanced one pass small out,        7094480
 silesia,                            small hash log,                     advanced one pass small out,        6525510
 silesia,                            small chain log,                    advanced one pass small out,        4912248
-silesia,                            explicit params,                    advanced one pass small out,        4794219
+silesia,                            explicit params,                    advanced one pass small out,        4791219
 silesia,                            uncompressed literals,              advanced one pass small out,        5117482
 silesia,                            uncompressed literals optimal,      advanced one pass small out,        4316644
 silesia,                            huffman literals,                   advanced one pass small out,        5321686
@@ -587,13 +587,13 @@ silesia.tar,                        level 0,                            advanced
 silesia.tar,                        level 1,                            advanced one pass small out,        5316794
 silesia.tar,                        level 3,                            advanced one pass small out,        4843429
 silesia.tar,                        level 4,                            advanced one pass small out,        4780657
-silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4669650
-silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4673119
-silesia.tar,                        level 5,                            advanced one pass small out,        4669650
-silesia.tar,                        level 6,                            advanced one pass small out,        4604925
-silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4570873
-silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4566314
-silesia.tar,                        level 7,                            advanced one pass small out,        4570873
+silesia.tar,                        level 5 row 1,                      advanced one pass small out,        4662847
+silesia.tar,                        level 5 row 2,                      advanced one pass small out,        4666825
+silesia.tar,                        level 5,                            advanced one pass small out,        4662847
+silesia.tar,                        level 6,                            advanced one pass small out,        4597877
+silesia.tar,                        level 7 row 1,                      advanced one pass small out,        4563998
+silesia.tar,                        level 7 row 2,                      advanced one pass small out,        4559520
+silesia.tar,                        level 7,                            advanced one pass small out,        4563998
 silesia.tar,                        level 9,                            advanced one pass small out,        4537558
 silesia.tar,                        level 11 row 1,                     advanced one pass small out,        4496590
 silesia.tar,                        level 11 row 2,                     advanced one pass small out,        4495225
@@ -609,7 +609,7 @@ silesia.tar,                        multithreaded long distance mode,   advanced
 silesia.tar,                        small window log,                   advanced one pass small out,        7100064
 silesia.tar,                        small hash log,                     advanced one pass small out,        6530222
 silesia.tar,                        small chain log,                    advanced one pass small out,        4915689
-silesia.tar,                        explicit params,                    advanced one pass small out,        4797958
+silesia.tar,                        explicit params,                    advanced one pass small out,        4790421
 silesia.tar,                        uncompressed literals,              advanced one pass small out,        5116329
 silesia.tar,                        uncompressed literals optimal,      advanced one pass small out,        4306289
 silesia.tar,                        huffman literals,                   advanced one pass small out,        5331382
@@ -769,44 +769,44 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced one pass small out,        38135
 github.tar,                         level 4 with dict copy,             advanced one pass small out,        38081
 github.tar,                         level 4 with dict load,             advanced one pass small out,        38088
-github.tar,                         level 5 row 1,                      advanced one pass small out,        39808
-github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39185
-github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39213
-github.tar,                         level 5 row 1 with dict copy,       advanced one pass small out,        39284
-github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        39155
-github.tar,                         level 5 row 2,                      advanced one pass small out,        39851
-github.tar,                         level 5 row 2 with dict dms,        advanced one pass small out,        39498
-github.tar,                         level 5 row 2 with dict dds,        advanced one pass small out,        39364
-github.tar,                         level 5 row 2 with dict copy,       advanced one pass small out,        39843
-github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        39312
-github.tar,                         level 5,                            advanced one pass small out,        39808
-github.tar,                         level 5 with dict,                  advanced one pass small out,        39284
-github.tar,                         level 5 with dict dms,              advanced one pass small out,        39185
-github.tar,                         level 5 with dict dds,              advanced one pass small out,        39213
-github.tar,                         level 5 with dict copy,             advanced one pass small out,        39284
-github.tar,                         level 5 with dict load,             advanced one pass small out,        39155
-github.tar,                         level 6,                            advanced one pass small out,        39455
-github.tar,                         level 6 with dict,                  advanced one pass small out,        38808
-github.tar,                         level 6 with dict dms,              advanced one pass small out,        38792
-github.tar,                         level 6 with dict dds,              advanced one pass small out,        38790
-github.tar,                         level 6 with dict copy,             advanced one pass small out,        38808
-github.tar,                         level 6 with dict load,             advanced one pass small out,        38796
-github.tar,                         level 7 row 1,                      advanced one pass small out,        38168
+github.tar,                         level 5 row 1,                      advanced one pass small out,        39651
+github.tar,                         level 5 row 1 with dict dms,        advanced one pass small out,        39043
+github.tar,                         level 5 row 1 with dict dds,        advanced one pass small out,        39069
+github.tar,                         level 5 row 1 with dict copy,       advanced one pass small out,        39145
+github.tar,                         level 5 row 1 with dict load,       advanced one pass small out,        39000
+github.tar,                         level 5 row 2,                      advanced one pass small out,        39701
+github.tar,                         level 5 row 2 with dict dms,        advanced one pass small out,        39365
+github.tar,                         level 5 row 2 with dict dds,        advanced one pass small out,        39233
+github.tar,                         level 5 row 2 with dict copy,       advanced one pass small out,        39715
+github.tar,                         level 5 row 2 with dict load,       advanced one pass small out,        39158
+github.tar,                         level 5,                            advanced one pass small out,        39651
+github.tar,                         level 5 with dict,                  advanced one pass small out,        39145
+github.tar,                         level 5 with dict dms,              advanced one pass small out,        39043
+github.tar,                         level 5 with dict dds,              advanced one pass small out,        39069
+github.tar,                         level 5 with dict copy,             advanced one pass small out,        39145
+github.tar,                         level 5 with dict load,             advanced one pass small out,        39000
+github.tar,                         level 6,                            advanced one pass small out,        39282
+github.tar,                         level 6 with dict,                  advanced one pass small out,        38656
+github.tar,                         level 6 with dict dms,              advanced one pass small out,        38640
+github.tar,                         level 6 with dict dds,              advanced one pass small out,        38643
+github.tar,                         level 6 with dict copy,             advanced one pass small out,        38656
+github.tar,                         level 6 with dict load,             advanced one pass small out,        38647
+github.tar,                         level 7 row 1,                      advanced one pass small out,        38005
 github.tar,                         level 7 row 1 with dict dms,        advanced one pass small out,        37832
 github.tar,                         level 7 row 1 with dict dds,        advanced one pass small out,        37857
 github.tar,                         level 7 row 1 with dict copy,       advanced one pass small out,        37839
-github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        37445
-github.tar,                         level 7 row 2,                      advanced one pass small out,        38235
+github.tar,                         level 7 row 1 with dict load,       advanced one pass small out,        37286
+github.tar,                         level 7 row 2,                      advanced one pass small out,        38077
 github.tar,                         level 7 row 2 with dict dms,        advanced one pass small out,        38012
 github.tar,                         level 7 row 2 with dict dds,        advanced one pass small out,        38014
 github.tar,                         level 7 row 2 with dict copy,       advanced one pass small out,        38101
-github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        37552
-github.tar,                         level 7,                            advanced one pass small out,        38168
+github.tar,                         level 7 row 2 with dict load,       advanced one pass small out,        37402
+github.tar,                         level 7,                            advanced one pass small out,        38005
 github.tar,                         level 7 with dict,                  advanced one pass small out,        37839
 github.tar,                         level 7 with dict dms,              advanced one pass small out,        37832
 github.tar,                         level 7 with dict dds,              advanced one pass small out,        37857
 github.tar,                         level 7 with dict copy,             advanced one pass small out,        37839
-github.tar,                         level 7 with dict load,             advanced one pass small out,        37445
+github.tar,                         level 7 with dict load,             advanced one pass small out,        37286
 github.tar,                         level 9,                            advanced one pass small out,        36723
 github.tar,                         level 9 with dict,                  advanced one pass small out,        36531
 github.tar,                         level 9 with dict dms,              advanced one pass small out,        36615
@@ -859,7 +859,7 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced one pass small out,        198535
 github.tar,                         small hash log,                     advanced one pass small out,        129870
 github.tar,                         small chain log,                    advanced one pass small out,        41669
-github.tar,                         explicit params,                    advanced one pass small out,        41605
+github.tar,                         explicit params,                    advanced one pass small out,        41385
 github.tar,                         uncompressed literals,              advanced one pass small out,        41709
 github.tar,                         uncompressed literals optimal,      advanced one pass small out,        35356
 github.tar,                         huffman literals,                   advanced one pass small out,        39099
@@ -871,31 +871,31 @@ silesia,                            level 0,                            advanced
 silesia,                            level 1,                            advanced streaming,                 5305682
 silesia,                            level 3,                            advanced streaming,                 4839173
 silesia,                            level 4,                            advanced streaming,                 4776074
-silesia,                            level 5 row 1,                      advanced streaming,                 4667049
-silesia,                            level 5 row 2,                      advanced streaming,                 4669474
-silesia,                            level 5,                            advanced streaming,                 4667049
-silesia,                            level 6,                            advanced streaming,                 4602956
-silesia,                            level 7 row 1,                      advanced streaming,                 4568785
-silesia,                            level 7 row 2,                      advanced streaming,                 4563722
-silesia,                            level 7,                            advanced streaming,                 4568785
-silesia,                            level 9,                            advanced streaming,                 4545850
-silesia,                            level 11 row 1,                     advanced streaming,                 4505658
-silesia,                            level 11 row 2,                     advanced streaming,                 4503429
-silesia,                            level 12 row 1,                     advanced streaming,                 4505658
-silesia,                            level 12 row 2,                     advanced streaming,                 4503429
-silesia,                            level 13,                           advanced streaming,                 4493990
-silesia,                            level 16,                           advanced streaming,                 4359652
-silesia,                            level 19,                           advanced streaming,                 4266582
+silesia,                            level 5 row 1,                      advanced streaming,                 4664679
+silesia,                            level 5 row 2,                      advanced streaming,                 4667307
+silesia,                            level 5,                            advanced streaming,                 4664679
+silesia,                            level 6,                            advanced streaming,                 4601116
+silesia,                            level 7 row 1,                      advanced streaming,                 4567082
+silesia,                            level 7 row 2,                      advanced streaming,                 4561992
+silesia,                            level 7,                            advanced streaming,                 4567082
+silesia,                            level 9,                            advanced streaming,                 4542474
+silesia,                            level 11 row 1,                     advanced streaming,                 4502322
+silesia,                            level 11 row 2,                     advanced streaming,                 4500050
+silesia,                            level 12 row 1,                     advanced streaming,                 4502322
+silesia,                            level 12 row 2,                     advanced streaming,                 4500050
+silesia,                            level 13,                           advanced streaming,                 4490650
+silesia,                            level 16,                           advanced streaming,                 4358094
+silesia,                            level 19,                           advanced streaming,                 4265908
 silesia,                            no source size,                     advanced streaming,                 4839137
 silesia,                            long distance mode,                 advanced streaming,                 4831125
 silesia,                            multithreaded,                      advanced streaming,                 4838949
 silesia,                            multithreaded long distance mode,   advanced streaming,                 4830419
 silesia,                            small window log,                   advanced streaming,                 7110591
-silesia,                            small hash log,                     advanced streaming,                 6526141
-silesia,                            small chain log,                    advanced streaming,                 4912197
-silesia,                            explicit params,                    advanced streaming,                 4795053
+silesia,                            small hash log,                     advanced streaming,                 6525259
+silesia,                            small chain log,                    advanced streaming,                 4911577
+silesia,                            explicit params,                    advanced streaming,                 4792505
 silesia,                            uncompressed literals,              advanced streaming,                 5117625
-silesia,                            uncompressed literals optimal,      advanced streaming,                 4316880
+silesia,                            uncompressed literals optimal,      advanced streaming,                 4316533
 silesia,                            huffman literals,                   advanced streaming,                 5321812
 silesia,                            multithreaded with advanced params, advanced streaming,                 5117795
 silesia.tar,                        level -5,                           advanced streaming,                 6857458
@@ -905,31 +905,31 @@ silesia.tar,                        level 0,                            advanced
 silesia.tar,                        level 1,                            advanced streaming,                 5311452
 silesia.tar,                        level 3,                            advanced streaming,                 4849720
 silesia.tar,                        level 4,                            advanced streaming,                 4787534
-silesia.tar,                        level 5 row 1,                      advanced streaming,                 4669420
-silesia.tar,                        level 5 row 2,                      advanced streaming,                 4673610
-silesia.tar,                        level 5,                            advanced streaming,                 4669420
-silesia.tar,                        level 6,                            advanced streaming,                 4604125
-silesia.tar,                        level 7 row 1,                      advanced streaming,                 4570206
-silesia.tar,                        level 7 row 2,                      advanced streaming,                 4565792
-silesia.tar,                        level 7,                            advanced streaming,                 4570206
-silesia.tar,                        level 9,                            advanced streaming,                 4555445
-silesia.tar,                        level 11 row 1,                     advanced streaming,                 4514959
-silesia.tar,                        level 11 row 2,                     advanced streaming,                 4513810
-silesia.tar,                        level 12 row 1,                     advanced streaming,                 4514514
-silesia.tar,                        level 12 row 2,                     advanced streaming,                 4514003
-silesia.tar,                        level 13,                           advanced streaming,                 4502956
-silesia.tar,                        level 16,                           advanced streaming,                 4360385
-silesia.tar,                        level 19,                           advanced streaming,                 4260939
+silesia.tar,                        level 5 row 1,                      advanced streaming,                 4664523
+silesia.tar,                        level 5 row 2,                      advanced streaming,                 4668292
+silesia.tar,                        level 5,                            advanced streaming,                 4664523
+silesia.tar,                        level 6,                            advanced streaming,                 4599420
+silesia.tar,                        level 7 row 1,                      advanced streaming,                 4565332
+silesia.tar,                        level 7 row 2,                      advanced streaming,                 4561064
+silesia.tar,                        level 7,                            advanced streaming,                 4565332
+silesia.tar,                        level 9,                            advanced streaming,                 4539391
+silesia.tar,                        level 11 row 1,                     advanced streaming,                 4498530
+silesia.tar,                        level 11 row 2,                     advanced streaming,                 4497297
+silesia.tar,                        level 12 row 1,                     advanced streaming,                 4498097
+silesia.tar,                        level 12 row 2,                     advanced streaming,                 4497497
+silesia.tar,                        level 13,                           advanced streaming,                 4486652
+silesia.tar,                        level 16,                           advanced streaming,                 4358029
+silesia.tar,                        level 19,                           advanced streaming,                 4258228
 silesia.tar,                        no source size,                     advanced streaming,                 4849716
 silesia.tar,                        long distance mode,                 advanced streaming,                 4829339
 silesia.tar,                        multithreaded,                      advanced streaming,                 4841902
 silesia.tar,                        multithreaded long distance mode,   advanced streaming,                 4834262
 silesia.tar,                        small window log,                   advanced streaming,                 7117024
-silesia.tar,                        small hash log,                     advanced streaming,                 6529209
-silesia.tar,                        small chain log,                    advanced streaming,                 4917021
-silesia.tar,                        explicit params,                    advanced streaming,                 4797673
+silesia.tar,                        small hash log,                     advanced streaming,                 6529503
+silesia.tar,                        small chain log,                    advanced streaming,                 4915956
+silesia.tar,                        explicit params,                    advanced streaming,                 4791739
 silesia.tar,                        uncompressed literals,              advanced streaming,                 5124811
-silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4308451
+silesia.tar,                        uncompressed literals optimal,      advanced streaming,                 4306968
 silesia.tar,                        huffman literals,                   advanced streaming,                 5326278
 silesia.tar,                        multithreaded with advanced params, advanced streaming,                 5116442
 github,                             level -5,                           advanced streaming,                 204407
@@ -1087,44 +1087,44 @@ github.tar,                         level 4 with dict dms,              advanced
 github.tar,                         level 4 with dict dds,              advanced streaming,                 38317
 github.tar,                         level 4 with dict copy,             advanced streaming,                 38270
 github.tar,                         level 4 with dict load,             advanced streaming,                 38259
-github.tar,                         level 5 row 1,                      advanced streaming,                 39986
-github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39370
-github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39396
-github.tar,                         level 5 row 1 with dict copy,       advanced streaming,                 39465
-github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 39332
-github.tar,                         level 5 row 2,                      advanced streaming,                 40038
-github.tar,                         level 5 row 2 with dict dms,        advanced streaming,                 39690
-github.tar,                         level 5 row 2 with dict dds,        advanced streaming,                 39555
-github.tar,                         level 5 row 2 with dict copy,       advanced streaming,                 40036
-github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 39498
-github.tar,                         level 5,                            advanced streaming,                 39986
-github.tar,                         level 5 with dict,                  advanced streaming,                 39465
-github.tar,                         level 5 with dict dms,              advanced streaming,                 39370
-github.tar,                         level 5 with dict dds,              advanced streaming,                 39396
-github.tar,                         level 5 with dict copy,             advanced streaming,                 39465
-github.tar,                         level 5 with dict load,             advanced streaming,                 39332
-github.tar,                         level 6,                            advanced streaming,                 39565
-github.tar,                         level 6 with dict,                  advanced streaming,                 38894
-github.tar,                         level 6 with dict dms,              advanced streaming,                 38901
-github.tar,                         level 6 with dict dds,              advanced streaming,                 38903
-github.tar,                         level 6 with dict copy,             advanced streaming,                 38894
-github.tar,                         level 6 with dict load,             advanced streaming,                 38906
-github.tar,                         level 7 row 1,                      advanced streaming,                 38295
+github.tar,                         level 5 row 1,                      advanced streaming,                 39651
+github.tar,                         level 5 row 1 with dict dms,        advanced streaming,                 39043
+github.tar,                         level 5 row 1 with dict dds,        advanced streaming,                 39069
+github.tar,                         level 5 row 1 with dict copy,       advanced streaming,                 39145
+github.tar,                         level 5 row 1 with dict load,       advanced streaming,                 39000
+github.tar,                         level 5 row 2,                      advanced streaming,                 39701
+github.tar,                         level 5 row 2 with dict dms,        advanced streaming,                 39365
+github.tar,                         level 5 row 2 with dict dds,        advanced streaming,                 39233
+github.tar,                         level 5 row 2 with dict copy,       advanced streaming,                 39715
+github.tar,                         level 5 row 2 with dict load,       advanced streaming,                 39158
+github.tar,                         level 5,                            advanced streaming,                 39651
+github.tar,                         level 5 with dict,                  advanced streaming,                 39145
+github.tar,                         level 5 with dict dms,              advanced streaming,                 39043
+github.tar,                         level 5 with dict dds,              advanced streaming,                 39069
+github.tar,                         level 5 with dict copy,             advanced streaming,                 39145
+github.tar,                         level 5 with dict load,             advanced streaming,                 39000
+github.tar,                         level 6,                            advanced streaming,                 39282
+github.tar,                         level 6 with dict,                  advanced streaming,                 38656
+github.tar,                         level 6 with dict dms,              advanced streaming,                 38640
+github.tar,                         level 6 with dict dds,              advanced streaming,                 38643
+github.tar,                         level 6 with dict copy,             advanced streaming,                 38656
+github.tar,                         level 6 with dict load,             advanced streaming,                 38647
+github.tar,                         level 7 row 1,                      advanced streaming,                 38005
 github.tar,                         level 7 row 1 with dict dms,        advanced streaming,                 37832
 github.tar,                         level 7 row 1 with dict dds,        advanced streaming,                 37857
 github.tar,                         level 7 row 1 with dict copy,       advanced streaming,                 37839
-github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 37565
-github.tar,                         level 7 row 2,                      advanced streaming,                 38369
+github.tar,                         level 7 row 1 with dict load,       advanced streaming,                 37286
+github.tar,                         level 7 row 2,                      advanced streaming,                 38077
 github.tar,                         level 7 row 2 with dict dms,        advanced streaming,                 38012
 github.tar,                         level 7 row 2 with dict dds,        advanced streaming,                 38014
 github.tar,                         level 7 row 2 with dict copy,       advanced streaming,                 38101
-github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 37688
-github.tar,                         level 7,                            advanced streaming,                 38295
+github.tar,                         level 7 row 2 with dict load,       advanced streaming,                 37402
+github.tar,                         level 7,                            advanced streaming,                 38005
 github.tar,                         level 7 with dict,                  advanced streaming,                 37839
 github.tar,                         level 7 with dict dms,              advanced streaming,                 37832
 github.tar,                         level 7 with dict dds,              advanced streaming,                 37857
 github.tar,                         level 7 with dict copy,             advanced streaming,                 37839
-github.tar,                         level 7 with dict load,             advanced streaming,                 37565
+github.tar,                         level 7 with dict load,             advanced streaming,                 37286
 github.tar,                         level 9,                            advanced streaming,                 36723
 github.tar,                         level 9 with dict,                  advanced streaming,                 36531
 github.tar,                         level 9 with dict dms,              advanced streaming,                 36615
@@ -1177,7 +1177,7 @@ github.tar,                         multithreaded long distance mode,   advanced
 github.tar,                         small window log,                   advanced streaming,                 199553
 github.tar,                         small hash log,                     advanced streaming,                 129870
 github.tar,                         small chain log,                    advanced streaming,                 41669
-github.tar,                         explicit params,                    advanced streaming,                 41768
+github.tar,                         explicit params,                    advanced streaming,                 41385
 github.tar,                         uncompressed literals,              advanced streaming,                 41784
 github.tar,                         uncompressed literals optimal,      advanced streaming,                 35356
 github.tar,                         huffman literals,                   advanced streaming,                 39226
@@ -1189,16 +1189,16 @@ silesia,                            level 0,                            old stre
 silesia,                            level 1,                            old streaming,                      5305682
 silesia,                            level 3,                            old streaming,                      4839173
 silesia,                            level 4,                            old streaming,                      4776074
-silesia,                            level 5,                            old streaming,                      4667049
-silesia,                            level 6,                            old streaming,                      4602956
-silesia,                            level 7,                            old streaming,                      4568785
-silesia,                            level 9,                            old streaming,                      4545850
-silesia,                            level 13,                           old streaming,                      4493990
-silesia,                            level 16,                           old streaming,                      4359652
-silesia,                            level 19,                           old streaming,                      4266582
+silesia,                            level 5,                            old streaming,                      4664679
+silesia,                            level 6,                            old streaming,                      4601116
+silesia,                            level 7,                            old streaming,                      4567082
+silesia,                            level 9,                            old streaming,                      4542474
+silesia,                            level 13,                           old streaming,                      4490650
+silesia,                            level 16,                           old streaming,                      4358094
+silesia,                            level 19,                           old streaming,                      4265908
 silesia,                            no source size,                     old streaming,                      4839137
 silesia,                            uncompressed literals,              old streaming,                      4839173
-silesia,                            uncompressed literals optimal,      old streaming,                      4266582
+silesia,                            uncompressed literals optimal,      old streaming,                      4265908
 silesia,                            huffman literals,                   old streaming,                      6174139
 silesia.tar,                        level -5,                           old streaming,                      6857458
 silesia.tar,                        level -3,                           old streaming,                      6508562
@@ -1207,16 +1207,16 @@ silesia.tar,                        level 0,                            old stre
 silesia.tar,                        level 1,                            old streaming,                      5311452
 silesia.tar,                        level 3,                            old streaming,                      4849720
 silesia.tar,                        level 4,                            old streaming,                      4787534
-silesia.tar,                        level 5,                            old streaming,                      4669420
-silesia.tar,                        level 6,                            old streaming,                      4604125
-silesia.tar,                        level 7,                            old streaming,                      4570206
-silesia.tar,                        level 9,                            old streaming,                      4555445
-silesia.tar,                        level 13,                           old streaming,                      4502956
-silesia.tar,                        level 16,                           old streaming,                      4360385
-silesia.tar,                        level 19,                           old streaming,                      4260939
+silesia.tar,                        level 5,                            old streaming,                      4664523
+silesia.tar,                        level 6,                            old streaming,                      4599420
+silesia.tar,                        level 7,                            old streaming,                      4565332
+silesia.tar,                        level 9,                            old streaming,                      4539391
+silesia.tar,                        level 13,                           old streaming,                      4486652
+silesia.tar,                        level 16,                           old streaming,                      4358029
+silesia.tar,                        level 19,                           old streaming,                      4258228
 silesia.tar,                        no source size,                     old streaming,                      4849716
 silesia.tar,                        uncompressed literals,              old streaming,                      4849720
-silesia.tar,                        uncompressed literals optimal,      old streaming,                      4260939
+silesia.tar,                        uncompressed literals optimal,      old streaming,                      4258228
 silesia.tar,                        huffman literals,                   old streaming,                      6178057
 github,                             level -5,                           old streaming,                      204407
 github,                             level -5 with dict,                 old streaming,                      45832
@@ -1265,11 +1265,11 @@ github.tar,                         level 3,                            old stre
 github.tar,                         level 3 with dict,                  old streaming,                      38309
 github.tar,                         level 4,                            old streaming,                      39247
 github.tar,                         level 4 with dict,                  old streaming,                      38270
-github.tar,                         level 5,                            old streaming,                      39986
-github.tar,                         level 5 with dict,                  old streaming,                      39465
-github.tar,                         level 6,                            old streaming,                      39565
-github.tar,                         level 6 with dict,                  old streaming,                      38894
-github.tar,                         level 7,                            old streaming,                      38295
+github.tar,                         level 5,                            old streaming,                      39651
+github.tar,                         level 5 with dict,                  old streaming,                      39145
+github.tar,                         level 6,                            old streaming,                      39282
+github.tar,                         level 6 with dict,                  old streaming,                      38656
+github.tar,                         level 7,                            old streaming,                      38005
 github.tar,                         level 7 with dict,                  old streaming,                      37839
 github.tar,                         level 9,                            old streaming,                      36723
 github.tar,                         level 9 with dict,                  old streaming,                      36531
@@ -1291,23 +1291,23 @@ silesia,                            level 0,                            old stre
 silesia,                            level 1,                            old streaming advanced,             5305682
 silesia,                            level 3,                            old streaming advanced,             4839173
 silesia,                            level 4,                            old streaming advanced,             4776074
-silesia,                            level 5,                            old streaming advanced,             4667049
-silesia,                            level 6,                            old streaming advanced,             4602956
-silesia,                            level 7,                            old streaming advanced,             4568785
-silesia,                            level 9,                            old streaming advanced,             4545850
-silesia,                            level 13,                           old streaming advanced,             4493990
-silesia,                            level 16,                           old streaming advanced,             4359652
-silesia,                            level 19,                           old streaming advanced,             4266582
+silesia,                            level 5,                            old streaming advanced,             4664679
+silesia,                            level 6,                            old streaming advanced,             4601116
+silesia,                            level 7,                            old streaming advanced,             4567082
+silesia,                            level 9,                            old streaming advanced,             4542474
+silesia,                            level 13,                           old streaming advanced,             4490650
+silesia,                            level 16,                           old streaming advanced,             4358094
+silesia,                            level 19,                           old streaming advanced,             4265908
 silesia,                            no source size,                     old streaming advanced,             4839137
 silesia,                            long distance mode,                 old streaming advanced,             4839173
 silesia,                            multithreaded,                      old streaming advanced,             4839173
 silesia,                            multithreaded long distance mode,   old streaming advanced,             4839173
 silesia,                            small window log,                   old streaming advanced,             7110591
-silesia,                            small hash log,                     old streaming advanced,             6526141
-silesia,                            small chain log,                    old streaming advanced,             4912197
-silesia,                            explicit params,                    old streaming advanced,             4795053
+silesia,                            small hash log,                     old streaming advanced,             6525259
+silesia,                            small chain log,                    old streaming advanced,             4911577
+silesia,                            explicit params,                    old streaming advanced,             4792505
 silesia,                            uncompressed literals,              old streaming advanced,             4839173
-silesia,                            uncompressed literals optimal,      old streaming advanced,             4266582
+silesia,                            uncompressed literals optimal,      old streaming advanced,             4265908
 silesia,                            huffman literals,                   old streaming advanced,             6174139
 silesia,                            multithreaded with advanced params, old streaming advanced,             4839173
 silesia.tar,                        level -5,                           old streaming advanced,             6857458
@@ -1317,23 +1317,23 @@ silesia.tar,                        level 0,                            old stre
 silesia.tar,                        level 1,                            old streaming advanced,             5311452
 silesia.tar,                        level 3,                            old streaming advanced,             4849720
 silesia.tar,                        level 4,                            old streaming advanced,             4787534
-silesia.tar,                        level 5,                            old streaming advanced,             4669420
-silesia.tar,                        level 6,                            old streaming advanced,             4604125
-silesia.tar,                        level 7,                            old streaming advanced,             4570206
-silesia.tar,                        level 9,                            old streaming advanced,             4555445
-silesia.tar,                        level 13,                           old streaming advanced,             4502956
-silesia.tar,                        level 16,                           old streaming advanced,             4360385
-silesia.tar,                        level 19,                           old streaming advanced,             4260939
+silesia.tar,                        level 5,                            old streaming advanced,             4664523
+silesia.tar,                        level 6,                            old streaming advanced,             4599420
+silesia.tar,                        level 7,                            old streaming advanced,             4565332
+silesia.tar,                        level 9,                            old streaming advanced,             4539391
+silesia.tar,                        level 13,                           old streaming advanced,             4486652
+silesia.tar,                        level 16,                           old streaming advanced,             4358029
+silesia.tar,                        level 19,                           old streaming advanced,             4258228
 silesia.tar,                        no source size,                     old streaming advanced,             4849716
 silesia.tar,                        long distance mode,                 old streaming advanced,             4849720
 silesia.tar,                        multithreaded,                      old streaming advanced,             4849720
 silesia.tar,                        multithreaded long distance mode,   old streaming advanced,             4849720
 silesia.tar,                        small window log,                   old streaming advanced,             7117027
-silesia.tar,                        small hash log,                     old streaming advanced,             6529209
-silesia.tar,                        small chain log,                    old streaming advanced,             4917021
-silesia.tar,                        explicit params,                    old streaming advanced,             4797673
+silesia.tar,                        small hash log,                     old streaming advanced,             6529503
+silesia.tar,                        small chain log,                    old streaming advanced,             4915956
+silesia.tar,                        explicit params,                    old streaming advanced,             4791739
 silesia.tar,                        uncompressed literals,              old streaming advanced,             4849720
-silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4260939
+silesia.tar,                        uncompressed literals optimal,      old streaming advanced,             4258228
 silesia.tar,                        huffman literals,                   old streaming advanced,             6178057
 silesia.tar,                        multithreaded with advanced params, old streaming advanced,             4849720
 github,                             level -5,                           old streaming advanced,             213265
@@ -1391,12 +1391,12 @@ github.tar,                         level 3,                            old stre
 github.tar,                         level 3 with dict,                  old streaming advanced,             38327
 github.tar,                         level 4,                            old streaming advanced,             39247
 github.tar,                         level 4 with dict,                  old streaming advanced,             38382
-github.tar,                         level 5,                            old streaming advanced,             39986
-github.tar,                         level 5 with dict,                  old streaming advanced,             39347
-github.tar,                         level 6,                            old streaming advanced,             39565
-github.tar,                         level 6 with dict,                  old streaming advanced,             38889
-github.tar,                         level 7,                            old streaming advanced,             38295
-github.tar,                         level 7 with dict,                  old streaming advanced,             37534
+github.tar,                         level 5,                            old streaming advanced,             39651
+github.tar,                         level 5 with dict,                  old streaming advanced,             39018
+github.tar,                         level 6,                            old streaming advanced,             39282
+github.tar,                         level 6 with dict,                  old streaming advanced,             38635
+github.tar,                         level 7,                            old streaming advanced,             38005
+github.tar,                         level 7 with dict,                  old streaming advanced,             37264
 github.tar,                         level 9,                            old streaming advanced,             36723
 github.tar,                         level 9 with dict,                  old streaming advanced,             36241
 github.tar,                         level 13,                           old streaming advanced,             35501
@@ -1413,7 +1413,7 @@ github.tar,                         multithreaded long distance mode,   old stre
 github.tar,                         small window log,                   old streaming advanced,             199556
 github.tar,                         small hash log,                     old streaming advanced,             129870
 github.tar,                         small chain log,                    old streaming advanced,             41669
-github.tar,                         explicit params,                    old streaming advanced,             41768
+github.tar,                         explicit params,                    old streaming advanced,             41385
 github.tar,                         uncompressed literals,              old streaming advanced,             39249
 github.tar,                         uncompressed literals optimal,      old streaming advanced,             32262
 github.tar,                         huffman literals,                   old streaming advanced,             42777
@@ -1440,9 +1440,9 @@ github.tar,                         level 0 with dict,                  old stre
 github.tar,                         level 1 with dict,                  old streaming cdict,                38716
 github.tar,                         level 3 with dict,                  old streaming cdict,                38281
 github.tar,                         level 4 with dict,                  old streaming cdict,                38259
-github.tar,                         level 5 with dict,                  old streaming cdict,                39332
-github.tar,                         level 6 with dict,                  old streaming cdict,                38906
-github.tar,                         level 7 with dict,                  old streaming cdict,                37565
+github.tar,                         level 5 with dict,                  old streaming cdict,                39000
+github.tar,                         level 6 with dict,                  old streaming cdict,                38647
+github.tar,                         level 7 with dict,                  old streaming cdict,                37286
 github.tar,                         level 9 with dict,                  old streaming cdict,                36322
 github.tar,                         level 13 with dict,                 old streaming cdict,                36010
 github.tar,                         level 16 with dict,                 old streaming cdict,                39081
@@ -1470,9 +1470,9 @@ github.tar,                         level 0 with dict,                  old stre
 github.tar,                         level 1 with dict,                  old streaming advanced cdict,       38513
 github.tar,                         level 3 with dict,                  old streaming advanced cdict,       38327
 github.tar,                         level 4 with dict,                  old streaming advanced cdict,       38382
-github.tar,                         level 5 with dict,                  old streaming advanced cdict,       39347
-github.tar,                         level 6 with dict,                  old streaming advanced cdict,       38889
-github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37534
+github.tar,                         level 5 with dict,                  old streaming advanced cdict,       39018
+github.tar,                         level 6 with dict,                  old streaming advanced cdict,       38635
+github.tar,                         level 7 with dict,                  old streaming advanced cdict,       37264
 github.tar,                         level 9 with dict,                  old streaming advanced cdict,       36241
 github.tar,                         level 13 with dict,                 old streaming advanced cdict,       35807
 github.tar,                         level 16 with dict,                 old streaming advanced cdict,       38578


### PR DESCRIPTION
These faster variants employs lighter sampling, smaller state and different hashing to decide when and where to split a block.

Thanks to their faster speed, it's now possible to apply block splitting heuristics for levels 3 to 7 (strategies `dfast`, `greedy` and `lazy`), with a negligible speed impact (<2%).

Unfortunately, this is still not fast enough for the `fast` strategy, which will require a very different variant.

`silesia.tar` :
level | `dev` | this PR | savings
| -- | -- | -- | -- |
| 3 | 66456850 | 66133685 | -323165 |
| 4 | 65255250 | 64956407 | -298843 |
| 5 | 63040521 | 62741063 | -299458 |
| 6 | 61540615 | 61230511 | -310104 |
| 7 | 60546773 | 60249475 | -297298 |

