### PR TITLE
tests: fix non-regular file test on GNU/Hurd

### DIFF
--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -109,10 +109,7 @@ isTerminal=${isTerminal:-$detectedTerminal}
 
 isWindows=false
 INTOVOID="/dev/null"
-case "$UNAME" in
-  GNU) DEVDEVICE="/dev/random" ;;
-  *) DEVDEVICE="/dev/zero" ;;
-esac
+DEVDEVICE="/dev/zero"
 case "$OS" in
   Windows*)
     isWindows=true


### PR DESCRIPTION
Since commit b21b03ca6 [1] the behaviour of writes to /dev/zero has been fixed and now the non-regular file removal test no longer needs to be done on /dev/random (which no longer works as random is not writable now).

[1] https://git.savannah.gnu.org/cgit/hurd/hurd.git/commit/?id=b21b03ca624b89caeedfe58430cea4b40317d39f