### PR TITLE
update `--rm` cmd help info

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -153,7 +153,7 @@ Usage: zstd [OPTIONS...] [INPUT... | -] [-o OUTPUT]
 Options:
   -o OUTPUT                     Write output to a single file, OUTPUT.
   -k, --keep                    Preserve INPUT file(s). [Default]
-  --rm                          Remove INPUT file(s) after successful (de)compression.
+  --rm                          Remove INPUT file(s) after successful (de)compression to file.
 
   -#                            Desired compression level, where `#` is a number between 1 and 19;
                                 lower numbers provide faster compression, higher numbers yield

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -147,7 +147,7 @@ static void usage(FILE* f, const char* programName)
     DISPLAY_F(f, "Options:\n");
     DISPLAY_F(f, "  -o OUTPUT                     Write output to a single file, OUTPUT.\n");
     DISPLAY_F(f, "  -k, --keep                    Preserve INPUT file(s). [Default] \n");
-    DISPLAY_F(f, "  --rm                          Remove INPUT file(s) after successful (de)compression.\n");
+    DISPLAY_F(f, "  --rm                          Remove INPUT file(s) after successful (de)compression to file.\n");
 #ifdef ZSTD_GZCOMPRESS
     if (exeNameMatch(programName, ZSTD_GZ)) {     /* behave like gzip */
         DISPLAY_F(f, "  -n, --no-name                 Do not store original filename when compressing.\n\n");

--- a/tests/cli-tests/basic/help.sh.stdout.glob
+++ b/tests/cli-tests/basic/help.sh.stdout.glob
@@ -6,7 +6,7 @@ Usage: zstd *OPTIONS...* *INPUT... | -* *-o OUTPUT*
 Options:
   -o OUTPUT                     Write output to a single file, OUTPUT.
   -k, --keep                    Preserve INPUT file(s). *Default*
-  --rm                          Remove INPUT file(s) after successful (de)compression.
+  --rm                          Remove INPUT file(s) after successful (de)compression to file.
 
   -#                            Desired compression level, where `#` is a number between 1 and 19;
                                 lower numbers provide faster compression, higher numbers yield


### PR DESCRIPTION
Starting from cee6bec9fa6aa249f2df9f84165b682eb793eab, --rm is ignored when the output is `stdout`.