### PR TITLE
warn when requesting decompression with multiple threads

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1350,7 +1350,7 @@ int main(int argCount, const char* argv[])
     if (operation == zom_compress)
         DISPLAYLEVEL(4, "Compressing with %u worker threads \n", nbWorkers);
 #else
-    (void)singleThread; (void)nbWorkers; (void)defaultLogicalCores;
+    (void)singleThread; (void)nbWorkers; (void)defaultLogicalCores; (void)setThreads_non1;
 #endif
 
     g_utilDisplayLevel = g_displayLevel;

--- a/tests/cli-tests/compression/multi-threaded.sh
+++ b/tests/cli-tests/compression/multi-threaded.sh
@@ -10,3 +10,13 @@ zstd -T0 -f file -q                     ; zstd -t file.zst
 zstd -T0 --auto-threads=logical -f file -q ; zstd -t file.zst
 zstd -T0 --auto-threads=physical -f file -q ; zstd -t file.zst
 zstd -T0 --jobsize=1M -f file -q        ; zstd -t file.zst
+
+# multi-thread decompression warning test
+zstd -T0 -f file -q                     ; zstd -t file.zst; zstd -T0 -d file.zst -o file3
+zstd -T0 -f file -q                     ; zstd -t file.zst; zstd -T2 -d file.zst -o file4
+# setting multi-thread via environment variable does not trigger decompression warning
+zstd -T0 -f file -q                     ; zstd -t file.zst; ZSTD_NBTHREADS=0 zstd -df file.zst -o file3
+zstd -T0 -f file -q                     ; zstd -t file.zst; ZSTD_NBTHREADS=2 zstd -df file.zst -o file4
+# setting nbThreads==1 does not trigger decompression warning
+zstd -T0 -f file -q                     ; zstd -t file.zst; zstd -T1 -df file.zst -o file3
+zstd -T0 -f file -q                     ; zstd -t file.zst; zstd -T2 -T1 -df file.zst -o file4

--- a/tests/cli-tests/compression/multi-threaded.sh.stderr.exact
+++ b/tests/cli-tests/compression/multi-threaded.sh.stderr.exact
@@ -5,3 +5,17 @@ file.zst            : 65537 bytes
 file.zst            : 65537 bytes 
 file.zst            : 65537 bytes 
 file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+Warning : decompression does not support multi-threading
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+Warning : decompression does not support multi-threading
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 
+file.zst            : 65537 bytes 


### PR DESCRIPTION
restore #2918 fix

This requires a new variable `setThreads_non1`
to track explicit user request(s) on command line.
