### PR TITLE
[fix] Added UNAME_TARGET_SYSTEM to make shared lib compile flag selection configurable

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -110,9 +110,6 @@ ifndef BUILD_DIR
 # determine BUILD_DIR from compilation flags
 
 libzstd.a:
-	@echo uname_target $(UNAME_TARGET)
-	@echo target_system $(TARGET_SYSTEM)
-	@echo uname $(uname)
 	$(SET_CACHE_DIRECTORY)
 
 else

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -73,13 +73,15 @@ endif
 
 # macOS linker doesn't support -soname, and use different extension
 # see : https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryDesignGuidelines.html
-ifeq ($(UNAME), Darwin)
+UNAME_TARGET_SYSTEM ?= $(UNAME)
+
+ifeq ($(UNAME_TARGET_SYSTEM), Darwin)
   SHARED_EXT = dylib
   SHARED_EXT_MAJOR = $(LIBVER_MAJOR).$(SHARED_EXT)
   SHARED_EXT_VER = $(LIBVER).$(SHARED_EXT)
   SONAME_FLAGS = -install_name $(LIBDIR)/libzstd.$(SHARED_EXT_MAJOR) -compatibility_version $(LIBVER_MAJOR) -current_version $(LIBVER)
 else
-  ifeq ($(UNAME), AIX)
+  ifeq ($(UNAME_TARGET_SYSTEM), AIX)
     SONAME_FLAGS =
   else
     SONAME_FLAGS = -Wl,-soname=libzstd.$(SHARED_EXT).$(LIBVER_MAJOR)
@@ -108,6 +110,9 @@ ifndef BUILD_DIR
 # determine BUILD_DIR from compilation flags
 
 libzstd.a:
+	@echo uname_target $(UNAME_TARGET)
+	@echo target_system $(TARGET_SYSTEM)
+	@echo uname $(uname)
 	$(SET_CACHE_DIRECTORY)
 
 else


### PR DESCRIPTION
Fixes #4219 by adding `UNAME_TARGET_SYSTEM` which, when not set, defaults to `UNAME`.