### PR TITLE
Fix formatting of lz4 flag in CLI help

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -224,7 +224,7 @@ Advanced compression options:
   --format=gzip                 Compress files to the `.gz` format.
   --format=xz                   Compress files to the `.xz` format.
   --format=lzma                 Compress files to the `.lzma` format.
-  --format=lz4                 Compress files to the `.lz4` format.
+  --format=lz4                  Compress files to the `.lz4` format.
 
 Advanced decompression options:
   -l                            Print information about Zstandard-compressed files.

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -264,7 +264,7 @@ static void usageAdvanced(const char* programName)
     DISPLAYOUT("  --format=lzma                 Compress files to the `.lzma` format.\n");
 #endif
 #ifdef ZSTD_LZ4COMPRESS
-    DISPLAYOUT( "  --format=lz4                 Compress files to the `.lz4` format.\n");
+    DISPLAYOUT( "  --format=lz4                  Compress files to the `.lz4` format.\n");
 #endif
 #endif  /* !ZSTD_NOCOMPRESS */
 


### PR DESCRIPTION
The `--format=lz4` flag was missing a space. This fixes it in both the CLI and README.
Before:
```
  --format=gzip                 Compress files to the `.gz` format.
  --format=xz                   Compress files to the `.xz` format.
  --format=lzma                 Compress files to the `.lzma` format.
  --format=lz4                 Compress files to the `.lz4` format.
```
After:
```
  --format=gzip                 Compress files to the `.gz` format.
  --format=xz                   Compress files to the `.xz` format.
  --format=lzma                 Compress files to the `.lzma` format.
  --format=lz4                  Compress files to the `.lz4` format.

```