### PR TITLE
Fix 32-bit zstdmt max job size allocation failure

### DIFF
--- a/lib/compress/zstdmt_compress.h
+++ b/lib/compress/zstdmt_compress.h
@@ -32,8 +32,8 @@
 #ifndef ZSTDMT_JOBSIZE_MIN   /* a different value can be selected at compile time */
 #  define ZSTDMT_JOBSIZE_MIN (512 KB)
 #endif
-#define ZSTDMT_JOBLOG_MAX   (MEM_32bits() ? 29 : 30)
-#define ZSTDMT_JOBSIZE_MAX  (MEM_32bits() ? (512 MB) : (1024 MB))
+#define ZSTDMT_JOBLOG_MAX   (MEM_32bits() ? 28 : 30)
+#define ZSTDMT_JOBSIZE_MAX  (MEM_32bits() ? (256 MB) : (1024 MB))
 
 
 /* ========================================================

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -3907,6 +3907,19 @@ static int basicUnitTests(U32 const seed, double compressibility)
         }
     }
 
+    DISPLAYLEVEL(3, "test%3i : job size bounds match architecture : ", testNb++);
+    {   ZSTD_bounds const bounds = ZSTD_cParam_getBounds(ZSTD_c_jobSize);
+#ifdef ZSTD_MULTITHREAD
+        int const expectedJobSizeMax = MEM_32bits() ? (256 MB) : (1024 MB);
+#else
+        int const expectedJobSizeMax = 0;
+#endif
+        CHECK_Z(bounds.error);
+        if (bounds.lowerBound != 0) goto _output_error;
+        if (bounds.upperBound != expectedJobSizeMax) goto _output_error;
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     /* advanced parameters for decompression */
     {   ZSTD_DCtx* const dctx = ZSTD_createDCtx();
         assert(dctx != NULL);


### PR DESCRIPTION
Fixes #4628.

## Summary

Reduces the 32-bit zstdmt maximum job size from 512 MB / log 29 to 256 MB / log 28.

On 32-bit builds, the previous bound could allow a threaded compression configuration at max compression level to attempt an oversized allocation, matching the failure described in #4628.

This follows the issue reporter's diagnosis and proposed cap reduction.

## Changes

- Lower `ZSTDMT_JOBLOG_MAX` on 32-bit builds from 29 to 28.
- Lower `ZSTDMT_JOBSIZE_MAX` on 32-bit builds from 512 MB to 256 MB.
- Add a bounds check in the fuzzer unit tests so `ZSTD_c_jobSize` reports the expected architecture-specific upper bound.

## Validation

- `git diff --check`
- Verified with a temporary GitHub Actions workflow on `linux/386` using Debian testing:
  - `make clean`
  - `make -j$(nproc)`
  - `make check`

The temporary validation workflow was kept out of this PR branch.