### PR TITLE
Move STATIC_BMI2 define to portability_macros.h

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -207,21 +207,6 @@
 #  pragma warning(disable : 4324)        /* disable: C4324: padded structure */
 #endif
 
-/* Like DYNAMIC_BMI2 but for compile time determination of BMI2 support */
-#ifndef STATIC_BMI2
-#  if defined(_MSC_VER)
-#    ifdef __AVX2__  /* MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2 */
-#       define STATIC_BMI2 1
-#    endif
-#  elif defined(__BMI2__)
-#    define STATIC_BMI2 1
-#  endif
-#endif
-
-#ifndef STATIC_BMI2
-#  define STATIC_BMI2 0
-#endif
-
 /* compile time determination of SIMD support */
 #if !defined(ZSTD_NO_INTRINSICS)
 #  if defined(__AVX2__)

--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -76,12 +76,10 @@
 
 /* Compile time determination of BMI2 support */
 #ifndef STATIC_BMI2
-#  if defined(_MSC_VER)
-#    ifdef __AVX2__  /* MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2 */
-#       define STATIC_BMI2 1
-#    endif
-#  elif defined(__BMI2__)
+#  if defined(__BMI2__)
 #    define STATIC_BMI2 1
+#  elif defined(_MSC_VER) && defined(__AVX2__)
+#    define STATIC_BMI2 1 /* MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2 */
 #  endif
 #endif
 

--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -74,7 +74,7 @@
 # define ZSTD_HIDE_ASM_FUNCTION(func)
 #endif
 
-/* Like DYNAMIC_BMI2 but for compile time determination of BMI2 support */
+/* Compile time determination of BMI2 support */
 #ifndef STATIC_BMI2
 #  if defined(_MSC_VER)
 #    ifdef __AVX2__  /* MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2 */

--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -74,6 +74,21 @@
 # define ZSTD_HIDE_ASM_FUNCTION(func)
 #endif
 
+/* Like DYNAMIC_BMI2 but for compile time determination of BMI2 support */
+#ifndef STATIC_BMI2
+#  if defined(_MSC_VER)
+#    ifdef __AVX2__  /* MSVC does not have a BMI2 specific flag, but every CPU that supports AVX2 also supports BMI2 */
+#       define STATIC_BMI2 1
+#    endif
+#  elif defined(__BMI2__)
+#    define STATIC_BMI2 1
+#  endif
+#endif
+
+#ifndef STATIC_BMI2
+#  define STATIC_BMI2 0
+#endif
+
 /* Enable runtime BMI2 dispatch based on the CPU.
  * Enabled for clang & gcc >=4.8 on x86 when BMI2 isn't enabled by default.
  */


### PR DESCRIPTION
This change makes sure that STATIC_BMI and DYNAMIC_BMI are defined close to each other, and not in other headers.
Also, it reorders `__BMI2__` check:
 + if `__BMI2__` defined, then set STATIC_BMI2 for all compilers
 + use `defined(_MSC_VER) && defined(__AVX2__)` as fallback for ms compiler