### PR TITLE
huf_decompress: enable 4-way fast loop on riscv64

### DIFF
--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -1627,7 +1627,7 @@ void HUF_decompress4X2_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* 
         }                                                               \
     } while (0)
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
 #  define HUF_4X2_4WAY 1
 #else
 #  define HUF_4X2_4WAY 0


### PR DESCRIPTION
## Summary
- In `lib/decompress/huf_decompress.c`, enable `HUF_4X2_4WAY` for `riscv64` (`defined(__riscv) && __riscv_xlen == 64`).
- Keep existing logic unchanged for all other architectures.
- No functional/format changes: only changes fast-loop scheduling policy in the hot decode path.

## Why this change is reasonable
- The `HUF_4X2_4WAY` switch controls whether the fast loop decodes all 4 streams in the main unrolled body, or uses a 3-way fallback to reduce register pressure.
- This loop is already enabled as 4-way on `aarch64`, which indicates the 4-way variant is considered stable and beneficial on modern 64-bit RISC-style cores with larger register files.
- `riscv64` has similar 64-bit execution characteristics for this scalar path (64-bit container ops, stream-parallel decode pattern), so selecting 4-way is a reasonable architecture-level default.
- Scope is intentionally conservative: only `riscv64` is opted in; `rv32` and all non-RISC-V targets keep existing behavior.
- If performance differs by compiler/micro-architecture, this change is still safe functionally because both paths implement the same decode semantics.