### PR TITLE
Fix ZSTD_readSkippableFrame with NULL dst

### DIFF
--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -622,7 +622,7 @@ size_t ZSTD_readSkippableFrame(void* dst, size_t dstCapacity,
         /* check input validity */
         RETURN_ERROR_IF(!ZSTD_isSkippableFrame(src, srcSize), frameParameter_unsupported, "");
         RETURN_ERROR_IF(skippableFrameSize < ZSTD_SKIPPABLEHEADERSIZE || skippableFrameSize > srcSize, srcSize_wrong, "");
-        RETURN_ERROR_IF(skippableContentSize > dstCapacity, dstSize_tooSmall, "");
+        RETURN_ERROR_IF(skippableContentSize > dstCapacity && dst != NULL, dstSize_tooSmall, "");
 
         /* deliver payload */
         if (skippableContentSize > 0  && dst != NULL)


### PR DESCRIPTION
Summary:
ZSTD_readSkippableFrame supports a NULL dst in the business logic but asserts if the frame size is greater than dst capacity. If dst is NULL, then dst capacity should be irrelevant.

Test Plan:
Read a skippable frame with a NULL dst just to get the frame size.