### PR TITLE
docs: remove stale Travis CI badge and update Meson CI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,10 @@ Should your project require another programming language,
 a list of known ports and bindings is provided on [Zstandard homepage](https://facebook.github.io/zstd/#other-languages).
 
 **Development branch status:**
-
-[![Build Status][travisDevBadge]][travisLink]
 [![Build status][CircleDevBadge]][CircleLink]
 [![Build status][CirrusDevBadge]][CirrusLink]
 [![Fuzzing Status][OSSFuzzBadge]][OSSFuzzLink]
 
-[travisDevBadge]: https://api.travis-ci.com/facebook/zstd.svg?branch=dev "Continuous Integration test suite"
-[travisLink]: https://travis-ci.com/facebook/zstd
 [CircleDevBadge]: https://circleci.com/gh/facebook/zstd/tree/dev.svg?style=shield "Short test suite"
 [CircleLink]: https://circleci.com/gh/facebook/zstd
 [CirrusDevBadge]: https://api.cirrus-ci.com/github/facebook/zstd.svg?branch=dev
@@ -174,7 +170,7 @@ sudo ninja install
 A Meson project is provided within [`build/meson`](build/meson). Follow
 build instructions in that directory.
 
-You can also take a look at [`.travis.yml`](.travis.yml) file for an
+You can also take a look at the [GitHub Actions workflows](.github/workflows) for an
 example about how Meson is used to build this project.
 
 Note that default build type is **release**.


### PR DESCRIPTION
Travis CI no longer provides free CI for open source projects. Removed the stale badge and replaced the .travis.yml reference in the Meson section with the current GitHub Actions workflows.