### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/lib/libzstd.pc.in
+++ b/lib/libzstd.pc.in
@@ -14,3 +14,4 @@ Version: @VERSION@
 Libs: -L${libdir} -lzstd @LIBS_MT@
 Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir} @LIBS_MT@
+License: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION
The pkg-config file has License variable that allows you to set the license for the software. 
This sets 'BSD-3-Clause OR GPL-2.0-only' to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116