### PR TITLE
Added a human-readable final success message at end of tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 task:
-  name: FreeBSD (shortest)
+  name: FreeBSD (make check)
   freebsd_instance:
     matrix:
       image_family: freebsd-14-1
   install_script: pkg install -y gmake coreutils
   script: |
     MOREFLAGS="-Werror" gmake -j all
-    gmake shortest
+    gmake check

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -30,7 +30,7 @@ jobs:
         make c99build; make clean
         make c11build; make clean
         make -j regressiontest; make clean
-        make shortest; make clean
+        make check; make clean
         make cxxtest; make clean
 
   short-tests-1:

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -144,11 +144,11 @@ jobs:
     - name: install valgrind
       run: |
         sudo apt-get -qqq update
-        make valgrindinstall
+        make valgrindinstall V=1
     - name: zlib wrapper test
-      run: make -C zlibWrapper test
+      run: make -C zlibWrapper test V=1
     - name: zlib wrapper test under valgrind
-      run: make -C zlibWrapper test-valgrind
+      run: make -C zlibWrapper test-valgrind V=1
 
   lz4-threadpool-libs:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Our contribution process works in three main stages:
         * Note: run local tests to ensure that your changes didn't break existing functionality
             * Quick check
             ```
-            make shortest
+            make check
             ```
             * Longer check
             ```

--- a/Makefile
+++ b/Makefile
@@ -85,14 +85,10 @@ test:
 	$(MAKE) -C $(TESTDIR) $@
 	ZSTD=../../programs/zstd $(MAKE) -C doc/educational_decoder $@
 
-## shortest: same as `make check`
-.PHONY: shortest
-shortest:
-	$(Q)$(MAKE) -C $(TESTDIR) $@
-
 ## check: run basic tests for `zstd` cli
 .PHONY: check
-check: shortest
+check:
+	$(Q)$(MAKE) -C $(TESTDIR) $@
 
 .PHONY: automated_benchmarking
 automated_benchmarking:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -312,12 +312,12 @@ endif
 list:
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
 
-.PHONY: shortest
-shortest: ZSTDRTTEST=  # remove long tests
-shortest: test-zstd
-
 .PHONY: check
-check: shortest
+check: ZSTDRTTEST=  # remove long tests
+check: test-zstd
+	@echo "\n******************************"
+	@echo "All tests completed successfully"
+	@echo "******************************"
 
 .PHONY: fuzztest
 fuzztest: test-fuzzer test-zstream test-decodecorpus
@@ -327,6 +327,9 @@ test: test-zstd test-cli-tests test-fullbench test-fuzzer test-zstream test-inva
 ifeq ($(QEMU_SYS),)
 test: test-pool
 endif
+	@echo "\n******************************"
+	@echo "All tests completed successfully"
+	@echo "******************************"
 
 .PHONY: test32
 test32: test-zstd32 test-fullbench32 test-fuzzer32 test-zstream32

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1554,7 +1554,6 @@ then
     roundTripTest -g4M "1 -T0 --auto-threads=physical"
     roundTripTest -g4M "1 -T0 --auto-threads=logical"
     roundTripTest -g8M "3 -T2"
-    roundTripTest -g8M "19 --long"
     roundTripTest -g8000K "2 --threads=2"
     fileRoundTripTest -g4M "19 -T2 -B1M"
 
@@ -1849,6 +1848,8 @@ roundTripTest -g18000016 -P84 16
 roundTripTest -g18000017 -P88 17
 roundTripTest -g18000018 -P94 18
 roundTripTest -g18000019 -P96 19
+
+roundTripTest -g8M "19 --long"
 
 roundTripTest -g5000000000 -P99 "1 --zstd=wlog=25"
 roundTripTest -g3700000000 -P0 "1 --zstd=strategy=6,wlog=25"   # ensure btlazy2 can survive an overflow rescale


### PR DESCRIPTION
A human just reading the test log, and unaware of shell's return code convention, will more easily determine that everything ran fine.

Answers #4245

Also: 
- made `make check` slightly shorter by moving one longer test to `make test`
- removed `shortest` target, which was effectively the same thing as `check` (it was created before the `check` target was implemented, and effectively deprecated for a pretty long time, seems safe to remove now)