### PR TITLE
seekable: reject seek tables exceeding ZSTD_SEEKABLE_MAXFRAMES

### DIFF
--- a/contrib/seekable_format/zstdseek_decompress.c
+++ b/contrib/seekable_format/zstdseek_decompress.c
@@ -393,8 +393,16 @@ static size_t ZSTD_seekable_loadSeekTable(ZSTD_seekable* zs)
 
     {   U32 const numFrames = MEM_readLE32(zs->inBuff);
         U32 const sizePerEntry = 8 + (checksumFlag?4:0);
-        U32 const tableSize = sizePerEntry * numFrames;
-        U32 const frameSize = tableSize + ZSTD_seekTableFooterSize + ZSTD_SKIPPABLEHEADERSIZE;
+        U32 tableSize;
+        U32 frameSize;
+
+        /* numFrames is bounded by ZSTD_SEEKABLE_MAXFRAMES on write; reject larger
+         * values to avoid overflowing the entry-array allocation below. */
+        if (numFrames > ZSTD_SEEKABLE_MAXFRAMES) {
+            return ERROR(corruption_detected);
+        }
+        tableSize = sizePerEntry * numFrames;
+        frameSize = tableSize + ZSTD_seekTableFooterSize + ZSTD_SKIPPABLEHEADERSIZE;
 
         U32 remaining = frameSize - ZSTD_seekTableFooterSize; /* don't need to re-read footer */
         {   U32 const toRead = MIN(remaining, SEEKABLE_BUFF_SIZE);


### PR DESCRIPTION
### What

`ZSTD_seekable_loadSeekTable()` reads `Number_Of_Frames` from the seek table footer and uses it, unbounded, to size:

- the seek-table arithmetic — `tableSize = sizePerEntry * numFrames` (`U32`), and
- the entry array — `malloc(sizeof(seekEntry_t) * (numFrames + 1))`.

It never checks the value against `ZSTD_SEEKABLE_MAXFRAMES`, the limit the writer enforces in `ZSTD_seekable_logFrame()` (`zstdseek_compress.c`). The reader therefore accepts a frame count the writer would never emit.

### Impact

A crafted seek table can set `Number_Of_Frames` close to `2^32`.

- On platforms where `size_t` is 32-bit, `sizeof(seekEntry_t) * (numFrames + 1)` overflows. The entry array is under-allocated, but the cumulative-position loop still writes `numFrames` entries — a heap out-of-bounds write.
- On 64-bit platforms the multiplication is done in a 64-bit `size_t`, so it does not overflow; the allocation simply becomes huge and fails cleanly, so there is no out-of-bounds write. The `U32` `tableSize` / `frameSize` arithmetic still wraps on these platforms.

The footer field is part of the trailer of an otherwise valid seekable archive, so a reader handed an attacker-influenced file reaches this path.

### Fix

Reject `Number_Of_Frames > ZSTD_SEEKABLE_MAXFRAMES` before the size computations, mirroring the bound applied on write. With the limit in place neither `sizePerEntry * numFrames` (≤ `12 * 0x8000000`) nor `sizeof(seekEntry_t) * (numFrames + 1)` can overflow a 32-bit `size_t`, and an over-large value is rejected with `corruption_detected`.

### Testing

- `contrib/seekable_format` compiles clean under `-Wall -Wextra -Werror`.
- `make -C contrib/seekable_format/tests test` passes (round-trip, the two no-hang cases, empty-string magic, multi-decompress) — valid archives are unaffected, since the bound (`0x8000000`) is far above any frame count a writer produces.
