### PR TITLE
meson: use SPDX expression for license

### DIFF
--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -10,7 +10,7 @@
 
 project('zstd',
   ['c', 'cpp'],
-  license: ['BSD', 'GPLv2'],
+  license: 'BSD-3-Clause OR GPL-2.0-only',
   default_options : [
     # There shouldn't be any need to force a C standard convention for zstd
     # but in case one would want that anyway, this can be done here.


### PR DESCRIPTION
This is the format [recommended](https://mesonbuild.com/Reference-manual_functions.html#project_license) by Meson documentation.