### PR TITLE
Pass invalid argument in valgrindTest to force failure

### DIFF
--- a/build/meson/tests/valgrindTest.py
+++ b/build/meson/tests/valgrindTest.py
@@ -19,7 +19,7 @@ def valgrindTest(valgrind, datagen, fuzzer, zstd, fullbench):
 
   subprocess.check_call([*VALGRIND_ARGS, datagen, '-g50M'], stdout=subprocess.DEVNULL)
 
-  if subprocess.call([*VALGRIND_ARGS, zstd],
+  if subprocess.call([*VALGRIND_ARGS, zstd, '--fake-stdin-is-console'],
                      stdout=subprocess.DEVNULL) == 0:
     raise subprocess.SubprocessError('zstd without argument should have failed')
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -281,7 +281,7 @@ test-valgrind: VALGRIND = valgrind --leak-check=full --show-leak-kinds=all --err
 test-valgrind: zstd datagen fuzzer fullbench
 	@echo "\n ---- valgrind tests : memory analyzer ----"
 	$(VALGRIND) ./datagen -g50M > $(VOID)
-	$(VALGRIND) $(PRGDIR)/zstd ; if [ $$? -eq 0 ] ; then echo "zstd without argument should have failed"; false; fi
+	$(VALGRIND) $(PRGDIR)/zstd --fake-stdin-is-console ; if [ $$? -eq 0 ] ; then echo "zstd without argument should have failed"; false; fi
 	./datagen -g80 | $(VALGRIND) $(PRGDIR)/zstd - -c > $(VOID)
 	./datagen -g16KB | $(VALGRIND) $(PRGDIR)/zstd -vf - -c > $(VOID)
 	./datagen -g2930KB | $(VALGRIND) $(PRGDIR)/zstd -5 -vf - -o tmp


### PR DESCRIPTION
zstd with no arguments prints help and exits 0. The valgrind test harness at `build/meson/tests/valgrindTest.py` and its mirror in `tests/Makefile` assume the opposite and raise `zstd without argument should have failed`. Pass `--parameter-does-not-exist` instead so zstd exits 1 via its unknown-flag path.

Fixes #4366.