### PR TITLE
benchmark mode specifies nb of threads with -v

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1312,7 +1312,8 @@ int main(int argCount, const char* argv[])
         nbWorkers = default_nbThreads();
       }
     }
-    DISPLAYLEVEL(4, "Compressing with %u worker threads \n", nbWorkers);
+    if (operation != zom_bench)
+        DISPLAYLEVEL(4, "Compressing with %u worker threads \n", nbWorkers);
 #else
     (void)singleThread; (void)nbWorkers; (void)defaultLogicalCores;
 #endif
@@ -1397,13 +1398,19 @@ int main(int argCount, const char* argv[])
         if (cLevel > ZSTD_maxCLevel()) cLevel = ZSTD_maxCLevel();
         if (cLevelLast > ZSTD_maxCLevel()) cLevelLast = ZSTD_maxCLevel();
         if (cLevelLast < cLevel) cLevelLast = cLevel;
-        if (cLevelLast > cLevel)
-            DISPLAYLEVEL(3, "Benchmarking levels from %d to %d\n", cLevel, cLevelLast);
+        DISPLAYLEVEL(3, "Benchmarking ");
+        if (filenames->tableSize > 1)
+            DISPLAYLEVEL(3, "%u files ", (unsigned)filenames->tableSize);
+        if (cLevelLast > cLevel) {
+            DISPLAYLEVEL(3, "from level %d to %d ", cLevel, cLevelLast);
+        } else {
+            DISPLAYLEVEL(3, "at level %d ", cLevel);
+        }
+        DISPLAYLEVEL(3, "using %i threads \n", nbWorkers);
         if (filenames->tableSize > 0) {
             if(separateFiles) {
                 unsigned i;
                 for(i = 0; i < filenames->tableSize; i++) {
-                    DISPLAYLEVEL(3, "Benchmarking %s \n", filenames->fileNames[i]);
                     operationResult = BMK_benchFilesAdvanced(&filenames->fileNames[i], 1, dictFileName, cLevel, cLevelLast, &compressionParams, g_displayLevel, &benchParams);
                 }
             } else {


### PR DESCRIPTION
Now that the benchmark mode uses the same default nb of threads as normal CLI compression, it's no longer obvious how many threads are being used in benchmark. This can lead to incorrect conclusions, when comparing the benchmark result with earlier versions, which always use 1 thread by default.

With this PR, this information is displayed if the benchmark mode `-b` is combined with verbose output `-v`.

Example : 
```
zstd -bv
Benchmarking at level 3 using 2 threads
 3#Lorem ipsum       :  10000000 ->   2983345 (x3.352),  205.2 MB/s,  866.3 MB/s

./zstd -b1e3v -S dirCalgary/b*    
Benchmarking 3 files from level 1 to 3 using 2 threads
 1#bib               :    111261 ->     40381 (x2.755),  266.2 MB/s, 1032.0 MB/s
 2#bib               :    111261 ->     39081 (x2.847),  243.3 MB/s   861.6 MB/s
 3#bib               :    111261 ->     37034 (x3.004),  196.4 MB/s   929.7 MB/s
 1#book1             :    768771 ->    349758 (x2.198),  161.5 MB/s, 1067.2 MB/s
 2#book1             :    768771 ->    317887 (x2.418),  139.5 MB/s,  824.2 MB/s
 3#book1             :    768771 ->    305288 (x2.518),  116.3 MB/s,  745.0 MB/s
 1#book2             :    610856 ->    228144 (x2.678),  238.9 MB/s, 1019.8 MB/s
 2#book2             :    610856 ->    215190 (x2.839),  182.4 MB/s,  860.3 MB/s
 3#book2             :    610856 ->    203784 (x2.998),  150.9 MB/s,  849.8 MB/s
```

compared to `dev` : 
```
zstd -bv                                   
 3#Lorem ipsum       :  10000000 ->   2983345 (x3.352),  201.4 MB/s,  866.1 MB/s

zstd -b1e3v -S dirCalgary/b* 
Benchmarking levels from 1 to 3
Benchmarking /home/cyan/dev/bench/dirCalgary/bib 
 1#bib               :    111261 ->     40381 (x2.755),  267.1 MB/s, 1029.1 MB/s
 2#bib               :    111261 ->     39081 (x2.847),  245.2 MB/s   863.5 MB/s
 3#bib               :    111261 ->     37034 (x3.004),  194.7 MB/s   925.5 MB/s
Benchmarking /home/cyan/dev/bench/dirCalgary/book1 
 1#book1             :    768771 ->    349758 (x2.198),  204.3 MB/s, 1057.3 MB/s
 2#book1             :    768771 ->    317887 (x2.418),  133.5 MB/s,  822.4 MB/s
 3#book1             :    768771 ->    305288 (x2.518),  113.9 MB/s,  743.3 MB/s
Benchmarking /home/cyan/dev/bench/dirCalgary/book2 
 1#book2             :    610856 ->    228144 (x2.678),  229.4 MB/s, 1025.0 MB/s
 2#book2             :    610856 ->    215190 (x2.839),  182.2 MB/s,  859.0 MB/s
 3#book2             :    610856 ->    203784 (x2.998),  152.8 MB/s,  854.1 MB/s

```