### PR TITLE
Split lib target types in their own export groups

### DIFF
--- a/build/cmake/CMakeModules/ZstdPackage.cmake
+++ b/build/cmake/CMakeModules/ZstdPackage.cmake
@@ -11,21 +11,24 @@ write_basic_package_version_file(
     COMPATIBILITY SameMajorVersion
 )
 
-# Export targets for build directory
-export(EXPORT zstdExports
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/zstdTargets.cmake"
-    NAMESPACE zstd::
-)
-
 # Configure package for installation
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/zstd)
 
-# Install exported targets
-install(EXPORT zstdExports
-    FILE zstdTargets.cmake
-    NAMESPACE zstd::
-    DESTINATION ${ConfigPackageLocation}
-)
+foreach(target_suffix IN ITEMS "_shared" "_static" "")
+    if(TARGET "libzstd${target_suffix}")
+        # Export targets for build directory
+        export(EXPORT "zstdExports${target_suffix}"
+                FILE "${CMAKE_CURRENT_BINARY_DIR}/zstdTargets${target_suffix}.cmake"
+                NAMESPACE zstd::
+        )
+        # Install exported targets
+        install(EXPORT "zstdExports${target_suffix}"
+                FILE "zstdTargets${target_suffix}.cmake"
+                NAMESPACE zstd::
+                DESTINATION ${ConfigPackageLocation}
+        )
+    endif()
+endforeach()
 
 # Configure and install package config file
 configure_package_config_file(

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -122,11 +122,9 @@ endmacro ()
 set(PUBLIC_INCLUDE_DIRS ${LIBRARY_DIR})
 set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I \"${LIBRARY_DIR}\"")
 # Split project to static and shared libraries build
-set(library_targets)
 if (ZSTD_BUILD_SHARED)
     add_library(libzstd_shared SHARED ${Sources} ${Headers} ${PlatformDependResources})
     target_include_directories(libzstd_shared INTERFACE $<BUILD_INTERFACE:${PUBLIC_INCLUDE_DIRS}>)
-    list(APPEND library_targets libzstd_shared)
     if (ZSTD_MULTITHREAD_SUPPORT)
         target_compile_definitions(libzstd_shared PUBLIC ZSTD_MULTITHREAD)
         if (UNIX)
@@ -140,7 +138,6 @@ endif ()
 if (ZSTD_BUILD_STATIC)
     add_library(libzstd_static STATIC ${Sources} ${Headers})
     target_include_directories(libzstd_static INTERFACE $<BUILD_INTERFACE:${PUBLIC_INCLUDE_DIRS}>)
-    list(APPEND library_targets libzstd_static)
     if (ZSTD_MULTITHREAD_SUPPORT)
         target_compile_definitions(libzstd_static PUBLIC ZSTD_MULTITHREAD)
         if (UNIX)
@@ -159,7 +156,6 @@ if (ZSTD_BUILD_SHARED AND NOT ZSTD_BUILD_STATIC)
     endif ()
     add_library(libzstd INTERFACE)
     target_link_libraries(libzstd INTERFACE libzstd_shared)
-    list(APPEND library_targets libzstd)
 endif ()
 if (ZSTD_BUILD_STATIC AND NOT ZSTD_BUILD_SHARED)
     if (BUILD_SHARED_LIBS)
@@ -167,7 +163,6 @@ if (ZSTD_BUILD_STATIC AND NOT ZSTD_BUILD_SHARED)
     endif ()
     add_library(libzstd INTERFACE)
     target_link_libraries(libzstd INTERFACE libzstd_static)
-    list(APPEND library_targets libzstd)
 endif ()
 if (ZSTD_BUILD_SHARED AND ZSTD_BUILD_STATIC)
     # If both ZSTD_BUILD_SHARED and ZSTD_BUILD_STATIC are set, which is the
@@ -176,11 +171,9 @@ if (ZSTD_BUILD_SHARED AND ZSTD_BUILD_STATIC)
     if (BUILD_SHARED_LIBS)
         add_library(libzstd INTERFACE)
         target_link_libraries(libzstd INTERFACE libzstd_shared)
-        list(APPEND library_targets libzstd)
     else ()
         add_library(libzstd INTERFACE)
         target_link_libraries(libzstd INTERFACE libzstd_static)
-        list(APPEND library_targets libzstd)
     endif ()
 endif ()
 
@@ -274,16 +267,20 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libzstd.pc" DESTINATION "${CMAKE_INST
 # install target
 install(FILES ${PublicHeaders} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-install(TARGETS ${library_targets}
-    EXPORT zstdExports
-    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    BUNDLE DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    FRAMEWORK DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT runtime OPTIONAL
-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    )
+foreach(target_suffix IN ITEMS "_shared" "_static" "")
+    if(TARGET "libzstd${target_suffix}")
+        install(TARGETS "libzstd${target_suffix}"
+            EXPORT "zstdExports${target_suffix}"
+            INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            BUNDLE DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            FRAMEWORK DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT runtime OPTIONAL
+            PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+            )
+    endif()
+endforeach()
 
 # uninstall target
 if (NOT TARGET uninstall)

--- a/build/cmake/zstdConfig.cmake.in
+++ b/build/cmake/zstdConfig.cmake.in
@@ -5,6 +5,9 @@ if(@ZSTD_MULTITHREAD_SUPPORT@ AND "@UNIX@")
   find_dependency(Threads)
 endif()
 
+foreach(lib_suffix IN ITEMS "_shared" "_static")
+    include("${CMAKE_CURRENT_LIST_DIR}/zstdTargets${lib_suffix}.cmake" OPTIONAL)
+endforeach()
 include("${CMAKE_CURRENT_LIST_DIR}/zstdTargets.cmake")
 
 check_required_components("zstd")


### PR DESCRIPTION
This allows for the non-primary library to be missing in the Config.cmake file, e.g. if the devel files have a separate static-devel package