### PR TITLE
Use _bzhi_u32 for 32-bit builds when building with STATIC_BMI2

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -162,11 +162,11 @@ MEM_STATIC size_t BIT_initCStream(BIT_CStream_t* bitC,
 FORCE_INLINE_TEMPLATE size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
 {
 #if defined(STATIC_BMI2) && STATIC_BMI2 == 1 && !defined(ZSTD_NO_INTRINSICS)
-#if defined(__x86_64__) || defined(_M_X64)
-    return _bzhi_u64(bitContainer, nbBits);
-#else
+#  if defined(__x86_64__) || defined(_M_X64)
+    return sizeof(size_t) == sizeof(U64) ? _bzhi_u64(bitContainer, nbBits) : _bzhi_u32((U32)bitContainer, nbBits);
+#  else
     return _bzhi_u32(bitContainer, nbBits);
-#endif
+#  endif
 #else
     assert(nbBits < BIT_MASK_SIZE);
     return bitContainer & BIT_mask[nbBits];

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -162,7 +162,11 @@ MEM_STATIC size_t BIT_initCStream(BIT_CStream_t* bitC,
 FORCE_INLINE_TEMPLATE size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
 {
 #if defined(STATIC_BMI2) && STATIC_BMI2 == 1 && !defined(ZSTD_NO_INTRINSICS)
-    return  _bzhi_u64(bitContainer, nbBits);
+#if defined(__x86_64__) || defined(_M_X64)
+    return _bzhi_u64(bitContainer, nbBits);
+#else
+    return _bzhi_u32(bitContainer, nbBits);
+#endif
 #else
     assert(nbBits < BIT_MASK_SIZE);
     return bitContainer & BIT_mask[nbBits];

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -165,7 +165,7 @@ FORCE_INLINE_TEMPLATE size_t BIT_getLowerBits(BitContainerType bitContainer, U32
 #  if (defined(__x86_64__) || defined(_M_X64)) && !defined(__ILP32__)
     return _bzhi_u64(bitContainer, nbBits);
 #  else
-    DEBUG_STATIC_ASSERT(sizeof(size_t) == sizeof(U32));
+    DEBUG_STATIC_ASSERT(sizeof(bitContainer) == sizeof(U32));
     return _bzhi_u32(bitContainer, nbBits);
 #  endif
 #else

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -159,7 +159,7 @@ MEM_STATIC size_t BIT_initCStream(BIT_CStream_t* bitC,
     return 0;
 }
 
-FORCE_INLINE_TEMPLATE size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
+FORCE_INLINE_TEMPLATE size_t BIT_getLowerBits(BitContainerType bitContainer, U32 const nbBits)
 {
 #if defined(STATIC_BMI2) && STATIC_BMI2 == 1 && !defined(ZSTD_NO_INTRINSICS)
 #  if (defined(__x86_64__) || defined(_M_X64)) && !defined(__ILP32__)

--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -162,9 +162,10 @@ MEM_STATIC size_t BIT_initCStream(BIT_CStream_t* bitC,
 FORCE_INLINE_TEMPLATE size_t BIT_getLowerBits(size_t bitContainer, U32 const nbBits)
 {
 #if defined(STATIC_BMI2) && STATIC_BMI2 == 1 && !defined(ZSTD_NO_INTRINSICS)
-#  if defined(__x86_64__) || defined(_M_X64)
-    return sizeof(size_t) == sizeof(U64) ? _bzhi_u64(bitContainer, nbBits) : _bzhi_u32((U32)bitContainer, nbBits);
+#  if (defined(__x86_64__) || defined(_M_X64)) && !defined(__ILP32__)
+    return _bzhi_u64(bitContainer, nbBits);
 #  else
+    DEBUG_STATIC_ASSERT(sizeof(size_t) == sizeof(U32));
     return _bzhi_u32(bitContainer, nbBits);
 #  endif
 #else


### PR DESCRIPTION
`_bzhi_u64` is available only for 64-bit builds, while `BIT_getLowerBits` expects `nbBits` to be less than `BIT_MASK_SIZE` (`BIT_MASK_SIZE` is 32)