### PR TITLE
Make ASM language conditional at CMake configure time

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -29,7 +29,7 @@ include(ZstdVersion)
 #-----------------------------------------------------------------------------
 project(zstd
     VERSION "${ZSTD_FULL_VERSION}"
-    LANGUAGES C ASM  # Main library is in C and ASM
+    LANGUAGES C   # Main library is in C and ASM, ASM is enabled conditionally
     HOMEPAGE_URL "${zstd_HOMEPAGE_URL}"
     DESCRIPTION "${zstd_DESCRIPTION}"
 )

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -7,7 +7,7 @@
 # in the COPYING file in the root directory of this source tree).
 # ################################################################
 
-project(libzstd C ASM)
+project(libzstd C) # ASM language is conditionally enabled where supported
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 option(ZSTD_BUILD_STATIC "BUILD STATIC LIBRARIES" ON)
@@ -40,6 +40,7 @@ if (MSVC)
     add_compile_options(-DZSTD_DISABLE_ASM)
 else ()
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|AMD64.*|x86_64.*|X86_64.*" AND ${ZSTD_HAS_NOEXECSTACK})
+        enable_language(ASM)
         set(DecompressSources ${DecompressSources} ${LIBRARY_DIR}/decompress/huf_decompress_amd64.S)
     else()
         add_compile_options(-DZSTD_DISABLE_ASM)


### PR DESCRIPTION
Having ASM enabled unconditionally by zstd on MSVC causes weird configure-time issues in larger projects where other parts use some kind of assembly langugage.

This PR removes the ASM language from the `project()` macro and conditionally enables via `enable_language(ASM)` when needed.