### PR TITLE
Move #includes out of `extern "C"` blocks

### DIFF
--- a/contrib/pzstd/test/PzstdTest.cpp
+++ b/contrib/pzstd/test/PzstdTest.cpp
@@ -7,9 +7,7 @@
  * in the COPYING file in the root directory of this source tree).
  */
 #include "Pzstd.h"
-extern "C" {
 #include "datagen.h"
-}
 #include "test/RoundTrip.h"
 #include "utils/ScopeGuard.h"
 

--- a/contrib/pzstd/test/RoundTripTest.cpp
+++ b/contrib/pzstd/test/RoundTripTest.cpp
@@ -6,9 +6,7 @@
  * LICENSE file in the root directory of this source tree) and the GPLv2 (found
  * in the COPYING file in the root directory of this source tree).
  */
-extern "C" {
 #include "datagen.h"
-}
 #include "Options.h"
 #include "test/RoundTrip.h"
 #include "utils/ScopeGuard.h"

--- a/contrib/seekable_format/zstd_seekable.h
+++ b/contrib/seekable_format/zstd_seekable.h
@@ -1,12 +1,12 @@
 #ifndef SEEKABLE_H
 #define SEEKABLE_H
 
+#include <stdio.h>
+#include "zstd.h"   /* ZSTDLIB_API */
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
-#include <stdio.h>
-#include "zstd.h"   /* ZSTDLIB_API */
 
 
 #define ZSTD_seekTableFooterSize 9

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -14,9 +14,6 @@
 #ifndef BITSTREAM_H_MODULE
 #define BITSTREAM_H_MODULE
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /*
 *  This API consists of small unitary functions, which must be inlined for best performance.
 *  Since link-time-optimization is not available for all compilers,
@@ -32,7 +29,6 @@ extern "C" {
 #include "error_private.h"  /* error codes and messages */
 #include "bits.h"           /* ZSTD_highbit32 */
 
-
 /*=========================================
 *  Target specific
 =========================================*/
@@ -42,6 +38,10 @@ extern "C" {
 #  elif defined(__ICCARM__)
 #    include <intrinsics.h>
 #  endif
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 #define STREAM_ACCUMULATOR_MIN_32  25

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -40,10 +40,6 @@
 #  endif
 #endif
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #define STREAM_ACCUMULATOR_MIN_32  25
 #define STREAM_ACCUMULATOR_MIN_64  57
 #define STREAM_ACCUMULATOR_MIN    ((U32)(MEM_32bits() ? STREAM_ACCUMULATOR_MIN_32 : STREAM_ACCUMULATOR_MIN_64))
@@ -449,9 +445,5 @@ MEM_STATIC unsigned BIT_endOfDStream(const BIT_DStream_t* DStream)
 {
     return ((DStream->ptr == DStream->start) && (DStream->bitsConsumed == sizeof(DStream->bitContainer)*8));
 }
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* BITSTREAM_H_MODULE */

--- a/lib/common/debug.h
+++ b/lib/common/debug.h
@@ -71,12 +71,9 @@
 #  endif
 #endif
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #if (DEBUGLEVEL>=2)
 #  define ZSTD_DEPS_NEED_IO
+#  include "zstd_deps.h"
 extern int g_debuglevel; /* the variable is only declared,
                             it actually lives in debug.c,
                             and is shared by the whole process.
@@ -105,11 +102,6 @@ extern int g_debuglevel; /* the variable is only declared,
 #else
 #  define RAWLOG(l, ...)   do { } while (0)    /* disabled */
 #  define DEBUGLOG(l, ...) do { } while (0)    /* disabled */
-#endif
-
-
-#if defined (__cplusplus)
-}
 #endif
 
 #endif /* DEBUG_H_12987983217 */

--- a/lib/common/debug.h
+++ b/lib/common/debug.h
@@ -32,10 +32,6 @@
 #ifndef DEBUG_H_12987983217
 #define DEBUG_H_12987983217
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 
 /* static assert is triggered at compile time, leaving no runtime artefact.
  * static assert only works with compile-time constants.
@@ -75,9 +71,12 @@ extern "C" {
 #  endif
 #endif
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #if (DEBUGLEVEL>=2)
 #  define ZSTD_DEPS_NEED_IO
-#  include "zstd_deps.h"
 extern int g_debuglevel; /* the variable is only declared,
                             it actually lives in debug.c,
                             and is shared by the whole process.

--- a/lib/common/error_private.h
+++ b/lib/common/error_private.h
@@ -21,10 +21,6 @@
 #include "debug.h"
 #include "zstd_deps.h"       /* size_t */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* ****************************************
 *  Compiler-specific
 ******************************************/
@@ -158,9 +154,5 @@ void _force_has_format_string(const char *format, ...) {
             return err_code;                                                       \
         }                                                                          \
     } while(0)
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ERROR_H_MODULE */

--- a/lib/common/error_private.h
+++ b/lib/common/error_private.h
@@ -13,11 +13,6 @@
 #ifndef ERROR_H_MODULE
 #define ERROR_H_MODULE
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-
 /* ****************************************
 *  Dependencies
 ******************************************/
@@ -26,6 +21,9 @@ extern "C" {
 #include "debug.h"
 #include "zstd_deps.h"       /* size_t */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* ****************************************
 *  Compiler-specific

--- a/lib/common/fse.h
+++ b/lib/common/fse.h
@@ -11,11 +11,6 @@
  * in the COPYING file in the root directory of this source tree).
  * You may select, at your option, one of the above-listed licenses.
 ****************************************************************** */
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #ifndef FSE_H
 #define FSE_H
 
@@ -25,6 +20,14 @@ extern "C" {
 ******************************************/
 #include "zstd_deps.h"    /* size_t, ptrdiff_t */
 
+#if defined(FSE_STATIC_LINKING_ONLY) && !defined(FSE_H_FSE_STATIC_LINKING_ONLY)
+#define FSE_H_FSE_STATIC_LINKING_ONLY
+#include "bitstream.h"
+#endif 
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /*-*****************************************
 *  FSE_PUBLIC_API : control library symbols visibility
@@ -232,9 +235,6 @@ If there is an error, the function will return an error code, which can be teste
 
 #if defined(FSE_STATIC_LINKING_ONLY) && !defined(FSE_H_FSE_STATIC_LINKING_ONLY)
 #define FSE_H_FSE_STATIC_LINKING_ONLY
-
-/* *** Dependency *** */
-#include "bitstream.h"
 
 
 /* *****************************************

--- a/lib/common/fse.h
+++ b/lib/common/fse.h
@@ -20,11 +20,6 @@
 ******************************************/
 #include "zstd_deps.h"    /* size_t, ptrdiff_t */
 
-#if defined(FSE_STATIC_LINKING_ONLY) && !defined(FSE_H_FSE_STATIC_LINKING_ONLY)
-#define FSE_H_FSE_STATIC_LINKING_ONLY
-#include "bitstream.h"
-#endif 
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -230,12 +225,16 @@ FSE_decompress_usingDTable() result will tell how many bytes were regenerated (<
 If there is an error, the function will return an error code, which can be tested using FSE_isError(). (ex: dst buffer too small)
 */
 
+#if defined (__cplusplus)
+}
+#endif
+
 #endif  /* FSE_H */
 
 
 #if defined(FSE_STATIC_LINKING_ONLY) && !defined(FSE_H_FSE_STATIC_LINKING_ONLY)
 #define FSE_H_FSE_STATIC_LINKING_ONLY
-
+#include "bitstream.h"
 
 /* *****************************************
 *  Static allocation
@@ -257,6 +256,10 @@ If there is an error, the function will return an error code, which can be teste
 /* *****************************************
  *  FSE advanced API
  ***************************************** */
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 unsigned FSE_optimalTableLog_internal(unsigned maxTableLog, size_t srcSize, unsigned maxSymbolValue, unsigned minus);
 /**< same as FSE_optimalTableLog(), which used `minus==2` */
@@ -631,10 +634,8 @@ MEM_STATIC unsigned FSE_endOfDState(const FSE_DState_t* DStatePtr)
 
 #define FSE_TABLESTEP(tableSize) (((tableSize)>>1) + ((tableSize)>>3) + 3)
 
-
-#endif /* FSE_STATIC_LINKING_ONLY */
-
-
 #if defined (__cplusplus)
 }
 #endif
+
+#endif /* FSE_STATIC_LINKING_ONLY */

--- a/lib/common/fse.h
+++ b/lib/common/fse.h
@@ -20,10 +20,6 @@
 ******************************************/
 #include "zstd_deps.h"    /* size_t, ptrdiff_t */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /*-*****************************************
 *  FSE_PUBLIC_API : control library symbols visibility
 ******************************************/
@@ -225,10 +221,6 @@ FSE_decompress_usingDTable() result will tell how many bytes were regenerated (<
 If there is an error, the function will return an error code, which can be tested using FSE_isError(). (ex: dst buffer too small)
 */
 
-#if defined (__cplusplus)
-}
-#endif
-
 #endif  /* FSE_H */
 
 
@@ -256,10 +248,6 @@ If there is an error, the function will return an error code, which can be teste
 /* *****************************************
  *  FSE advanced API
  ***************************************** */
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
 
 unsigned FSE_optimalTableLog_internal(unsigned maxTableLog, size_t srcSize, unsigned maxSymbolValue, unsigned minus);
 /**< same as FSE_optimalTableLog(), which used `minus==2` */
@@ -633,9 +621,5 @@ MEM_STATIC unsigned FSE_endOfDState(const FSE_DState_t* DStatePtr)
 #endif
 
 #define FSE_TABLESTEP(tableSize) (((tableSize)>>1) + ((tableSize)>>3) + 3)
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* FSE_STATIC_LINKING_ONLY */

--- a/lib/common/huf.h
+++ b/lib/common/huf.h
@@ -21,10 +21,6 @@
 #define FSE_STATIC_LINKING_ONLY
 #include "fse.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* ***   Tool functions *** */
 #define HUF_BLOCKSIZE_MAX (128 * 1024)   /**< maximum input size for a single block compressed with HUF_compress */
 size_t HUF_compressBound(size_t size);   /**< maximum compressed size (worst case) */
@@ -276,10 +272,6 @@ size_t HUF_readDTableX1_wksp(HUF_DTable* DTable, const void* src, size_t srcSize
 #endif
 #ifndef HUF_FORCE_DECOMPRESS_X1
 size_t HUF_readDTableX2_wksp(HUF_DTable* DTable, const void* src, size_t srcSize, void* workSpace, size_t wkspSize, int flags);
-#endif
-
-#if defined (__cplusplus)
-}
 #endif
 
 #endif   /* HUF_H_298734234 */

--- a/lib/common/huf.h
+++ b/lib/common/huf.h
@@ -278,8 +278,8 @@ size_t HUF_readDTableX1_wksp(HUF_DTable* DTable, const void* src, size_t srcSize
 size_t HUF_readDTableX2_wksp(HUF_DTable* DTable, const void* src, size_t srcSize, void* workSpace, size_t wkspSize, int flags);
 #endif
 
-#endif   /* HUF_H_298734234 */
-
 #if defined (__cplusplus)
 }
 #endif
+
+#endif   /* HUF_H_298734234 */

--- a/lib/common/huf.h
+++ b/lib/common/huf.h
@@ -12,10 +12,6 @@
  * You may select, at your option, one of the above-listed licenses.
 ****************************************************************** */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #ifndef HUF_H_298734234
 #define HUF_H_298734234
 
@@ -25,6 +21,9 @@ extern "C" {
 #define FSE_STATIC_LINKING_ONLY
 #include "fse.h"
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* ***   Tool functions *** */
 #define HUF_BLOCKSIZE_MAX (128 * 1024)   /**< maximum input size for a single block compressed with HUF_compress */

--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -11,10 +11,6 @@
 #ifndef MEM_H_MODULE
 #define MEM_H_MODULE
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /*-****************************************
 *  Dependencies
 ******************************************/
@@ -76,6 +72,10 @@ extern "C" {
   typedef   signed long long  S64;
 #endif
 
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /*-**************************************************************
 *  Memory I/O API

--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -72,11 +72,6 @@
   typedef   signed long long  S64;
 #endif
 
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /*-**************************************************************
 *  Memory I/O API
 *****************************************************************/
@@ -423,10 +418,5 @@ MEM_STATIC void MEM_writeBEST(void* memPtr, size_t val)
 
 /* code only tested on 32 and 64 bits systems */
 MEM_STATIC void MEM_check(void) { DEBUG_STATIC_ASSERT((sizeof(size_t)==4) || (sizeof(size_t)==8)); }
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* MEM_H_MODULE */

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -11,14 +11,14 @@
 #ifndef POOL_H
 #define POOL_H
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 
 #include "zstd_deps.h"
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_customMem */
 #include "../zstd.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 typedef struct POOL_ctx_s POOL_ctx;
 

--- a/lib/common/pool.h
+++ b/lib/common/pool.h
@@ -16,10 +16,6 @@
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_customMem */
 #include "../zstd.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 typedef struct POOL_ctx_s POOL_ctx;
 
 /*! POOL_create() :
@@ -81,10 +77,5 @@ void POOL_add(POOL_ctx* ctx, POOL_function function, void* opaque);
  * @return : 1 if successful, 0 if not.
  */
 int POOL_tryAdd(POOL_ctx* ctx, POOL_function function, void* opaque);
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif

--- a/lib/common/threading.h
+++ b/lib/common/threading.h
@@ -140,7 +140,6 @@ int ZSTD_pthread_cond_destroy(ZSTD_pthread_cond_t* cond);
 #else  /* ZSTD_MULTITHREAD not defined */
 /* No multithreading support */
 
-
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -160,10 +159,11 @@ typedef int ZSTD_pthread_cond_t;
 
 /* do not use ZSTD_pthread_t */
 
-#endif /* ZSTD_MULTITHREAD */
-
 #if defined (__cplusplus)
 }
 #endif
+
+#endif /* ZSTD_MULTITHREAD */
+
 
 #endif /* THREADING_H_938743 */

--- a/lib/common/threading.h
+++ b/lib/common/threading.h
@@ -16,10 +16,6 @@
 
 #include "debug.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #if defined(ZSTD_MULTITHREAD) && defined(_WIN32)
 
 /**
@@ -60,6 +56,11 @@ extern "C" {
 #define ZSTD_pthread_cond_signal(a)     WakeConditionVariable((a))
 #define ZSTD_pthread_cond_broadcast(a)  WakeAllConditionVariable((a))
 
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 /* ZSTD_pthread_create() and ZSTD_pthread_join() */
 typedef HANDLE ZSTD_pthread_t;
 
@@ -73,9 +74,18 @@ int ZSTD_pthread_join(ZSTD_pthread_t thread);
  */
 
 
+#if defined (__cplusplus)
+}
+#endif
+
 #elif defined(ZSTD_MULTITHREAD)    /* posix assumed ; need a better detection method */
 /* ===   POSIX Systems   === */
 #  include <pthread.h>
+
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 #if DEBUGLEVEL < 1
 
@@ -123,8 +133,17 @@ int ZSTD_pthread_cond_destroy(ZSTD_pthread_cond_t* cond);
 
 #endif
 
+#if defined (__cplusplus)
+}
+#endif
+
 #else  /* ZSTD_MULTITHREAD not defined */
 /* No multithreading support */
+
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 typedef int ZSTD_pthread_mutex_t;
 #define ZSTD_pthread_mutex_init(a, b)   ((void)(a), (void)(b), 0)

--- a/lib/common/threading.h
+++ b/lib/common/threading.h
@@ -56,11 +56,6 @@
 #define ZSTD_pthread_cond_signal(a)     WakeConditionVariable((a))
 #define ZSTD_pthread_cond_broadcast(a)  WakeAllConditionVariable((a))
 
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* ZSTD_pthread_create() and ZSTD_pthread_join() */
 typedef HANDLE ZSTD_pthread_t;
 
@@ -73,19 +68,9 @@ int ZSTD_pthread_join(ZSTD_pthread_t thread);
  * add here more wrappers as required
  */
 
-
-#if defined (__cplusplus)
-}
-#endif
-
 #elif defined(ZSTD_MULTITHREAD)    /* posix assumed ; need a better detection method */
 /* ===   POSIX Systems   === */
 #  include <pthread.h>
-
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
 
 #if DEBUGLEVEL < 1
 
@@ -133,16 +118,8 @@ int ZSTD_pthread_cond_destroy(ZSTD_pthread_cond_t* cond);
 
 #endif
 
-#if defined (__cplusplus)
-}
-#endif
-
 #else  /* ZSTD_MULTITHREAD not defined */
 /* No multithreading support */
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
 
 typedef int ZSTD_pthread_mutex_t;
 #define ZSTD_pthread_mutex_init(a, b)   ((void)(a), (void)(b), 0)
@@ -158,10 +135,6 @@ typedef int ZSTD_pthread_cond_t;
 #define ZSTD_pthread_cond_broadcast(a)  ((void)(a))
 
 /* do not use ZSTD_pthread_t */
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_MULTITHREAD */
 

--- a/lib/common/xxhash.h
+++ b/lib/common/xxhash.h
@@ -227,10 +227,6 @@
  * xxHash prototypes and implementation
  */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* ****************************
  *  INLINE mode
  ******************************/
@@ -537,6 +533,9 @@ extern "C" {
 /*! @brief Version number, encoded as two digits each */
 #define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @brief Obtains the xxHash version.
  *
@@ -547,6 +546,9 @@ extern "C" {
  */
 XXH_PUBLIC_API XXH_CONSTF unsigned XXH_versionNumber (void);
 
+#if defined (__cplusplus)
+}
+#endif
 
 /* ****************************
 *  Common basic types
@@ -591,6 +593,10 @@ typedef uint32_t XXH32_hash_t;
 #   else
 #     error "unsupported platform: need a 32-bit type"
 #   endif
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 /*!
@@ -821,6 +827,9 @@ XXH_PUBLIC_API XXH_PUREF XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canoni
 #endif
 /*! @endcond */
 
+#if defined (__cplusplus)
+} /* end of extern "C" */
+#endif
 
 /*!
  * @}
@@ -859,6 +868,9 @@ typedef uint64_t XXH64_hash_t;
 #  endif
 #endif
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @}
  *
@@ -1562,6 +1574,11 @@ XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH128_hashFromCanonical(XXH_NOESCAPE con
 
 
 #endif  /* !XXH_NO_XXH3 */
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif  /* XXH_NO_LONG_LONG */
 
 /*!
@@ -1747,6 +1764,10 @@ struct XXH3_state_s {
         tmp_xxh3_state_ptr->extSecret = NULL;                \
     } while(0)
 
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /*!
  * @brief Calculates the 128-bit hash of @p data using XXH3.
@@ -1963,8 +1984,13 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
                                      XXH64_hash_t seed64);
 #endif /* !XXH_NO_STREAM */
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif  /* !XXH_NO_XXH3 */
 #endif  /* XXH_NO_LONG_LONG */
+
 #if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
 #  define XXH_IMPLEMENTATION
 #endif
@@ -2263,10 +2289,12 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
  * @{
  */
 
-
 /* *************************************
 *  Includes & Memory related functions
 ***************************************/
+#include <string.h>   /* memcmp, memcpy */
+#include <limits.h>   /* ULLONG_MAX */
+
 #if defined(XXH_NO_STREAM)
 /* nothing */
 #elif defined(XXH_NO_STDLIB)
@@ -2280,8 +2308,16 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
  * without access to dynamic allocation.
  */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 static XXH_CONSTF void* XXH_malloc(size_t s) { (void)s; return NULL; }
 static void XXH_free(void* p) { (void)p; }
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 
 #else
 
@@ -2291,6 +2327,9 @@ static void XXH_free(void* p) { (void)p; }
  */
 #include <stdlib.h>
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @internal
  * @brief Modify this function to use a different routine than malloc().
@@ -2303,10 +2342,15 @@ static XXH_MALLOCF void* XXH_malloc(size_t s) { return malloc(s); }
  */
 static void XXH_free(void* p) { free(p); }
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif  /* XXH_NO_STDLIB */
 
-#include <string.h>
-
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @internal
  * @brief Modify this function to use a different routine than memcpy().
@@ -2316,8 +2360,9 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
     return memcpy(dest,src,size);
 }
 
-#include <limits.h>   /* ULLONG_MAX */
-
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 
 /* *************************************
 *  Compiler Specific Options
@@ -2450,6 +2495,10 @@ typedef XXH32_hash_t xxh_u32;
 #  define BYTE xxh_u8
 #  define U8   xxh_u8
 #  define U32  xxh_u32
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 /* ***   Memory access   *** */
@@ -3608,6 +3657,10 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
     return XXH_readBE64(src);
 }
 
+#if defined (__cplusplus)
+}
+#endif
+
 #ifndef XXH_NO_XXH3
 
 /* *********************************************************************
@@ -3928,6 +3981,10 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  pragma GCC optimize("-O2")
 #endif
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #if XXH_VECTOR == XXH_NEON
 
 /*
@@ -4050,6 +4107,10 @@ XXH_vmlal_high_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
 # endif
 #endif  /* XXH_VECTOR == XXH_NEON */
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 /*
  * VSX and Z Vector helpers.
  *
@@ -4111,6 +4172,9 @@ typedef xxh_u64x2 xxh_aliasing_u64x2 XXH_ALIASING;
 #  if defined(__POWER9_VECTOR__) || (defined(__clang__) && defined(__s390x__))
 #    define XXH_vec_revb vec_revb
 #  else
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * A polyfill for POWER9's vec_revb().
  */
@@ -4120,9 +4184,15 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_revb(xxh_u64x2 val)
                                   0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08 };
     return vec_perm(val, val, vByteSwap);
 }
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 #  endif
 # endif /* XXH_VSX_BE */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * Performs an unaligned vector load and byte swaps it on big endian.
  */
@@ -4167,6 +4237,11 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mule(xxh_u32x4 a, xxh_u32x4 b)
     return result;
 }
 # endif /* XXH_vec_mulo, XXH_vec_mule */
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif /* XXH_VECTOR == XXH_VSX */
 
 #if XXH_VECTOR == XXH_SVE
@@ -4200,7 +4275,9 @@ do { \
 #  endif
 #endif  /* XXH_NO_PREFETCH */
 
-
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /* ==========================================
  * XXH3 default settings
  * ========================================== */
@@ -6877,8 +6954,6 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (XXH_NOESCAPE const XXH3_state_
 #endif /* !XXH_NO_STREAM */
 /* 128-bit utility functions */
 
-#include <string.h>   /* memcmp, memcpy */
-
 /* return : 1 is equal, 0 if different */
 /*! @ingroup XXH3_family */
 XXH_PUBLIC_API int XXH128_isEqual(XXH128_hash_t h1, XXH128_hash_t h2)
@@ -7007,14 +7082,13 @@ XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed)
 
 #endif  /* XXH_NO_LONG_LONG */
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif  /* XXH_NO_XXH3 */
 
 /*!
  * @}
  */
 #endif  /* XXH_IMPLEMENTATION */
-
-
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif

--- a/lib/common/xxhash.h
+++ b/lib/common/xxhash.h
@@ -533,6 +533,9 @@
 /*! @brief Version number, encoded as two digits each */
 #define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @brief Obtains the xxHash version.
  *
@@ -542,6 +545,10 @@
  * @return @ref XXH_VERSION_NUMBER of the invoked library.
  */
 XXH_PUBLIC_API XXH_CONSTF unsigned XXH_versionNumber (void);
+
+#if defined (__cplusplus)
+}
+#endif
 
 /* ****************************
 *  Common basic types
@@ -586,6 +593,10 @@ typedef uint32_t XXH32_hash_t;
 #   else
 #     error "unsupported platform: need a 32-bit type"
 #   endif
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 /*!
@@ -816,6 +827,10 @@ XXH_PUBLIC_API XXH_PUREF XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canoni
 #endif
 /*! @endcond */
 
+#if defined (__cplusplus)
+} /* end of extern "C" */
+#endif
+
 /*!
  * @}
  * @ingroup public
@@ -853,6 +868,9 @@ typedef uint64_t XXH64_hash_t;
 #  endif
 #endif
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @}
  *
@@ -1557,6 +1575,10 @@ XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH128_hashFromCanonical(XXH_NOESCAPE con
 
 #endif  /* !XXH_NO_XXH3 */
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif  /* XXH_NO_LONG_LONG */
 
 /*!
@@ -1741,6 +1763,11 @@ struct XXH3_state_s {
         tmp_xxh3_state_ptr->seed = 0;                        \
         tmp_xxh3_state_ptr->extSecret = NULL;                \
     } while(0)
+
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /*!
  * @brief Calculates the 128-bit hash of @p data using XXH3.
@@ -1956,6 +1983,10 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
                                      XXH_NOESCAPE const void* secret, size_t secretSize,
                                      XXH64_hash_t seed64);
 #endif /* !XXH_NO_STREAM */
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 
 #endif  /* !XXH_NO_XXH3 */
 #endif  /* XXH_NO_LONG_LONG */
@@ -2277,8 +2308,16 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
  * without access to dynamic allocation.
  */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 static XXH_CONSTF void* XXH_malloc(size_t s) { (void)s; return NULL; }
 static void XXH_free(void* p) { (void)p; }
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 
 #else
 
@@ -2288,6 +2327,9 @@ static void XXH_free(void* p) { (void)p; }
  */
 #include <stdlib.h>
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @internal
  * @brief Modify this function to use a different routine than malloc().
@@ -2300,8 +2342,15 @@ static XXH_MALLOCF void* XXH_malloc(size_t s) { return malloc(s); }
  */
 static void XXH_free(void* p) { free(p); }
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif  /* XXH_NO_STDLIB */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * @internal
  * @brief Modify this function to use a different routine than memcpy().
@@ -2310,6 +2359,10 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 {
     return memcpy(dest,src,size);
 }
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 
 /* *************************************
 *  Compiler Specific Options
@@ -2442,6 +2495,10 @@ typedef XXH32_hash_t xxh_u32;
 #  define BYTE xxh_u8
 #  define U8   xxh_u8
 #  define U32  xxh_u32
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 /* ***   Memory access   *** */
@@ -3600,6 +3657,10 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
     return XXH_readBE64(src);
 }
 
+#if defined (__cplusplus)
+}
+#endif
+
 #ifndef XXH_NO_XXH3
 
 /* *********************************************************************
@@ -3920,6 +3981,10 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  pragma GCC optimize("-O2")
 #endif
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #if XXH_VECTOR == XXH_NEON
 
 /*
@@ -4042,6 +4107,10 @@ XXH_vmlal_high_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
 # endif
 #endif  /* XXH_VECTOR == XXH_NEON */
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 /*
  * VSX and Z Vector helpers.
  *
@@ -4103,6 +4172,9 @@ typedef xxh_u64x2 xxh_aliasing_u64x2 XXH_ALIASING;
 #  if defined(__POWER9_VECTOR__) || (defined(__clang__) && defined(__s390x__))
 #    define XXH_vec_revb vec_revb
 #  else
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * A polyfill for POWER9's vec_revb().
  */
@@ -4112,9 +4184,15 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_revb(xxh_u64x2 val)
                                   0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08 };
     return vec_perm(val, val, vByteSwap);
 }
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 #  endif
 # endif /* XXH_VSX_BE */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /*!
  * Performs an unaligned vector load and byte swaps it on big endian.
  */
@@ -4160,6 +4238,10 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mule(xxh_u32x4 a, xxh_u32x4 b)
 }
 # endif /* XXH_vec_mulo, XXH_vec_mule */
 
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
+
 #endif /* XXH_VECTOR == XXH_VSX */
 
 #if XXH_VECTOR == XXH_SVE
@@ -4193,6 +4275,9 @@ do { \
 #  endif
 #endif  /* XXH_NO_PREFETCH */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 /* ==========================================
  * XXH3 default settings
  * ========================================== */
@@ -6993,6 +7078,11 @@ XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed)
   && defined(__GNUC__) && !defined(__clang__) /* GCC, not Clang */ \
   && defined(__OPTIMIZE__) && XXH_SIZE_OPT <= 0 /* respect -O0 and -Os */
 #  pragma GCC pop_options
+#endif
+
+
+#if defined (__cplusplus)
+} /* extern "C" */
 #endif
 
 #endif  /* XXH_NO_LONG_LONG */

--- a/lib/common/xxhash.h
+++ b/lib/common/xxhash.h
@@ -533,9 +533,6 @@
 /*! @brief Version number, encoded as two digits each */
 #define XXH_VERSION_NUMBER  (XXH_VERSION_MAJOR *100*100 + XXH_VERSION_MINOR *100 + XXH_VERSION_RELEASE)
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /*!
  * @brief Obtains the xxHash version.
  *
@@ -545,10 +542,6 @@ extern "C" {
  * @return @ref XXH_VERSION_NUMBER of the invoked library.
  */
 XXH_PUBLIC_API XXH_CONSTF unsigned XXH_versionNumber (void);
-
-#if defined (__cplusplus)
-}
-#endif
 
 /* ****************************
 *  Common basic types
@@ -593,10 +586,6 @@ typedef uint32_t XXH32_hash_t;
 #   else
 #     error "unsupported platform: need a 32-bit type"
 #   endif
-#endif
-
-#if defined (__cplusplus)
-extern "C" {
 #endif
 
 /*!
@@ -827,10 +816,6 @@ XXH_PUBLIC_API XXH_PUREF XXH32_hash_t XXH32_hashFromCanonical(const XXH32_canoni
 #endif
 /*! @endcond */
 
-#if defined (__cplusplus)
-} /* end of extern "C" */
-#endif
-
 /*!
  * @}
  * @ingroup public
@@ -868,9 +853,6 @@ typedef uint64_t XXH64_hash_t;
 #  endif
 #endif
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /*!
  * @}
  *
@@ -1575,10 +1557,6 @@ XXH_PUBLIC_API XXH_PUREF XXH128_hash_t XXH128_hashFromCanonical(XXH_NOESCAPE con
 
 #endif  /* !XXH_NO_XXH3 */
 
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
-
 #endif  /* XXH_NO_LONG_LONG */
 
 /*!
@@ -1763,11 +1741,6 @@ struct XXH3_state_s {
         tmp_xxh3_state_ptr->seed = 0;                        \
         tmp_xxh3_state_ptr->extSecret = NULL;                \
     } while(0)
-
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
 
 /*!
  * @brief Calculates the 128-bit hash of @p data using XXH3.
@@ -1983,10 +1956,6 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
                                      XXH_NOESCAPE const void* secret, size_t secretSize,
                                      XXH64_hash_t seed64);
 #endif /* !XXH_NO_STREAM */
-
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
 
 #endif  /* !XXH_NO_XXH3 */
 #endif  /* XXH_NO_LONG_LONG */
@@ -2308,16 +2277,8 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
  * without access to dynamic allocation.
  */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 static XXH_CONSTF void* XXH_malloc(size_t s) { (void)s; return NULL; }
 static void XXH_free(void* p) { (void)p; }
-
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
 
 #else
 
@@ -2327,9 +2288,6 @@ static void XXH_free(void* p) { (void)p; }
  */
 #include <stdlib.h>
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /*!
  * @internal
  * @brief Modify this function to use a different routine than malloc().
@@ -2342,15 +2300,8 @@ static XXH_MALLOCF void* XXH_malloc(size_t s) { return malloc(s); }
  */
 static void XXH_free(void* p) { free(p); }
 
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
-
 #endif  /* XXH_NO_STDLIB */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /*!
  * @internal
  * @brief Modify this function to use a different routine than memcpy().
@@ -2359,10 +2310,6 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
 {
     return memcpy(dest,src,size);
 }
-
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
 
 /* *************************************
 *  Compiler Specific Options
@@ -2495,10 +2442,6 @@ typedef XXH32_hash_t xxh_u32;
 #  define BYTE xxh_u8
 #  define U8   xxh_u8
 #  define U32  xxh_u32
-#endif
-
-#if defined (__cplusplus)
-extern "C" {
 #endif
 
 /* ***   Memory access   *** */
@@ -3657,10 +3600,6 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
     return XXH_readBE64(src);
 }
 
-#if defined (__cplusplus)
-}
-#endif
-
 #ifndef XXH_NO_XXH3
 
 /* *********************************************************************
@@ -3981,10 +3920,6 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
 #  pragma GCC optimize("-O2")
 #endif
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #if XXH_VECTOR == XXH_NEON
 
 /*
@@ -4107,10 +4042,6 @@ XXH_vmlal_high_u32(uint64x2_t acc, uint32x4_t lhs, uint32x4_t rhs)
 # endif
 #endif  /* XXH_VECTOR == XXH_NEON */
 
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
-
 /*
  * VSX and Z Vector helpers.
  *
@@ -4172,9 +4103,6 @@ typedef xxh_u64x2 xxh_aliasing_u64x2 XXH_ALIASING;
 #  if defined(__POWER9_VECTOR__) || (defined(__clang__) && defined(__s390x__))
 #    define XXH_vec_revb vec_revb
 #  else
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /*!
  * A polyfill for POWER9's vec_revb().
  */
@@ -4184,15 +4112,9 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_revb(xxh_u64x2 val)
                                   0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08 };
     return vec_perm(val, val, vByteSwap);
 }
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
 #  endif
 # endif /* XXH_VSX_BE */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /*!
  * Performs an unaligned vector load and byte swaps it on big endian.
  */
@@ -4238,10 +4160,6 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mule(xxh_u32x4 a, xxh_u32x4 b)
 }
 # endif /* XXH_vec_mulo, XXH_vec_mule */
 
-#if defined (__cplusplus)
-} /* extern "C" */
-#endif
-
 #endif /* XXH_VECTOR == XXH_VSX */
 
 #if XXH_VECTOR == XXH_SVE
@@ -4275,9 +4193,6 @@ do { \
 #  endif
 #endif  /* XXH_NO_PREFETCH */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 /* ==========================================
  * XXH3 default settings
  * ========================================== */
@@ -7078,11 +6993,6 @@ XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed)
   && defined(__GNUC__) && !defined(__clang__) /* GCC, not Clang */ \
   && defined(__OPTIMIZE__) && XXH_SIZE_OPT <= 0 /* respect -O0 and -Os */
 #  pragma GCC pop_options
-#endif
-
-
-#if defined (__cplusplus)
-} /* extern "C" */
 #endif
 
 #endif  /* XXH_NO_LONG_LONG */

--- a/lib/common/xxhash.h
+++ b/lib/common/xxhash.h
@@ -7080,12 +7080,12 @@ XXH3_generateSecret_fromSeed(XXH_NOESCAPE void* secretBuffer, XXH64_hash_t seed)
 #  pragma GCC pop_options
 #endif
 
-#endif  /* XXH_NO_LONG_LONG */
 
 #if defined (__cplusplus)
 } /* extern "C" */
 #endif
 
+#endif  /* XXH_NO_LONG_LONG */
 #endif  /* XXH_NO_XXH3 */
 
 /*!

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -39,10 +39,6 @@
 #  define ZSTD_TRACE 0
 #endif
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* ---- static assert (debug) --- */
 #define ZSTD_STATIC_ASSERT(c) DEBUG_STATIC_ASSERT(c)
 #define ZSTD_isError ERR_isError   /* for inlining */
@@ -384,9 +380,5 @@ MEM_STATIC int ZSTD_cpuSupportsBmi2(void)
     ZSTD_cpuid_t cpuid = ZSTD_cpuid();
     return ZSTD_cpuid_bmi1(cpuid) && ZSTD_cpuid_bmi2(cpuid);
 }
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif   /* ZSTD_CCOMMON_H_MODULE */

--- a/lib/common/zstd_trace.h
+++ b/lib/common/zstd_trace.h
@@ -13,10 +13,6 @@
 
 #include <stddef.h>
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* weak symbol support
  * For now, enable conservatively:
  * - Only GNUC
@@ -156,9 +152,5 @@ ZSTD_WEAK_ATTR void ZSTD_trace_decompress_end(
     ZSTD_Trace const* trace);
 
 #endif /* ZSTD_TRACE */
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_TRACE_H */

--- a/lib/common/zstd_trace.h
+++ b/lib/common/zstd_trace.h
@@ -11,11 +11,11 @@
 #ifndef ZSTD_TRACE_H
 #define ZSTD_TRACE_H
 
+#include <stddef.h>
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
-#include <stddef.h>
 
 /* weak symbol support
  * For now, enable conservatively:

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -26,10 +26,6 @@
 #include "../common/bits.h" /* ZSTD_highbit32, ZSTD_NbCommonBytes */
 #include "zstd_preSplit.h" /* ZSTD_SLIPBLOCK_WORKSPACESIZE */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /*-*************************************
 *  Constants
 ***************************************/
@@ -1425,10 +1421,6 @@ MEM_STATIC int ZSTD_comparePackedTags(size_t packedTag1, size_t packedTag2) {
     U32 const tag2 = packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK;
     return tag1 == tag2;
 }
-
-#if defined (__cplusplus)
-}
-#endif
 
 /* ===============================================================
  * Shared internal declarations

--- a/lib/compress/zstd_cwksp.h
+++ b/lib/compress/zstd_cwksp.h
@@ -19,10 +19,6 @@
 #include "../common/portability_macros.h"
 #include "../common/compiler.h" /* ZS2_isPower2 */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /*-*************************************
 *  Constants
 ***************************************/
@@ -765,9 +761,5 @@ MEM_STATIC void ZSTD_cwksp_bump_oversized_duration(
         ws->workspaceOversizedDuration = 0;
     }
 }
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_CWKSP_H */

--- a/lib/compress/zstd_double_fast.h
+++ b/lib/compress/zstd_double_fast.h
@@ -11,12 +11,12 @@
 #ifndef ZSTD_DOUBLE_FAST_H
 #define ZSTD_DOUBLE_FAST_H
 
+#include "../common/mem.h"      /* U32 */
+#include "zstd_compress_internal.h"     /* ZSTD_CCtx, size_t */
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
-#include "../common/mem.h"      /* U32 */
-#include "zstd_compress_internal.h"     /* ZSTD_CCtx, size_t */
 
 #ifndef ZSTD_EXCLUDE_DFAST_BLOCK_COMPRESSOR
 

--- a/lib/compress/zstd_double_fast.h
+++ b/lib/compress/zstd_double_fast.h
@@ -14,10 +14,6 @@
 #include "../common/mem.h"      /* U32 */
 #include "zstd_compress_internal.h"     /* ZSTD_CCtx, size_t */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #ifndef ZSTD_EXCLUDE_DFAST_BLOCK_COMPRESSOR
 
 void ZSTD_fillDoubleHashTable(ZSTD_matchState_t* ms,
@@ -42,9 +38,5 @@ size_t ZSTD_compressBlock_doubleFast_extDict(
 #define ZSTD_COMPRESSBLOCK_DOUBLEFAST_DICTMATCHSTATE NULL
 #define ZSTD_COMPRESSBLOCK_DOUBLEFAST_EXTDICT NULL
 #endif /* ZSTD_EXCLUDE_DFAST_BLOCK_COMPRESSOR */
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_DOUBLE_FAST_H */

--- a/lib/compress/zstd_fast.h
+++ b/lib/compress/zstd_fast.h
@@ -11,12 +11,12 @@
 #ifndef ZSTD_FAST_H
 #define ZSTD_FAST_H
 
+#include "../common/mem.h"      /* U32 */
+#include "zstd_compress_internal.h"
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
-#include "../common/mem.h"      /* U32 */
-#include "zstd_compress_internal.h"
 
 void ZSTD_fillHashTable(ZSTD_matchState_t* ms,
                         void const* end, ZSTD_dictTableLoadMethod_e dtlm,

--- a/lib/compress/zstd_fast.h
+++ b/lib/compress/zstd_fast.h
@@ -14,10 +14,6 @@
 #include "../common/mem.h"      /* U32 */
 #include "zstd_compress_internal.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 void ZSTD_fillHashTable(ZSTD_matchState_t* ms,
                         void const* end, ZSTD_dictTableLoadMethod_e dtlm,
                         ZSTD_tableFillPurpose_e tfp);
@@ -30,9 +26,5 @@ size_t ZSTD_compressBlock_fast_dictMatchState(
 size_t ZSTD_compressBlock_fast_extDict(
         ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
         void const* src, size_t srcSize);
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_FAST_H */

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -13,10 +13,6 @@
 
 #include "zstd_compress_internal.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /**
  * Dedicated Dictionary Search Structure bucket log. In the
  * ZSTD_dedicatedDictSearch mode, the hashTable has
@@ -192,11 +188,6 @@ size_t ZSTD_compressBlock_btlazy2_extDict(
 #define ZSTD_COMPRESSBLOCK_BTLAZY2 NULL
 #define ZSTD_COMPRESSBLOCK_BTLAZY2_DICTMATCHSTATE NULL
 #define ZSTD_COMPRESSBLOCK_BTLAZY2_EXTDICT NULL
-#endif
-
-
-#if defined (__cplusplus)
-}
 #endif
 
 #endif /* ZSTD_LAZY_H */

--- a/lib/compress/zstd_lazy.h
+++ b/lib/compress/zstd_lazy.h
@@ -11,11 +11,11 @@
 #ifndef ZSTD_LAZY_H
 #define ZSTD_LAZY_H
 
+#include "zstd_compress_internal.h"
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
-#include "zstd_compress_internal.h"
 
 /**
  * Dedicated Dictionary Search Structure bucket log. In the

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -11,12 +11,12 @@
 #ifndef ZSTD_LDM_H
 #define ZSTD_LDM_H
 
+#include "zstd_compress_internal.h"   /* ldmParams_t, U32 */
+#include "../zstd.h"   /* ZSTD_CCtx, size_t */
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
-#include "zstd_compress_internal.h"   /* ldmParams_t, U32 */
-#include "../zstd.h"   /* ZSTD_CCtx, size_t */
 
 /*-*************************************
 *  Long distance matching

--- a/lib/compress/zstd_ldm.h
+++ b/lib/compress/zstd_ldm.h
@@ -14,10 +14,6 @@
 #include "zstd_compress_internal.h"   /* ldmParams_t, U32 */
 #include "../zstd.h"   /* ZSTD_CCtx, size_t */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /*-*************************************
 *  Long distance matching
 ***************************************/
@@ -109,9 +105,5 @@ size_t ZSTD_ldm_getMaxNbSeq(ldmParams_t params, size_t maxChunkSize);
  */
 void ZSTD_ldm_adjustParameters(ldmParams_t* params,
                                ZSTD_compressionParameters const* cParams);
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_FAST_H */

--- a/lib/compress/zstd_opt.h
+++ b/lib/compress/zstd_opt.h
@@ -11,11 +11,11 @@
 #ifndef ZSTD_OPT_H
 #define ZSTD_OPT_H
 
+#include "zstd_compress_internal.h"
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
-#include "zstd_compress_internal.h"
 
 #if !defined(ZSTD_EXCLUDE_BTLAZY2_BLOCK_COMPRESSOR) \
  || !defined(ZSTD_EXCLUDE_BTOPT_BLOCK_COMPRESSOR) \

--- a/lib/compress/zstd_opt.h
+++ b/lib/compress/zstd_opt.h
@@ -13,10 +13,6 @@
 
 #include "zstd_compress_internal.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #if !defined(ZSTD_EXCLUDE_BTLAZY2_BLOCK_COMPRESSOR) \
  || !defined(ZSTD_EXCLUDE_BTOPT_BLOCK_COMPRESSOR) \
  || !defined(ZSTD_EXCLUDE_BTULTRA_BLOCK_COMPRESSOR)
@@ -71,10 +67,6 @@ size_t ZSTD_compressBlock_btultra2(
 #define ZSTD_COMPRESSBLOCK_BTULTRA_DICTMATCHSTATE NULL
 #define ZSTD_COMPRESSBLOCK_BTULTRA_EXTDICT NULL
 #define ZSTD_COMPRESSBLOCK_BTULTRA2 NULL
-#endif
-
-#if defined (__cplusplus)
-}
 #endif
 
 #endif /* ZSTD_OPT_H */

--- a/lib/compress/zstd_preSplit.h
+++ b/lib/compress/zstd_preSplit.h
@@ -13,10 +13,6 @@
 
 #include <stddef.h>  /* size_t */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #define ZSTD_SLIPBLOCK_WORKSPACESIZE 8208
 
 /* ZSTD_splitBlock():
@@ -33,9 +29,5 @@ extern "C" {
 size_t ZSTD_splitBlock(const void* blockStart, size_t blockSize,
                     int level,
                     void* workspace, size_t wkspSize);
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_PRESPLIT_H */

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -16,11 +16,6 @@
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_parameters */
 #include "../zstd.h"            /* ZSTD_inBuffer, ZSTD_outBuffer, ZSTDLIB_API */
 
- #if defined (__cplusplus)
- extern "C" {
- #endif
-
-
 /* Note : This is an internal API.
  *        These APIs used to be exposed with ZSTDLIB_API,
  *        because it used to be the only way to invoke MT compression.
@@ -103,10 +98,5 @@ void ZSTDMT_updateCParams_whileCompressing(ZSTDMT_CCtx* mtctx, const ZSTD_CCtx_p
  *  able to count progression inside worker threads.
  */
 ZSTD_frameProgression ZSTDMT_getFrameProgression(ZSTDMT_CCtx* mtctx);
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif   /* ZSTDMT_COMPRESS_H */

--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -11,6 +11,11 @@
  #ifndef ZSTDMT_COMPRESS_H
  #define ZSTDMT_COMPRESS_H
 
+/* ===   Dependencies   === */
+#include "../common/zstd_deps.h"   /* size_t */
+#define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_parameters */
+#include "../zstd.h"            /* ZSTD_inBuffer, ZSTD_outBuffer, ZSTDLIB_API */
+
  #if defined (__cplusplus)
  extern "C" {
  #endif
@@ -24,12 +29,6 @@
  *        This API requires ZSTD_MULTITHREAD to be defined during compilation,
  *        otherwise ZSTDMT_createCCtx*() will fail.
  */
-
-/* ===   Dependencies   === */
-#include "../common/zstd_deps.h"   /* size_t */
-#define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_parameters */
-#include "../zstd.h"            /* ZSTD_inBuffer, ZSTD_outBuffer, ZSTDLIB_API */
-
 
 /* ===   Constants   === */
 #ifndef ZSTDMT_NBWORKERS_MAX /* a different value can be selected at compile time */

--- a/lib/dictBuilder/divsufsort.h
+++ b/lib/dictBuilder/divsufsort.h
@@ -27,11 +27,6 @@
 #ifndef _DIVSUFSORT_H
 #define _DIVSUFSORT_H 1
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-
 /*- Prototypes -*/
 
 /**
@@ -58,10 +53,5 @@ divsufsort(const unsigned char *T, int *SA, int n, int openMP);
  */
 int
 divbwt(const unsigned char *T, unsigned char *U, int *A, int n, unsigned char * num_indexes, int * indexes, int openMP);
-
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif /* __cplusplus */
 
 #endif /* _DIVSUFSORT_H */

--- a/lib/zdict.h
+++ b/lib/zdict.h
@@ -271,10 +271,18 @@ ZDICTLIB_API size_t ZDICT_getDictHeaderSize(const void* dictBuffer, size_t dictS
 ZDICTLIB_API unsigned ZDICT_isError(size_t errorCode);
 ZDICTLIB_API const char* ZDICT_getErrorName(size_t errorCode);
 
+#if defined (__cplusplus)
+}
+#endif
+
 #endif   /* ZSTD_ZDICT_H */
 
 #if defined(ZDICT_STATIC_LINKING_ONLY) && !defined(ZSTD_ZDICT_H_STATIC)
 #define ZSTD_ZDICT_H_STATIC
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* This can be overridden externally to hide static symbols. */
 #ifndef ZDICTLIB_STATIC_API
@@ -466,9 +474,8 @@ ZDICTLIB_STATIC_API
 size_t ZDICT_addEntropyTablesFromBuffer(void* dictBuffer, size_t dictContentSize, size_t dictBufferCapacity,
                                   const void* samplesBuffer, const size_t* samplesSizes, unsigned nbSamples);
 
-
-#endif   /* ZSTD_ZDICT_H_STATIC */
-
 #if defined (__cplusplus)
 }
 #endif
+
+#endif   /* ZSTD_ZDICT_H_STATIC */

--- a/lib/zdict.h
+++ b/lib/zdict.h
@@ -8,16 +8,16 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #ifndef ZSTD_ZDICT_H
 #define ZSTD_ZDICT_H
+
 
 /*======  Dependencies  ======*/
 #include <stddef.h>  /* size_t */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* =====   ZDICTLIB_API : control library symbols visibility   ===== */
 #ifndef ZDICTLIB_VISIBLE

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -7,16 +7,22 @@
  * in the COPYING file in the root directory of this source tree).
  * You may select, at your option, one of the above-listed licenses.
  */
-#if defined (__cplusplus)
-extern "C" {
-#endif
 
 #ifndef ZSTD_H_235446
 #define ZSTD_H_235446
 
+
 /* ======   Dependencies   ======*/
 #include <stddef.h>   /* size_t */
 
+#include "zstd_errors.h" /* list of errors */
+#if defined(ZSTD_STATIC_LINKING_ONLY) && !defined(ZSTD_H_ZSTD_STATIC_LINKING_ONLY)
+#include <limits.h>   /* INT_MAX */
+#endif /* ZSTD_STATIC_LINKING_ONLY */
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* =====   ZSTDLIB_API : control library symbols visibility   ===== */
 #ifndef ZSTDLIB_VISIBLE
@@ -240,7 +246,6 @@ ZSTDLIB_API size_t ZSTD_compressBound(size_t srcSize); /*!< maximum compressed s
 
 
 /*======  Error helper functions  ======*/
-#include "zstd_errors.h" /* list of errors */
 /* ZSTD_isError() :
  * Most ZSTD_* functions returning a size_t value can be tested for error,
  * using ZSTD_isError().
@@ -1214,8 +1219,6 @@ ZSTDLIB_API size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 #if defined(ZSTD_STATIC_LINKING_ONLY) && !defined(ZSTD_H_ZSTD_STATIC_LINKING_ONLY)
 #define ZSTD_H_ZSTD_STATIC_LINKING_ONLY
-
-#include <limits.h>   /* INT_MAX */
 
 /* This can be overridden externally to hide static symbols. */
 #ifndef ZSTDLIB_STATIC_API

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -1205,6 +1205,10 @@ ZSTDLIB_API size_t ZSTD_sizeof_DStream(const ZSTD_DStream* zds);
 ZSTDLIB_API size_t ZSTD_sizeof_CDict(const ZSTD_CDict* cdict);
 ZSTDLIB_API size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
+#if defined (__cplusplus)
+}
+#endif
+
 #endif  /* ZSTD_H_235446 */
 
 
@@ -1219,6 +1223,10 @@ ZSTDLIB_API size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict);
 
 #if defined(ZSTD_STATIC_LINKING_ONLY) && !defined(ZSTD_H_ZSTD_STATIC_LINKING_ONLY)
 #define ZSTD_H_ZSTD_STATIC_LINKING_ONLY
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* This can be overridden externally to hide static symbols. */
 #ifndef ZSTDLIB_STATIC_API
@@ -3138,8 +3146,8 @@ ZSTDLIB_STATIC_API size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx, void* dst, size_
 ZSTD_DEPRECATED("The block API is deprecated in favor of the normal compression API. See docs.")
 ZSTDLIB_STATIC_API size_t ZSTD_insertBlock    (ZSTD_DCtx* dctx, const void* blockStart, size_t blockSize);  /**< insert uncompressed block into `dctx` history. Useful for multi-blocks decompression. */
 
-#endif   /* ZSTD_H_ZSTD_STATIC_LINKING_ONLY */
-
 #if defined (__cplusplus)
 }
 #endif
+
+#endif   /* ZSTD_H_ZSTD_STATIC_LINKING_ONLY */

--- a/programs/benchfn.h
+++ b/programs/benchfn.h
@@ -15,16 +15,16 @@
  * or detecting and returning an error
  */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #ifndef BENCH_FN_H_23876
 #define BENCH_FN_H_23876
 
 /* ===  Dependencies  === */
 #include <stddef.h>   /* size_t */
 
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* ====  Benchmark any function, iterated on a set of blocks  ==== */
 

--- a/programs/benchfn.h
+++ b/programs/benchfn.h
@@ -21,11 +21,6 @@
 /* ===  Dependencies  === */
 #include <stddef.h>   /* size_t */
 
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* ====  Benchmark any function, iterated on a set of blocks  ==== */
 
 /* BMK_runTime_t: valid result return type */
@@ -175,9 +170,4 @@ typedef union {
 } BMK_timedFnState_shell;
 BMK_timedFnState_t* BMK_initStatic_timedFnState(void* buffer, size_t size, unsigned total_ms, unsigned run_ms);
 
-
 #endif   /* BENCH_FN_H_23876 */
-
-#if defined (__cplusplus)
-}
-#endif

--- a/programs/benchzstd.h
+++ b/programs/benchzstd.h
@@ -14,10 +14,6 @@
   * and display progress result and final summary
   */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #ifndef BENCH_ZSTD_H_3242387
 #define BENCH_ZSTD_H_3242387
 
@@ -26,6 +22,10 @@ extern "C" {
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_compressionParameters */
 #include "../lib/zstd.h"     /* ZSTD_compressionParameters */
 
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /* ===  Constants  === */
 

--- a/programs/benchzstd.h
+++ b/programs/benchzstd.h
@@ -22,11 +22,6 @@
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_compressionParameters */
 #include "../lib/zstd.h"     /* ZSTD_compressionParameters */
 
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* ===  Constants  === */
 
 #define MB_UNIT 1000000
@@ -194,7 +189,3 @@ BMK_benchOutcome_t BMK_benchMemAdvanced(const void* srcBuffer, size_t srcSize,
 
 
 #endif   /* BENCH_ZSTD_H_3242387 */
-
-#if defined (__cplusplus)
-}
-#endif

--- a/programs/datagen.h
+++ b/programs/datagen.h
@@ -14,6 +14,10 @@
 
 #include <stddef.h>   /* size_t */
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 void RDG_genStdout(unsigned long long size, double matchProba, double litProba, unsigned seed);
 void RDG_genBuffer(void* buffer, size_t size, double matchProba, double litProba, unsigned seed);
 /*!RDG_genBuffer
@@ -26,5 +30,9 @@ void RDG_genBuffer(void* buffer, size_t size, double matchProba, double litProba
    RDG_genStdout
    Same as RDG_genBuffer, but generates data into stdout
 */
+
+#if defined (__cplusplus)
+} /* extern "C" */
+#endif
 
 #endif

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -17,11 +17,6 @@
 #define ZSTD_STATIC_LINKING_ONLY   /* ZSTD_compressionParameters */
 #include "../lib/zstd.h"           /* ZSTD_* */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-
 /* *************************************
 *  Special i/o constants
 **************************************/
@@ -172,10 +167,5 @@ void FIO_addAbortHandler(void);
 char const* FIO_zlibVersion(void);
 char const* FIO_lz4Version(void);
 char const* FIO_lzmaVersion(void);
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif  /* FILEIO_H_23981798732 */

--- a/programs/fileio_asyncio.h
+++ b/programs/fileio_asyncio.h
@@ -22,10 +22,6 @@
 #ifndef ZSTD_FILEIO_ASYNCIO_H
 #define ZSTD_FILEIO_ASYNCIO_H
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #include "../lib/common/mem.h"     /* U32, U64 */
 #include "fileio_types.h"
 #include "platform.h"
@@ -34,6 +30,10 @@ extern "C" {
 #include "../lib/common/threading.h"
 
 #define MAX_IO_JOBS          (10)
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 typedef struct {
     /* These struct fields should be set only on creation and not changed afterwards */

--- a/programs/fileio_asyncio.h
+++ b/programs/fileio_asyncio.h
@@ -31,10 +31,6 @@
 
 #define MAX_IO_JOBS          (10)
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 typedef struct {
     /* These struct fields should be set only on creation and not changed afterwards */
     POOL_ctx* threadPool;
@@ -195,9 +191,5 @@ FILE* AIO_ReadPool_getFile(const ReadPoolCtx_t *ctx);
 /* AIO_ReadPool_closeFile:
  * Closes the current set file. Waits for all current enqueued tasks to complete and resets state. */
 int AIO_ReadPool_closeFile(ReadPoolCtx_t *ctx);
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZSTD_FILEIO_ASYNCIO_H */

--- a/programs/fileio_common.h
+++ b/programs/fileio_common.h
@@ -23,10 +23,6 @@
 #   include <windows.h>
 #endif
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /*-*************************************
 *  Macros
 ***************************************/
@@ -124,7 +120,4 @@ extern UTIL_time_t g_displayClock;
 #   define LONG_TELL ftell
 #endif
 
-#if defined (__cplusplus)
-}
-#endif
 #endif /* ZSTD_FILEIO_COMMON_H */

--- a/programs/fileio_common.h
+++ b/programs/fileio_common.h
@@ -11,14 +11,21 @@
 #ifndef ZSTD_FILEIO_COMMON_H
 #define ZSTD_FILEIO_COMMON_H
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #include "../lib/common/mem.h"     /* U32, U64 */
 #include "fileio_types.h"
 #include "platform.h"
 #include "timefn.h"     /* UTIL_getTime, UTIL_clockSpanMicro */
+
+#if !(defined(_MSC_VER) && _MSC_VER >= 1400) \
+    && !(!defined(__64BIT__) && (PLATFORM_POSIX_VERSION >= 200112L)) \
+    && !(defined(__MINGW32__) && !defined(__STRICT_ANSI__) && !defined(__NO_MINGW_LFS) && defined(__MSVCRT__)) \
+    && (defined(_WIN32) && !defined(__DJGPP__))
+#   include <windows.h>
+#endif
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
 
 /*-*************************************
 *  Macros
@@ -89,7 +96,6 @@ extern UTIL_time_t g_displayClock;
 #   define LONG_SEEK fseeko64
 #   define LONG_TELL ftello64
 #elif defined(_WIN32) && !defined(__DJGPP__)
-#   include <windows.h>
     static int LONG_SEEK(FILE* file, __int64 offset, int origin) {
         LARGE_INTEGER off;
         DWORD method;

--- a/programs/fileio_common.h
+++ b/programs/fileio_common.h
@@ -16,13 +16,6 @@
 #include "platform.h"
 #include "timefn.h"     /* UTIL_getTime, UTIL_clockSpanMicro */
 
-#if !(defined(_MSC_VER) && _MSC_VER >= 1400) \
-    && !(!defined(__64BIT__) && (PLATFORM_POSIX_VERSION >= 200112L)) \
-    && !(defined(__MINGW32__) && !defined(__STRICT_ANSI__) && !defined(__NO_MINGW_LFS) && defined(__MSVCRT__)) \
-    && (defined(_WIN32) && !defined(__DJGPP__))
-#   include <windows.h>
-#endif
-
 /*-*************************************
 *  Macros
 ***************************************/
@@ -92,6 +85,7 @@ extern UTIL_time_t g_displayClock;
 #   define LONG_SEEK fseeko64
 #   define LONG_TELL ftello64
 #elif defined(_WIN32) && !defined(__DJGPP__)
+#   include <windows.h>
     static int LONG_SEEK(FILE* file, __int64 offset, int origin) {
         LARGE_INTEGER off;
         DWORD method;

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -11,12 +11,6 @@
 #ifndef PLATFORM_H_MODULE
 #define PLATFORM_H_MODULE
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-
-
 /* **************************************
 *  Compiler Options
 ****************************************/
@@ -144,10 +138,20 @@ extern "C" {
 #  include <io.h>      /* _isatty */
 #  include <windows.h> /* DeviceIoControl, HANDLE, FSCTL_SET_SPARSE */
 #  include <stdio.h>   /* FILE */
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 static __inline int IS_CONSOLE(FILE* stdStream) {
     DWORD dummy;
     return _isatty(_fileno(stdStream)) && GetConsoleMode((HANDLE)_get_osfhandle(_fileno(stdStream)), &dummy);
 }
+
+#if defined (__cplusplus)
+}
+#endif
+
 #else
 #  define IS_CONSOLE(stdStream) 0
 #endif
@@ -208,11 +212,6 @@ static __inline int IS_CONSOLE(FILE* stdStream) {
 #  else
 #     define ZSTD_NANOSLEEP_SUPPORT 0
 #  endif
-#endif
-
-
-#if defined (__cplusplus)
-}
 #endif
 
 #endif /* PLATFORM_H_MODULE */

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -26,11 +26,6 @@
   typedef unsigned long long PTime;  /* does not support compilers without long long support */
 #endif
 
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 /* UTIL_time_t contains a nanosecond time counter.
  * The absolute value is not meaningful.
  * It's only valid to compute the difference between 2 measurements. */
@@ -60,10 +55,5 @@ PTime UTIL_getSpanTimeMicro(UTIL_time_t clockStart, UTIL_time_t clockEnd);
 PTime UTIL_clockSpanMicro(UTIL_time_t clockStart);
 
 #define SEC_TO_MICRO ((PTime)1000000)  /* nb of microseconds in a second */
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* TIME_FN_H_MODULE_287987 */

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -11,12 +11,6 @@
 #ifndef TIME_FN_H_MODULE_287987
 #define TIME_FN_H_MODULE_287987
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-
-
 /*-****************************************
 *  Types
 ******************************************/
@@ -30,6 +24,11 @@ extern "C" {
   typedef uint64_t           PTime;  /* Precise Time */
 #else
   typedef unsigned long long PTime;  /* does not support compilers without long long support */
+#endif
+
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 /* UTIL_time_t contains a nanosecond time counter.

--- a/programs/util.c
+++ b/programs/util.c
@@ -8,11 +8,6 @@
  * You may select, at your option, one of the above-listed licenses.
  */
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-
 /*-****************************************
 *  Dependencies
 ******************************************/
@@ -1646,7 +1641,3 @@ int UTIL_countLogicalCores(void)
 {
     return UTIL_countCores(1);
 }
-
-#if defined (__cplusplus)
-}
-#endif

--- a/programs/util.h
+++ b/programs/util.h
@@ -20,6 +20,9 @@
 #include <sys/types.h>    /* stat, utime */
 #include <sys/stat.h>     /* stat, chmod */
 #include "../lib/common/mem.h"          /* U64 */
+#if not (defined(_MSC_VER) || defined(__MINGW32__) || defined (__MSVCRT__))
+#include <libgen.h>
+#endif
 
 /*-************************************************************
 *  Fix fseek()'s 2GiB barrier with MSVC, macOS, *BSD, MinGW
@@ -116,7 +119,6 @@ int UTIL_requireUserConfirmation(const char* prompt, const char* abortMsg, const
 #define STRDUP(s) _strdup(s)
 #else
 #define PATH_SEP '/'
-#include <libgen.h>
 #define STRDUP(s) strdup(s)
 #endif
 

--- a/programs/util.h
+++ b/programs/util.h
@@ -20,7 +20,7 @@
 #include <sys/types.h>    /* stat, utime */
 #include <sys/stat.h>     /* stat, chmod */
 #include "../lib/common/mem.h"          /* U64 */
-#if not (defined(_MSC_VER) || defined(__MINGW32__) || defined (__MSVCRT__))
+#if !(defined(_MSC_VER) || defined(__MINGW32__) || defined (__MSVCRT__))
 #include <libgen.h>
 #endif
 

--- a/zlibWrapper/zstd_zlibwrapper.h
+++ b/zlibWrapper/zstd_zlibwrapper.h
@@ -11,11 +11,6 @@
 #ifndef ZSTD_ZLIBWRAPPER_H
 #define ZSTD_ZLIBWRAPPER_H
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-
 #define ZLIB_CONST
 #define Z_PREFIX
 #define ZLIB_INTERNAL   /* disables gz*64 functions but fixes zlib 1.2.4 with Z_PREFIX */
@@ -27,6 +22,11 @@ extern "C" {
 
 #if !defined(_Z_OF)
     #define _Z_OF OF
+#endif
+
+
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
 /* returns a string with version of zstd library */


### PR DESCRIPTION
Do some include shuffling for `**.h` files within lib, programs, tests, and zlibWrapper. `lib/legacy` and `lib/deprecated` are untouched.
`#include`s within `extern "C"` blocks in .cpp files are untouched.

todo: shuffling for `xxhash.h`

I have no way of exhaustively testing this... CI to the rescue?