### PR TITLE
Add configurable input buffer size for decompression (--ibuf-size)

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -573,6 +573,7 @@ FIO_prefs_t* FIO_createPreferences(void)
     ret->allowBlockDevices = 0;
     ret->asyncIO = AIO_supported();
     ret->passThrough = -1;
+    ret->inputBufferSize = 0;  /* 0 = use default */
     return ret;
 }
 
@@ -680,6 +681,10 @@ void FIO_setTargetCBlockSize(FIO_prefs_t* const prefs, size_t targetCBlockSize) 
 
 void FIO_setSrcSizeHint(FIO_prefs_t* const prefs, size_t srcSizeHint) {
     prefs->srcSizeHint = (int)MIN((size_t)INT_MAX, srcSizeHint);
+}
+
+void FIO_setInputBufferSize(FIO_prefs_t* const prefs, size_t inputBufferSize) {
+    prefs->inputBufferSize = inputBufferSize;
 }
 
 void FIO_setTestMode(FIO_prefs_t* const prefs, int testMode) {
@@ -2611,7 +2616,8 @@ static dRess_t FIO_createDResources(FIO_prefs_t* const prefs, const char* dictFi
     }
 
     ress.writeCtx = AIO_WritePool_create(prefs, ZSTD_DStreamOutSize());
-    ress.readCtx = AIO_ReadPool_create(prefs, ZSTD_DStreamInSize());
+    ress.readCtx = AIO_ReadPool_create(prefs, 
+        prefs->inputBufferSize > 0 ? prefs->inputBufferSize : ZSTD_DStreamInSize());
     return ress;
 }
 

--- a/programs/fileio.h
+++ b/programs/fileio.h
@@ -87,6 +87,7 @@ void FIO_setRsyncable(FIO_prefs_t* const prefs, int rsyncable);
 void FIO_setStreamSrcSize(FIO_prefs_t* const prefs, size_t streamSrcSize);
 void FIO_setTargetCBlockSize(FIO_prefs_t* const prefs, size_t targetCBlockSize);
 void FIO_setSrcSizeHint(FIO_prefs_t* const prefs, size_t srcSizeHint);
+void FIO_setInputBufferSize(FIO_prefs_t* const prefs, size_t inputBufferSize);
 void FIO_setTestMode(FIO_prefs_t* const prefs, int testMode);
 void FIO_setLiteralCompressionMode(
         FIO_prefs_t* const prefs,

--- a/programs/fileio_types.h
+++ b/programs/fileio_types.h
@@ -59,6 +59,7 @@ typedef struct FIO_prefs_s {
     int removeSrcFile;
     int overwrite;
     int asyncIO;
+    size_t inputBufferSize;  /* size of the input buffer for decompression (0 = default) */
 
     /* Computation resources preferences */
     unsigned memLimit;

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -245,6 +245,7 @@ static void usageAdvanced(const char* programName)
     DISPLAYOUT("  --exclude-compressed          Only compress files that are not already compressed.\n\n");
 
     DISPLAYOUT("  --stream-size=#               Specify size of streaming input from STDIN.\n");
+    DISPLAYOUT("  --ibuf-size=#                 Specify input buffer size for decompression. Helps with large files on slow disks.\n");
     DISPLAYOUT("  --size-hint=#                 Optimize compression parameters for streaming input of approximately size #.\n");
     DISPLAYOUT("  --target-compressed-block-size=#\n");
     DISPLAYOUT("                                Generate compressed blocks of approximately # size.\n\n");
@@ -912,6 +913,7 @@ int main(int argCount, const char* argv[])
     size_t streamSrcSize = 0;
     size_t targetCBlockSize = 0;
     size_t srcSizeHint = 0;
+    size_t inputBufferSize = 0;
     size_t nbInputFileNames = 0;
     int dictCLevel = g_defaultDictCLevel;
     unsigned dictSelect = g_defaultSelectivityLevel;
@@ -1096,6 +1098,7 @@ int main(int argCount, const char* argv[])
                 if (longCommandWArg(&argument, "--dictID")) { NEXT_UINT32(dictID); continue; }
                 if (longCommandWArg(&argument, "--zstd=")) { if (!parseCompressionParameters(argument, &compressionParams)) { badUsage(programName, originalArgument); CLEAN_RETURN(1); } ; cType = FIO_zstdCompression; continue; }
                 if (longCommandWArg(&argument, "--stream-size")) { NEXT_TSIZE(streamSrcSize); continue; }
+                if (longCommandWArg(&argument, "--ibuf-size")) { NEXT_TSIZE(inputBufferSize); continue; }
                 if (longCommandWArg(&argument, "--target-compressed-block-size")) { NEXT_TSIZE(targetCBlockSize); continue; }
                 if (longCommandWArg(&argument, "--size-hint")) { NEXT_TSIZE(srcSizeHint); continue; }
                 if (longCommandWArg(&argument, "--output-dir-flat")) {
@@ -1615,6 +1618,7 @@ int main(int argCount, const char* argv[])
         FIO_setStreamSrcSize(prefs, streamSrcSize);
         FIO_setTargetCBlockSize(prefs, targetCBlockSize);
         FIO_setSrcSizeHint(prefs, srcSizeHint);
+        FIO_setInputBufferSize(prefs, inputBufferSize);
         FIO_setLiteralCompressionMode(prefs, literalCompressionMode);
         FIO_setSparseWrite(prefs, 0);
         if (adaptMin > cLevel) cLevel = adaptMin;


### PR DESCRIPTION
## Description

This PR adds a new  command-line option to zstd to allow users to configure the input buffer size during decompression.

## Problem

When decompressing large files (1TB+) on mechanical hard drives, both reading and writing occur simultaneously, resulting in:
- Concurrent read and write operations (~80MB/s + ~50MB/s)
- Excessive disk seeking between operations
- Sub-optimal total throughput (130MB/s vs 250MB/s+ possible)
- CPU usage only at ~20%

## Solution

This feature enables users to specify a larger input buffer size (1-5GB), allowing sequential disk reads to fill the buffer before decompression begins. This reduces disk seek operations and improves overall throughput.

## Usage

```bash
# Decompress with 1GB input buffer
zstd -d largefile.zst --ibuf-size=1024M

# Decompress with 5GB input buffer for very large files
zstd -d largefile.zst --ibuf-size=5120M
```

## Changes

- Add 'inputBufferSize' field to FIO_prefs_t structure
- Implement FIO_setInputBufferSize() setter function
- Use configured buffer size in FIO_createDResources()
- Add --ibuf-size command-line option with help documentation

## Testing

- [x] Compilation succeeds
- [x] Default behavior unchanged (backward compatible)
- [x] Works with various buffer sizes (256M, 512M, 1024M)
- [x] Output files are byte-for-byte identical
- [x] Works with stdin/stdout
- [x] Help message displays correctly

## Performance Impact

Expected improvements for the scenario described (12TB file on mechanical drive):
- Before: ~130MB/s (concurrent read+write with seeking)
- After: ~250MB/s+ (sequential reads with larger buffer)

Actual improvements depend on disk characteristics, available RAM, compression ratio, and CPU speed.