### PR TITLE
fix(cmake): resolve build error due to malformed if() expression on Android platform.

### DIFF
--- a/build/cmake/CMakeModules/ZstdOptions.cmake
+++ b/build/cmake/CMakeModules/ZstdOptions.cmake
@@ -23,7 +23,7 @@ endif()
 if(ANDROID)
     set(ZSTD_MULTITHREAD_SUPPORT_DEFAULT OFF)
     # Handle old Android API levels
-    if((NOT ANDROID_PLATFORM_LEVEL) OR (ANDROID_PLATFORM_LEVEL VERSION_LESS 24))
+    if((NOT ANDROID_PLATFORM_LEVEL) OR ANDROID_PLATFORM_LEVEL VERSION_LESS 24)
         message(STATUS "Configuring for old Android API - disabling fseeko/ftello")
         add_compile_definitions(LIBC_NO_FSEEKO)
     endif()


### PR DESCRIPTION
# Description
When building Zstd v1.5.7 for the Android platform using CMake, the following error occurs during configuration:
```
CMake Error at CMakeLists.txt:95 (if):
  if given arguments:

    "(" "NOT" ")" "OR" "VERSION_LESS" "24"

  Unknown arguments specified
```
This regression was introduced in [49fe2ec](https://github.com/facebook/zstd/commit/49fe2ec79332b6706bdcac3ddca6c15a84da85b1) (refactor: modularize CMakeLists.txt for better maintainability). The problematic conditional logic is:
```
if((NOT ANDROID_PLATFORM_LEVEL) OR (ANDROID_PLATFORM_LEVEL VERSION_LESS 24))
    message(STATUS "Configuring for old Android API - disabling fseeko/ftello")
    add_compile_definitions(LIBC_NO_FSEEKO)
endif()

 ```
CMake is picky about parentheses for logical grouping inside if() statements. This leads to a parsing failure on valid Android configurations.

# Fix
The parentheses surrounding the version check is removed to comply with CMake syntax rules. 

```
if(NOT ANDROID_PLATFORM_LEVEL OR ANDROID_PLATFORM_LEVEL VERSION_LESS 24)
    message(STATUS "Configuring for old Android API - disabling fseeko/ftello")
    add_compile_definitions(LIBC_NO_FSEEKO)
endif()
```

# Validation
Manually triggered a successful cross-compiled build with Android NDK26.