### PR TITLE
Fix potential memory leak in function `benchMem`

### DIFF
--- a/contrib/largeNbDicts/largeNbDicts.c
+++ b/contrib/largeNbDicts/largeNbDicts.c
@@ -739,6 +739,8 @@ static int benchMem(slice_collection_t dstBlocks, slice_collection_t srcBlocks,
     /* BMK_benchTimedFn may not run exactly nbRounds iterations */
     double speedAggregated =
         aggregateData(speedPerRound, roundNb + 1, metricAggregatePref);
+    free(speedPerRound);
+    
     if (metricAggregatePref == fastest)
       DISPLAY("Fastest Speed : %.1f MB/s \n", speedAggregated);
     else


### PR DESCRIPTION
`speedPerRound` is allocated at the start of function `benchMem` to collect per-round speeds, but is never freed, causing a potential memory leak.
```c
double *const speedPerRound = (double *)malloc(nbRounds * sizeof(double));
``` 

We add `free(speedPerRound);` after aggregating the data to release the heap allocation and prevent memory buildup.