### PR TITLE
enable MEM_FORCE_MEMORY_ACCESS=2 for RISC-V targets with zicclsm

### DIFF
--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -129,7 +129,9 @@ MEM_STATIC size_t MEM_swapST(size_t in);
  * Default  : method 1 if supported, else method 0
  */
 #ifndef MEM_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
-#  ifdef __GNUC__
+#  if defined(__riscv) && defined(__riscv_zicclsm)
+#    define MEM_FORCE_MEMORY_ACCESS 2
+#  elif defined(__GNUC__)
 #    define MEM_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif


### PR DESCRIPTION
# Summary

This PR updates `lib/common/mem.h` to select `MEM_FORCE_MEMORY_ACCESS=2` for RISC-V builds when both `__riscv` and `__riscv_zicclsm` are defined.

## Motivation

`Zicclsm` indicates support for misaligned loads/stores in main memory.  
For these targets, using method 2 enables direct unaligned memory access in `mem.h`.
References
[GCC Zicclsm](https://gcc.gnu.org/pipermail/gcc-patches/2024-February/644655.html)
[RVA20U64 specification](https://github.com/riscv/riscv-profiles/blob/5879c13c924ec5636995c5883f40337e83f6049a/src/profiles.adoc#L658)

## Changes

- Updated the default `MEM_FORCE_MEMORY_ACCESS` selection logic:
  - `MEM_FORCE_MEMORY_ACCESS=2` when `defined(__riscv) && defined(__riscv_zicclsm)`
  - Keep existing GCC fallback: `MEM_FORCE_MEMORY_ACCESS=1` for other GCC targets
- No changes to behavior when `MEM_FORCE_MEMORY_ACCESS` is explicitly set by the build system.

## Validation

- Verified the updated preprocessor branch compiles cleanly in `mem.h`.
- No linter issues reported for the modified file.

## Benchmark Data (Compression Speed) 
Method| zstd -1 Speed| vs Method 0
-- | -- | --
Method 2 | 74.2 MB/s | +74% 
Method 1 | 59.2 MB/s | +39% 
Method 0 | 42.5 MB/s | -  

## Data screenshot
<img width="826" height="629" alt="image" src="https://github.com/user-attachments/assets/2426876c-bc73-48a1-ba9d-7d8ae3ebf4c8" />