### PR TITLE
Block splitter control parameter

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -598,7 +598,7 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
         bounds.upperBound = 1;
         return bounds;
 
-    case ZSTD_c_useBlockSplitter:
+    case ZSTD_c_splitAfterSequences:
         bounds.lowerBound = (int)ZSTD_ps_auto;
         bounds.upperBound = (int)ZSTD_ps_disable;
         return bounds;
@@ -701,7 +701,7 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     case ZSTD_c_stableOutBuffer:
     case ZSTD_c_blockDelimiters:
     case ZSTD_c_validateSequences:
-    case ZSTD_c_useBlockSplitter:
+    case ZSTD_c_splitAfterSequences:
     case ZSTD_c_useRowMatchFinder:
     case ZSTD_c_deterministicRefPrefix:
     case ZSTD_c_prefetchCDictTables:
@@ -760,7 +760,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
     case ZSTD_c_stableOutBuffer:
     case ZSTD_c_blockDelimiters:
     case ZSTD_c_validateSequences:
-    case ZSTD_c_useBlockSplitter:
+    case ZSTD_c_splitAfterSequences:
     case ZSTD_c_blockSplitterLevel:
     case ZSTD_c_useRowMatchFinder:
     case ZSTD_c_deterministicRefPrefix:
@@ -982,8 +982,8 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
         CCtxParams->validateSequences = value;
         return (size_t)CCtxParams->validateSequences;
 
-    case ZSTD_c_useBlockSplitter:
-        BOUNDCHECK(ZSTD_c_useBlockSplitter, value);
+    case ZSTD_c_splitAfterSequences:
+        BOUNDCHECK(ZSTD_c_splitAfterSequences, value);
         CCtxParams->postBlockSplitter = (ZSTD_paramSwitch_e)value;
         return CCtxParams->postBlockSplitter;
 
@@ -1147,7 +1147,7 @@ size_t ZSTD_CCtxParams_getParameter(
     case ZSTD_c_validateSequences :
         *value = (int)CCtxParams->validateSequences;
         break;
-    case ZSTD_c_useBlockSplitter :
+    case ZSTD_c_splitAfterSequences :
         *value = (int)CCtxParams->postBlockSplitter;
         break;
     case ZSTD_c_blockSplitterLevel :

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -603,7 +603,7 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
         bounds.upperBound = (int)ZSTD_ps_disable;
         return bounds;
 
-    case ZSTD_c_blockSplitter_level:
+    case ZSTD_c_blockSplitterLevel:
         bounds.lowerBound = 0;
         bounds.upperBound = ZSTD_BLOCKSPLITTER_LEVEL_MAX;
         return bounds;
@@ -674,7 +674,7 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     case ZSTD_c_minMatch:
     case ZSTD_c_targetLength:
     case ZSTD_c_strategy:
-    case ZSTD_c_blockSplitter_level:
+    case ZSTD_c_blockSplitterLevel:
         return 1;
 
     case ZSTD_c_format:
@@ -761,7 +761,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
     case ZSTD_c_blockDelimiters:
     case ZSTD_c_validateSequences:
     case ZSTD_c_useBlockSplitter:
-    case ZSTD_c_blockSplitter_level:
+    case ZSTD_c_blockSplitterLevel:
     case ZSTD_c_useRowMatchFinder:
     case ZSTD_c_deterministicRefPrefix:
     case ZSTD_c_prefetchCDictTables:
@@ -987,8 +987,8 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
         CCtxParams->postBlockSplitter = (ZSTD_paramSwitch_e)value;
         return CCtxParams->postBlockSplitter;
 
-    case ZSTD_c_blockSplitter_level:
-        BOUNDCHECK(ZSTD_c_blockSplitter_level, value);
+    case ZSTD_c_blockSplitterLevel:
+        BOUNDCHECK(ZSTD_c_blockSplitterLevel, value);
         CCtxParams->preBlockSplitter_level = value;
         return (size_t)CCtxParams->preBlockSplitter_level;
 
@@ -1150,7 +1150,7 @@ size_t ZSTD_CCtxParams_getParameter(
     case ZSTD_c_useBlockSplitter :
         *value = (int)CCtxParams->postBlockSplitter;
         break;
-    case ZSTD_c_blockSplitter_level :
+    case ZSTD_c_blockSplitterLevel :
         *value = CCtxParams->preBlockSplitter_level;
         break;
     case ZSTD_c_useRowMatchFinder :

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -603,6 +603,11 @@ ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter param)
         bounds.upperBound = (int)ZSTD_ps_disable;
         return bounds;
 
+    case ZSTD_c_blockSplitter_level:
+        bounds.lowerBound = 0;
+        bounds.upperBound = ZSTD_BLOCKSPLITTER_LEVEL_MAX;
+        return bounds;
+
     case ZSTD_c_useRowMatchFinder:
         bounds.lowerBound = (int)ZSTD_ps_auto;
         bounds.upperBound = (int)ZSTD_ps_disable;
@@ -669,6 +674,7 @@ static int ZSTD_isUpdateAuthorized(ZSTD_cParameter param)
     case ZSTD_c_minMatch:
     case ZSTD_c_targetLength:
     case ZSTD_c_strategy:
+    case ZSTD_c_blockSplitter_level:
         return 1;
 
     case ZSTD_c_format:
@@ -755,6 +761,7 @@ size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)
     case ZSTD_c_blockDelimiters:
     case ZSTD_c_validateSequences:
     case ZSTD_c_useBlockSplitter:
+    case ZSTD_c_blockSplitter_level:
     case ZSTD_c_useRowMatchFinder:
     case ZSTD_c_deterministicRefPrefix:
     case ZSTD_c_prefetchCDictTables:
@@ -980,6 +987,11 @@ size_t ZSTD_CCtxParams_setParameter(ZSTD_CCtx_params* CCtxParams,
         CCtxParams->postBlockSplitter = (ZSTD_paramSwitch_e)value;
         return CCtxParams->postBlockSplitter;
 
+    case ZSTD_c_blockSplitter_level:
+        BOUNDCHECK(ZSTD_c_blockSplitter_level, value);
+        CCtxParams->preBlockSplitter_level = value;
+        return (size_t)CCtxParams->preBlockSplitter_level;
+
     case ZSTD_c_useRowMatchFinder:
         BOUNDCHECK(ZSTD_c_useRowMatchFinder, value);
         CCtxParams->useRowMatchFinder = (ZSTD_paramSwitch_e)value;
@@ -1137,6 +1149,9 @@ size_t ZSTD_CCtxParams_getParameter(
         break;
     case ZSTD_c_useBlockSplitter :
         *value = (int)CCtxParams->postBlockSplitter;
+        break;
+    case ZSTD_c_blockSplitter_level :
+        *value = CCtxParams->preBlockSplitter_level;
         break;
     case ZSTD_c_useRowMatchFinder :
         *value = (int)CCtxParams->useRowMatchFinder;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2114,7 +2114,7 @@ static size_t ZSTD_resetCCtx_internal(ZSTD_CCtx* zc,
 {
     ZSTD_cwksp* const ws = &zc->workspace;
     DEBUGLOG(4, "ZSTD_resetCCtx_internal: pledgedSrcSize=%u, wlog=%u, useRowMatchFinder=%d useBlockSplitter=%d",
-                (U32)pledgedSrcSize, params->cParams.windowLog, (int)params->useRowMatchFinder, (int)params->useBlockSplitter);
+                (U32)pledgedSrcSize, params->cParams.windowLog, (int)params->useRowMatchFinder, (int)params->postBlockSplitter);
     assert(!ZSTD_isError(ZSTD_checkCParams(params->cParams)));
 
     zc->isFirstBlock = 1;
@@ -4520,7 +4520,10 @@ static size_t ZSTD_optimalBlockSize(ZSTD_CCtx* cctx, const void* src, size_t src
      * require verified savings to allow pre-splitting.
      * Note: as a consequence, the first full block is not split.
      */
-    if (savings < 3) return 128 KB;
+    if (savings < 3) {
+        DEBUGLOG(6, "don't attempt splitting: savings (%lli) too low", savings);
+        return 128 KB;
+    }
     /* apply @splitLevel, or use default value (which depends on @strat).
      * note that splitting heuristic is still conditioned by @savings >= 3,
      * so the first block will not reach this code path */

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -4521,7 +4521,7 @@ static size_t ZSTD_optimalBlockSize(ZSTD_CCtx* cctx, const void* src, size_t src
      * Note: as a consequence, the first full block is not split.
      */
     if (savings < 3) {
-        DEBUGLOG(6, "don't attempt splitting: savings (%lli) too low", savings);
+        DEBUGLOG(6, "don't attempt splitting: savings (%i) too low", (int)savings);
         return 128 KB;
     }
     /* apply @splitLevel, or use default value (which depends on @strat).

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -343,8 +343,21 @@ struct ZSTD_CCtx_params_s {
     ZSTD_sequenceFormat_e blockDelimiters;
     int validateSequences;
 
-    /* Block splitting */
-    ZSTD_paramSwitch_e useBlockSplitter;
+    /* Block splitting
+     * @postBlockSplitter executes split analysis after sequences are produced,
+     * it's more accurate but consumes more resources.
+     * @preBlockSplitter_level splits before knowing sequences,
+     * it's more approximative but also cheaper.
+     * Valid @preBlockSplitter_level values range from 0 to 6 (included).
+     * 0 means auto, 1 means do not split,
+     * then levels are sorted in increasing cpu budget, from 2 (fastest) to 6 (slowest).
+     * Highest @preBlockSplitter_level combines well with @postBlockSplitter.
+     */
+    ZSTD_paramSwitch_e postBlockSplitter;
+    int preBlockSplitter_level;
+
+    /* Adjust the max block size*/
+    size_t maxBlockSize;
 
     /* Param for deciding whether to use row-based matchfinder */
     ZSTD_paramSwitch_e useRowMatchFinder;
@@ -367,9 +380,6 @@ struct ZSTD_CCtx_params_s {
      * It is not possible to set these parameters individually through the public API. */
     void* extSeqProdState;
     ZSTD_sequenceProducer_F extSeqProdFunc;
-
-    /* Adjust the max block size*/
-    size_t maxBlockSize;
 
     /* Controls repcode search in external sequence parsing */
     ZSTD_paramSwitch_e searchForExternalRepcodes;

--- a/lib/compress/zstd_preSplit.c
+++ b/lib/compress/zstd_preSplit.c
@@ -229,6 +229,7 @@ size_t ZSTD_splitBlock(const void* blockStart, size_t blockSize,
                     int level,
                     void* workspace, size_t wkspSize)
 {
+    DEBUGLOG(6, "ZSTD_splitBlock (level=%i)", level);
     assert(0<=level && level<=4);
     if (level == 0)
         return ZSTD_splitBlock_fromBorders(blockStart, blockSize, workspace, wkspSize);

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -496,7 +496,7 @@ typedef enum {
      * ZSTD_c_prefetchCDictTables
      * ZSTD_c_enableSeqProducerFallback
      * ZSTD_c_maxBlockSize
-     * ZSTD_c_blockSplitter_level
+     * ZSTD_c_blockSplitterLevel
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -2265,7 +2265,7 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  */
 #define ZSTD_c_searchForExternalRepcodes ZSTD_c_experimentalParam19
 
-/* ZSTD_c_blockSplitter_level
+/* ZSTD_c_blockSplitterLevel
  * note: this parameter only influences the first splitter stage,
  *       which is active before producing the sequences.
  *       ZSTD_c_useBlockSplitter influence the next splitter stage,
@@ -2281,7 +2281,7 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  * to ensure expansion guarantees in presence of incompressible data.
  */
 #define ZSTD_BLOCKSPLITTER_LEVEL_MAX 6
-#define ZSTD_c_blockSplitter_level ZSTD_c_experimentalParam20
+#define ZSTD_c_blockSplitterLevel ZSTD_c_experimentalParam20
 
 /*! ZSTD_CCtx_getParameter() :
  *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -491,12 +491,12 @@ typedef enum {
      * ZSTD_c_stableOutBuffer
      * ZSTD_c_blockDelimiters
      * ZSTD_c_validateSequences
-     * ZSTD_c_useBlockSplitter
+     * ZSTD_c_blockSplitterLevel
+     * ZSTD_c_splitAfterSequences
      * ZSTD_c_useRowMatchFinder
      * ZSTD_c_prefetchCDictTables
      * ZSTD_c_enableSeqProducerFallback
      * ZSTD_c_maxBlockSize
-     * ZSTD_c_blockSplitterLevel
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -2150,8 +2150,32 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  */
 #define ZSTD_c_validateSequences ZSTD_c_experimentalParam12
 
-/* ZSTD_c_useBlockSplitter
- * Controlled with ZSTD_paramSwitch_e enum.
+/* ZSTD_c_blockSplitterLevel
+ * note: this parameter only influences the first splitter stage,
+ *       which is active before producing the sequences.
+ *       ZSTD_c_splitAfterSequences controls the next splitter stage,
+ *       which is active after sequence production.
+ *       Note that both can be combined.
+ * Allowed values are between 0 and ZSTD_BLOCKSPLITTER_LEVEL_MAX included.
+ * 0 means "auto", which will select a value depending on current ZSTD_c_strategy.
+ * 1 means no splitting.
+ * Then, values from 2 to 6 are sorted in increasing cpu load order.
+ *
+ * Note that currently the first block is never split,
+ * to ensure expansion guarantees in presence of incompressible data.
+ */
+#define ZSTD_BLOCKSPLITTER_LEVEL_MAX 6
+#define ZSTD_c_blockSplitterLevel ZSTD_c_experimentalParam20
+
+/* ZSTD_c_splitAfterSequences
+ * This is a stronger splitter algorithm,
+ * based on actual sequences previously produced by the selected parser.
+ * It's also slower, and as a consequence, mostly used for high compression levels.
+ * While the post-splitter does overlap with the pre-splitter,
+ * both can nonetheless be combined,
+ * notably with ZSTD_c_blockSplitterLevel at ZSTD_BLOCKSPLITTER_LEVEL_MAX,
+ * resulting in higher compression ratio than just one of them.
+ *
  * Default is ZSTD_ps_auto.
  * Set to ZSTD_ps_disable to never use block splitter.
  * Set to ZSTD_ps_enable to always use block splitter.
@@ -2159,7 +2183,7 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  * By default, in ZSTD_ps_auto, the library will decide at runtime whether to use
  * block splitting based on the compression parameters.
  */
-#define ZSTD_c_useBlockSplitter ZSTD_c_experimentalParam13
+#define ZSTD_c_splitAfterSequences ZSTD_c_experimentalParam13
 
 /* ZSTD_c_useRowMatchFinder
  * Controlled with ZSTD_paramSwitch_e enum.
@@ -2265,23 +2289,6 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  */
 #define ZSTD_c_searchForExternalRepcodes ZSTD_c_experimentalParam19
 
-/* ZSTD_c_blockSplitterLevel
- * note: this parameter only influences the first splitter stage,
- *       which is active before producing the sequences.
- *       ZSTD_c_useBlockSplitter influence the next splitter stage,
- *       which is active after sequence production,
- *       and is more accurate but also slower.
- *       Both can be combined.
- * Allowed values are between 0 and 6.
- * 0 means "auto", which will select a value depending on current ZSTD_c_strategy.
- * 1 means no splitting.
- * Then, values from 2 to 6 are sorted in increasing cpu load order.
- *
- * Note that currently the first block is never split,
- * to ensure expansion guarantees in presence of incompressible data.
- */
-#define ZSTD_BLOCKSPLITTER_LEVEL_MAX 6
-#define ZSTD_c_blockSplitterLevel ZSTD_c_experimentalParam20
 
 /*! ZSTD_CCtx_getParameter() :
  *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -496,6 +496,7 @@ typedef enum {
      * ZSTD_c_prefetchCDictTables
      * ZSTD_c_enableSeqProducerFallback
      * ZSTD_c_maxBlockSize
+     * ZSTD_c_blockSplitter_level
      * Because they are not stable, it's necessary to define ZSTD_STATIC_LINKING_ONLY to access them.
      * note : never ever use experimentalParam? names directly;
      *        also, the enums values themselves are unstable and can still change.
@@ -518,7 +519,8 @@ typedef enum {
      ZSTD_c_experimentalParam16=1013,
      ZSTD_c_experimentalParam17=1014,
      ZSTD_c_experimentalParam18=1015,
-     ZSTD_c_experimentalParam19=1016
+     ZSTD_c_experimentalParam19=1016,
+     ZSTD_c_experimentalParam20=1017
 } ZSTD_cParameter;
 
 typedef struct {
@@ -2236,7 +2238,6 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  * that overrides the default ZSTD_BLOCKSIZE_MAX. It cannot be used to set upper
  * bounds greater than ZSTD_BLOCKSIZE_MAX or bounds lower than 1KB (will make
  * compressBound() inaccurate). Only currently meant to be used for testing.
- *
  */
 #define ZSTD_c_maxBlockSize ZSTD_c_experimentalParam18
 
@@ -2263,6 +2264,24 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  * set to ZSTD_sf_explicitBlockDelimiters. That may change in the future.
  */
 #define ZSTD_c_searchForExternalRepcodes ZSTD_c_experimentalParam19
+
+/* ZSTD_c_blockSplitter_level
+ * note: this parameter only influences the first splitter stage,
+ *       which is active before producing the sequences.
+ *       ZSTD_c_useBlockSplitter influence the next splitter stage,
+ *       which is active after sequence production,
+ *       and is more accurate but also slower.
+ *       Both can be combined.
+ * Allowed values are between 0 and 6.
+ * 0 means "auto", which will select a value depending on current ZSTD_c_strategy.
+ * 1 means no splitting.
+ * Then, values from 2 to 6 are sorted in increasing cpu load order.
+ *
+ * Note that currently the first block is never split,
+ * to ensure expansion guarantees in presence of incompressible data.
+ */
+#define ZSTD_BLOCKSPLITTER_LEVEL_MAX 6
+#define ZSTD_c_blockSplitter_level ZSTD_c_experimentalParam20
 
 /*! ZSTD_CCtx_getParameter() :
  *  Get the requested compression parameter value, selected by enum ZSTD_cParameter,

--- a/tests/fuzz/zstd_helpers.c
+++ b/tests/fuzz/zstd_helpers.c
@@ -140,7 +140,8 @@ void FUZZ_setRandomParameters(ZSTD_CCtx *cctx, size_t srcSize, FUZZ_dataProducer
     setRand(cctx, ZSTD_c_forceMaxWindow, 0, 1, producer);
     setRand(cctx, ZSTD_c_literalCompressionMode, 0, 2, producer);
     setRand(cctx, ZSTD_c_forceAttachDict, 0, 2, producer);
-    setRand(cctx, ZSTD_c_useBlockSplitter, 0, 2, producer);
+    setRand(cctx, ZSTD_c_blockSplitterLevel, 0, ZSTD_BLOCKSPLITTER_LEVEL_MAX, producer);
+    setRand(cctx, ZSTD_c_splitAfterSequences, 0, 2, producer);
     setRand(cctx, ZSTD_c_deterministicRefPrefix, 0, 1, producer);
     setRand(cctx, ZSTD_c_prefetchCDictTables, 0, 2, producer);
     setRand(cctx, ZSTD_c_maxBlockSize, ZSTD_BLOCKSIZE_MAX_MIN, ZSTD_BLOCKSIZE_MAX, producer);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -576,7 +576,6 @@ static void test_blockSplitter_incompressibleExpansionProtection(unsigned testNb
 
         /* let's fill input with random noise (incompressible) */
         RDG_genBuffer(incompressible, srcSize, 0.0, 0.0, seed);
-        DISPLAYLEVEL(4, "(hash: %llx) ", XXH64(incompressible, srcSize, 0));
 
         /* this pattern targets the fastest _byChunk variant's sampling (level 3).
          * manually checked that, without the @savings protection, it would over-split.

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -595,11 +595,11 @@ static void test_blockSplitter_incompressibleExpansionProtection(unsigned testNb
         }
 
         /* run first without splitting */
-        ZSTD_CCtx_setParameter(cctx, ZSTD_c_blockSplitter_level, 1 /* no split */);
+        ZSTD_CCtx_setParameter(cctx, ZSTD_c_blockSplitterLevel, 1 /* no split */);
         cSizeNoSplit = ZSTD_compress2(cctx, cBuffer, dstCapacity, incompressible, srcSize);
 
         /* run with sample43 splitter, check it's still the same */
-        ZSTD_CCtx_setParameter(cctx, ZSTD_c_blockSplitter_level, 3 /* sample43, fastest _byChunk variant */);
+        ZSTD_CCtx_setParameter(cctx, ZSTD_c_blockSplitterLevel, 3 /* sample43, fastest _byChunk variant */);
         cSizeWithSplit = ZSTD_compress2(cctx, cBuffer, dstCapacity, incompressible, srcSize);
 
         if (cSizeWithSplit != cSizeNoSplit) {

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1420,7 +1420,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 19));
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_minMatch, 7));
-        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_useBlockSplitter, ZSTD_ps_enable));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_splitAfterSequences, ZSTD_ps_enable));
 
         cSize = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, data, srcSize);
         CHECK_Z(cSize);
@@ -1737,8 +1737,8 @@ static int basicUnitTests(U32 const seed, double compressibility)
     {   ZSTD_CCtx* const cctx = ZSTD_createCCtx();
         int value;
         ZSTD_compressionParameters cparams = ZSTD_getCParams(1, 0, 0);
-        cparams.strategy = -1;
-        /* Set invalid cParams == no change. */
+        cparams.strategy = (ZSTD_strategy)-1; /* set invalid value, on purpose */
+        /* Set invalid cParams == error out, and no change. */
         CHECK(ZSTD_isError(ZSTD_CCtx_setCParams(cctx, cparams)));
 
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_windowLog, &value));
@@ -1801,12 +1801,12 @@ static int basicUnitTests(U32 const seed, double compressibility)
         ZSTD_freeCCtx(cctx);
     }
 
-    DISPLAYLEVEL(3, "test%3d : ZSTD_CCtx_setCarams() : ", testNb++);
+    DISPLAYLEVEL(3, "test%3d : ZSTD_CCtx_setParams() : ", testNb++);
     {   ZSTD_CCtx* const cctx = ZSTD_createCCtx();
         int value;
         ZSTD_parameters params = ZSTD_getParams(1, 0, 0);
-        params.cParams.strategy = -1;
-        /* Set invalid params == no change. */
+        params.cParams.strategy = (ZSTD_strategy)-1; /* set invalid value, on purpose */
+        /* Set invalid params == error out, and no change. */
         CHECK(ZSTD_isError(ZSTD_CCtx_setParams(cctx, params)));
 
         CHECK_Z(ZSTD_CCtx_getParameter(cctx, ZSTD_c_windowLog, &value));
@@ -2252,7 +2252,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
 
     DISPLAYLEVEL(3, "test%3i : compress with block splitting : ", testNb++)
     {   ZSTD_CCtx* cctx = ZSTD_createCCtx();
-        CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_c_useBlockSplitter, ZSTD_ps_enable) );
+        CHECK_Z( ZSTD_CCtx_setParameter(cctx, ZSTD_c_splitAfterSequences, ZSTD_ps_enable) );
         cSize = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, CNBuffer, CNBuffSize);
         CHECK_Z(cSize);
         ZSTD_freeCCtx(cctx);


### PR DESCRIPTION
Make it possible to explicit select a block splitter level, via a new `CCtx` parameter `ZSTD_c_blockSplitter_level`.

This capability is then exploited in a test, ensuring that incompressible data is not overly split, even in presence of an adversarial input (with full knowledge of the sampling pattern).

Note: possible follow-up:
This PR just adds a new parameter, to control the behavior of the new block splitter.
It doesn't modify the existing parameters.

But as a consequence, there are now 2 parameters for block splitters,
one (legacy) that is controlling the post block-splitter (after sequences are determined)
and a new one that is controlling the new pre block-splitter (before sequences are produced).
Already, it's debatable if it's useful for a user to be exposed to these concepts.
More importantly, the distinction between pre and post block splitter is not clear from the current parameters' names (`ZSTD_c_useBlockSplitter` vs `ZSTD_c_blockSplitter_level`).

So it opens the question of a refactoring of these parameters.
For example, maybe both parameters could be fused into a single one, the new `ZSTD_c_blockSplitter_level`, that would be charged to enable both when level is high enough.
Or maybe there is still value in keeping both these parameters separated, for example for an optimizer tool which could more naturally influence both code paths and maybe find a better combination for some specific use case. In which case, it's probably still useful to debate about meaningful parameter names.