### PR TITLE
Fix function signature mismatch for ZSTD_convertBlockSequences

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -1523,7 +1523,7 @@ typedef struct {
 /* for benchmark */
 size_t ZSTD_convertBlockSequences(ZSTD_CCtx* cctx,
                         const ZSTD_Sequence* const inSeqs, size_t nbSequences,
-                        int const repcodeResolution);
+                        int repcodeResolution);
 
 typedef struct {
     size_t nbSequences;


### PR DESCRIPTION
In commit [`ab0f179`](https://github.com/facebook/zstd/commit/ab0f1798e8ec85dc03d39412513c84a5ef5539ff), the function signature of ZSTD_convertBlockSequences was changed in the definition, but the declaration was not updated. This PR fixes the inconsistency.
