### PR TITLE
Fix stale README references for CI and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,9 @@ sudo ninja install
 A Meson project is provided within [`build/meson`](build/meson). Follow
 build instructions in that directory.
 
-You can also take a look at [`.travis.yml`](.travis.yml) file for an
-example about how Meson is used to build this project.
+You can also take a look at the workflow files in
+[`.github/workflows/`](.github/workflows) for examples of how this project is
+built in CI.
 
 Note that default build type is **release**.
 
@@ -223,7 +224,8 @@ You can integrate zstd into your Bazel project by using the module hosted on the
 ## Testing
 
 You can run quick local smoke tests by running `make check`.
-If you can't use `make`, execute the `playTest.sh` script from the `src/tests` directory.
+If you can't use `make`, execute the `tests/playTests.sh` script from the
+repository root.
 Two env variables `$ZSTD_BIN` and `$DATAGEN_BIN` are needed for the test script to locate the `zstd` and `datagen` binary.
 For information on CI testing, please refer to `TESTING.md`.
 


### PR DESCRIPTION

**Repo:** facebook/zstd (⭐ 25000)
**Type:** docs
**Files changed:** 1
**Lines:** +5/-3

## What
Updates the top-level README to point readers at the current CI workflow location and the actual local test script path. The change replaces a dead reference to `.travis.yml` with `.github/workflows/`, and fixes the testing instructions from `playTest.sh` in `src/tests` to `tests/playTests.sh` from the repository root.

## Why
The existing README sends contributors to a file that no longer exists and documents a test command that cannot work as written. Fixing both keeps the first-run contributor experience accurate, avoids avoidable confusion during local validation, and aligns the README with the current repository layout.

## Testing
Verified the referenced paths locally in the repository:
- `.github/workflows/` exists and contains the active CI workflow files.
- `tests/playTests.sh` exists.
No runtime checks were needed because this is a documentation-only change.

## Risk
Low - documentation-only update that aligns README instructions with files already present in the repo.
