### PR TITLE
MacOS release builds

### DIFF
--- a/.github/workflows/macos-artifacts.yml
+++ b/.github/workflows/macos-artifacts.yml
@@ -1,0 +1,71 @@
+name: macos-artifacts
+
+on:
+  push:
+    branches: [test_artifacts, macos_artifacts, release]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  macos-artifacts:
+    permissions:
+      contents: write # to fetch code and upload artifacts
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - { os: macos-15, ziparch: macos-arm64 }
+          - { os: macos-15, ziparch: macos-x86_64 }
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+
+      - name: display versions
+        run: |
+          make -v
+          cc -v
+
+      # Build dependencies
+      - name: Building zlib to static link
+        run: |
+          git clone --depth 1 --branch v1.3.1 https://github.com/madler/zlib
+          cd zlib && ./configure --static && make libz.a
+
+      - name: Building lz4 to static link
+        run: |
+          git clone --depth 1 --branch v1.10.0 https://github.com/lz4/lz4
+          # ensure both libraries use the same version of libxxhash
+          cp lib/common/xxhash.* lz4/lib
+          CPPFLAGS=-DXXH_NAMESPACE=LZ4_ make -C lz4/lib liblz4.a V=1
+
+      # Build zstd
+      - name: Building zstd programs
+        run: |
+          CPPFLAGS="-I../zlib -I../lz4/lib" make -j allzstd V=1 HAVE_ZLIB=1 HAVE_LZ4=1 HAVE_LZMA=0 LDLIBS="../zlib/libz.a ../lz4/lib/liblz4.a"
+
+      - name: Create artifacts
+        run: |
+          ./lib/dll/example/build_package.sh || exit 1
+          mv bin/ zstd-${{ github.ref_name }}-${{ matrix.ziparch }}/
+
+      - name: Publish zstd-$VERSION-${{ matrix.ziparch }}.tar.gz for manual inspection
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # tag=v6.0.0
+        with:
+          compression-level: 9 # maximum compression
+          if-no-files-found: error # defaults to `warn`
+          path: ${{ github.workspace }}/zstd-${{ github.ref_name }}-${{ matrix.ziparch }}/
+          name: zstd-${{ github.ref_name }}-${{ matrix.ziparch }}
+
+      - name: Package artifact for upload
+        run: |
+          tar -czf "zstd-${{ github.ref_name }}-${{ matrix.ziparch }}.tar.gz" "zstd-${{ github.ref_name }}-${{ matrix.ziparch }}"
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" "zstd-${{ github.ref_name }}-${{ matrix.ziparch }}.tar.gz" --clobber

--- a/lib/dll/example/build_package.sh
+++ b/lib/dll/example/build_package.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -e
+
+echo Detected build type: make
+
+# Create required directories
+mkdir -p bin/dll bin/static bin/example bin/include
+
+copy_file() {
+    cp $1 "$2" || { echo "Failed to copy $1"; exit 1; }
+}
+
+# Copy common files using a function. Exits immediately on failure.
+copy_file "tests/fullbench.c"              "bin/example/"
+copy_file "programs/datagen.c"             "bin/example/"
+copy_file "programs/datagen.h"             "bin/example/"
+copy_file "programs/util.h"                "bin/example/"
+copy_file "programs/platform.h"            "bin/example/"
+copy_file "lib/common/mem.h"               "bin/example/"
+copy_file "lib/common/zstd_internal.h"     "bin/example/"
+copy_file "lib/common/error_private.h"     "bin/example/"
+copy_file "lib/common/xxhash.h"            "bin/example/"
+copy_file "lib/dll/example/Makefile"        "bin/example/"
+copy_file "lib/dll/example/fullbench-dll.sln"    "bin/example/"
+copy_file "lib/dll/example/fullbench-dll.vcxproj" "bin/example/"
+copy_file "lib/zstd.h"        "bin/include/"
+copy_file "lib/zstd_errors.h" "bin/include/"
+copy_file "lib/zdict.h"       "bin/include/"
+
+# Copy build-specific files
+echo Copying Make build artifacts...
+copy_file "lib/libzstd.a" "bin/static/libzstd.a"
+
+DYLIB_FULL=$(ls lib/libzstd.*.*.*.dylib 2>/dev/null | head -1)
+if [ -z "$DYLIB_FULL" ]; then
+    echo "Error: could not find libzstd.X.Y.Z.dylib in lib/"
+    exit 1
+fi
+DYLIB_NAME=$(basename "$DYLIB_FULL")
+copy_file "$DYLIB_FULL" "bin/dll/"
+
+MAJOR=$(echo "$DYLIB_NAME" | sed 's/libzstd\.\([0-9]*\)\..*/\1/')
+ln -sf "$DYLIB_NAME" "bin/dll/libzstd.${MAJOR}.dylib"
+ln -sf "$DYLIB_NAME" "bin/dll/libzstd.dylib"
+
+copy_file "programs/zstd" "bin/zstd"
+copy_file "lib/dll/example/README.md" "bin/"
+
+echo Build package created successfully for make build!


### PR DESCRIPTION
Attempt to fix #3818 partially.

This is currently just a 1:1 copy of the windows release without any attempt to DRY up pinned `checkout` version (or other dependencies).

When triggered appropriately this will build `zstd` using the same structure as the windows equivalents. Both work when I tested it manually on 26.2 on an M2.

Missing is code signing so currently users need to execute `xattr -cr` on the binaries.

Any preferences here on how to approach this, e.g.

1. Document `xattr -cr`?
2. Ad-hoc signing with `codesign`?
3. `codesign` backed by a real developer id?

Open issues:

- [ ] Decide on code signing strategy (see above)