### PR TITLE
fix: in zstd_edist in zstd_edist.c

### DIFF
--- a/contrib/match_finders/zstd_edist.c
+++ b/contrib/match_finders/zstd_edist.c
@@ -402,12 +402,19 @@ static void ZSTD_eDist_combineMatches(ZSTD_eDist_state* state)
 {
     /* Create a new buffer to put the combined matches into 
      * and memcpy to state->matches after */ 
-    ZSTD_eDist_match* combinedMatches = 
-        ZSTD_malloc(state->nbMatches * sizeof(ZSTD_eDist_match), 
-        ZSTD_defaultCMem);
-
+    ZSTD_eDist_match* combinedMatches;
     U32 nbCombinedMatches = 1;
     size_t i;
+
+    /* Guard against empty match list to avoid zero-size allocation and
+     * the unconditional memcpy below writing beyond an empty buffer */
+    if (state->nbMatches == 0) return;
+
+    combinedMatches = ZSTD_malloc(state->nbMatches * sizeof(ZSTD_eDist_match),
+        ZSTD_defaultCMem);
+
+    /* Guard against allocation failure before any memcpy */
+    if (combinedMatches == NULL) return;
 
     /* Make sure that the srcIdx and dictIdx are in sorted order.
      * The combination step won't work otherwise */ 
@@ -427,11 +434,15 @@ static void ZSTD_eDist_combineMatches(ZSTD_eDist_state* state)
                 nbCombinedMatches--;
             }
 
+            /* Bounds check: ensure we don't write beyond the allocated buffer */
+            if (nbCombinedMatches >= state->nbMatches) break;
+
             memcpy(combinedMatches + nbCombinedMatches, 
                 state->matches + i, sizeof(ZSTD_eDist_match));
             nbCombinedMatches++;
         }
     }
+    /* nbCombinedMatches <= state->nbMatches, so this is always within bounds */
     memcpy(state->matches, combinedMatches, nbCombinedMatches * sizeof(ZSTD_eDist_match));
     state->nbMatches = nbCombinedMatches;
     ZSTD_free(combinedMatches, ZSTD_defaultCMem);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `contrib/match_finders/zstd_edist.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `contrib/match_finders/zstd_edist.c:416` |

**Description**: In zstd_edist.c, three memcpy operations at lines 416, 430, and 435 copy match data into and out of combinedMatches without validating that nbCombinedMatches * sizeof(ZSTD_eDist_match) fits within the allocated buffer. If nbCombinedMatches is derived from attacker-controlled compressed input and exceeds the allocated capacity, the memcpy at line 435 writes beyond the heap buffer boundary, corrupting adjacent heap memory.

## Changes
- `contrib/match_finders/zstd_edist.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
