### PR TITLE
Remove need for trailing forward slash in dir

### DIFF
--- a/contrib/premake/zstd.lua
+++ b/contrib/premake/zstd.lua
@@ -2,6 +2,7 @@
 -- Basic usage: project_zstd(ZSTD_DIR)
 
 function project_zstd(dir, compression, decompression, deprecated, dictbuilder, legacy)
+	if string.sub(dir, -1, 1) ~= '/' then dir = dir .. '/' end
 	if compression == nil then compression = true end
 	if decompression == nil then decompression = true end
 	if deprecated == nil then deprecated = false end


### PR DESCRIPTION
If a trailing forward slash wasn't present you would get cryptic build errors.

Alternatively, it should be documented that a slash at the end is necessary:
```lua
-- dir needs a slash at the end
```