### PR TITLE
fixed an obvious macro name typo

### DIFF
--- a/programs/platform.h
+++ b/programs/platform.h
@@ -32,7 +32,7 @@
 #if defined __ia64 || defined _M_IA64                                                                               /* Intel Itanium */ \
   || defined __powerpc64__ || defined __ppc64__ || defined __PPC64__                                                /* POWER 64-bit */  \
   || (defined __sparc && (defined __sparcv9 || defined __sparc_v9__ || defined __arch64__)) || defined __sparc64__  /* SPARC 64-bit */  \
-  || defined __x86_64__s || defined _M_X64                                                                          /* x86 64-bit */    \
+  || defined __x86_64__ || defined _M_X64                                                                           /* x86 64-bit */    \
   || defined __arm64__ || defined __aarch64__ || defined __ARM64_ARCH_8__                                           /* ARM 64-bit */    \
   || (defined __mips  && (__mips == 64 || __mips == 4 || __mips == 3))                                              /* MIPS 64-bit */   \
   || defined _LP64 || defined __LP64__ /* NetBSD, OpenBSD */ || defined __64BIT__ /* AIX */ || defined _ADDR64 /* Cray */               \


### PR DESCRIPTION
it seems there was no consequence, but it's nonetheless better fixed