### PR TITLE
modulemap: remove `config_macros`

### DIFF
--- a/lib/module.modulemap
+++ b/lib/module.modulemap
@@ -1,27 +1,6 @@
 module libzstd [extern_c] {
     header "zstd.h"
     export *
-    config_macros [exhaustive] \
-        /* zstd.h */ \
-        ZSTD_STATIC_LINKING_ONLY, \
-        ZSTDLIB_VISIBILITY, \
-        ZSTDLIB_VISIBLE, \
-        ZSTDLIB_HIDDEN, \
-        ZSTD_DLL_EXPORT, \
-        ZSTDLIB_STATIC_API, \
-        ZSTD_DISABLE_DEPRECATE_WARNINGS, \
-        ZSTD_CLEVEL_DEFAULT, \
-        /* zdict.h */ \
-        ZDICT_STATIC_LINKING_ONLY, \
-        ZDICTLIB_VISIBLE, \
-        ZDICTLIB_HIDDEN, \
-        ZDICTLIB_VISIBILITY, \
-        ZDICTLIB_STATIC_API, \
-        ZDICT_DISABLE_DEPRECATE_WARNINGS, \
-        /* zstd_errors.h */ \
-        ZSTDERRORLIB_VISIBLE, \
-        ZSTDERRORLIB_HIDDEN, \
-        ZSTDERRORLIB_VISIBILITY
 
     module dictbuilder [extern_c] {
         header "zdict.h"


### PR DESCRIPTION
fixes #3328 and #3892

issue at hand: the module.modulemap file was changed in #2953 and #3363 to contain a `config_macros` block with a list of most of the macros that can be used to configure various aspects of how Zstd builds and behaves.

however, clang's definition of a "config macro" is different from what one might instinctively assume a config macro to be: it only covers those macros that are exclusively passed via the command line (e.g. as `-DMACRO_NAME`), and does not allow the macro be `#define`-d within the codebase, even if it wasn't defined via the CLI.

zstd.h (and some other headers) currently contain blocks that conditionally `#define` some of the macros used to configure zstd, setting them to their default values if they are undefined (ie, if they haven't explicitly been set somewhere prior in the build process).
this causes clang to emit a warning for each of these macros, unless the program using zstd explicitly specifies their values via the command line (which a program that wants to simply use the default value obviously would not do)

you can see e.g. [here](https://reviews.llvm.org/D41239) for an example of clang's / LLVM's usage & meaning of the term "config macro": they're effectively simple valueless macros that derive their meaning exclusively from the fact whether they are defined or whether they are not defined.