### PR TITLE
Release resources before returning

### DIFF
--- a/contrib/externalSequenceProducer/main.c
+++ b/contrib/externalSequenceProducer/main.c
@@ -27,6 +27,7 @@ do {                                                    \
 } while (0)                                             \
 
 int main(int argc, char *argv[]) {
+    int retn = 0;
     if (argc != 2) {
         printf("Usage: externalSequenceProducer <file>\n");
         return 1;
@@ -96,12 +97,12 @@ int main(int argc, char *argv[]) {
                 break;
             }
         }
-        return 1;
+        retn = 1;
     }
 
     ZSTD_freeCCtx(zc);
     free(src);
     free(dst);
     free(val);
-    return 0;
+    return retn;
 }


### PR DESCRIPTION
In main, resources were freed on the success path but not in the error path. This change ensures all allocated resources are released before returning.