### PR TITLE
Enable PREFETCH_L1 for RISC-V to improve performance

### DIFF
--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -1020,7 +1020,7 @@ size_t ZSTD_execSequence(BYTE* op,
     assert(op != NULL /* Precondition */);
     assert(oend_w < oend /* No underflow */);
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__riscv)
     /* prefetch sequence starting from match that will be used for copy later */
     PREFETCH_L1(match);
 #endif


### PR DESCRIPTION
### Description
This PR enables `PREFETCH_L1(match)` in `zstd_decompress_block.c` for the RISC-V architecture. 
Similar to AArch64, prefetching the match sequence before copying can bring a slight performance improvement on high-performance RISC-V processors.

**Why is it needed?**
Currently, this prefetch optimization is only enabled for `__aarch64__`. By extending the macro to include `__riscv`, we can take advantage of hardware data prefetching on RISC-V platforms, resulting in better CPU cache utilization during decompression.

**Benchmark Results**
Tests were performed on a **SOPHON SG2044** RISC-V machine using the `silesia.tar` dataset.
Command: `numactl -l -C 12 ./zstd -b1 -e1 ../silesia.tar`

| Metric | Before (MB/s) | After (MB/s) | Improvement |
| :--- | :---: | :---: | :---: |
| **Compression (Level 1)** | 85.34 | **85.58** | **+0.28%** |
| **Decompression** | 237.01 | **237.33** | **+0.14%** |
