### PR TITLE
cmake: Fix #4038 MacOS target older OS and SDK versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,9 @@ travis-install:
 .PHONY: clangbuild-darwin-fat
 clangbuild-darwin-fat: clean
 	clang -v
-	CXX=clang++ CC=clang CFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation -arch arm64" $(MAKE) zstd-release
+	CXX=clang++ CC=clang CFLAGS+="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation -arch arm64" $(MAKE) zstd-release
 	mv programs/zstd programs/zstd_arm64
-	CXX=clang++ CC=clang CFLAGS="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation -arch x86_64" $(MAKE) zstd-release
+	CXX=clang++ CC=clang CFLAGS+="-Werror -Wconversion -Wno-sign-conversion -Wdocumentation -arch x86_64" $(MAKE) zstd-release
 	mv programs/zstd programs/zstd_x64
 	lipo -create programs/zstd_x64 programs/zstd_arm64 -output programs/zstd
 


### PR DESCRIPTION
This fix ensures that when `MACOSX_DEPLOYMENT_TARGET` and `SDKROOT` are set, they are respected when building the libraries and executables.

How to test (on a MacOS machine):

You will have to download an older SDK version. In this case I'm using 11.3.

```
export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk
export MACOSX_DEPLOYMENT_TARGET=11.0
make install
otool -l lib/libzstd.1.5.7.dylib
```

The output will include:

```
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 11.0
      sdk 11.3
```

Without this fix, the output will looks something like:

```
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 13.0
      sdk 13.0
```

Depending on the version of MacOS installed and the SDK installed.