### PR TITLE
Check `DYNAMIC_BMI2` instead of `DYNAMIC_BMI2 != 0`

### DIFF
--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -154,7 +154,7 @@ struct ZSTD_DCtx_s
     size_t rleSize;
     size_t staticSize;
     int isFrameDecompression;
-#if DYNAMIC_BMI2 != 0
+#if DYNAMIC_BMI2
     int bmi2;                     /* == 1 if the CPU supports BMI2 and 0 otherwise. CPU support is determined dynamically once per context lifetime. */
 #endif
 
@@ -211,11 +211,11 @@ struct ZSTD_DCtx_s
 };  /* typedef'd to ZSTD_DCtx within "zstd.h" */
 
 MEM_STATIC int ZSTD_DCtx_get_bmi2(const struct ZSTD_DCtx_s *dctx) {
-#if DYNAMIC_BMI2 != 0
-	return dctx->bmi2;
+#if DYNAMIC_BMI2
+    return dctx->bmi2;
 #else
     (void)dctx;
-	return 0;
+    return 0;
 #endif
 }
 


### PR DESCRIPTION
`#if DYNAMIC_BMI2` is consistent with the rest of the code.

 + use spaces instead of tabs