### PR TITLE
fix: quote include directory for resource compiler

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -92,6 +92,31 @@ jobs:
         sudo apt install liblzma-dev
         FUZZERTEST=-T1mn ZSTREAM_TESTTIME=-T1mn make cmakebuild V=1
 
+  cmake-source-directory-with-spaces:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            generator: "Unix Makefiles"
+          - os: windows-latest
+            generator: "NMake Makefiles"
+          - os: macos-latest
+            generator: "Unix Makefiles"
+    env:
+      SRC_DIR: "source directory with spaces"
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
+      with:
+        path: "${{ env.SRC_DIR }}"
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: ${{ matrix.generator == 'NMake Makefiles' }}
+    - name: cmake build on a source directory with spaces
+      run: |
+        cmake -S "${{ env.SRC_DIR }}/build/cmake" -B build -DBUILD_TESTING=ON -G "${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Release --install-prefix "${{ runner.temp }}/install"
+        cmake --build build --config Release
+        cmake --install build --config Release
+
   cpp-gnu90-c99-compatibility:
     runs-on: ubuntu-latest
     steps:

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -118,7 +118,7 @@ endmacro ()
 
 # Define directories containing the library's public headers
 set(PUBLIC_INCLUDE_DIRS ${LIBRARY_DIR})
-set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I ${LIBRARY_DIR}")
+set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I \"${LIBRARY_DIR}\"")
 # Split project to static and shared libraries build
 set(library_targets)
 if (ZSTD_BUILD_SHARED)


### PR DESCRIPTION
## Description

Fixes [https://github.com/facebook/zstd/issues/4268](https://github.com/facebook/zstd/issues/4268)

## Test

1. Open a x64 MSVC dev prompt
2. Execute the commands below (like the steps described [https://github.com/facebook/zstd/issues/4268](https://github.com/facebook/zstd/issues/4268)) to see that the issue has been fixed:
    ```batch
    SET MY_SRC_DIR=%TEMP%\zstd fork with spaces
    SET MY_BUILD_DIR=%TEMP%\zstd-fork-build-dir
    SET MY_INSTALL_DIR=%TEMP%\zstd-fork-install-dir
    git clone https://github.com/luau-project/zstd --branch=fix-rc-include "%MY_SRC_DIR%"
    cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release --install-prefix "%MY_INSTALL_DIR%" -S "%MY_SRC_DIR%\build\cmake" -B "%MY_BUILD_DIR%"
    cmake --build "%MY_BUILD_DIR%" --config Release
    cmake --install "%MY_BUILD_DIR%" --config Release
    ```
3. The build / install should succeed.