### PR TITLE
[doc] Use Compressed_Literals_Block in Size_Format bullet for consistency (fixes #4673)

### DIFF
--- a/doc/zstd_compression_format.md
+++ b/doc/zstd_compression_format.md
@@ -489,7 +489,7 @@ __`Size_Format`__
 - For `Raw_Literals_Block` and `RLE_Literals_Block`,
   it's only necessary to decode `Regenerated_Size`.
   There is no `Compressed_Size` field.
-- For `Compressed_Block` and `Treeless_Literals_Block`,
+- For `Compressed_Literals_Block` and `Treeless_Literals_Block`,
   it's required to decode both `Compressed_Size`
   and `Regenerated_Size` (the decompressed size).
   It's also necessary to decode the number of streams (1 or 4).


### PR DESCRIPTION
Fixes #4673.

In `doc/zstd_compression_format.md`, the `Size_Format` bullet in the `Literals_Block_Type` section currently reads:

> - For `Compressed_Block` and `Treeless_Literals_Block`, it's required to decode both `Compressed_Size` and `Regenerated_Size`...

`Compressed_Block` is the *block-level* type defined in section 3.1.1.1 (the four-way `Raw_Block` / `RLE_Block` / `Compressed_Block` / `Reserved` enum on line 357). The value the `Literals_Block_Type` enum can actually hold here, and the one the parallel bullet for the `Raw_Literals_Block` / `RLE_Literals_Block` pair already uses, is `Compressed_Literals_Block`.

The sub-section that immediately follows ("__`Size_Format` for `Compressed_Literals_Block` and `Treeless_Literals_Block`__", line 521) already uses `Compressed_Literals_Block` in its heading, so this is the only remaining occurrence using the wrong term in this section.

This PR changes that one occurrence to `Compressed_Literals_Block` to match.