### PR TITLE
docs: list Apache Parquet usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,6 +308,7 @@ Peazip is a free multi-platforms archiver by Giorgio Tani with [support for Zsta
   <ul class="list-inline">
     <li><a href="https://rocksdb.org/"             ><img src="images/rocksdb.png" /></a> [RocksDB](https://twitter.com/rocksdb/status/771387757306388480) </li>
     <li><a href="https://hadoop.apache.org/"       ><img src="images/hadoop.png"  /></a> [Hadoop](https://issues.apache.org/jira/browse/HADOOP-13578) </li>
+    <li>[Apache Parquet](https://parquet.apache.org/docs/file-format/data-pages/compression/)</li>
     <li><a href="https://www.mysql.com/"           ><img src="images/mysql.png"   /></a> [MySQL](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-18.html#mysqld-8-0-18-connection-control) </li>
     <li><a href="https://cassandra.apache.org/"    ><img src="images/cassandra.png"/></a> [Cassandra](https://issues.apache.org/jira/browse/CASSANDRA-14482) </li>
     <li><a href="https://www.mongodb.com/"         ><img src="images/mongo.png"   /></a> [MongoDB](http://mongodb.github.io/mongo-java-driver/3.12/driver-async/tutorials/compression/) </li>


### PR DESCRIPTION
Fixes #4588.

Adds Apache Parquet to the website list of projects and formats that use Zstandard, linking to the Parquet compression documentation.

Validation:
- `git diff --check`