### PR TITLE
cli: add --output alias for -o

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -148,7 +148,7 @@ static void usage(FILE* f, const char* programName)
     DISPLAY_F(f, "Compress or decompress the INPUT file(s); reads from STDIN if INPUT is `-` or not provided.\n\n");
     DISPLAY_F(f, "Usage: %s [OPTIONS...] [INPUT... | -] [-o OUTPUT]\n\n", programName);
     DISPLAY_F(f, "Options:\n");
-    DISPLAY_F(f, "  -o OUTPUT                     Write output to a single file, OUTPUT.\n");
+    DISPLAY_F(f, "  -o, --output OUTPUT           Write output to a single file, OUTPUT.\n");
     DISPLAY_F(f, "  -c, --stdout                  Write to STDOUT (even if it is a console) and keep the INPUT file(s).\n");
     DISPLAY_F(f, "  -k, --keep                    Preserve INPUT file(s). [Default] \n");
     DISPLAY_F(f, "  --rm                          Remove INPUT file(s) after successful (de)compression to file.\n");
@@ -1139,6 +1139,7 @@ int main(int argCount, const char* argv[])
                     continue;
                 }
 #endif
+                if (longCommandWArg(&argument, "--output")) { NEXT_FIELD(outFileName); continue; }
 #ifndef ZSTD_NOTRACE
                 if (longCommandWArg(&argument, "--trace")) { char const* traceFile; NEXT_FIELD(traceFile); TRACE_enable(traceFile); continue; }
 #endif

--- a/tests/cli-tests/basic/output.sh
+++ b/tests/cli-tests/basic/output.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "some data" > file
+
+println "+ zstd -q file --output compressed.zst"
+zstd -q file --output compressed.zst
+test -f compressed.zst || die "Expected --output to create compressed.zst"
+
+println "+ zstd -q -d compressed.zst --output roundtrip"
+zstd -q -d compressed.zst --output roundtrip
+cmp file roundtrip || die "Expected --output decompression to round-trip"
+
+exit 0


### PR DESCRIPTION
## Summary

Adds `--output` as a long-form alias for `-o`, matching the existing output-file behavior requested in #4651.

This PR also updates the short help text and adds a CLI regression test covering both compression and decompression with `--output`.

Fixes #4651.

## Validation

Validated from a clean copy under `/tmp/zstd-output-build` because the local workspace path contains a space and zstd's makefiles break on that path:

- `make -j2 zstd`
- `./tests/cli-tests/run.py basic/output.sh`
- `./tests/cli-tests/run.py basic/output_dir.sh`
- direct smoke: `./zstd --help | grep -- '--output'` plus compress/decompress round-trip with `--output`
