### PR TITLE
Improve speed of ZSTD_compressSequencesAndLiterals using Neon

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -435,8 +435,8 @@ jobs:
         make clean
         LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make -j check
         LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make -j -C tests test-cli-tests
-        CFLAGS="-march=armv8.2-a+sve2" LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make -j check
-        CFLAGS="-march=armv8.2-a+sve2" LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make -j -C tests test-cli-tests
+        CFLAGS="-O3 -march=armv8.2-a+sve2" LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make -j check
+        CFLAGS="-O3 -march=armv8.2-a+sve2" LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make -j -C tests test-cli-tests
 # This test is only compatible with standard libraries that support BTI (Branch Target Identification).
 # Unfortunately, the standard library provided on Ubuntu 24.04 does not have this feature enabled.
 #        make clean


### PR DESCRIPTION
This PR improves the generic implementation of `ZSTD_get1BlockSummary` and adds a Neon implementation  of `convertSequences_noRepcodes` to speed up `ZSTD_compressSequencesAndLiterals`. Details are in the commit messages. Unit tests included.

Relative performance of `ZSTD_get1BlockSummary` with `./fullbench -b19 -l5 enwik5` using GCC-13 as baseline:
```
    Neoverse-V2   before     after    uplift
    GCC-13:      100.000%  290.527%   2.905x
    GCC-14:      100.000%  291.714%   2.917x
    GCC-15:       99.914%  291.495%   2.917x
    Clang-18:    148.072%  264.524%   1.786x
    Clang-19:    148.075%  264.512%   1.786x
    Clang-20:    148.062%  264.490%   1.786x

    Cortex-A720   before     after    uplift
    GCC-13:      100.000%  235.261%   2.352x
    GCC-14:      101.064%  234.903%   2.324x
    GCC-15:      112.977%  218.547%   1.934x
    Clang-18:    127.135%  180.359%   1.418x
    Clang-19:    127.149%  180.297%   1.417x
    Clang-20:    127.154%  180.260%   1.417x
```

Relative performance of `convertSequences_noRepcodes` with `./fullbench -b18 -l5 enwik5` using Clang-18 as baseline:
```
    Neoverse-V2   before     after    uplift
    Clang-18:    100.000%  311.703%   3.117x
    Clang-19:    100.191%  311.714%   3.111x
    Clang-20:    100.181%  311.723%   3.111x
    GCC-13:      107.520%  252.309%   2.346x
    GCC-14:      107.652%  253.158%   2.351x
    GCC-15:      107.674%  253.168%   2.351x

    Cortex-A720   before     after    uplift
    Clang-18:    100.000%  204.512%   2.045x
    Clang-19:    102.825%  204.600%   1.989x
    Clang-20:    102.807%  204.558%   1.989x
    GCC-13:      110.668%  203.594%   1.839x
    GCC-14:      110.684%  203.978%   1.842x
    GCC-15:      102.864%  204.299%   1.986x
```

Relative performance of `ZSTD_compressSequencesAndLiterals` with `./fullbench -b17 -l5 enwik5` using GCC-13 as baseline:
```
    Neoverse-V2   before     after    uplift
    GCC-13:      100.000%  108.730%   1.087x
    GCC-14:      100.428%  109.235%   1.087x
    GCC-15:       98.730%  106.345%   1.077x
    Clang-18:    107.889%  117.064%   1.085x
    Clang-19:    108.088%  117.354%   1.085x
    Clang-20:    108.027%  117.614%   1.088x

    Cortex-A720   before     after    uplift
    GCC-13:      100.000%  108.104%   1.081x
    GCC-14:       99.860%  108.164%   1.083x
    GCC-15:       98.028%  105.675%   1.078x
    Clang-18:    104.380%  113.002%   1.082x
    Clang-19:    105.117%  113.998%   1.084x
    Clang-20:    105.276%  114.038%   1.083x
```

An additional commit enables optimized SVE2 builds for QEMU, reducing its runtime from ~27 minutes to ~14 minutes.

Co-authored by, Thomas Daubney <Thomas.Daubney@arm.com>