### PR TITLE
Fix potential NULL pointer dereference in ZSTD_customCalloc when cust…

### DIFF
--- a/lib/common/allocations.h
+++ b/lib/common/allocations.h
@@ -33,9 +33,13 @@ MEM_STATIC void* ZSTD_customMalloc(size_t size, ZSTD_customMem customMem)
 MEM_STATIC void* ZSTD_customCalloc(size_t size, ZSTD_customMem customMem)
 {
     if (customMem.customAlloc) {
-        /* calloc implemented as malloc+memset;
-         * not as efficient as calloc, but next best guess for custom malloc */
+        /* calloc implemented as malloc+memset */
         void* const ptr = customMem.customAlloc(customMem.opaque, size);
+
+        if (ptr == NULL) {
+            return NULL;
+        }
+
         ZSTD_memset(ptr, 0, size);
         return ptr;
     }


### PR DESCRIPTION
…om allocator fails

The fix introduces a NULL check immediately after the custom allocation call. If allocation fails, the function now safely returns NULL instead of dereferencing the pointer.

This improves the robustness of the memory allocation path and prevents possible crashes when using custom memory allocators.