### PR TITLE
Add noexecstack flag for gcc/clang C and CPP in Meson

### DIFF
--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -116,10 +116,16 @@ if [compiler_gcc, compiler_clang].contains(cc_id)
   if cc_id == compiler_clang
     common_warning_flags += ['-Wconversion', '-Wno-sign-conversion', '-Wdocumentation']
   endif
-  cc_compile_flags = cc.get_supported_arguments(common_warning_flags + ['-Wstrict-prototypes'])
-  cxx_compile_flags = cxx.get_supported_arguments(common_warning_flags)
+  noexecstack_flags = ['-Wa,--noexecstack' ]
+  noexecstack_link_flags = ['-Wl,-z,noexecstack']
+  cc_compile_flags = cc.get_supported_arguments(common_warning_flags + noexecstack_flags + ['-Wstrict-prototypes'])
+  cxx_compile_flags = cxx.get_supported_arguments(common_warning_flags + noexecstack_flags)
   add_project_arguments(cc_compile_flags, language : 'c')
   add_project_arguments(cxx_compile_flags, language : 'cpp')
+  cc_link_flags = cc.get_supported_link_arguments(noexecstack_link_flags)
+  cxx_link_flags = cxx.get_supported_link_arguments(noexecstack_link_flags)
+  add_project_link_arguments(cc_link_flags, language: 'c')
+  add_project_link_arguments(cxx_link_flags, language: 'cpp')
 elif cc_id == compiler_msvc
   msvc_compile_flags = [ '/D_UNICODE', '/DUNICODE' ]
   if use_multi_thread


### PR DESCRIPTION
The `-Wl,-z,noexecstack` and `-Wa,--noexecstack` flags are already set for CMake, but not for Meson. This brings the flags to the Meson build as well. Note that this maintains the discrepancy in behavior between CMake and Meson when it comes to enabling ASM: on CMake, the ZSTD_HAS_NOEXECSTACK variable is set and these flags added for GCC/Clang and MinGW. Then later, the ZSTD_HAS_NOEXECSTACK variable is checked (along with some other conditions) to enable or disable ASM. However on Meson, this logic is restricted to simply checking for GCC/Clang. This patch maintains this behavior; noexecstack is dependent on GCC/Clang only.

## Testing
Testing on PA-RISC is obviously difficult. At the very least, this change builds on my local machine:
```
zstd/build/meson$ meson setup --reconfigure build
The Meson build system
Version: 1.4.1
Source dir: /home/csv/zstd/build/meson
Build dir: /home/csv/zstd/build/meson/build
Build type: native build
Program GetZstdLibraryVersion.py found: YES (/usr/bin/python3 /home/csv/zstd/build/meson/GetZstdLibraryVersion.py)
Project name: zstd
Project version: 1.5.7
C compiler for the host machine: ccache cc (gcc 14.2.1 "cc (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)")
C linker for the host machine: cc ld.bfd 2.41-38
C++ compiler for the host machine: ccache c++ (gcc 14.2.1 "c++ (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)")
C++ linker for the host machine: c++ ld.bfd 2.41-38
Host machine cpu family: x86_64
Host machine cpu: x86_64
Library m found: YES
Dependency threads found: YES unknown (cached)
Dependency zlib found: YES 1.3.1.zlib-ng (cached)
Found pkg-config: YES (/usr/bin/pkg-config) 2.1.1
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency liblzma found: NO (tried pkgconfig and cmake)
Run-time dependency liblz4 found: NO (tried pkgconfig and cmake)
Compiler for C supports arguments -Wundef: YES (cached)
Compiler for C supports arguments -Wshadow: YES (cached)
Compiler for C supports arguments -Wcast-align: YES (cached)
Compiler for C supports arguments -Wcast-qual: YES (cached)
Compiler for C supports arguments -Wa,--noexecstack: YES (cached)
Compiler for C supports arguments -Wstrict-prototypes: YES (cached)
Compiler for C++ supports arguments -Wundef: YES (cached)
Compiler for C++ supports arguments -Wshadow: YES (cached)
Compiler for C++ supports arguments -Wcast-align: YES (cached)
Compiler for C++ supports arguments -Wcast-qual: YES (cached)
Compiler for C++ supports arguments -Wa,--noexecstack: YES (cached)
Compiler for C supports link arguments -Wl,-z,noexecstack: YES 
Compiler for C++ supports link arguments -Wl,-z,noexecstack: YES 
Message: Enable legacy support back to version 0.5
Message: Enable multi-threading support
Has header "execinfo.h" skipped: feature backtrace disabled
Build targets in project: 4

Found ninja-1.12.1 at /usr/bin/ninja
zstd/build/meson$ cd build
zstd/build/meson/build$ meson compile
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja
[54/54] Linking target programs/zstd
```