### PR TITLE
- Modify the GCC version used for CI testing of the RISCV architecture

### DIFF
--- a/.github/workflows/dev-short-tests.yml
+++ b/.github/workflows/dev-short-tests.yml
@@ -403,7 +403,7 @@ jobs:
           { name: PPC64LE,  xcc_pkg: gcc-powerpc64le-linux-gnu, xcc: powerpc64le-linux-gnu-gcc, xemu_pkg: qemu-system-ppc,    xemu: qemu-ppc64le-static },
           { name: S390X,    xcc_pkg: gcc-s390x-linux-gnu,       xcc: s390x-linux-gnu-gcc,       xemu_pkg: qemu-system-s390x,  xemu: qemu-s390x-static   },
           { name: MIPS,     xcc_pkg: gcc-mips-linux-gnu,        xcc: mips-linux-gnu-gcc,        xemu_pkg: qemu-system-mips,   xemu: qemu-mips-static    },
-          { name: RISC-V,   xcc_pkg: gcc-riscv64-linux-gnu,     xcc: riscv64-linux-gnu-gcc,     xemu_pkg: qemu-system-riscv64,xemu: qemu-riscv64-static },
+          { name: RISC-V,   xcc_pkg: gcc-14-riscv64-linux-gnu,  xcc: riscv64-linux-gnu-gcc-14,  xemu_pkg: qemu-system-riscv64,xemu: qemu-riscv64-static },
           { name: M68K,     xcc_pkg: gcc-m68k-linux-gnu,        xcc: m68k-linux-gnu-gcc,        xemu_pkg: qemu-system-m68k,   xemu: qemu-m68k-static    },
           { name: SPARC,    xcc_pkg: gcc-sparc64-linux-gnu,     xcc: sparc64-linux-gnu-gcc,     xemu_pkg: qemu-system-sparc,  xemu: qemu-sparc64-static },
         ]

--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -224,16 +224,11 @@
 #  if defined(__ARM_FEATURE_SVE2)
 #    define ZSTD_ARCH_ARM_SVE2
 #  endif
-#if defined(__riscv) && defined(__riscv_vector)
-    #if defined(__GNUC__)
-        #if (__GNUC__ > 14 || (__GNUC__ == 14 && __GNUC_MINOR__ >= 1))
-            #define ZSTD_ARCH_RISCV_RVV
-        #endif
-    #elif defined(__clang__)
-        #if __clang_major__ > 18 || (__clang_major__ == 18 && __clang_minor__ >= 1)
-            #define ZSTD_ARCH_RISCV_RVV
-        #endif
-    #endif
+#  if defined(__riscv) && defined(__riscv_vector)
+#    if ((defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 14) || \
+        (defined(__clang__) && __clang_major__ >= 19))
+        #define ZSTD_ARCH_RISCV_RVV
+#  endif
 #endif
 #
 #  if defined(ZSTD_ARCH_X86_AVX2)

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -185,6 +185,8 @@ static void ZSTD_copy16(void* dst, const void* src) {
     vst1q_u8((uint8_t*)dst, vld1q_u8((const uint8_t*)src));
 #elif defined(ZSTD_ARCH_X86_SSE2)
     _mm_storeu_si128((__m128i*)dst, _mm_loadu_si128((const __m128i*)src));
+#elif defined(ZSTD_ARCH_RISCV_RVV)
+    __riscv_vse8_v_u8m1((uint8_t*)dst, __riscv_vle8_v_u8m1((const uint8_t*)src, 16), 16);
 #elif defined(__clang__)
     ZSTD_memmove(dst, src, 16);
 #else

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -7292,7 +7292,7 @@ size_t convertSequences_noRepcodes(
     return longLen;
 }
 
-#elif defined ZSTD_ARCH_RISCV_RVV
+#elif defined (ZSTD_ARCH_RISCV_RVV)
 #include <riscv_vector.h>
 /*
  * Convert `vl` sequences per iteration, using RVV intrinsics:
@@ -7824,7 +7824,7 @@ BlockSummary ZSTD_get1BlockSummary(const ZSTD_Sequence* seqs, size_t nbSeqs)
     }
 }
 
-#elif defined ZSTD_ARCH_RISCV_RVV
+#elif defined (ZSTD_ARCH_RISCV_RVV)
 
 BlockSummary ZSTD_get1BlockSummary(const ZSTD_Sequence* seqs, size_t nbSeqs)
 {

--- a/lib/compress/zstd_lazy.c
+++ b/lib/compress/zstd_lazy.c
@@ -1052,33 +1052,39 @@ ZSTD_row_getNEONMask(const U32 rowEntries, const BYTE* const src, const BYTE tag
 #endif
 #if defined(ZSTD_ARCH_RISCV_RVV) && (__riscv_xlen == 64)
 FORCE_INLINE_TEMPLATE ZSTD_VecMask
-ZSTD_row_getRVVMask(int nbChunks, const BYTE* const src, const BYTE tag, const U32 head)
+ZSTD_row_getRVVMask(int rowEntries, const BYTE* const src, const BYTE tag, const U32 head)
 {
     ZSTD_VecMask matches;
     size_t vl;
 
     if (rowEntries == 16) {
         vl = __riscv_vsetvl_e8m1(16);
-        vuint8m1_t chunk = __riscv_vle8_v_u8m1(src, vl);
-        vbool8_t mask = __riscv_vmseq_vx_u8m1_b8(chunk, tag, vl);
-        vuint16m1_t mask_u16 = __riscv_vreinterpret_v_b8_u16m1(mask);
-        matches = __riscv_vmv_x_s_u16m1_u16(mask_u16);
-        return ZSTD_rotateRight_U16((U16)matches, head);
+        {
+            vuint8m1_t chunk = __riscv_vle8_v_u8m1(src, vl);
+            vbool8_t mask = __riscv_vmseq_vx_u8m1_b8(chunk, tag, vl);
+            vuint16m1_t mask_u16 = __riscv_vreinterpret_v_b8_u16m1(mask);
+            matches = __riscv_vmv_x_s_u16m1_u16(mask_u16);
+            return ZSTD_rotateRight_U16((U16)matches, head);
+        }
 
     } else if (rowEntries == 32) {
         vl = __riscv_vsetvl_e8m2(32);
-        vuint8m2_t chunk = __riscv_vle8_v_u8m2(src, vl);
-        vbool4_t mask = __riscv_vmseq_vx_u8m2_b4(chunk, tag, vl);
-        vuint32m1_t mask_u32 = __riscv_vreinterpret_v_b4_u32m1(mask);
-        matches = __riscv_vmv_x_s_u32m1_u32(mask_u32);
-        return ZSTD_rotateRight_U32((U32)matches, head);
+        {
+            vuint8m2_t chunk = __riscv_vle8_v_u8m2(src, vl);
+            vbool4_t mask = __riscv_vmseq_vx_u8m2_b4(chunk, tag, vl);
+            vuint32m1_t mask_u32 = __riscv_vreinterpret_v_b4_u32m1(mask);
+            matches = __riscv_vmv_x_s_u32m1_u32(mask_u32);
+            return ZSTD_rotateRight_U32((U32)matches, head);
+        }
     } else { // rowEntries = 64
         vl = __riscv_vsetvl_e8m4(64);
-        vuint8m4_t chunk = __riscv_vle8_v_u8m4(src, vl);
-        vbool2_t mask = __riscv_vmseq_vx_u8m4_b2(chunk, tag, vl);
-        vuint64m1_t mask_u64 = __riscv_vreinterpret_v_b2_u64m1(mask);
-        matches = __riscv_vmv_x_s_u64m1_u64(mask_u64);
-        return ZSTD_rotateRight_U64(matches, head);
+        {
+            vuint8m4_t chunk = __riscv_vle8_v_u8m4(src, vl);
+            vbool2_t mask = __riscv_vmseq_vx_u8m4_b2(chunk, tag, vl);
+            vuint64m1_t mask_u64 = __riscv_vreinterpret_v_b2_u64m1(mask);
+            matches = __riscv_vmv_x_s_u64m1_u64(mask_u64);
+            return ZSTD_rotateRight_U64(matches, head);
+        }
     }
 }
 #endif


### PR DESCRIPTION
The previous GCC version for RISCV CI was 13, but according to the [link](https://github.com/riscv-non-isa/rvv-intrinsic-doc), GCC 14 supports RVV 1.0, so change the GCC version for CI testing.
Fix a bug on the ZSTD_row_getRVVMask() function.
Improve some performance by adding RVV optimization to the ZSTD_copy16 function.
After modification:
[root@musecard-00-oerv tests]# ./fullbench enwiki5.txt

  | After modification: | before modification: | ([After modification]-[before modification]/[before modification]|
-- | -- | -- | -- |
compress | 22.6 MB/s  (   40160) | 21.6 MB/s  (   40160) | 4%
decompress | 123.4 MB/s  (  100811) | 115.0 MB/s  (  100811) | 7%
compress_freshCCtx | 22.1 MB/s  (   40160) | 21.9 MB/s  (   40160) | 0.9%
decompressDCtx | 123.2 MB/s  (  100811) | 114.9 MB/s  (  100811) | 7%
compressContinue | 22.2 MB/s  (   40160) | 21.9 MB/s  (   40160) | 1%
compressContinue_extDict | 18.2 MB/s  (   40150) | 18.3 MB/s  (   40150) | -0.5%
decompressContinue | 123.1 MB/s  (  100811) | 114.3 MB/s  (  100811) | 7%
compressStream | 20.9 MB/s  (   40157) | 19.9 MB/s  (   40157) | 5%
compressStream_freshCCtx | 20.0 MB/s  (   40157) | 20.4 MB/s  (   40157) | -1%
decompressStream | 123.1 MB/s  (  100811) | 114.8 MB/s  (  100811) | 7%
compress2 | 22.4 MB/s  (   40160) | 21.9 MB/s  (   40160) | 2%
compressStream2, end | 22.5 MB/s  (   40160) | 22.3 MB/s  (   40160) | 0.8%
compressStream2, end & short | 20.5 MB/s  (   40160) | 20.4 MB/s  (   40160) | 0.4%
compressStream2, continue | 20.3 MB/s  (   40157) | 20.5 MB/s  (   40157) | -0.4%
compressStream2, -T2, continue | 18.3 MB/s  (   40157) | 18.2 MB/s  (   40157) | 5%
compressStream2, -T2, end | 22.5 MB/s  (   40160) | 21.8 MB/s  (   40160) | 3%
compressSequences | 77.2 MB/s  (   40047) | 74.4 MB/s  (   40047) | 3%
compressSequencesAndLiterals | 95.6 MB/s  (   40047) | 90.7 MB/s  (   40047) | 5%
convertSequences (1st block) | 3738.2 MB/s  (    7193) | 3746.8 MB/s  (    7193) | -0.2%
get1BlockSummary (1st block) | 4732.1 MB/s  (    7193) | 4712.7 MB/s  (    7193) | 0.4%
decodeLiteralsHeader (1st block: | 9415.3 MB/s  (      81) | 9264.3 MB/s  (      81) | 1.6%
decodeLiteralsBlock (1st block) | 367.3 MB/s  (   21537) | 371.7 MB/s  (   21537) | -1%
decodeSeqHeaders (1st block) | 2083.7 MB/s  (      62) | 1861.0 MB/s  (      62) | 11%
