### PR TITLE
--max command

### DIFF
--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -163,8 +163,8 @@ the last one takes effect.
     `--memory=windowSize` needs to be passed to the decompressor.
 * `--max`:
     set advanced parameters to maximum compression.
-    warning: this setting uses a lot of resources and is very slow.
-    note that the amount of resource required is typically too large for 32-bit.
+    warning: this setting is very slow and uses a lot of resources.
+    It's inappropriate for 32-bit mode and therefore disabled in this mode.
 * `-D DICT`:
     use `DICT` as Dictionary to compress or decompress FILE(s)
 * `--patch-from FILE`:

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -164,6 +164,7 @@ the last one takes effect.
 * `--max`:
     set advanced parameters to maximum compression.
     warning: this setting uses a lot of resources and is very slow.
+    note that the amount of resource required is typically too large for 32-bit.
 * `-D DICT`:
     use `DICT` as Dictionary to compress or decompress FILE(s)
 * `--patch-from FILE`:

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -161,6 +161,9 @@ the last one takes effect.
 
     Note: If `windowLog` is set to larger than 27, `--long=windowLog` or
     `--memory=windowSize` needs to be passed to the decompressor.
+* `--max`:
+    set advanced parameters to maximum compression.
+    warning: this setting uses a lot of resources and is very slow.
 * `-D DICT`:
     use `DICT` as Dictionary to compress or decompress FILE(s)
 * `--patch-from FILE`:

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -810,22 +810,22 @@ static unsigned default_nbThreads(void) {
             CLEAN_RETURN(1);      \
 }   }   }
 
-#define NEXT_UINT32(val32) {      \
-    const char* __nb;             \
-    NEXT_FIELD(__nb);             \
+#define NEXT_UINT32(val32) {        \
+    const char* __nb;               \
+    NEXT_FIELD(__nb);               \
     val32 = readU32FromChar(&__nb); \
-    if(*__nb != 0) {         \
+    if(*__nb != 0) {                \
         errorOut("error: only numeric values with optional suffixes K, KB, KiB, M, MB, MiB are allowed"); \
-    }                             \
+    }                               \
 }
 
-#define NEXT_TSIZE(valTsize) {      \
-    const char* __nb;             \
-    NEXT_FIELD(__nb);             \
+#define NEXT_TSIZE(valTsize) {           \
+    const char* __nb;                    \
+    NEXT_FIELD(__nb);                    \
     valTsize = readSizeTFromChar(&__nb); \
-    if(*__nb != 0) {         \
+    if(*__nb != 0) {                     \
         errorOut("error: only numeric values with optional suffixes K, KB, KiB, M, MB, MiB are allowed"); \
-    }                             \
+    }                                    \
 }
 
 typedef enum { zom_compress, zom_decompress, zom_test, zom_bench, zom_train, zom_list } zstd_operation_mode;
@@ -973,7 +973,6 @@ int main(int argCount, const char* argv[])
                 if (!strcmp(argument, "--quiet")) { g_displayLevel--; continue; }
                 if (!strcmp(argument, "--stdout")) { forceStdout=1; outFileName=stdoutmark; continue; }
                 if (!strcmp(argument, "--ultra")) { ultra=1; continue; }
-                if (!strcmp(argument, "--max")) { ultra=1; ldmFlag = 1; setMaxCompression(&compressionParams); continue; }
                 if (!strcmp(argument, "--check")) { FIO_setChecksumFlag(prefs, 2); continue; }
                 if (!strcmp(argument, "--no-check")) { FIO_setChecksumFlag(prefs, 0); continue; }
                 if (!strcmp(argument, "--sparse")) { FIO_setSparseWrite(prefs, 2); continue; }
@@ -1023,6 +1022,16 @@ int main(int argCount, const char* argv[])
                 if (!strcmp(argument, "--fake-stdout-is-console")) { UTIL_fakeStdoutIsConsole(); continue; }
                 if (!strcmp(argument, "--fake-stderr-is-console")) { UTIL_fakeStderrIsConsole(); continue; }
                 if (!strcmp(argument, "--trace-file-stat")) { UTIL_traceFileStat(); continue; }
+
+                if (!strcmp(argument, "--max")) {
+                    if (sizeof(void*)==4) {
+                        DISPLAYLEVEL(2, "--max is incompatible with 32-bit mode \n");
+                        badUsage(programName, originalArgument);
+                        CLEAN_RETURN(1);
+                    }
+                    ultra=1; ldmFlag = 1; setMaxCompression(&compressionParams);
+                    continue;
+                }
 
                 /* long commands with arguments */
 #ifndef ZSTD_NODICT

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -639,6 +639,22 @@ static unsigned parseCompressionParameters(const char* stringPtr, ZSTD_compressi
     return 1;
 }
 
+static void setMaxCompression(ZSTD_compressionParameters* params)
+{
+    params->windowLog = ZSTD_WINDOWLOG_MAX;
+    params->chainLog = ZSTD_CHAINLOG_MAX;
+    params->hashLog = ZSTD_HASHLOG_MAX;
+    params->searchLog = ZSTD_SEARCHLOG_MAX;
+    params->minMatch = ZSTD_MINMATCH_MIN;
+    params->targetLength = ZSTD_TARGETLENGTH_MAX;
+    params->strategy = ZSTD_STRATEGY_MAX;
+    g_overlapLog = ZSTD_OVERLAPLOG_MAX;
+    g_ldmHashLog = ZSTD_LDM_HASHLOG_MAX;
+    g_ldmHashRateLog = 0; /* automatically derived */
+    g_ldmMinMatch = 32; /* heuristic */
+    g_ldmBucketSizeLog = ZSTD_LDM_BUCKETSIZELOG_MAX;
+}
+
 static void printVersion(void)
 {
     if (g_displayLevel < DISPLAY_LEVEL_DEFAULT) {
@@ -957,6 +973,7 @@ int main(int argCount, const char* argv[])
                 if (!strcmp(argument, "--quiet")) { g_displayLevel--; continue; }
                 if (!strcmp(argument, "--stdout")) { forceStdout=1; outFileName=stdoutmark; continue; }
                 if (!strcmp(argument, "--ultra")) { ultra=1; continue; }
+                if (!strcmp(argument, "--max")) { ultra=1; ldmFlag = 1; setMaxCompression(&compressionParams); continue; }
                 if (!strcmp(argument, "--check")) { FIO_setChecksumFlag(prefs, 2); continue; }
                 if (!strcmp(argument, "--no-check")) { FIO_setChecksumFlag(prefs, 0); continue; }
                 if (!strcmp(argument, "--sparse")) { FIO_setSparseWrite(prefs, 2); continue; }

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -651,7 +651,7 @@ static void setMaxCompression(ZSTD_compressionParameters* params)
     g_overlapLog = ZSTD_OVERLAPLOG_MAX;
     g_ldmHashLog = ZSTD_LDM_HASHLOG_MAX;
     g_ldmHashRateLog = 0; /* automatically derived */
-    g_ldmMinMatch = 32; /* heuristic */
+    g_ldmMinMatch = 16; /* heuristic */
     g_ldmBucketSizeLog = ZSTD_LDM_BUCKETSIZELOG_MAX;
 }
 

--- a/tests/cli-tests/compression/levels.sh
+++ b/tests/cli-tests/compression/levels.sh
@@ -10,9 +10,11 @@ zstd --fast=10 file -o file-f10.zst -q
 zstd --fast=1 file -o file-f1.zst -q
 zstd -1 file -o file-1.zst -q
 zstd -19 file -o file-19.zst -q
+zstd --max file -o file-max.zst -q
 
-zstd -t file-f10.zst file-f1.zst file-1.zst file-19.zst
+zstd -t file-f10.zst file-f1.zst file-1.zst file-19.zst file-max.zst
 
+cmp_size -le file-max.zst file-19.zst
 cmp_size -lt file-19.zst file-1.zst
 cmp_size -lt file-1.zst file-f1.zst
 cmp_size -lt file-f1.zst file-f10.zst

--- a/tests/cli-tests/compression/levels.sh
+++ b/tests/cli-tests/compression/levels.sh
@@ -5,12 +5,20 @@ set -v
 
 datagen > file
 
+# Retrieve the program's version information
+version_info=$(zstd -V)
+
 # Compress with various levels and ensure that their sizes are ordered
 zstd --fast=10 file -o file-f10.zst -q
 zstd --fast=1 file -o file-f1.zst -q
 zstd -1 file -o file-1.zst -q
 zstd -19 file -o file-19.zst -q
-zstd --max file -o file-max.zst -q
+if echo "$version_info" | grep -q '32-bit'; then
+    # skip --max test: not enough address space
+    cp file-19.zst file-max.zst
+else
+    zstd --max file -o file-max.zst -q
+fi
 
 zstd -t file-f10.zst file-f1.zst file-1.zst file-19.zst file-max.zst
 

--- a/tests/cli-tests/compression/levels.sh
+++ b/tests/cli-tests/compression/levels.sh
@@ -6,7 +6,10 @@ set -v
 datagen > file
 
 # Retrieve the program's version information
+# Note: command echoing differs between macos and linux, so it's disabled below
+set +v
 version_info=$(zstd -V)
+set -v
 
 # Compress with various levels and ensure that their sizes are ordered
 zstd --fast=10 file -o file-f10.zst -q

--- a/tests/cli-tests/compression/levels.sh.stderr.exact
+++ b/tests/cli-tests/compression/levels.sh.stderr.exact
@@ -1,12 +1,20 @@
 
 datagen > file
 
+# Retrieve the program's version information
+version_info=$(zstd -V)
+
 # Compress with various levels and ensure that their sizes are ordered
 zstd --fast=10 file -o file-f10.zst -q
 zstd --fast=1 file -o file-f1.zst -q
 zstd -1 file -o file-1.zst -q
 zstd -19 file -o file-19.zst -q
-zstd --max file -o file-max.zst -q
+if echo "$version_info" | grep -q '32-bit'; then
+    # skip --max test: not enough address space
+    cp file-19.zst file-max.zst
+else
+    zstd --max file -o file-max.zst -q
+fi
 
 zstd -t file-f10.zst file-f1.zst file-1.zst file-19.zst file-max.zst
 5 files decompressed : 327685 bytes total 

--- a/tests/cli-tests/compression/levels.sh.stderr.exact
+++ b/tests/cli-tests/compression/levels.sh.stderr.exact
@@ -2,7 +2,8 @@
 datagen > file
 
 # Retrieve the program's version information
-version_info=$(zstd -V)
+# Note: command echoing differs between macos and linux, so it's disabled below
+set +v
 
 # Compress with various levels and ensure that their sizes are ordered
 zstd --fast=10 file -o file-f10.zst -q

--- a/tests/cli-tests/compression/levels.sh.stderr.exact
+++ b/tests/cli-tests/compression/levels.sh.stderr.exact
@@ -6,10 +6,12 @@ zstd --fast=10 file -o file-f10.zst -q
 zstd --fast=1 file -o file-f1.zst -q
 zstd -1 file -o file-1.zst -q
 zstd -19 file -o file-19.zst -q
+zstd --max file -o file-max.zst -q
 
-zstd -t file-f10.zst file-f1.zst file-1.zst file-19.zst
-4 files decompressed : 262148 bytes total 
+zstd -t file-f10.zst file-f1.zst file-1.zst file-19.zst file-max.zst
+5 files decompressed : 327685 bytes total 
 
+cmp_size -le file-max.zst file-19.zst
 cmp_size -lt file-19.zst file-1.zst
 cmp_size -lt file-1.zst file-f1.zst
 cmp_size -lt file-f1.zst file-f10.zst


### PR DESCRIPTION
New `--max` command, which attempts to provide the best possible compression ratio, at the expense of everything else, cpu and memory, by pushing all parameters to their maximum value.

Warning: this setting is extremely wasteful, and not meant to be practical for larger files,
as illustrated by the following example:

compressing `enwik9` (1,000,000,000 bytes) at `--max` level, on a i7-9700k platform:

| level | cSize | cTime | cMem |
| --- | --- | --- | --- |
| `--ultra -22` | 213,898,083 | ~6 mn | ~ 3 GB |
| `--max` | 202,507,076 | ~72 mn | ~ 18 GB |