### PR TITLE
SPM: ZSTDLIB_STATIC_API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "libzstd",
+            type: .static,
             targets: [ "libzstd" ])
     ],
     dependencies: [
@@ -25,7 +26,7 @@ let package = Package(
             name: "libzstd",
             path: "lib",
             sources: [ "common", "compress", "decompress", "dictBuilder" ],
-            publicHeadersPath: ".",
+            publicHeadersPath: "spm",
             cSettings: [
                 .headerSearchPath(".")
             ])

--- a/lib/spm/module.modulemap
+++ b/lib/spm/module.modulemap
@@ -1,0 +1,14 @@
+module libzstd [extern_c] {
+    header "zstd_shim.h"
+    export *
+
+    module dictbuilder [extern_c] {
+        header "zdict_shim.h"
+        export *
+    }
+
+    module errors [extern_c] {
+        header "../zstd_errors.h"
+        export *
+    }
+}

--- a/lib/spm/zdict_shim.h
+++ b/lib/spm/zdict_shim.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+#ifndef ZSTD_ZDICT_SHIM_H
+#define ZSTD_ZDICT_SHIM_H
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include "../zdict.h"
+
+#endif /* ZSTD_SHIM_H */

--- a/lib/spm/zdict_shim.h
+++ b/lib/spm/zdict_shim.h
@@ -14,4 +14,4 @@
 #define ZSTD_STATIC_LINKING_ONLY
 #include "../zdict.h"
 
-#endif /* ZSTD_SHIM_H */
+#endif /* ZSTD_ZDICT_SHIM_H */

--- a/lib/spm/zstd_shim.h
+++ b/lib/spm/zstd_shim.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+#ifndef ZSTD_SHIM_H
+#define ZSTD_SHIM_H
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include "../zstd.h"
+
+#endif /* ZSTD_SHIM_H */


### PR DESCRIPTION
see #4581 for details

context / thoughts:
- SPM already very aggressively favors static linking over dynamic linking, so explicitly defining the library type as static should, effectively have no impact on this
    - not defining it explicitly allows SPM to choose between making the package product a static or dynamic library, which in effect means that it will be a static library, unless it contains resources, which is not the case here
    - if, at some point in the future, we'd want to offer dynamic linking for the Swift package, this would be possible: the convention would be to define a `libzstdDynamic` package product, whose kind is explicitly set to dynamic
- this PR introduces a second modulemap file
    - looking at the commit history, it seems that the current modulemap file exists solely to support the Package.swift file
    - but: i'm not 100% sure that there isn't some other toolchain/setup somewhere that also depends on the modulemap, so IMO defining a fully separate modulemap for these changes is better than modifying the existing one
    - since the new modulemap is in a dedicated `spm` directory, it will only be seen if clang is actually pointed at the `spm` directory (as is now happening in the Package.swift file)
    - any existing code should continue to work as-is, and not see the new modulemap at all (since there will be no existing code that `#include`s the spm directory