### PR TITLE
enable DYNAMIC_BMI2 by default on x86 (32-bit mode)

### DIFF
--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -78,15 +78,15 @@
  * Enabled for clang & gcc >=4.8 on x86 when BMI2 isn't enabled by default.
  */
 #ifndef DYNAMIC_BMI2
-  #if ((defined(__clang__) && __has_attribute(__target__)) \
+#  if ((defined(__clang__) && __has_attribute(__target__)) \
       || (defined(__GNUC__) \
           && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)))) \
-      && (defined(__x86_64__) || defined(_M_X64)) \
+      && (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)) \
       && !defined(__BMI2__)
-  #  define DYNAMIC_BMI2 1
-  #else
-  #  define DYNAMIC_BMI2 0
-  #endif
+#    define DYNAMIC_BMI2 1
+#  else
+#    define DYNAMIC_BMI2 0
+#  endif
 #endif
 
 /**


### PR DESCRIPTION
Following #4251 and #4248, 
it's now possible to get `bmi2` working in x86 32-bit mode.

This development opens the opportunity to enable `DYNAMIC_BMI2` automatically in 32-bit mode
(so far, it was only enabled for x64).

`DYNAMIC_BMI2` will only capture a portion of the speed benefits of native `bmi2 + avx2`
as illustrated by below benchmark : 

Decompression speed benchmark, measured on a i7-9700k, ubuntu 24.04, `gcc` 13.3.0: 
| dataset | `-m32` `dev` | `-m32` this `PR` (w/ `DYNAMIC_BMI2`) | `-m32 -mavx2 -mbmi2` | 
| --- | --- | --- | --- |
| silesia.tar | 861 MB/s | 898 MB/s | 948 MB/s | 
| calgary.tar | 836 MB/s | 864 MB/s | 915 MB/s | 
| enwik7 | 752 MB/s | 782 MB/s | 822 MB/s | 

As one can see, `DYNAMIC_BMI2` does not match the speed of native `bmi2 + avx2` (although it still outperforms the absence of `bmi2`). This discrepancy may be attributed to the specific benefits of `avx2`, which likely alleviates register pressure on the `x86` architecture.

`DYNAMIC_BMI2` can still be manually overridden, allowing it to be disabled as needed.