### PR TITLE
Check for build environment instead of just _GNU_SOURCE

### DIFF
--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -21,10 +21,12 @@
 /*-*************************************
 *  Dependencies
 ***************************************/
-/* qsort_r is an extension. */
-#if defined(__linux) || defined(__linux__) || defined(linux) || defined(__gnu_linux__) || \
-    defined(__CYGWIN__) || defined(__MSYS__)
-# if !defined(_GNU_SOURCE) && !defined(__ANDROID__) /* NDK doesn't ship qsort_r(). */
+/* qsort_r is an extension.
+ *
+ * Android NDK does not ship qsort_r().
+ */
+#if (defined(__linux__) && !defined(__ANDROID__)) || defined(__CYGWIN__) || defined(__MSYS__)
+# ifndef _GNU_SOURCE
 #   define _GNU_SOURCE
 # endif
 #endif
@@ -77,7 +79,7 @@
 #ifndef ZDICT_QSORT
 # if defined(__APPLE__)
 #   define ZDICT_QSORT ZDICT_QSORT_APPLE /* uses qsort_r() with a different order for parameters */
-# elif defined(_GNU_SOURCE)
+# elif (defined(__linux__) && !defined(__ANDROID__)) || defined(__CYGWIN__) || defined(__MSYS__)
 #   define ZDICT_QSORT ZDICT_QSORT_GNU /* uses qsort_r() */
 # elif defined(_WIN32) && defined(_MSC_VER)
 #   define ZDICT_QSORT ZDICT_QSORT_MSVC /* uses qsort_s() with a different order for parameters */


### PR DESCRIPTION
Fixes the build on OpenBSD and NetBSD. It is too easy for _GNU_SOURCE
to be defined even on non-Linux systems. Found via py-zstandard with
the embedded copy of zstandard and Python defines _GNU_SOURCE.

Also simplify the Linux checking, there is no need to check the rest
of the symbol names.