### PR TITLE
build(single_file_libs): don't close sys.stdout in combine.py

### DIFF
--- a/build/single_file_libs/combine.py
+++ b/build/single_file_libs/combine.py
@@ -230,5 +230,6 @@ try:
         destn = args.output
     add_file(args.input)
 finally:
-    if (destn):
+    # Only close a file we opened; never close sys.stdout (the default).
+    if (destn is not sys.stdout):
         destn.close()


### PR DESCRIPTION
`combine.py`'s output handle `destn` defaults to `sys.stdout` and is only reassigned to a real file when `-o/--output` is supplied. The `finally` block then calls `destn.close()` unconditionally — so running without `-o` (a documented mode; the `-o` help says output goes to stdout otherwise) closes `sys.stdout`.

Fix: only close the handle when it isn't `sys.stdout`.

Verified locally: with no `-o`, the stdout stream is no longer left closed after the run; with `-o`, the output file is still written/closed as before.