### PR TITLE
Ensure BMK_timedFnState is always freed in benchMem

### DIFF
--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -890,6 +890,7 @@ static int benchMem(unsigned scenarioID,
             if (!BMK_isSuccessful_runOutcome(bOutcome)) {
                 DISPLAY("ERROR: Scenario %u: %s \n", scenarioID, ZSTD_getErrorName(BMK_extract_errorResult(bOutcome)));
                 errorcode = 1;
+                BMK_freeTimedFnState(tfs);
                 goto _cleanOut;
             }
 


### PR DESCRIPTION
When an error occurs in BMK_isSuccessful_runOutcome, the code previously skipped the call to BMK_freeTimedFnState(tfs), leaking the allocated tfs object.
Fiexed by calling BMK_freeTimedFnState(tfs) before goto _cleanOut.