### PR TITLE
Fix SIGFPE in ZSTD_estimateCCtxSize_usingCCtxParams when LDM is enabled

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -1771,15 +1771,19 @@ size_t ZSTD_estimateCCtxSize_usingCCtxParams(const ZSTD_CCtx_params* params)
 {
     ZSTD_compressionParameters const cParams =
                 ZSTD_getCParamsFromCCtxParams(params, ZSTD_CONTENTSIZE_UNKNOWN, 0, ZSTD_cpm_noAttachDict);
+    ldmParams_t ldmParams = params->ldmParams;
     ZSTD_ParamSwitch_e const useRowMatchFinder = ZSTD_resolveRowMatchFinderMode(params->useRowMatchFinder,
                                                                                &cParams);
 
     RETURN_ERROR_IF(params->nbWorkers > 0, GENERIC, "Estimate CCtx size is supported for single-threaded compression only.");
+    if (ldmParams.enableLdm == ZSTD_ps_enable) {
+        ZSTD_ldm_adjustParameters(&ldmParams, &cParams);
+    }
     /* estimateCCtxSize is for one-shot compression. So no buffers should
      * be needed. However, we still allocate two 0-sized buffers, which can
      * take space under ASAN. */
     return ZSTD_estimateCCtxSize_usingCCtxParams_internal(
-        &cParams, &params->ldmParams, 1, useRowMatchFinder, 0, 0, ZSTD_CONTENTSIZE_UNKNOWN, ZSTD_hasExtSeqProd(params), params->maxBlockSize);
+        &cParams, &ldmParams, 1, useRowMatchFinder, 0, 0, ZSTD_CONTENTSIZE_UNKNOWN, ZSTD_hasExtSeqProd(params), params->maxBlockSize);
 }
 
 size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters cParams)
@@ -1829,6 +1833,7 @@ size_t ZSTD_estimateCStreamSize_usingCCtxParams(const ZSTD_CCtx_params* params)
     RETURN_ERROR_IF(params->nbWorkers > 0, GENERIC, "Estimate CCtx size is supported for single-threaded compression only.");
     {   ZSTD_compressionParameters const cParams =
                 ZSTD_getCParamsFromCCtxParams(params, ZSTD_CONTENTSIZE_UNKNOWN, 0, ZSTD_cpm_noAttachDict);
+        ldmParams_t ldmParams = params->ldmParams;
         size_t const blockSize = MIN(ZSTD_resolveMaxBlockSize(params->maxBlockSize), (size_t)1 << cParams.windowLog);
         size_t const inBuffSize = (params->inBufferMode == ZSTD_bm_buffered)
                 ? ((size_t)1 << cParams.windowLog) + blockSize
@@ -1838,8 +1843,11 @@ size_t ZSTD_estimateCStreamSize_usingCCtxParams(const ZSTD_CCtx_params* params)
                 : 0;
         ZSTD_ParamSwitch_e const useRowMatchFinder = ZSTD_resolveRowMatchFinderMode(params->useRowMatchFinder, &params->cParams);
 
+        if (ldmParams.enableLdm == ZSTD_ps_enable) {
+            ZSTD_ldm_adjustParameters(&ldmParams, &cParams);
+        }
         return ZSTD_estimateCCtxSize_usingCCtxParams_internal(
-            &cParams, &params->ldmParams, 1, useRowMatchFinder, inBuffSize, outBuffSize,
+            &cParams, &ldmParams, 1, useRowMatchFinder, inBuffSize, outBuffSize,
             ZSTD_CONTENTSIZE_UNKNOWN, ZSTD_hasExtSeqProd(params), params->maxBlockSize);
     }
 }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -2515,6 +2515,25 @@ static int basicUnitTests(U32 const seed, double compressibility)
                 }
             }
             DISPLAYLEVEL(3, "OK \n");
+
+            DISPLAYLEVEL(3, "test%3i : estimation functions with LDM enabled (issue #4590) : ", testNb++);
+            {
+                /* ZSTD_estimateCCtxSize_usingCCtxParams must adjust zeroed-out
+                 * LDM parameters when LDM is enabled, to avoid division by zero
+                 * in ZSTD_ldm_getMaxNbSeq. */
+                ZSTD_CCtx_params* params = ZSTD_createCCtxParams();
+                size_t cctxSize;
+                CHECK_Z(ZSTD_CCtxParams_setParameter(params, ZSTD_c_compressionLevel, 22));
+                CHECK_Z(ZSTD_CCtxParams_setParameter(params, ZSTD_c_enableLongDistanceMatching, ZSTD_ps_enable));
+                cctxSize = ZSTD_estimateCCtxSize_usingCCtxParams(params);
+                if (ZSTD_isError(cctxSize)) goto _output_error;
+                if (cctxSize == 0) goto _output_error;
+                cctxSize = ZSTD_estimateCStreamSize_usingCCtxParams(params);
+                if (ZSTD_isError(cctxSize)) goto _output_error;
+                if (cctxSize == 0) goto _output_error;
+                ZSTD_freeCCtxParams(params);
+            }
+            DISPLAYLEVEL(3, "OK \n");
         }
         free(staticCCtxBuffer);
         free(staticDCtxBuffer);


### PR DESCRIPTION
## Summary

Fixes #4590

`ZSTD_estimateCCtxSize_usingCCtxParams` and `ZSTD_estimateCStreamSize_usingCCtxParams` raise a `SIGFPE` (division by zero) on x86 when long distance matching (LDM) is enabled via `ZSTD_CCtxParams_setParameter` but the individual LDM sub-parameters (hashLog, bucketSizeLog, minMatchLength, hashRateLog) remain at their default zero values.

The division by zero occurs in `ZSTD_ldm_getMaxNbSeq()` at `lib/compress/zstd_ldm.c:181`, where `maxChunkSize / params.minMatchLength` is computed with `minMatchLength == 0`.

## Root Cause

When the user enables LDM through `ZSTD_CCtxParams_setParameter(params, ZSTD_c_enableLongDistanceMatching, 1)`, only the `enableLdm` flag is set. The other LDM parameters stay at zero. The existing `ZSTD_estimateCCtxSize_usingCParams` path avoids this by going through `ZSTD_makeCCtxParamsFromCParams`, which calls `ZSTD_ldm_adjustParameters()` to fill in sensible defaults. However, `ZSTD_estimateCCtxSize_usingCCtxParams` and `ZSTD_estimateCStreamSize_usingCCtxParams` skip this adjustment step and pass the raw (zeroed) LDM params directly to the internal estimation function.

## Fix

Both `ZSTD_estimateCCtxSize_usingCCtxParams` and `ZSTD_estimateCStreamSize_usingCCtxParams` now copy the LDM parameters to a local and call `ZSTD_ldm_adjustParameters()` when LDM is enabled, consistent with the pattern already used in `ZSTD_makeCCtxParamsFromCParams`.

## Changes
- `lib/compress/zstd_compress.c`: Added LDM parameter adjustment in both estimation functions
- `tests/fuzzer.c`: Added regression test that enables LDM via CCtxParams and calls both estimation functions

## Steps to Reproduce (before fix)

```c
#define ZSTD_STATIC_LINKING_ONLY
#include <zstd.h>
#include <stdio.h>
#include <stdlib.h>

int main(void) {
    ZSTD_CCtx_params* p = ZSTD_createCCtxParams();
    ZSTD_CCtxParams_setParameter(p, ZSTD_c_compressionLevel, 22);
    ZSTD_CCtxParams_setParameter(p, ZSTD_c_enableLongDistanceMatching, 1);
    size_t r = ZSTD_estimateCCtxSize_usingCCtxParams(p);
    /* SIGFPE on x86, incorrect result on ARM */
    printf("estimated CCtx size: %zu\n", r);
    ZSTD_freeCCtxParams(p);
    return 0;
}
```

Compile and run:
```
cc -g -I lib repro.c lib/libzstd.a -o repro && ./repro
```

## Testing

- Verified the reproducer no longer crashes and returns a correct estimation
- `make check` passes
- `make -C tests fuzzer && tests/fuzzer -t1` passes including the new regression test