### PR TITLE
prevent possible segfault when creating seek table

### DIFF
--- a/contrib/seekable_format/zstdseek_decompress.c
+++ b/contrib/seekable_format/zstdseek_decompress.c
@@ -252,6 +252,8 @@ size_t ZSTD_seekable_free(ZSTD_seekable* zs)
 
 ZSTD_seekTable* ZSTD_seekTable_create_fromSeekable(const ZSTD_seekable* zs)
 {
+    assert(zs != NULL);
+    if (zs->seekTable.entries == NULL) return NULL;
     ZSTD_seekTable* const st = (ZSTD_seekTable*)malloc(sizeof(ZSTD_seekTable));
     if (st==NULL) return NULL;
 


### PR DESCRIPTION
Add a check in `ZSTD_seekTable_create_fromSeekable` whether the seek table of a `ZSTD_seekable` is initialized before creating a new seek table from it. Formerly, the function created a segfault when the seek table of `ZSTD_seekable`was not initialized.

Fixes https://github.com/facebook/zstd/issues/4200