### PR TITLE
Fix typo in streaming compression example

### DIFF
--- a/examples/multiple_streaming_compression.c
+++ b/examples/multiple_streaming_compression.c
@@ -9,7 +9,7 @@
  */
 
 
-/* The objective of this example is to show of to compress multiple successive files
+/* The objective of this example is to show how to compress multiple successive files
 *  while preserving memory management.
 *  All structures and buffers will be created only once,
 *  and shared across all compression operations */


### PR DESCRIPTION
## Summary
- Fix a small typo in the multiple streaming compression example comment.

## Testing
- Not run; comment-only change.