### PR TITLE
add riscv  ci

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -461,9 +461,9 @@ jobs:
       if: ${{ matrix.name == 'RISC-V' }}
       run: |
         LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make clean check
-        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=128" make clean check
-        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=256" make clean check
-        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=512" make clean check
+        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static -DMEM_FORCE_MEMORY_ACCESS=0" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=128" make clean check
+        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static -DMEM_FORCE_MEMORY_ACCESS=0" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=256" make clean check
+        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static -DMEM_FORCE_MEMORY_ACCESS=0" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=512" make clean check
     - name: M68K
       if: ${{ matrix.name == 'M68K' }}
       run: |

--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -461,6 +461,9 @@ jobs:
       if: ${{ matrix.name == 'RISC-V' }}
       run: |
         LDFLAGS="-static" CC=$XCC QEMU_SYS=$XEMU make clean check
+        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=128" make clean check
+        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=256" make clean check
+        CFLAGS="-march=rv64gcv -O3" LDFLAGS="-static" CC=$XCC QEMU_SYS="$XEMU -cpu rv64,v=true,vlen=512" make clean check
     - name: M68K
       if: ${{ matrix.name == 'M68K' }}
       run: |

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -224,9 +224,17 @@
 #  if defined(__ARM_FEATURE_SVE2)
 #    define ZSTD_ARCH_ARM_SVE2
 #  endif
-# if defined(__riscv) && defined(__riscv_vector)
-#   define ZSTD_ARCH_RISCV_RVV
-# endif
+#if defined(__riscv) && defined(__riscv_vector)
+    #if defined(__GNUC__)
+        #if (__GNUC__ > 14 || (__GNUC__ == 14 && __GNUC_MINOR__ >= 1))
+            #define ZSTD_ARCH_RISCV_RVV
+        #endif
+    #elif defined(__clang__)
+        #if __clang_major__ > 18 || (__clang_major__ == 18 && __clang_minor__ >= 1)
+            #define ZSTD_ARCH_RISCV_RVV
+        #endif
+    #endif
+#endif
 #
 #  if defined(ZSTD_ARCH_X86_AVX2)
 #    include <immintrin.h>


### PR DESCRIPTION
This PR adds RISCV RVV CI support, including tests for vlen=128, 256, 512, and includes detection of compiler versions for RVV extensions. Some compilation warnings have also been fixed. Additionally, on the Spacemit® X60 @1.6 GHz platform, when the RISC-V Vector (V) extension is enabled along with O3 optimization,unaligned memory access errors may occur if `-DMEM_FORCE_MEMORY_ACCESS=0` is not specified. Therefore, this compile-time flag has been added to the CI configuration.This PR is largely identical to a previous one(#4422 ). The reason for closing and resubmitting is that the previous branch was out of sync due to an outdated version. After pulling the latest changes, the PR is re-submitted.