### PR TITLE
fix minor warning in zstreamtest

### DIFF
--- a/tests/zstreamtest.c
+++ b/tests/zstreamtest.c
@@ -1896,7 +1896,7 @@ static int basicUnitTests(U32 seed, double compressibility, int bigTests)
         CHECK_Z(ZSTD_CCtx_setParameter(zc, ZSTD_c_checksumFlag, 1));
         /* Write a bunch of 6 byte blocks */
         while (remainingInput > 0) {
-          char testBuffer[6] = "\xAA\xAA\xAA\xAA\xAA\xAA";
+          char testBuffer[6] = { 0x66, 0x66, 0x66, 0x66, 0x66, 0x66 };
           const size_t kSmallBlockSize = sizeof(testBuffer);
           ZSTD_inBuffer in = {testBuffer, kSmallBlockSize, 0};
 


### PR DESCRIPTION
```
zstreamtest.c:1899:32: error: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (7 chars into 6 available) [-Werror=unterminated-string-initialization]
 1899 |           char testBuffer[6] = "\xAA\xAA\xAA\xAA\xAA\xAA";
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

It's indeed a (minor) mistake. Not sure why it only flags now, maybe only latest version of `gcc` are able to detect it.
