### PR TITLE
docs(website): add Parquet to Zstandard is used by section

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,6 +376,7 @@ Peazip is a free multi-platforms archiver by Giorgio Tani with [support for Zsta
     <li><a href="http://www.blosc.org/"            ><img src="images/blosc.png"   /></a> [Blosc](https://www.blosc.org/posts/zstd-has-just-landed-in-blosc/) </li>
     <li><a href="http://bcolz.blosc.org/en/latest/"><img src="images/bcolz.png"   /></a> [bcolz](https://github.com/Blosc/bcolz/tree/master/c-blosc/internal-complibs/zstd-1.1.2) </li>
     <li><a href="https://arrow.apache.org/"        ><img src="images/apache-arrow.png"/></a> [Apache Arrow](https://arrow.apache.org/blog/2020/04/21/0.17.0-release/) </li>
+    <li><a href="https://parquet.apache.org/docs/file-format/data-pages/compression/"><img src="images/blank.png"/></a> [Parquet](https://parquet.apache.org/docs/file-format/data-pages/compression/) </li>
     <li><a href="https://pypi.python.org/pypi/mrcz"><img src="images/mrc.png"     /></a> [mrcz](https://github.com/em-MRCZ/c-mrcz) </li>
     <li><a href="http://www.well.ox.ac.uk/~gav/bgen_format/bgen_format.html"><img src="images/oxford.png" /></a> [bgen](http://www.well.ox.ac.uk/~gav/bgen_format/bgen_format.html) </li>
     <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Gecko"><img src="images/gecko.png"    /></a> [Gecko](https://bug635044.bugzilla.mozilla.org/show_bug.cgi?id=1316183) </li>


### PR DESCRIPTION
## Summary

Adds [Apache Parquet](https://parquet.apache.org/) to the **Serialization** section of the project homepage (`index.html` on `gh-pages`), with a link to the [Parquet compression format documentation](https://parquet.apache.org/docs/file-format/data-pages/compression/) that specifies ZSTD as a supported codec.

Uses `images/blank.png` as placeholder icon (same pattern as LiveScan3D and other entries without a dedicated logo).

Fixes #4588

## Test plan

- [x] Open `index.html` locally and verify the new list item markup matches siblings
- [x] Documentation-only change on `gh-pages`

Made with [Cursor](https://cursor.com)