### PR TITLE
Add RISC-V 64-bit support to sequence decoding optimization path

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -1236,7 +1236,7 @@ FORCE_INLINE_TEMPLATE seq_t
 ZSTD_decodeSequence(seqState_t* seqState, const ZSTD_longOffset_e longOffsets, const int isLastSeq)
 {
     seq_t seq;
-#if defined(__aarch64__)
+#if defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
     size_t prevOffset0 = seqState->prevOffset[0];
     size_t prevOffset1 = seqState->prevOffset[1];
     size_t prevOffset2 = seqState->prevOffset[2];


### PR DESCRIPTION
The optimization specifically targets the decompression speed

Testing:

Platform: Zhihe A210 C908 RISC-V64
Command: ./zstd -b1 -e22 silesia.tar
Data Set: silesia.tar

| Compression Level | Before (MB/s) | After (MB/s) | Improvement (%) |
|-------------------|---------------|--------------|-----------------|
| 1                 | 240.1         | 247.1        | 2.9%            |
| 2                 | 179.7         | 183.0        | 1.8%            |
| 3                 | 144.3         | 147.2        | 2.0%            |
| 4                 | 120.9         | 122.0        | 0.9%            |
| 5                 | 129.7         | 130.5        | 0.6%            |
| 6                 | 140.5         | 141.5        | 0.7%            |
| 7                 | 127.6         | 128.8        | 0.9%            |
| 8                 | 132.6         | 134.0        | 1.1%            |
| 9                 | 121.7         | 122.7        | 0.8%            |
| 10                | 115.1         | 116.2        | 1.0%            |
| 11                | 112.1         | 112.9        | 0.7%            |
| 12                | 111.2         | 112.3        | 1.0%            |
| 13                | 113.6         | 114.4        | 0.7%            |
| 14                | 111.1         | 111.8        | 0.6%            |
| 15                | 108.7         | 109.6        | 0.8%            |
| 16                | 114.3         | 115.3        | 0.9%            |
| 17                | 110.6         | 111.1        | 0.5%            |
| 18                | 104.9         | 105.6        | 0.7%            |
| 19                | 104.2         | 105.1        | 0.9%            |
| 20                | 117.2         | 118.1        | 0.8%            |
| 21                | 117.6         | 118.2        | 0.5%            |
| 22                | 117.4         | 118.9        | 1.3%            |