### PR TITLE
--ultra automatically triggered with --long and --patch-from

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1082,10 +1082,11 @@ int main(int argCount, const char* argv[])
 #ifndef ZSTD_NOTRACE
                 if (longCommandWArg(&argument, "--trace")) { char const* traceFile; NEXT_FIELD(traceFile); TRACE_enable(traceFile); continue; }
 #endif
-                if (longCommandWArg(&argument, "--patch-from")) { NEXT_FIELD(patchFromDictFileName); continue; }
+                if (longCommandWArg(&argument, "--patch-from")) { NEXT_FIELD(patchFromDictFileName); ultra = 1; continue; }
                 if (longCommandWArg(&argument, "--long")) {
                     unsigned ldmWindowLog = 0;
                     ldmFlag = 1;
+                    ultra = 1;
                     /* Parse optional window log */
                     if (*argument == '=') {
                         ++argument;


### PR DESCRIPTION
The `--ultra` flag serves to explicitly require user consent for generating window sizes exceeding 8 MB.

Note that selecting either the `--long` or `--patch-from` options implies agreement to generate large window sizes.

As a result, when either `--long` or `--patch-from` is specified, `--ultra` is implicitly set, hence no longer required.