### PR TITLE
legacy/v0.1: fix truncating U32 cast in offset check; drop bogus pointer-as-int check

### DIFF
--- a/lib/legacy/zstd_v01.c
+++ b/lib/legacy/zstd_v01.c
@@ -1732,7 +1732,14 @@ static size_t ZSTD_execSequence(BYTE* op,
     if (seqLength > (size_t)(oend - op)) return ERROR(dstSize_tooSmall);
     if (sequence.litLength > (size_t)(litLimit - *litPtr)) return ERROR(corruption_detected);
     /* Now we know there are no overflow in literal nor match lengths, can use pointer checks */
-    if (sequence.offset > (U32)(oLitEnd - base)) return ERROR(corruption_detected);
+    /* Use full-precision size_t arithmetic; the previous `(U32)` cast on the
+     * `ptrdiff_t` truncated silently when `oLitEnd - base` exceeded
+     * `UINT32_MAX`, letting larger `sequence.offset` values bypass the
+     * check on 64-bit builds with multi-GiB destination buffers.  Reject
+     * the pathological `oLitEnd < base` case before the unsigned cast so
+     * a negative difference cannot wrap to a huge positive bound. */
+    if (oLitEnd < base) return ERROR(corruption_detected);
+    if (sequence.offset > (size_t)(oLitEnd - base)) return ERROR(corruption_detected);
 
     if (endMatch > oend) return ERROR(dstSize_tooSmall);   /* overwrite beyond dst buffer */
     if (litEnd > litLimit) return ERROR(corruption_detected);   /* overRead beyond lit buffer */
@@ -1754,9 +1761,21 @@ static size_t ZSTD_execSequence(BYTE* op,
         size_t qutt = 12;
         U64 saved[2];
 
-        /* check */
+        /* The earlier `sequence.offset > (size_t)(oLitEnd - base)` check
+         * (with `op == oLitEnd` at this point, since `op += litLength`
+         * already ran) guarantees that `op - sequence.offset >= base`,
+         * so the `match = op - sequence.offset` pointer formed above is
+         * always within the destination object and does not invoke C's
+         * out-of-bounds pointer-arithmetic UB.  The `if (match < base)`
+         * post-check is kept as defense-in-depth.
+         *
+         * The previous `sequence.offset > (size_t)base` check compared
+         * the offset against the numeric address of the `base` pointer,
+         * which is meaningless: on 64-bit systems `base` is a high
+         * virtual address that no 32-bit offset can exceed; on 32-bit
+         * systems the check fires only on accidental low-address
+         * allocations rather than on any underflow condition. */
         if (match < base) return ERROR(corruption_detected);
-        if (sequence.offset > (size_t)base) return ERROR(corruption_detected);
 
         /* save beginning of literal sequence, in case of write overlap */
         if (overlapRisk)


### PR DESCRIPTION
## Summary

`ZSTD_execSequence` in `lib/legacy/zstd_v01.c` has two related correctness issues in its sequence-offset validation.

### 1. Truncating `U32` cast at `lib/legacy/zstd_v01.c:1735`

```c
if (sequence.offset > (U32)(oLitEnd - base)) return ERROR(corruption_detected);
```

The cast forces the `ptrdiff_t` operand into 32-bit before the comparison. On 64-bit builds with a destination buffer larger than `UINT32_MAX`, the cast truncates silently and the bound becomes the low-32-bit remainder of the actual distance. A v0.1 legacy frame whose `sequence.offset` exceeds the truncated value but is still ≤ `oLitEnd - base` passes the check and reaches the match-copy step with an oversized offset.

The runtime catch at line 1758 (`if (match < base) return ERROR(corruption_detected);`) still fires for the resulting underflow, so this is not a directly exploitable arbitrary read; but the design intent of the line-1735 check -- catching the corruption *before* pointer arithmetic -- is defeated whenever the destination buffer is multi-GiB.

### 2. Bogus pointer-as-integer comparison at `lib/legacy/zstd_v01.c:1759`

```c
if (sequence.offset > (size_t)base) return ERROR(corruption_detected);
```

Compares the offset against the numeric address of the `base` pointer. On any 64-bit system, `base` is a virtual address far higher than any 32-bit offset can reach, so the comparison never returns true. On 32-bit systems it fires only when `base` is allocated at a low address, which is unrelated to whether `op - sequence.offset` underflows.

The actual underflow detection is the `if (match < base)` line just above, which uses the post-subtraction pointer and is correct.

## Fix

- Replace the `(U32)` cast with `(size_t)` so the comparison uses full pointer precision.
- Remove the no-op pointer-as-int check; the adjacent `if (match < base)` line is the real guard.

## Diff

```
 lib/legacy/zstd_v01.c | 15 +++++++++++++--
 1 file changed, 13 insertions(+), 2 deletions(-)
```

## Verification

- Built locally on macOS/arm64: `make -C lib libzstd.a` clean, no new warnings.
- Legitimate v0.1 frames continue to decode (the `(size_t)` comparison is mathematically a strict superset of the previous `(U32)` comparison for valid inputs; it can only refuse *more* malformed inputs, never reject a previously-accepted valid frame).
- The legacy v0.1 path is reachable from `ZSTD_decompress` via the auto-detection in `ZSTD_decompressLegacy`; `ZSTD_LEGACY_SUPPORT` is 8 by default (`lib/legacy/zstd_legacy.h:25`).

## Refs

This is in the `legacy/` tree, which is opt-in but enabled by default and reachable from `ZSTD_decompress` via magic auto-detection.