### PR TITLE
Fix memory leak in pthread init functions on failure

### DIFF
--- a/lib/common/threading.c
+++ b/lib/common/threading.c
@@ -143,7 +143,14 @@ int ZSTD_pthread_mutex_init(ZSTD_pthread_mutex_t* mutex, pthread_mutexattr_t con
     *mutex = (pthread_mutex_t*)ZSTD_malloc(sizeof(pthread_mutex_t));
     if (!*mutex)
         return 1;
-    return pthread_mutex_init(*mutex, attr);
+    {
+        int const ret = pthread_mutex_init(*mutex, attr);
+        if (ret != 0) {
+            ZSTD_free(*mutex);
+            *mutex = NULL;
+        }
+        return ret;
+    }
 }
 
 int ZSTD_pthread_mutex_destroy(ZSTD_pthread_mutex_t* mutex)
@@ -164,7 +171,14 @@ int ZSTD_pthread_cond_init(ZSTD_pthread_cond_t* cond, pthread_condattr_t const* 
     *cond = (pthread_cond_t*)ZSTD_malloc(sizeof(pthread_cond_t));
     if (!*cond)
         return 1;
-    return pthread_cond_init(*cond, attr);
+    {
+        int const ret = pthread_cond_init(*cond, attr);
+        if (ret != 0) {
+            ZSTD_free(*cond);
+            *cond = NULL;
+        }
+        return ret;
+    }
 }
 
 int ZSTD_pthread_cond_destroy(ZSTD_pthread_cond_t* cond)


### PR DESCRIPTION
## Summary
This PR fixes a memory leak in the debug implementation of pthread initialization functions when pthread_mutex_init() or pthread_cond_init() fails.

## Problem
In the debug implementation (used when `DEBUGLEVEL >= 1`), the `ZSTD_pthread_mutex_init()` and `ZSTD_pthread_cond_init()` functions allocate memory using `ZSTD_malloc()` but fail to free it if the subsequent pthread initialization calls fail. This leads to memory leaks in error conditions.

The affected functions are:
- `ZSTD_pthread_mutex_init()` at lib/common/threading.c:146
- `ZSTD_pthread_cond_init()` at lib/common/threading.c:167

## Solution
The fix adds proper error handling to free the allocated memory when pthread initialization fails:
1. Store the return value of pthread_mutex_init/pthread_cond_init
2. If initialization fails (non-zero return), free the allocated memory and set the pointer to NULL
3. Return the error code

## Impact
This fix is particularly important for:
- Long-running applications where repeated initialization failures could accumulate memory leaks
- Resource-constrained environments where pthread initialization might fail due to system limits
- Ensuring proper resource cleanup in all error paths

## Testing
- All existing tests pass (`make check` completed successfully)
- Pool tests specifically verified (`make poolTests && ./poolTests` passed)
- The fix only affects error paths and maintains the same interface behavior

## Changes
- Modified `lib/common/threading.c` to add proper cleanup on pthread initialization failure

This is a defensive programming improvement that ensures no resources are leaked even in uncommon error scenarios.