### PR TITLE
visual studio compilation tests: error out on warnings

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -375,7 +375,7 @@ jobs:
         cd build\cmake
         mkdir build
         cd build
-        cmake.exe -G "${{matrix.generator}}" ${{matrix.flags}} -DCMAKE_BUILD_TYPE=Debug -DZSTD_BUILD_TESTS:BOOL=ON -DZSTD_ZSTREAM_FLAGS=-T30s -DZSTD_FUZZER_FLAGS=-T30s -DZSTD_FULLBENCH_FLAGS=-i0 ..
+        cmake.exe -G "${{matrix.generator}}" ${{matrix.flags}} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DZSTD_BUILD_TESTS:BOOL=ON -DZSTD_ZSTREAM_FLAGS=-T30s -DZSTD_FUZZER_FLAGS=-T30s -DZSTD_FULLBENCH_FLAGS=-i0 ..
         cmake.exe --build .
         ctest.exe -V -C Debug
 

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -7400,7 +7400,7 @@ BlockSummary ZSTD_get1BlockSummary(const ZSTD_Sequence* seqs, size_t nbSeqs)
     /* Process 2 structs (32 bytes) at a time */
     for (i = 0; i + 2 <= nbSeqs; i += 2) {
         /* Load two consecutive ZSTD_Sequence (8×4 = 32 bytes) */
-        __m256i data     = _mm256_loadu_si256((const __m256i*)&seqs[i]);
+        __m256i data     = _mm256_loadu_si256((const __m256i*)(const void*)&seqs[i]);
         /* check end of block signal */
         __m256i cmp      = _mm256_cmpeq_epi32(data, zeroVec);
         int cmp_res      = _mm256_movemask_epi8(cmp);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -7191,7 +7191,7 @@ static size_t convertSequences_noRepcodes(
     /* Process 2 sequences per loop iteration */
     for (; i + 1 < nbSequences; i += 2) {
         /* Load 2 ZSTD_Sequence (32 bytes) */
-        __m256i vin  = _mm256_loadu_si256((__m256i const*)&inSeqs[i]);
+        __m256i vin  = _mm256_loadu_si256((const __m256i*)(const void*)&inSeqs[i]);
 
         /* Add {2, 0, -3, 0} in each 128-bit half */
         __m256i vadd = _mm256_add_epi32(vin, addition);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -7218,7 +7218,7 @@ static size_t convertSequences_noRepcodes(
          */
 
         /* Store only the lower 16 bytes => 2 SeqDef (8 bytes each) */
-        _mm_storeu_si128((__m128i *)&dstSeqs[i], _mm256_castsi256_si128(vperm));
+        _mm_storeu_si128((__m128i *)(void*)&dstSeqs[i], _mm256_castsi256_si128(vperm));
         /*
          * This writes out 16 bytes total:
          *   - offset 0..7  => seq0 (offBase, litLength, mlBase)

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -696,7 +696,7 @@ check_compressedSequences(const void* compressed, size_t cSize, const void* orig
     if (decompressed == NULL) return 2;
 
     decSize = ZSTD_decompress(decompressed, origSize, compressed, cSize);
-    if (decSize != origSize) { free(decompressed); DISPLAY("ZSTD_decompress failed (%zu) ", decSize); return 1; }
+    if (decSize != origSize) { free(decompressed); DISPLAY("ZSTD_decompress failed (%u) ", (unsigned)decSize); return 1; }
 
     diff = memcmp(decompressed, orig, origSize);
     if (diff) { free(decompressed); return 1; }
@@ -904,7 +904,7 @@ static int benchMem(unsigned scenarioID,
                 if (verif_f) {
                     size_t const vRes = verif_f(dst, newResult.sumOfReturn, origSrc, origSrcSize);
                     if (vRes) {
-                        DISPLAY(" validation failed ! (%zu)\n", vRes);
+                        DISPLAY(" validation failed ! (%u)\n", (unsigned)vRes);
                         break;
                     }
                 }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1918,7 +1918,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         params.fParams.contentSizeFlag = 0;
         params.cParams.windowLog = ZSTD_WINDOWLOG_MAX;
         for (cnb = 0; cnb < nbCompressions; ++cnb) {
-            DISPLAYLEVEL(6, "run %zu / %zu \n", cnb, nbCompressions);
+            DISPLAYLEVEL(6, "run %u / %u \n", (unsigned)cnb, (unsigned)nbCompressions);
             CHECK_Z( ZSTD_compressBegin_advanced(cctx, NULL, 0, params, ZSTD_CONTENTSIZE_UNKNOWN) );  /* reuse same parameters */
             CHECK_Z( ZSTD_compressEnd(cctx, compressedBuffer, compressedBufferSize, CNBuffer, CNBuffSize) );
         }
@@ -1936,8 +1936,8 @@ static int basicUnitTests(U32 const seed, double compressibility)
                 assert(smallCCtx != NULL);
                 CHECK_Z(ZSTD_compressCCtx(smallCCtx, compressedBuffer, compressedBufferSize, CNBuffer, 1, 1));
                 {   size_t const smallCCtxSize = ZSTD_sizeof_CCtx(smallCCtx);
-                    DISPLAYLEVEL(5, "(large) %zuKB > 32*%zuKB (small) : ",
-                                largeCCtxSize>>10, smallCCtxSize>>10);
+                    DISPLAYLEVEL(5, "(large) %uKB > 32*%uKB (small) : ",
+                                (unsigned)(largeCCtxSize>>10), (unsigned)(smallCCtxSize>>10));
                     assert(largeCCtxSize > 32* smallCCtxSize);  /* note : "too large" definition is handled within zstd_compress.c .
                                                                  * make this test case extreme, so that it doesn't depend on a possibly fluctuating definition */
                 }
@@ -3480,7 +3480,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
             {   size_t const compressionResult = ZSTD_compress2(cctx,
                                     compressedBuffer, compressedBufferSize,
                                     CNBuffer, srcSize);
-                DISPLAYLEVEL(5, "simple=%zu vs %zu=advanced : ", cSize_1pass, compressionResult);
+                DISPLAYLEVEL(5, "simple=%u vs %u=advanced : ", (unsigned)cSize_1pass, (unsigned)compressionResult);
                 if (ZSTD_isError(compressionResult)) goto _output_error;
                 if (compressionResult != cSize_1pass) goto _output_error;
         }   }
@@ -4361,8 +4361,8 @@ static int basicUnitTests(U32 const seed, double compressibility)
         for (; level < ZSTD_maxCLevel(); ++level) {
             size_t const currSize = ZSTD_estimateCCtxSize(level);
             if (prevSize > currSize) {
-                DISPLAYLEVEL(3, "Error! previous cctx size: %zu at level: %d is larger than current cctx size: %zu at level: %d",
-                             prevSize, level-1, currSize, level);
+                DISPLAYLEVEL(3, "Error! previous cctx size: %u at level: %d is larger than current cctx size: %u at level: %d",
+                             (unsigned)prevSize, level-1, (unsigned)currSize, level);
                 goto _output_error;
             }
             prevSize = currSize;
@@ -4386,8 +4386,8 @@ static int basicUnitTests(U32 const seed, double compressibility)
                     if (cctxSizeUsingLevel < cctxSizeUsingCParams
                      || ZSTD_isError(cctxSizeUsingCParams)
                      || ZSTD_isError(cctxSizeUsingLevel)) {
-                        DISPLAYLEVEL(3, "error! l: %d dict: %zu srcSize: %zu cctx size cpar: %zu, cctx size level: %zu\n",
-                                     level, dictSize, srcSize, cctxSizeUsingCParams, cctxSizeUsingLevel);
+                        DISPLAYLEVEL(3, "error! l: %d dict: %u srcSize: %u cctx size cpar: %u, cctx size level: %u\n",
+                                     level, (unsigned)dictSize, (unsigned)srcSize, (unsigned)cctxSizeUsingCParams, (unsigned)cctxSizeUsingLevel);
                         goto _output_error;
     }   }   }   }   }
     DISPLAYLEVEL(3, "OK \n");

--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -537,7 +537,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
     outBuff.size = compressedBufferSize;
     outBuff.pos = 0;
     {   size_t const r = ZSTD_endStream(zc, &outBuff);
-        CHECK(r != 0, "Error or some data not flushed (ret=%zu)", r);
+        CHECK(r != 0, "Error or some data not flushed (ret=%i)", ZSTD_getErrorCode(r));
     }
     inBuff.src = outBuff.dst;
     inBuff.size = outBuff.pos;
@@ -567,7 +567,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
         outBuff.size = compressedBufferSize;
         outBuff.pos = 0;
         {   size_t const r = ZSTD_endStream(zc, &outBuff);
-            CHECK(r != 0, "Error or some data not flushed (ret=%zu)", r);
+            CHECK(r != 0, "Error or some data not flushed (ret=%i)", ZSTD_getErrorCode(r));
         }
         inBuff.src = outBuff.dst;
         inBuff.size = outBuff.pos;
@@ -595,7 +595,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
     CHECK_Z( ZSTD_compressStream(zc, &outBuff, &inBuff) );
     CHECK(inBuff.pos != inBuff.size, "Entire input should be consumed");
     {   size_t const r = ZSTD_endStream(zc, &outBuff);
-        CHECK(r != 0, "Error or some data not flushed (ret=%zu)", r);
+        CHECK(r != 0, "Error or some data not flushed (ret=%i)", ZSTD_getErrorCode(r));
     }
     {   unsigned long long origSize = ZSTD_findDecompressedSize(outBuff.dst, outBuff.pos);
         CHECK(origSize == ZSTD_CONTENTSIZE_UNKNOWN, "Unknown!");
@@ -777,7 +777,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
 
         CHECK(streamingSize < singlePassSize + (1 << 18) + 3 * ZSTD_BLOCKSIZE_MAX, "Streaming doesn't use the right amount of memory");
         CHECK(streamingSize != streaming2KSize + 3 * (ZSTD_BLOCKSIZE_MAX - 2048), "ZSTD_d_blockSizeMax didn't save the right amount of memory");
-        DISPLAYLEVEL(3, "| %zu | %zu | %zu | ", singlePassSize, streaming2KSize, streamingSize);
+        DISPLAYLEVEL(3, "| %u | %u | %u | ", (unsigned)singlePassSize, (unsigned)streaming2KSize, (unsigned)streamingSize);
 
         ZSTD_freeDCtx(dctx);
     }
@@ -999,7 +999,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
                 void* const verifBuf = (char*)outBuf.dst + outBuf.pos;
                 const size_t decSize = ZSTD_decompress(verifBuf, inputSize, outBuf.dst, outBuf.pos);
                 CHECK_Z(decSize);
-                CHECK(decSize != inputSize, "regenerated %zu bytes, instead of %zu", decSize, inputSize);
+                CHECK(decSize != inputSize, "regenerated %u bytes, instead of %u", (unsigned)decSize, (unsigned)inputSize);
                 CHECK(memcmp(realSrcStart, verifBuf, inputSize) != 0, "regenerated data different from original");
         }   }
         DISPLAYLEVEL(3, "OK \n");
@@ -1029,14 +1029,14 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
                 void* const verifBuf = (char*)outBuf.dst + outBuf.pos;
                 const size_t decSize = ZSTD_decompress(verifBuf, inputSize, outBuf.dst, outBuf.pos);
                 CHECK_Z(decSize);
-                CHECK(decSize != inputSize, "regenerated %zu bytes, instead of %zu", decSize, inputSize);
+                CHECK(decSize != inputSize, "regenerated %u bytes, instead of %u", (unsigned)decSize, (unsigned)inputSize);
                 CHECK(memcmp(realSrcStart, verifBuf, inputSize) != 0, "regenerated data different from original");
         }   }
         DISPLAYLEVEL(3, "OK \n");
 
         DISPLAYLEVEL(3, "test%3i : ZSTD_compressStream2() with ZSTD_c_stableInBuffer: context size : ", testNb++);
         {   size_t const cctxSize = ZSTD_sizeof_CCtx(cctx);
-            DISPLAYLEVEL(4, "cctxSize1=%zu; cctxSize=%zu; cctxSize2=%zu : ", cctxSize1, cctxSize, cctxSize2);
+            DISPLAYLEVEL(4, "cctxSize1=%u; cctxSize=%u; cctxSize2=%u : ", (unsigned)cctxSize1, (unsigned)cctxSize, (unsigned)cctxSize2);
             CHECK(!(cctxSize1 < cctxSize), "Must be bigger than single-pass");
             CHECK(!(cctxSize < cctxSize2), "Must be smaller than streaming");
             cctxSize1 = cctxSize;
@@ -1071,7 +1071,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
 
         DISPLAYLEVEL(3, "test%3i : ZSTD_compressStream2() with ZSTD_c_stableOutBuffer: context size : ", testNb++);
         {   size_t const cctxSize = ZSTD_sizeof_CCtx(cctx);
-            DISPLAYLEVEL(4, "cctxSize1=%zu; cctxSize=%zu; cctxSize2=%zu : ", cctxSize1, cctxSize, cctxSize2);
+            DISPLAYLEVEL(4, "cctxSize1=%u; cctxSize=%u; cctxSize2=%u : ", (unsigned)cctxSize1, (unsigned)cctxSize, (unsigned)cctxSize2);
             CHECK(!(cctxSize1 < cctxSize), "Must be bigger than single-pass and stableInBuffer");
             CHECK(!(cctxSize < cctxSize2), "Must be smaller than streaming");
         }
@@ -2983,7 +2983,7 @@ static int fuzzerTests_newAPI(U32 seed, int nbTests, int startTest,
                 const U32 windowLogMax = bigTests ? 24 : 20;
                 const U32 searchLogMax = bigTests ? 15 : 13;
                 if (dictSize)
-                    DISPLAYLEVEL(5, "t%u: with dictionary of size : %zu \n", testNb, dictSize);
+                    DISPLAYLEVEL(5, "t%u: with dictionary of size : %u \n", testNb, (unsigned)dictSize);
 
                 /* mess with compression parameters */
                 cParams.windowLog += (FUZ_rand(&lseed) & 3) - 1;
@@ -3178,7 +3178,7 @@ static int fuzzerTests_newAPI(U32 seed, int nbTests, int startTest,
                 }
                 cSize = outBuff.pos;
                 compressedCrcs[iter] = XXH64(cBuffer, cSize, 0);
-                DISPLAYLEVEL(5, "Frame completed : %zu bytes \n", cSize);
+                DISPLAYLEVEL(5, "Frame completed : %u bytes \n", (unsigned)cSize);
             }
             CHECK(!(compressedCrcs[0] == compressedCrcs[1]), "Compression is not deterministic!");
         }
@@ -3194,7 +3194,7 @@ static int fuzzerTests_newAPI(U32 seed, int nbTests, int startTest,
             CHECK_Z( ZSTD_resetDStream(zd) );
         } else {
             if (dictSize)
-                DISPLAYLEVEL(5, "using dictionary of size %zu \n", dictSize);
+                DISPLAYLEVEL(5, "using dictionary of size %u \n", (unsigned)dictSize);
             CHECK_Z( ZSTD_initDStream_usingDict(zd, dict, dictSize) );
         }
         if (FUZ_rand(&lseed) & 1) {


### PR DESCRIPTION
Multiple minor warnings have accumulated over time due to CI tests silently accepting them.
Fixed in this PR.