### PR TITLE
Default nb threads

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1410,6 +1410,7 @@ int main(int argCount, const char* argv[])
     /* Check if benchmark is selected */
     if (operation==zom_bench) {
 #ifndef ZSTD_NOBENCH
+        int const benchThreadsMsgLevel = 2 + (nbWorkers <= 1);
         if (cType != FIO_zstdCompression) {
             DISPLAYLEVEL(1, "benchmark mode is only compatible with zstd format \n");
             CLEAN_RETURN(1);
@@ -1435,7 +1436,7 @@ int main(int argCount, const char* argv[])
         if (cLevel > ZSTD_maxCLevel()) cLevel = ZSTD_maxCLevel();
         if (cLevelLast > ZSTD_maxCLevel()) cLevelLast = ZSTD_maxCLevel();
         if (cLevelLast < cLevel) cLevelLast = cLevel;
-        DISPLAYLEVEL(2, "Benchmarking ");
+        DISPLAYLEVEL(benchThreadsMsgLevel, "Benchmarking ");
         if (filenames->tableSize > 1)
             DISPLAYLEVEL(3, "%u files ", (unsigned)filenames->tableSize);
         if (cLevelLast > cLevel) {
@@ -1443,7 +1444,7 @@ int main(int argCount, const char* argv[])
         } else {
             DISPLAYLEVEL(3, "at level %d ", cLevel);
         }
-        DISPLAYLEVEL(2, "using %i threads \n", nbWorkers);
+        DISPLAYLEVEL(benchThreadsMsgLevel, "using %i threads \n", nbWorkers);
         if (filenames->tableSize > 0) {
             if(separateFiles) {
                 unsigned i;

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -803,6 +803,7 @@ static unsigned init_nbWorkers(unsigned defaultNbWorkers) {
 
     return defaultNbWorkers;
 #else
+    (void)defaultNbWorkers;
     return 1;
 #endif
 }

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -1435,7 +1435,7 @@ int main(int argCount, const char* argv[])
         if (cLevel > ZSTD_maxCLevel()) cLevel = ZSTD_maxCLevel();
         if (cLevelLast > ZSTD_maxCLevel()) cLevelLast = ZSTD_maxCLevel();
         if (cLevelLast < cLevel) cLevelLast = cLevel;
-        DISPLAYLEVEL(3, "Benchmarking ");
+        DISPLAYLEVEL(2, "Benchmarking ");
         if (filenames->tableSize > 1)
             DISPLAYLEVEL(3, "%u files ", (unsigned)filenames->tableSize);
         if (cLevelLast > cLevel) {
@@ -1443,7 +1443,7 @@ int main(int argCount, const char* argv[])
         } else {
             DISPLAYLEVEL(3, "at level %d ", cLevel);
         }
-        DISPLAYLEVEL(3, "using %i threads \n", nbWorkers);
+        DISPLAYLEVEL(2, "using %i threads \n", nbWorkers);
         if (filenames->tableSize > 0) {
             if(separateFiles) {
                 unsigned i;

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -233,7 +233,7 @@ static void usageAdvanced(const char* programName)
     DISPLAYOUT("  --patch-from=REF              Use REF as the reference point for Zstandard's diff engine. \n");
     DISPLAYOUT("  --patch-apply                 Equivalent for `-d --patch-from` \n\n");
 # ifdef ZSTD_MULTITHREAD
-    DISPLAYOUT("  -T#                           Spawn # compression threads. [Default: 1; pass 0 for core count.]\n");
+    DISPLAYOUT("  -T#                           Spawn # compression threads. [Default: %i; pass 0 for core count.]\n", ZSTDCLI_NBTHREADS_DEFAULT);
     DISPLAYOUT("  --single-thread               Share a single thread for I/O and compression (slightly different than `-T1`).\n");
     DISPLAYOUT("  --auto-threads={physical|logical}\n");
     DISPLAYOUT("                                Use physical/logical cores when using `-T0`. [Default: Physical]\n\n");


### PR DESCRIPTION
- `zstd -H` correctly states the default number of threads (dynamically determined)
- benchmark states the nb of threads used during benchmark when it is > 1
- benchmark defaults to 1 thread

Respects this priority order :
Command line argument > Environment variable > Binary default