### PR TITLE
Optimize ZSTD_count with RISC-V Vector (RVV) intrinsics

### DIFF
--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -860,15 +860,34 @@ MEM_STATIC size_t ZSTD_count(const BYTE* pIn, const BYTE* pMatch, const BYTE* co
         { size_t const diff = MEM_readST(pMatch) ^ MEM_readST(pIn);
           if (diff) return ZSTD_NbCommonBytes(diff); }
         pIn+=sizeof(size_t); pMatch+=sizeof(size_t);
-        while (pIn < pInLoopLimit) {
-            size_t const diff = MEM_readST(pMatch) ^ MEM_readST(pIn);
-            if (!diff) { pIn+=sizeof(size_t); pMatch+=sizeof(size_t); continue; }
-            pIn += ZSTD_NbCommonBytes(diff);
-            return (size_t)(pIn - pStart);
-    }   }
+    }
+#if defined(ZSTD_ARCH_RISCV_RVV)
+    {
+        size_t vl;
+        while (pIn < pInLimit) {
+            vl = __riscv_vsetvl_e8m1((size_t)(pInLimit - pIn));
+            vuint8m1_t v_in = __riscv_vle8_v_u8m1(pIn, vl);
+            vuint8m1_t v_match = __riscv_vle8_v_u8m1(pMatch, vl);
+            vbool8_t mask = __riscv_vmsne_vv_u8m1_b8(v_in, v_match, vl);
+            long first_diff = __riscv_vfirst_m_b8(mask, vl);
+            if (first_diff >= 0) {
+                return (size_t)(pIn + first_diff - pStart);
+            }
+            pIn += vl;
+            pMatch += vl;
+        }
+    }
+#else
+    while (pIn < pInLoopLimit) {
+        size_t const diff = MEM_readST(pMatch) ^ MEM_readST(pIn);
+        if (!diff) { pIn+=sizeof(size_t); pMatch+=sizeof(size_t); continue; }
+        pIn += ZSTD_NbCommonBytes(diff);
+        return (size_t)(pIn - pStart);
+    }
     if (MEM_64bits() && (pIn<(pInLimit-3)) && (MEM_read32(pMatch) == MEM_read32(pIn))) { pIn+=4; pMatch+=4; }
     if ((pIn<(pInLimit-1)) && (MEM_read16(pMatch) == MEM_read16(pIn))) { pIn+=2; pMatch+=2; }
     if ((pIn<pInLimit) && (*pMatch == *pIn)) pIn++;
+#endif
     return (size_t)(pIn - pStart);
 }
 


### PR DESCRIPTION
## Description

This PR introduces RISC-V Vector (RVV) intrinsics to optimize the `ZSTD_count` function in `zstd_compress_internal.h`. 

`ZSTD_count` is a highly frequently called function during the match-finding phase. The original scalar implementation processes data in machine-word chunks (`sizeof(size_t)`) and requires a fallback mechanism to handle the remaining tail bytes safely. 

By leveraging the RISC-V Vector extension (`__riscv_vsetvl_e8m1`), we can dramatically simplify the loop. The `vsetvl` instruction automatically manages the application vector length (AVL), seamlessly absorbing the tail without the need for additional branching or scalar tail-handling code, while safely avoiding out-of-bounds reads.

To maximize performance, the initial scalar fast-path (`MEM_readST`) is preserved to quickly catch early mismatches (which covers the vast majority of cases), switching to the RVV loop only for longer matches.

## Performance Evaluation
**Test Environment:**
- **CPU:** RISC-V r2044
- **Dataset:** `silesia.tar` (211,957,760 bytes)
- **Command:** `numactl -l -C 12 ./zstd -b1 -e1 ../silesia.tar`
### Benchmark Results
| Implementation | Run 1 (MB/s) | Run 2 (MB/s) | Run 3 (MB/s) | Average Compression | Ratio |
| :--- | :---: | :---: | :---: | :---: | :---: |
| **Scalar (Before PR)** | 85.2 | 85.5 | 85.2 | **85.30 MB/s** | Base |
| **RVV (After PR)** | 91.9 | 91.4 | 91.7 | **91.67 MB/s** | **+7.47%** |

**Before PR (Scalar):**
<img width="654" height="95" alt="image" src="https://github.com/user-attachments/assets/22c11090-9aa6-4833-bf76-809032dc2ca8" />

**After PR (RVV Optimized):**
<img width="674" height="95" alt="image" src="https://github.com/user-attachments/assets/bd88daa7-be06-4ac4-b071-f95fa02e2228" />

