### PR TITLE
BMI2 detection in 32-bit mode

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -149,6 +149,13 @@ The file structure is designed to make this selection manually achievable for an
   will expose the deprecated `ZSTDMT` API exposed by `zstdmt_compress.h` in
   the shared library, which is now hidden by default.
 
+- The build macro `STATIC_BMI2` can be set to 1 to force usage of `bmi2` instructions.
+  It is generally not necessary to set this build macro,
+  because `STATIC_BMI2` will be automatically set to 1
+  on detecting the presence of the corresponding instruction set in the compilation target.
+  It's nonetheless available as an optional manual toggle for better control,
+  and can also be used to forcefully disable `bmi2` instructions by setting it to 0.
+
 - The build macro `DYNAMIC_BMI2` can be set to 1 or 0 in order to generate binaries
   which can detect at runtime the presence of BMI2 instructions, and use them only if present.
   These instructions contribute to better performance, notably on the decoder side.

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -209,11 +209,11 @@
 
 /* Like DYNAMIC_BMI2 but for compile time determination of BMI2 support */
 #ifndef STATIC_BMI2
-#  if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_I86))
+#  if defined(_MSC_VER)
 #    ifdef __AVX2__  /* MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2 */
 #       define STATIC_BMI2 1
 #    endif
-#  elif defined(__BMI2__) && defined(__x86_64__) && defined(__GNUC__)
+#  elif defined(__BMI2__)
 #    define STATIC_BMI2 1
 #  endif
 #endif


### PR DESCRIPTION
Following the fix #4248,
`bmi2` mode is no longer limited to `x64` 64-bit mode.

Consequently, this patch makes it possible to automatically detect and use this instruction set at compilation time, even when the target is 32-bit.

This makes it possible to use this instruction set in 32-bit mode, resulting in significant speed gains, notably on the decompression side. 

Decompression speed benchmark, measured on a i7-9700k, ubuntu 24.04, gcc 13.3.0: 

| dataset | `-m32` | `-m32 -mavx2 -mbmi2` | difference |
| --- | --- | --- | --- |
| silesia.tar | 861 MB/s | 948 MB/s | +10.1 % |
| calgary.tar | 836 MB/s | 915 MB/s | +9.4 % |
| enwik7 | 752 MB/s | 822 MB/s | +9.3% |

Also: updated library documentation, to feature `STATIC_BMI2` build variable