### PR TITLE
Check API manual and man pages before release

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
-    - name: ensure zstd can be build with c89/c90 compilers (+ long long support + variadic macros)
+    - name: ensure zstd can be built with c89/c90 compilers (+ long long support + variadic macros)
       run: |
         make c89build V=1
 

--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -1,4 +1,4 @@
-name: check_manual
+name: release_checks
 
 on:
   push:
@@ -26,6 +26,39 @@ jobs:
       - name: Compare manuals
         run: |
           if ! cmp -s doc/zstd_manual.html doc/zstd_manual_saved.html; then
-            echo "The manual was not updated before release !"
+            echo "The API manual was not updated before release !"
             exit 1
           fi
+
+  verify-man-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby ruby-dev
+          sudo gem install ronn
+
+      - name: Display ronn version
+        run: ronn --version
+
+      - name: Save current man pages
+        run: |
+          mv programs/zstd.1 programs/zstd.1.saved
+          mv programs/zstdgrep.1 programs/zstdgrep.1.saved
+          mv programs/zstdless.1 programs/zstdless.1.saved
+
+      - name: Generate new manual pages
+        run: make -C programs man
+
+      - name: Compare man pages
+        run: |
+          for file in zstd.1 zstdgrep.1 zstdless.1; do
+            if ! cmp -s programs/$file programs/$file.saved; then
+              echo "The man page $file should have been updated."
+              exit 1
+            fi
+          done

--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -1,0 +1,31 @@
+name: check_manual
+
+on:
+  push:
+    branches:
+      - release
+  pull_request:
+    branches:
+      - release
+
+permissions: read-all
+
+jobs:
+  verify-manual:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Save current manual
+        run: mv doc/zstd_manual.html doc/zstd_manual_saved.html
+
+      - name: Generate new manual
+        run: make manual
+
+      - name: Compare manuals
+        run: |
+          if ! cmp -s doc/zstd_manual.html doc/zstd_manual_saved.html; then
+            echo "The manual was not updated before release !"
+            exit 1
+          fi


### PR DESCRIPTION
This PR adds 2 checks in CI
to ensure that the man pages and the API manual are correctly updated before reaching the `release` branch.

This will avoid issues like #4301 in the future.

These new tests are triggered when merging or presenting a PR onto the `release` branch (only).
They were tested in my local fork.
For instance, after making an intentional modification to `zstd.1.md`, it triggered the following error signal: https://github.com/Cyan4973/zstd/actions/runs/13444836104/job/37567684872?pr=4