### PR TITLE
fuzz: Fix FUZZ_malloc_rand() to return non-NULL for zero-size allocations

### DIFF
--- a/tests/fuzz/fuzz_helpers.c
+++ b/tests/fuzz/fuzz_helpers.c
@@ -31,12 +31,11 @@ void* FUZZ_malloc_rand(size_t size, FUZZ_dataProducer_t *producer)
         return mem;
     } else {
         uintptr_t ptr = 0;
-        /* Add +- 1M 50% of the time */
+        /* Return junk pointer 50% of the time */
         if (FUZZ_dataProducer_uint32Range(producer, 0, 1))
-            FUZZ_dataProducer_int32Range(producer, -1000000, 1000000);
+            ptr += FUZZ_dataProducer_int32Range(producer, -1000000, 1000000);
         return (void*)ptr;
     }
-
 }
 
 int FUZZ_memcmp(void const* lhs, void const* rhs, size_t size)

--- a/tests/fuzz/fuzz_helpers.h
+++ b/tests/fuzz/fuzz_helpers.h
@@ -66,6 +66,7 @@ void* FUZZ_malloc(size_t size);
 /**
  * malloc except returns random pointer for zero sized data and FUZZ_ASSERT
  * that malloc doesn't fail.
+ * WARNING: Only free the returned pointer if size > 0!
  */
 void* FUZZ_malloc_rand(size_t size,  FUZZ_dataProducer_t *producer);
 


### PR DESCRIPTION
This PR fixes a bug in the `FUZZ_malloc_rand` helper function introduced in fcaf06ddb489f683.

The FUZZ_malloc_rand() function was incorrectly always returning NULL for zero-size allocations. The random offset generated by FUZZ_dataProducer_int32Range() was not being added to the pointer variable, causing the function to always return (void *)0.