### PR TITLE
meson: Call `meson.override_dependency()` if Meson is new enough

### DIFF
--- a/build/meson/lib/meson.build
+++ b/build/meson/lib/meson.build
@@ -127,6 +127,10 @@ libzstd = library('zstd',
 libzstd_dep = declare_dependency(link_with: libzstd,
   include_directories: join_paths(zstd_rootdir,'lib')) # Do not expose private headers
 
+if meson.version().version_compare('>=0.54.0')
+  meson.override_dependency('libzstd', libzstd_dep)
+endif
+
 # we link to both:
 # - the shared library (for public symbols)
 # - the static library (for private symbols)


### PR DESCRIPTION
This tells Meson that we intend `libzstd_dep` to be used by a parent project if the parent looks for a dependency named `libzstd`.  Without this, the mapping from `libzstd` to our variable `libzstd_dep` must be encoded in the Meson wrap file or in the parent's `meson.build`.