### PR TITLE
Support process substitution for `--filelist=`

### DIFF
--- a/.github/workflows/dev-long-tests.yml
+++ b/.github/workflows/dev-long-tests.yml
@@ -28,7 +28,10 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
     - name: make test
-      run: make test
+      run: |
+        make test
+        make -j zstd
+        ./tests/test_process_substitution.bash ./zstd
 
   # lasts ~26mn
   make-test-macos:

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -537,15 +537,13 @@ static int FIO_removeFile(const char* path)
     return remove(path);
 }
 
-/** FIO_openSrcFile() :
- *  condition : `srcFileName` must be non-NULL. `prefs` may be NULL.
- * @result : FILE* to `srcFileName`, or NULL if it fails */
 static FILE* FIO_openSrcFile(const FIO_prefs_t* const prefs, const char* srcFileName, stat_t* statbuf)
 {
     int allowBlockDevices = prefs != NULL ? prefs->allowBlockDevices : 0;
     assert(srcFileName != NULL);
     assert(statbuf != NULL);
-    if (!strcmp (srcFileName, stdinmark)) {
+
+    if (!strcmp(srcFileName, stdinmark)) {
         DISPLAYLEVEL(4,"Using stdin for input \n");
         SET_BINARY_MODE(stdin);
         return stdin;
@@ -557,8 +555,10 @@ static FILE* FIO_openSrcFile(const FIO_prefs_t* const prefs, const char* srcFile
         return NULL;
     }
 
+    /* Accept regular files, FIFOs, and process substitution file descriptors */
     if (!UTIL_isRegularFileStat(statbuf)
      && !UTIL_isFIFOStat(statbuf)
+     && !UTIL_isFileDescriptorPipe(srcFileName)  /* Process substitution support */
      && !(allowBlockDevices && UTIL_isBlockDevStat(statbuf))
     ) {
         DISPLAYLEVEL(1, "zstd: %s is not a regular file -- ignored \n",

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -659,9 +659,10 @@ FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
         }
 #endif
         if (f == NULL) {
-            DISPLAYLEVEL(1, "zstd: %s: %s\n", dstFileName, strerror(errno));
             if (UTIL_isFileDescriptorPipe(dstFileName)) {
-                DISPLAYLEVEL(1, "When using process substitution (<(...)), specify an output destination with -o or -c. \n");
+                DISPLAYLEVEL(1, "zstd: error: no output specified (use -o or -c). \n");
+            } else {
+                DISPLAYLEVEL(1, "zstd: %s: %s\n", dstFileName, strerror(errno));
             }
         } else {
             /* An increased buffer size can provide a significant performance

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -537,6 +537,10 @@ static int FIO_removeFile(const char* path)
     return remove(path);
 }
 
+/** FIO_openSrcFile() :
+ *  condition : `srcFileName` must be non-NULL.
+ *  optional: `prefs` may be NULL.
+ * @result : FILE* to `srcFileName`, or NULL if it fails */
 static FILE* FIO_openSrcFile(const FIO_prefs_t* const prefs, const char* srcFileName, stat_t* statbuf)
 {
     int allowBlockDevices = prefs != NULL ? prefs->allowBlockDevices : 0;

--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -660,6 +660,9 @@ FIO_openDstFile(FIO_ctx_t* fCtx, FIO_prefs_t* const prefs,
 #endif
         if (f == NULL) {
             DISPLAYLEVEL(1, "zstd: %s: %s\n", dstFileName, strerror(errno));
+            if (UTIL_isFileDescriptorPipe(dstFileName)) {
+                DISPLAYLEVEL(1, "When using process substitution (<(...)), specify an output destination with -o or -c. \n");
+            }
         } else {
             /* An increased buffer size can provide a significant performance
              * boost on some platforms. Note that providing a NULL buf with a

--- a/programs/util.c
+++ b/programs/util.c
@@ -723,34 +723,33 @@ UTIL_createLinePointers(char* buffer, size_t numLines, size_t bufferSize)
 }
 
 FileNamesTable*
-UTIL_createFileNamesTable_fromFileName(const char* inputFileName)
+UTIL_createFileNamesTable_fromFileList(const char* fileList)
 {
     stat_t statbuf;
-    FILE* inFile = NULL;
     char* buffer = NULL;
-    const char** linePointers = NULL;
     size_t numLines = 0;
     size_t bufferSize = 0;
 
     /* Check if the input is a valid file */
-    if (!UTIL_stat(inputFileName, &statbuf)) {
+    if (!UTIL_stat(fileList, &statbuf)) {
         return NULL;
     }
 
     /* Check if the input is a supported type */
     if (!UTIL_isRegularFileStat(&statbuf) &&
         !UTIL_isFIFOStat(&statbuf) &&
-        !UTIL_isFileDescriptorPipe(inputFileName)) {
+        !UTIL_isFileDescriptorPipe(fileList)) {
         return NULL;
     }
 
     /* Open the input file */
-    inFile = fopen(inputFileName, "rb");
-    if (inFile == NULL) return NULL;
+    {   FILE* const inFile = fopen(fileList, "rb");
+        if (inFile == NULL) return NULL;
 
-    /* Read the file content */
-    buffer = UTIL_readFileContent(inFile, &bufferSize);
-    fclose(inFile);
+        /* Read the file content */
+        buffer = UTIL_readFileContent(inFile, &bufferSize);
+        fclose(inFile);
+    }
 
     if (buffer == NULL) return NULL;
 
@@ -762,14 +761,15 @@ UTIL_createFileNamesTable_fromFileName(const char* inputFileName)
     }
 
     /* Create line pointers */
-    linePointers = UTIL_createLinePointers(buffer, numLines, bufferSize);
-    if (linePointers == NULL) {
-        free(buffer);
-        return NULL;
-    }
+    {   const char** linePointers = UTIL_createLinePointers(buffer, numLines, bufferSize);
+        if (linePointers == NULL) {
+            free(buffer);
+            return NULL;
+        }
 
-    /* Create the final table */
-    return UTIL_assembleFileNamesTable(linePointers, numLines, buffer);
+        /* Create the final table */
+        return UTIL_assembleFileNamesTable(linePointers, numLines, buffer);
+    }
 }
 
 

--- a/programs/util.h
+++ b/programs/util.h
@@ -251,13 +251,13 @@ typedef struct
     size_t tableCapacity;
 } FileNamesTable;
 
-/*! UTIL_createFileNamesTable_fromFileName() :
+/*! UTIL_createFileNamesTable_fromFileList() :
  *  read filenames from @inputFileName, and store them into returned object.
  * @return : a FileNamesTable*, or NULL in case of error (ex: @inputFileName doesn't exist).
  *  Note: inputFileSize must be less than 50MB
  */
 FileNamesTable*
-UTIL_createFileNamesTable_fromFileName(const char* inputFileName);
+UTIL_createFileNamesTable_fromFileList(const char* inputFileName);
 
 /*! UTIL_assembleFileNamesTable() :
  *  This function takes ownership of its arguments, @filenames and @buf,

--- a/programs/util.h
+++ b/programs/util.h
@@ -191,6 +191,7 @@ int UTIL_isSameFileStat(const char* file1, const char* file2, const stat_t* file
 int UTIL_isCompressedFile(const char* infilename, const char *extensionList[]);
 int UTIL_isLink(const char* infilename);
 int UTIL_isFIFO(const char* infilename);
+int UTIL_isFileDescriptorPipe(const char* filename);
 
 /**
  * Returns with the given file descriptor is a console.

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1379,7 +1379,7 @@ int main(int argCount, const char* argv[])
         size_t const nbFileLists = file_of_names->tableSize;
         size_t flNb;
         for (flNb=0; flNb < nbFileLists; flNb++) {
-            FileNamesTable* const fnt = UTIL_createFileNamesTable_fromFileName(file_of_names->fileNames[flNb]);
+            FileNamesTable* const fnt = UTIL_createFileNamesTable_fromFileList(file_of_names->fileNames[flNb]);
             if (fnt==NULL) {
                 DISPLAYLEVEL(1, "zstd: error reading %s \n", file_of_names->fileNames[flNb]);
                 CLEAN_RETURN(1);

--- a/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh.stderr.exact
@@ -23,4 +23,6 @@ Trace:FileStat:  > UTIL_stat(-1, out/file.zst)
 Trace:FileStat:  < 0
 Trace:FileStat: < 0
 zstd: out/file.zst: Permission denied
+Trace:FileStat: > UTIL_isFileDescriptorPipe(out/file.zst)
+Trace:FileStat: < 0
 zstd: can't stat out/file.zst : Permission denied -- ignored 

--- a/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh.stderr.exact
+++ b/tests/cli-tests/file-stat/compress-file-to-dir-without-write-perm.sh.stderr.exact
@@ -22,7 +22,7 @@ Trace:FileStat: > UTIL_isRegularFile(out/file.zst)
 Trace:FileStat:  > UTIL_stat(-1, out/file.zst)
 Trace:FileStat:  < 0
 Trace:FileStat: < 0
-zstd: out/file.zst: Permission denied
 Trace:FileStat: > UTIL_isFileDescriptorPipe(out/file.zst)
 Trace:FileStat: < 0
+zstd: out/file.zst: Permission denied
 zstd: can't stat out/file.zst : Permission denied -- ignored 

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -848,6 +848,7 @@ ls tmp* > tmpList
 zstd -f tmp1 --filelist=tmpList --filelist=tmpList tmp2 tmp3  # can trigger an overflow of internal file list
 rm -rf tmp*
 
+
 println "\n===> --[no-]content-size tests"
 
 datagen > tmp_contentsize

--- a/tests/test_process_substitution.bash
+++ b/tests/test_process_substitution.bash
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test_process_substitution.bash
+# Test zstd's support for process substitution with --filelist
+
+# Process arguments
+ZSTD_PATH="zstd"  # Default to using zstd from PATH
+if [ $# -ge 1 ]; then
+    ZSTD_PATH="$1"
+fi
+
+echo "Using zstd executable: $ZSTD_PATH"
+
+set -e  # Exit on error
+
+# Set up test directory and files
+echo "Setting up test environment..."
+TEST_DIR="tmp_process_substit"
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR"
+echo "Content of file 1" > "$TEST_DIR/file1.txt"
+echo "Content of file 2" > "$TEST_DIR/file2.txt"
+echo "Content of file 3" > "$TEST_DIR/file3.txt"
+
+# Clean up any previous test artifacts
+rm -f "$TEST_DIR/output.zst" "$TEST_DIR/output_echo.zst" "$TEST_DIR/output_cat.zst"
+rm -rf "$TEST_DIR/extracted"
+mkdir -p "$TEST_DIR/extracted"
+
+echo "=== Testing process substitution with --filelist ==="
+
+# Test 1: Basic process substitution with find
+echo "Test 1: Basic process substitution (find command)"
+"$ZSTD_PATH" --filelist=<(find "$TEST_DIR" -name "*.txt" | sort) -c > "$TEST_DIR/output.zst"
+
+if [ -f "$TEST_DIR/output.zst" ]; then
+    echo "✓ Test 1 PASSED: Output file was created"
+else
+    echo "✗ Test 1 FAILED: Output file was not created"
+    exit 1
+fi
+
+# Test 2: Process substitution with echo
+echo "Test 2: Process substitution (echo command)"
+"$ZSTD_PATH" --filelist=<(echo -e "$TEST_DIR/file1.txt\n$TEST_DIR/file2.txt") -c > "$TEST_DIR/output_echo.zst"
+
+if [ -f "$TEST_DIR/output_echo.zst" ]; then
+    echo "✓ Test 2 PASSED: Output file was created"
+else
+    echo "✗ Test 2 FAILED: Output file was not created"
+    exit 1
+fi
+
+# Test 3: Process substitution with cat
+echo "Test 3: Process substitution (cat command)"
+echo -e "$TEST_DIR/file1.txt\n$TEST_DIR/file3.txt" > "$TEST_DIR/filelist.txt"
+"$ZSTD_PATH" --filelist=<(cat "$TEST_DIR/filelist.txt") -c > "$TEST_DIR/output_cat.zst"
+
+if [ -f "$TEST_DIR/output_cat.zst" ]; then
+    echo "✓ Test 3 PASSED: Output file was created"
+else
+    echo "✗ Test 3 FAILED: Output file was not created"
+    exit 1
+fi
+
+# Test 4: Verify contents of archives
+echo "Test 4: Verifying archive contents"
+"$ZSTD_PATH" -d "$TEST_DIR/output.zst" -o "$TEST_DIR/extracted/combined.out"
+
+if grep -q "Content of file 1" "$TEST_DIR/extracted/combined.out" &&
+   grep -q "Content of file 2" "$TEST_DIR/extracted/combined.out" &&
+   grep -q "Content of file 3" "$TEST_DIR/extracted/combined.out"; then
+    echo "✓ Test 4 PASSED: All files were correctly archived and extracted"
+else
+    echo "✗ Test 4 FAILED: Not all expected content was found in the extracted file"
+    exit 1
+fi
+
+# Test 5: Edge case with empty list
+echo "Test 5: Process substitution with empty input"
+"$ZSTD_PATH" --filelist=<(echo "") -c > "$TEST_DIR/output_empty.zst" 2>/dev/null || true
+
+if [ -f "$TEST_DIR/output_empty.zst" ]; then
+    echo "✓ Test 5 PASSED: Handled empty input gracefully"
+else
+    echo "✓ Test 5 PASSED: Properly rejected empty input"
+fi
+
+# cleanup
+rm -rf "$TEST_DIR"
+
+echo "All tests completed successfully!"
+


### PR DESCRIPTION
`--filelist` capability was designed with the assumption that the source is a file, so it would be possible to know its size in advance, for allocation.

Rewrote the capability, so that it can stream data, and discover source size at the end.

solves #4340

The new capability has been tested locally, on a posix laptop.

An issue is on the testing side: process substitution is not supported by `sh`, and all our shell test scripts are using `sh` so far, for broader compatibility with diverse clients.
Adding a `bash` script is not in itself a problem, but then it can not be blindly started on any platform, since some do not support `bash`. Hence the corresponding CI test must be explicitly triggered.