### PR TITLE
correct mmap error check

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1050,7 +1050,9 @@ static size_t FIO_setDictBufferMMap(FIO_Dict_t* dict, const char* fileName, FIO_
     }
 
     *bufferPtr = mmap(NULL, (size_t)fileSize, PROT_READ, MAP_PRIVATE, fileHandle, 0);
-    if (*bufferPtr==NULL) EXM_THROW(34, "%s", strerror(errno));
+    if (*bufferPtr == MAP_FAILED) {
+      EXM_THROW(34, "%s", strerror(errno))
+    }
 
     close(fileHandle);
     return (size_t)fileSize;


### PR DESCRIPTION
According to the [mmap docs](https://man7.org/linux/man-pages/man2/mmap.2.html)  `MAP_FAILED` is returned upon error:

> On success, mmap() returns a pointer to the mapped area.  On
       error, the value MAP_FAILED (that is, (void *) -1) is returned,
       and [errno](https://man7.org/linux/man-pages/man3/errno.3.html) is set to indicate the error.

Update mmap error validation to check for `MAP_FAILED` instead of NULL. POSIX specifies that mmap returns `MAP_FAILED` (-1) on failure.

Reported-by: Clang 21 Static Analyzer