### PR TITLE
Fix data race in POOL_create_advanced by protecting threadLimit

### DIFF
--- a/lib/common/pool.c
+++ b/lib/common/pool.c
@@ -146,15 +146,20 @@ POOL_ctx* POOL_create_advanced(size_t numThreads, size_t queueSize,
     /* Check for errors */
     if (!ctx->threads || !ctx->queue) { POOL_free(ctx); return NULL; }
     /* Initialize the threads */
-    {   size_t i;
+    {   
+        size_t i;
         for (i = 0; i < numThreads; ++i) {
             if (ZSTD_pthread_create(&ctx->threads[i], NULL, &POOL_thread, ctx)) {
                 ctx->threadCapacity = i;
                 POOL_free(ctx);
                 return NULL;
-        }   }
+            }   
+        }
         ctx->threadCapacity = numThreads;
+
+        ZSTD_pthread_mutex_lock(&ctx->queueMutex);
         ctx->threadLimit = numThreads;
+        ZSTD_pthread_mutex_unlock(&ctx->queueMutex);
     }
     return ctx;
 }


### PR DESCRIPTION
Fixes a potential data race in `POOL_create_advanced` where `ctx->threadLimit` was being updated without holding the `queueMutex`. Worker threads could access `threadLimit` before it was fully initialized, leading to undefined behavior.

The update to `ctx->threadLimit` is now protected by the `ctx->queueMutex`  to ensure thread safety during initialization.

`ctx->threadCapacity` remains unprotected, as it is only modified by the parent thread during setup.

Fix for #4547