### PR TITLE
Build: Add `-mno-strict-align` flag for RISC-V architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,13 @@ else
   EXT =
 endif
 
+# Detect if the architecture is RISC-V (native build)
+UNAME_M ?= $(shell uname -m)
+ifneq (,$(filter riscv%,$(UNAME_M)))
+    MOREFLAGS += -mno-strict-align
+    export MOREFLAGS
+endif
+
 ## default: Build lib-release and zstd-release
 .PHONY: default
 default: lib-release zstd-release


### PR DESCRIPTION
## Description
This PR updates the root `Makefile` to automatically detect RISC-V architectures (via `uname -m`) and append the `-mno-strict-align` flag to `MOREFLAGS`.

On many RISC-V implementations standard builds can suffer from significant performance degradation. Adding `-mno-strict-align` instructs the compiler to generate code that handles unaligned accesses via byte-wise instructions or other safe methods, thereby avoiding expensive traps and improving runtime performance.

## Changes
- Detects `riscv%` in `UNAME_M`.
- Appends `-mno-strict-align` to `MOREFLAGS`.
- Exports `MOREFLAGS` to ensure the flag is correctly propagated to sub-makefiles (lib, programs, etc.).

## Validation & Benchmarks
Tested on a RISC-V device (Sophon SG2044 / 64-core RISC-V).

**Benchmark Environment:**
- **Hardware:** Sophon SG2044
- **OS:** Linux (RISC-V 64-bit)
- **Compiler:** GCC 12.3.1

**Results:**
Comparison between the original build and the build with `-mno-strict-align`.

| Metric | Original | With `-mno-strict-align` | Improvement rate |
| :--- | :--- | :--- | :--- |
| **Compression Speed** | 64.0 MB/s | 75.2 MB/s | **+17.50%** |
| **Decompression Speed** | 102.9 MB/s | 165.1 MB/s | **+60.45%** |

*(Note: Data collected using `zstd -b` benchmark)*