### PR TITLE
bitstream: fix `BIT_readBits` and `BIT_reloadDStream` prototypes

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -102,8 +102,8 @@ typedef enum { BIT_DStream_unfinished = 0,  /* fully refilled */
     } BIT_DStream_status;  /* result of BIT_reloadDStream() */
 
 MEM_STATIC size_t   BIT_initDStream(BIT_DStream_t* bitD, const void* srcBuffer, size_t srcSize);
-MEM_STATIC BitContainerType BIT_readBits(BIT_DStream_t* bitD, unsigned nbBits);
-MEM_STATIC BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD);
+FORCE_INLINE_TEMPLATE BitContainerType BIT_readBits(BIT_DStream_t* bitD, unsigned nbBits);
+FORCE_INLINE_TEMPLATE BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD);
 MEM_STATIC unsigned BIT_endOfDStream(const BIT_DStream_t* bitD);
 
 


### PR DESCRIPTION
Align the declarations of `BIT_readBits()` and `BIT_reloadDStream()` in `bitstream.h` with their `FORCE_INLINE_TEMPLATE `definitions.

The previous `MEM_STATIC` declarations caused an attribute mismatch between the header and the definitions, which can lead to incorrect compiler assumptions under certain toolchains and optimization levels.

---

```rust
  CC [M]  zstd/lib/common/entropy_common.o
In file included from /data/zstd/lib/common/fse.h:230,
                 from /data/zstd/lib/common/entropy_common.c:22:
/data/zstd/lib/common/bitstream.h:363:40: error: 'gnu_inline' attribute present on 'BIT_readBits'
  363 | FORCE_INLINE_TEMPLATE BitContainerType BIT_readBits(BIT_DStream_t* bitD, unsigned nbBits)
      |                                        ^~~~~~~~~~~~
/data/zstd/lib/common/bitstream.h:106:29: error: but not here
  106 | MEM_STATIC BitContainerType BIT_readBits(BIT_DStream_t* bitD, unsigned nbBits);
      |                             ^~~~~~~~~~~~
/data/zstd/lib/common/bitstream.h:413:42: error: 'gnu_inline' attribute present on 'BIT_reloadDStream'
  413 | FORCE_INLINE_TEMPLATE BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD)
      |                                          ^~~~~~~~~~~~~~~~~
/data/zstd/lib/common/bitstream.h:107:31: error: but not here
  107 | MEM_STATIC BIT_DStream_status BIT_reloadDStream(BIT_DStream_t* bitD);
      |                               ^~~~~~~~~~~~~~~~~
```