### PR TITLE
fix ci tests

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install gcc-powerpc-linux-gnu gcc-arm-linux-gnueabi gcc-aarch64-linux-gnu libc6-dev-ppc64-powerpc-cross libcurl4-gnutls-dev lib64gcc-11-dev-powerpc-cross
+        sudo apt-get install gcc-powerpc-linux-gnu gcc-arm-linux-gnueabi gcc-aarch64-linux-gnu libc6-dev-ppc64-powerpc-cross libcurl4-gnutls-dev lib64gcc-13-dev-powerpc-cross
     - name: gnu90 build
       run: make gnu90build && make clean
     - name: gnu99 build

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -45,16 +45,24 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gcc-powerpc-linux-gnu gcc-arm-linux-gnueabi gcc-aarch64-linux-gnu libc6-dev-ppc64-powerpc-cross libcurl4-gnutls-dev lib64gcc-11-dev-powerpc-cross
-    - name: Test
-      run: |-
-        make gnu90build; make clean
-        make gnu99build; make clean
-        make ppc64build V=1; make clean
-        make ppcbuild   V=1; make clean
-        make armbuild   V=1; make clean
-        make aarch64build V=1; make clean
-        make -C tests test-legacy test-longmatch; make clean
-        make -C lib libzstd-nomt; make clean
+    - name: gnu90 build
+      run: make gnu90build && make clean
+    - name: gnu99 build
+      run: make gnu99build && make clean
+    - name: ppc64 build
+      run: make ppc64build V=1 && make clean
+    - name: ppc build
+      run: make ppcbuild V=1 && make clean
+    - name: arm build
+      run: make armbuild V=1 && make clean
+    - name: aarch64 build
+      run: make aarch64build V=1 && make clean
+    - name: test-legacy
+      run: make -C tests test-legacy V=1 && make clean
+    - name: test-longmatch
+      run: make -C tests test-longmatch V=1 && make clean
+    - name: libzstd-nomt build
+      run: make -C lib libzstd-nomt V=1 && make clean
 
   regression-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -141,12 +141,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
-    - name: zlib wrapper test
+    - name: install valgrind
       run: |
         sudo apt-get -qqq update
         make valgrindinstall
-        make -C zlibWrapper test
-        make -C zlibWrapper test-valgrind
+    - name: zlib wrapper test
+      run: make -C zlibWrapper test
+    - name: zlib wrapper test under valgrind
+      run: make -C zlibWrapper test-valgrind
 
   lz4-threadpool-libs:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get -y install build-essential python3-pip ninja-build liblz4-dev
+          sudo apt-get -y install build-essential python3-pip ninja-build liblz4-dev liblzma-dev
           pip install --pre meson
       - name: Build with Meson
         run: |

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -615,18 +615,6 @@ jobs:
       run: |
         make clangbuild
 
-  clang-pgo:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
-    - name: Build PGO Zstd with Clang
-      env:
-        CC: clang-14
-        LLVM_PROFDATA: llvm-profdata-14
-      run: |
-        make -C programs zstd-pgo
-        ./programs/zstd -b
-
   gcc-pgo:
     runs-on: ubuntu-latest
     steps:
@@ -635,6 +623,19 @@ jobs:
       env:
         CC: gcc
       run: |
+        make -C programs zstd-pgo
+        ./programs/zstd -b
+
+  clang-pgo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
+    - name: Build PGO Zstd with Clang
+      env:
+        CC: clang
+      run: |
+        sudo apt install -y llvm
+        llvm-profdata --version
         make -C programs zstd-pgo
         ./programs/zstd -b
 

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -89,6 +89,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
     - name: cmake build and test
       run: |
+        sudo apt install liblzma-dev
         FUZZERTEST=-T1mn ZSTREAM_TESTTIME=-T1mn make cmakebuild V=1
 
   cpp-gnu90-c99-compatibility:

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -199,7 +199,9 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
       - name: Build with ${{matrix.name}}
-        run: ${{matrix.flags}} make zstd
+        run: |
+          sudo apt install liblzma-dev
+          ${{matrix.flags}} make zstd
 
 
   implicit-fall-through:

--- a/zlibWrapper/examples/example.c
+++ b/zlibWrapper/examples/example.c
@@ -340,7 +340,7 @@ void test_large_deflate(Byte *compr, uLong comprLen, Byte *uncompr,
 
 /* ===========================================================================
  * Test inflate() with large buffers
- */ 
+ */
 void test_large_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
                         uLong uncomprLen) {
     int err;
@@ -442,8 +442,8 @@ void test_sync(Byte *compr, uLong comprLen, Byte *uncompr, uLong uncomprLen) {
     CHECK_ERR(err, "inflateSync");
 
     err = inflate(&d_stream, Z_FINISH);
-    if (err != Z_DATA_ERROR) {
-        fprintf(stderr, "inflate should report DATA_ERROR\n");
+    if (err != Z_STREAM_END) {
+        fprintf(stderr, "inflate reported %i != %i (Z_STREAM_END)\n", err, Z_STREAM_END);
         /* Because of incorrect adler32 */
         exit(1);
     }


### PR DESCRIPTION
Some Github CI tests have started failing recently, as a consequence of updating the underlying ubuntu image.
Try to fix the created issues one by one in this PR, to end up on an all-green signal.

- `clang-pgo` : this test was tied to `clang-14`, which is no longer supported in latest ubuntu image. Use the "generic" `clang` instead, requiring installation of the companion profiler tool.
- `meson-linux`, `cmake-build-and-check`, `make-external-compressor` : require explicit installation of `liblzma-dev` package (no longer provided by default in the image)