### PR TITLE
fix: off-by-one error in `convertPathnameToDirName`

### DIFF
--- a/programs/util.c
+++ b/programs/util.c
@@ -1148,11 +1148,11 @@ static void convertPathnameToDirName(char *pathname)
     /* remove trailing '/' chars */
     len = strlen(pathname);
     assert(len > 0);
-    while (pathname[len] == PATH_SEP) {
-        pathname[len] = '\0';
+    while (pathname[len-1] == PATH_SEP) {
+        pathname[len-1] = '\0';
         len--;
+        if (len == 0) return;
     }
-    if (len == 0) return;
 
     /* if input is a single file, return '.' instead. i.e.
      * "xyz/abc/file.txt" => "xyz/abc"


### PR DESCRIPTION
## Fixes #4380 

- Use `pathname[len-1]` instead of `pathname[len]` to compare/modify last character instead of null terminator
- Move `len == 0` check to inside loop to avoid OOB