### PR TITLE
Check STATIC_BMI2 instead of __BMI2__

### DIFF
--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -95,7 +95,7 @@
       || (defined(__GNUC__) \
           && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)))) \
       && (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)) \
-      && !defined(__BMI2__)
+      && !STATIC_BMI2
 #    define DYNAMIC_BMI2 1
 #  else
 #    define DYNAMIC_BMI2 0
@@ -143,7 +143,7 @@
 #if !defined(ZSTD_DISABLE_ASM) &&                                 \
     ZSTD_ASM_SUPPORTED &&                                         \
     defined(__x86_64__) &&                                        \
-    (DYNAMIC_BMI2 || defined(__BMI2__))
+    (DYNAMIC_BMI2 || STATIC_BMI2)
 # define ZSTD_ENABLE_ASM_X86_64_BMI2 1
 #else
 # define ZSTD_ENABLE_ASM_X86_64_BMI2 0

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -913,7 +913,7 @@ static size_t HUF_decompress4X1_usingDTable_internal(void* dst, size_t dstSize, 
     }
 #endif
 
-#if ZSTD_ENABLE_ASM_X86_64_BMI2
+#if ZSTD_ENABLE_ASM_X86_64_BMI2 && STATIC_BMI2
     if (!(flags & HUF_flags_disableAsm)) {
         loopFn = HUF_decompress4X1_usingDTable_internal_fast_asm_loop;
     }
@@ -1735,7 +1735,7 @@ static size_t HUF_decompress4X2_usingDTable_internal(void* dst, size_t dstSize, 
     }
 #endif
 
-#if ZSTD_ENABLE_ASM_X86_64_BMI2
+#if ZSTD_ENABLE_ASM_X86_64_BMI2 && STATIC_BMI2
     if (!(flags & HUF_flags_disableAsm)) {
         loopFn = HUF_decompress4X2_usingDTable_internal_fast_asm_loop;
     }

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -913,7 +913,7 @@ static size_t HUF_decompress4X1_usingDTable_internal(void* dst, size_t dstSize, 
     }
 #endif
 
-#if ZSTD_ENABLE_ASM_X86_64_BMI2 && defined(__BMI2__)
+#if ZSTD_ENABLE_ASM_X86_64_BMI2
     if (!(flags & HUF_flags_disableAsm)) {
         loopFn = HUF_decompress4X1_usingDTable_internal_fast_asm_loop;
     }
@@ -1735,7 +1735,7 @@ static size_t HUF_decompress4X2_usingDTable_internal(void* dst, size_t dstSize, 
     }
 #endif
 
-#if ZSTD_ENABLE_ASM_X86_64_BMI2 && defined(__BMI2__)
+#if ZSTD_ENABLE_ASM_X86_64_BMI2
     if (!(flags & HUF_flags_disableAsm)) {
         loopFn = HUF_decompress4X2_usingDTable_internal_fast_asm_loop;
     }


### PR DESCRIPTION
`ZSTD_ENABLE_ASM_X86_64_BMI2` already implies BMI2 by its name, and by the way it tests defines