### PR TITLE
Add RISC-V Zicclsm support to MEM_FORCE_MEMORY_ACCESS

### DIFF
--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -126,10 +126,13 @@ MEM_STATIC size_t MEM_swapST(size_t in);
  * Method 1 : Use compiler extension to set unaligned access.
  * Method 2 : direct access. This method is portable but violate C standard.
  *            It can generate buggy code on targets depending on alignment.
- * Default  : method 1 if supported, else method 0
+ * Default  : method 2 for RISC-V with zicclsm extension (GNUC), 
+ *            method 1 for other GNUC environments, else method 0
  */
 #ifndef MEM_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
-#  ifdef __GNUC__
+#  if defined(__GNUC__) && (defined(__riscv) && defined(__riscv_zicclsm))
+#    define MEM_FORCE_MEMORY_ACCESS 2
+#  elif defined(__GNUC__)
 #    define MEM_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -35,6 +35,7 @@
   || defined __x86_64__ || defined _M_X64                                                                           /* x86 64-bit */    \
   || defined __arm64__ || defined __aarch64__ || defined __ARM64_ARCH_8__                                           /* ARM 64-bit */    \
   || (defined __mips  && (__mips == 64 || __mips == 4 || __mips == 3))                                              /* MIPS 64-bit */   \
+  || (defined(__riscv) && __riscv_xlen == 64)                                                                       /* RISC-V 64-bit */ \
   || defined _LP64 || defined __LP64__ /* NetBSD, OpenBSD */ || defined __64BIT__ /* AIX */ || defined _ADDR64 /* Cray */               \
   || (defined __SIZEOF_POINTER__ && __SIZEOF_POINTER__ == 8) /* gcc */
 #  if !defined(__64BIT__)


### PR DESCRIPTION
Zicclsm: Main memory supports misaligned loads/stores
According to the RVA20U64 specification, the Zicclsm extension is mandatory and is supported in gcc versions 14.1 and above.
References
[GCC Zicclsm](https://gcc.gnu.org/pipermail/gcc-patches/2024-February/644655.html)
[RVA20U64 specification](https://github.com/riscv/riscv-profiles/blob/5879c13c924ec5636995c5883f40337e83f6049a/src/profiles.adoc#L658)

### Performance Test Results: zstd with Different MEM_FORCE_MEMORY_ACCESS Settings
Test Environment
```shell
[root@r2044-r1-s1 ~]# dmidecode -t processor | grep "Version"
        Version: SG2044
[root@r2044-r1-s1 ~]# uname -a
Linux r2044-r1-s1 6.12.47-25.09.16.17.riscv64 #1 SMP Tue Sep 16 17:47:24 CST 2025 riscv64 riscv64 riscv64 GNU/Linux
```

Compressor | Metric | MEM_FORCE_MEMORY_ACCESS=2  | MEM_FORCE_MEMORY_ACCESS=1  | Improvement Ratio*
-- | -- | -- | -- | --
zstd 1.5.7 -1 | Compression Speed | 72.0 MB/s | 57.5 MB/s | ~25.2%
zstd 1.5.7 -1 | Decompression Speed | 93.7 MB/s | 93.4 MB/s | ~0.3%
zstd 1.5.7 -22 | Compression Speed | 0.24 MB/s | 0.22 MB/s | ~9.1%
zstd 1.5.7 -22 | Decompression Speed | 71.0 MB/s | 66.8 MB/s | ~6.3%

1. MEM_FORCE_MEMORY_ACCESS=1
```shell
[root@r2044-r1-s1 lzbench-master]#./lzbench -t0,0 -i5,5 -ezstd,1,22 ../silesia.tar
lzbench 2.1 | GCC 12.3.1 | 64-bit Linux |

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
zstd 1.5.7 -1            57.5 MB/s  93.4 MB/s    73216302  34.54 ../silesia.tar
zstd 1.5.7 -22           0.22 MB/s  66.8 MB/s    52222248  24.64 ../silesia.tar
[Params] cIters=5 dIters=5 cTime=0.0 dTime=0.0 chunkSize=0KB cSpeed=0MB
```

2. MEM_FORCE_MEMORY_ACCESS=2
```shell
[root@r2044-r1-s1 lzbench-master]#./lzbench -t0,0 -i5,5 -ezstd,1,22 ../silesia.tar
lzbench 2.1 | GCC 12.3.1 | 64-bit Linux |

Compressor name         Compress. Decompress. Compr. size  Ratio Filename
zstd 1.5.7 -1            72.0 MB/s  93.7 MB/s    73216302  34.54 ../silesia.tar
zstd 1.5.7 -22           0.24 MB/s  71.0 MB/s    52222248  24.64 ../silesia.tar
[Params] cIters=5 dIters=5 cTime=0.0 dTime=0.0 chunkSize=0KB cSpeed=0MB
```
