### PR TITLE
build_package.bat: fix path to zstd_errors.h, avoid silently ignore of the errors if build failed

### DIFF
--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Create artifacts
       run: |
-        ./lib/dll/example/build_package.bat
+        ./lib/dll/example/build_package.bat || exit 1
         mv bin/ zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
         7z a -tzip -mx9 zstd-${{ github.ref_name }}-${{matrix.ziparch}}.zip zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
         cd ..

--- a/lib/dll/example/build_package.bat
+++ b/lib/dll/example/build_package.bat
@@ -15,6 +15,6 @@ COPY lib\dll\example\Makefile bin\example\
 COPY lib\dll\example\fullbench-dll.* bin\example\
 COPY lib\dll\example\README.md bin\
 COPY lib\zstd.h bin\include\
-COPY lib\common\zstd_errors.h bin\include\
+COPY lib\zstd_errors.h bin\include\
 COPY lib\dictBuilder\zdict.h bin\include\
 COPY programs\zstd.exe bin\zstd.exe

--- a/lib/dll/example/build_package.bat
+++ b/lib/dll/example/build_package.bat
@@ -1,20 +1,30 @@
 @ECHO OFF
 MKDIR bin\dll bin\static bin\example bin\include
-COPY tests\fullbench.c bin\example\
-COPY programs\datagen.c bin\example\
-COPY programs\datagen.h bin\example\
-COPY programs\util.h bin\example\
-COPY programs\platform.h bin\example\
-COPY lib\common\mem.h bin\example\
-COPY lib\common\zstd_internal.h bin\example\
-COPY lib\common\error_private.h bin\example\
-COPY lib\common\xxhash.h bin\example\
-COPY lib\libzstd.a bin\static\libzstd_static.lib
-COPY lib\dll\libzstd.* bin\dll\
-COPY lib\dll\example\Makefile bin\example\
-COPY lib\dll\example\fullbench-dll.* bin\example\
-COPY lib\dll\example\README.md bin\
-COPY lib\zstd.h bin\include\
-COPY lib\zstd_errors.h bin\include\
-COPY lib\dictBuilder\zdict.h bin\include\
-COPY programs\zstd.exe bin\zstd.exe
+SET CpyError=
+COPY tests\fullbench.c bin\example\ || (SET CpyError=%CpyError% tests\fullbench.c)
+COPY programs\datagen.c bin\example\ || (SET CpyError=%CpyError% programs\datagen.c)
+COPY programs\datagen.h bin\example\ || (SET CpyError=%CpyError% programs\datagen.h)
+COPY programs\util.h bin\example\ || (SET CpyError=%CpyError% programs\util.h)
+COPY programs\platform.h bin\example\ || (SET CpyError=%CpyError% programs\platform.h)
+COPY lib\common\mem.h bin\example\ || (SET CpyError=%CpyError% lib\common\mem.h)
+COPY lib\common\zstd_internal.h bin\example\ || (SET CpyError=%CpyError% lib\common\zstd_internal.h)
+COPY lib\common\error_private.h bin\example\ || (SET CpyError=%CpyError% lib\common\error_private.h)
+COPY lib\common\xxhash.h bin\example\ || (SET CpyError=%CpyError% lib\common\xxhash.h)
+COPY lib\libzstd.a bin\static\libzstd_static.lib || (SET CpyError=%CpyError% lib\libzstd.a)
+COPY lib\dll\libzstd.* bin\dll\ || (SET CpyError=%CpyError% lib\dll\libzstd.*)
+COPY lib\dll\example\Makefile bin\example\ || (SET CpyError=%CpyError% lib\dll\example\Makefile)
+COPY lib\dll\example\fullbench-dll.* bin\example\ || (SET CpyError=%CpyError% lib\dll\example\fullbench)
+COPY lib\dll\example\README.md bin\ || (SET CpyError=%CpyError% lib\dll\example\README.md)
+COPY lib\zstd.h bin\include\ || (SET CpyError=%CpyError% lib\zstd.h)
+COPY lib\zstd_errors.h bin\include\ || (SET CpyError=%CpyError% lib\zstd_errors.h)
+COPY lib\dictBuilder\zdict.h bin\include\ || (SET CpyError=%CpyError% lib\dictBuilder\zdict.h)
+COPY programs\zstd.exe bin\zstd.exe || (SET CpyError=%CpyError% programs\zstd.exe)
+
+IF "[%CpyError%]" == "[]" goto :EOF
+
+:error
+echo Failed with error #%errorlevel%: unable to copy following files:
+echo   %CpyError%
+exit /b %errorlevel%
+
+:EOF


### PR DESCRIPTION
This PR fixes:
- build_package.bat: fix path to `zstd_errors.h` (it is in `lib` not in `lib/common`)
  also closes #4318
- build_package.bat: don't swallow the error(s) by copy, exit with error if it failed somewhere
- GHA/windows-artifacts.yml: don't ignore the error if build-package batch failed
