### PR TITLE
Automate Windows Artifact generation and publication

### DIFF
--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Building zlib to static link
       run: |
-        git clone --depth 1 --branch v1.2.11 https://github.com/madler/zlib
+        git clone --depth 1 --branch v1.3.1 https://github.com/madler/zlib
         make -C zlib -f win32/Makefile.gcc libz.a
 
     - name: Building zstd programs

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Building zstd programs
       run: |
-        CPPFLAGS=-I../zlib LDFLAGS=../zlib/libz.a make -j allzstd MOREFLAGS=-static V=1
+        CPPFLAGS=-I../zlib LDLIBS=../zlib/libz.a LDFLAGS=-static make -j allzstd V=1
 
     - name: Create artifacts
       run: |

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -2,7 +2,7 @@ name: windows-artifacts
 
 on:
   push:
-    branches: [ test_artifacts, win_artifacts ]
+    branches: [ test_artifacts, win_artifacts, release ]
   release:
     types:
       - published
@@ -53,5 +53,6 @@ jobs:
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # tag=v4.3.1
       with:
         compression-level: 9  # maximum compression
+        if-no-files-found: error # defaults to `warn`
         path: ${{ github.workspace }}/zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
         name: zstd-${{ github.ref_name }}-${{matrix.ziparch}}

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # tag=v2.27.0
       with:
         msystem: ${{ matrix.msystem }}
-        install: make zlib git p7zip mingw-w64-${{matrix.env}}-gcc
+        install: make zlib git mingw-w64-${{matrix.env}}-gcc
         update: true
 
     - name: display versions
@@ -48,11 +48,10 @@ jobs:
       run: |
         ./lib/dll/example/build_package.bat || exit 1
         mv bin/ zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
-        7z a -tzip -mx9 zstd-${{ github.ref_name }}-${{matrix.ziparch}}.zip zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
-        cd ..
 
     - name: Publish zstd-$VERSION-${{matrix.ziparch}}.zip
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # tag=v4.3.1
       with:
-        path: ${{ github.workspace }}/zstd-${{ github.ref_name }}-${{matrix.ziparch}}.zip
-        name: zstd-${{ github.ref_name }}-${{matrix.ziparch}}.zip
+        compression-level: 9  # maximum compression
+        path: ${{ github.workspace }}/zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
+        name: zstd-${{ github.ref_name }}-${{matrix.ziparch}}

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -11,6 +11,8 @@ permissions: read-all
 
 jobs:
   windows-artifacts:
+    permissions:
+      contents: write # to fetch code and upload artifacts
     # see https://ariya.io/2020/07/on-github-actions-with-msys2
     runs-on: windows-latest
     # see https://github.com/msys2/setup-msys2
@@ -27,7 +29,7 @@ jobs:
     - uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # tag=v2.27.0
       with:
         msystem: ${{ matrix.msystem }}
-        install: make zlib git mingw-w64-${{matrix.env}}-gcc
+        install: make zlib p7zip git mingw-w64-${{matrix.env}}-gcc
         update: true
 
     - name: display versions
@@ -49,10 +51,24 @@ jobs:
         ./lib/dll/example/build_package.bat || exit 1
         mv bin/ zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
 
-    - name: Publish zstd-$VERSION-${{matrix.ziparch}}.zip
+    - name: Publish zstd-$VERSION-${{matrix.ziparch}}.zip for manual inspection
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # tag=v4.3.1
       with:
         compression-level: 9  # maximum compression
         if-no-files-found: error # defaults to `warn`
         path: ${{ github.workspace }}/zstd-${{ github.ref_name }}-${{matrix.ziparch}}/
         name: zstd-${{ github.ref_name }}-${{matrix.ziparch}}
+
+    - name: Package artifact for upload
+      run: |
+        7z a -tzip -mx9 "$(cygpath -u '${{ github.workspace }}/zstd-${{ github.ref_name }}-${{ matrix.ziparch }}.zip')" "$(cygpath -u '${{ github.workspace }}/zstd-${{ github.ref_name }}-${{ matrix.ziparch }}')"
+
+    - name: Upload release asset
+      if: github.event_name == 'release'
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload "${{ github.ref_name }}" "$env:GITHUB_WORKSPACE/zstd-${{ github.ref_name }}-${{ matrix.ziparch }}.zip" --clobber
+
+

--- a/lib/dll/example/build_package.bat
+++ b/lib/dll/example/build_package.bat
@@ -21,12 +21,16 @@ call :copyFile "lib\dll\example\fullbench-dll.*" "bin\example\"
 call :copyFile "lib\dll\example\README.md" "bin\"
 call :copyFile "lib\zstd.h" "bin\include\"
 call :copyFile "lib\zstd_errors.h" "bin\include\"
-call :copyFile "lib\dictBuilder\zdict.h" "bin\include\"
+call :copyFile "lib\zdict.h" "bin\include\"
 call :copyFile "programs\zstd.exe" "bin\zstd.exe"
 
 endlocal
-exit /b
+exit /b 0
 
 :copyFile
-copy "%~1" "%~2" || (echo Failure processing "%~1" & exit /b %errorlevel%)
-goto :eof
+copy "%~1" "%~2"
+if errorlevel 1 (
+    echo Failed to copy "%~1"
+    exit 1
+)
+exit /b

--- a/lib/dll/example/build_package.bat
+++ b/lib/dll/example/build_package.bat
@@ -1,31 +1,32 @@
-@ECHO OFF
-MKDIR bin\dll bin\static bin\example bin\include
-SET CpyError=
-COPY tests\fullbench.c bin\example\ || (SET CpyError=%CpyError% tests\fullbench.c)
-COPY programs\datagen.c bin\example\ || (SET CpyError=%CpyError% programs\datagen.c)
-COPY programs\datagen.h bin\example\ || (SET CpyError=%CpyError% programs\datagen.h)
-COPY programs\util.h bin\example\ || (SET CpyError=%CpyError% programs\util.h)
-COPY programs\platform.h bin\example\ || (SET CpyError=%CpyError% programs\platform.h)
-COPY lib\common\mem.h bin\example\ || (SET CpyError=%CpyError% lib\common\mem.h)
-COPY lib\common\zstd_internal.h bin\example\ || (SET CpyError=%CpyError% lib\common\zstd_internal.h)
-COPY lib\common\error_private.h bin\example\ || (SET CpyError=%CpyError% lib\common\error_private.h)
-COPY lib\common\xxhash.h bin\example\ || (SET CpyError=%CpyError% lib\common\xxhash.h)
-COPY lib\libzstd.a bin\static\libzstd_static.lib || (SET CpyError=%CpyError% lib\libzstd.a)
-COPY lib\dll\libzstd.* bin\dll\ || (SET CpyError=%CpyError% lib\dll\libzstd.*)
-COPY lib\dll\example\Makefile bin\example\ || (SET CpyError=%CpyError% lib\dll\example\Makefile)
-COPY lib\dll\example\fullbench-dll.* bin\example\ || (SET CpyError=%CpyError% lib\dll\example\fullbench)
-COPY lib\dll\example\README.md bin\ || (SET CpyError=%CpyError% lib\dll\example\README.md)
-COPY lib\zstd.h bin\include\ || (SET CpyError=%CpyError% lib\zstd.h)
-COPY lib\zstd_errors.h bin\include\ || (SET CpyError=%CpyError% lib\zstd_errors.h)
-COPY lib\dictBuilder\zdict.h bin\include\ || (SET CpyError=%CpyError% lib\dictBuilder\zdict.h)
-COPY programs\zstd.exe bin\zstd.exe || (SET CpyError=%CpyError% programs\zstd.exe)
+@echo off
+setlocal
 
-IF "[%CpyError%]" == "[]" goto :EOF
+rem Create required directories.
+mkdir bin\dll bin\static bin\example bin\include
 
-:error
-SET errorlevel=1
-echo Failed with error #%errorlevel%: unable to copy following files:
-echo   %CpyError%
-exit /b %errorlevel%
+rem Copy files using a subroutine. Exits immediately on failure.
+call :copyFile "tests\fullbench.c" "bin\example\"
+call :copyFile "programs\datagen.c" "bin\example\"
+call :copyFile "programs\datagen.h" "bin\example\"
+call :copyFile "programs\util.h" "bin\example\"
+call :copyFile "programs\platform.h" "bin\example\"
+call :copyFile "lib\common\mem.h" "bin\example\"
+call :copyFile "lib\common\zstd_internal.h" "bin\example\"
+call :copyFile "lib\common\error_private.h" "bin\example\"
+call :copyFile "lib\common\xxhash.h" "bin\example\"
+call :copyFile "lib\libzstd.a" "bin\static\libzstd_static.lib"
+call :copyFile "lib\dll\libzstd.*" "bin\dll\"
+call :copyFile "lib\dll\example\Makefile" "bin\example\"
+call :copyFile "lib\dll\example\fullbench-dll.*" "bin\example\"
+call :copyFile "lib\dll\example\README.md" "bin\"
+call :copyFile "lib\zstd.h" "bin\include\"
+call :copyFile "lib\zstd_errors.h" "bin\include\"
+call :copyFile "lib\dictBuilder\zdict.h" "bin\include\"
+call :copyFile "programs\zstd.exe" "bin\zstd.exe"
 
-:EOF
+endlocal
+exit /b
+
+:copyFile
+copy "%~1" "%~2" || (echo Failure processing "%~1" & exit /b %errorlevel%)
+goto :eof

--- a/lib/dll/example/build_package.bat
+++ b/lib/dll/example/build_package.bat
@@ -23,6 +23,7 @@ COPY programs\zstd.exe bin\zstd.exe || (SET CpyError=%CpyError% programs\zstd.ex
 IF "[%CpyError%]" == "[]" goto :EOF
 
 :error
+SET errorlevel=1
 echo Failed with error #%errorlevel%: unable to copy following files:
 echo   %CpyError%
 exit /b %errorlevel%


### PR DESCRIPTION
which generates the directory for the Windows Release packages.

- Rewrite the script to use a subroutine, reducing the size of each line
- Ensure that the script fails (i.e. generates a red signal in CI) when one of the expected input (file) isn't present as expected. This will fix silent issues like the recent https://github.com/facebook/zstd/issues/4318 reported by @sebres
- update `zlib` dependency to `v1.3.1`