### PR TITLE
[MSVC] Wrong define checked when building for 64bit with Visual Studio

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -309,7 +309,7 @@ FORCE_INLINE_TEMPLATE size_t BIT_getMiddleBits(BitContainerType bitContainer, U3
      * such cpus old (pre-Haswell, 2013) and their performance is not of that
      * importance.
      */
-#if defined(__x86_64__) || defined(_M_X86)
+#if defined(__x86_64__) || defined(_M_X64)
     return (bitContainer >> (start & regMask)) & ((((U64)1) << nbBits) - 1);
 #else
     return (bitContainer >> (start & regMask)) & BIT_mask[nbBits];


### PR DESCRIPTION
Should check defined(_M_X64) not defined(_M_X86) when building with MSVC.

_M_X86 is only defined under MSVC 32Bit
_M_X64 is only defined under MSVC 64Bit