### PR TITLE
Add RISC-V 64-bit architecture detection

### DIFF
--- a/programs/platform.h
+++ b/programs/platform.h
@@ -35,6 +35,7 @@
   || defined __x86_64__ || defined _M_X64                                                                           /* x86 64-bit */    \
   || defined __arm64__ || defined __aarch64__ || defined __ARM64_ARCH_8__                                           /* ARM 64-bit */    \
   || (defined __mips  && (__mips == 64 || __mips == 4 || __mips == 3))                                              /* MIPS 64-bit */   \
+  || (defined(__riscv) && __riscv_xlen == 64)                                                                       /* RISC-V 64-bit */ \
   || defined _LP64 || defined __LP64__ /* NetBSD, OpenBSD */ || defined __64BIT__ /* AIX */ || defined _ADDR64 /* Cray */               \
   || (defined __SIZEOF_POINTER__ && __SIZEOF_POINTER__ == 8) /* gcc */
 #  if !defined(__64BIT__)


### PR DESCRIPTION
- Add compile-time check for RISC-V 64-bit via __riscv and __riscv_xlen == 64
- Align with existing 64-bit architecture detection logic (x86_64/ARM64 etc.)
- Ensure __64BIT__ is defined for RISC-V 64-bit builds