### PR TITLE
Fix size_t underflow in COVER_ctx_init for small training sets

### DIFF
--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -644,6 +644,16 @@ static size_t COVER_ctx_init(COVER_ctx_t *ctx, const void *samplesBuffer,
                  (unsigned)(totalSamplesSize>>20), (COVER_MAX_SAMPLES_SIZE >> 20));
     return ERROR(srcSize_wrong);
   }
+  /* The training set must be large enough for the partial suffix array, whose
+   * size is `trainingSamplesSize - MAX(d, sizeof(U64)) + 1`. When splitPoint
+   * < 1.0 the training set is a subset of the corpus, so it can be smaller
+   * than the total even after the check above. Guard against the size_t
+   * subtraction underflowing into a huge allocation. */
+  if (trainingSamplesSize < MAX(d, sizeof(U64))) {
+    DISPLAYLEVEL(1, "Training samples size is too small (%u), minimum size is %u\n",
+                 (unsigned)trainingSamplesSize, (unsigned)MAX(d, sizeof(U64)));
+    return ERROR(srcSize_wrong);
+  }
   /* Check if there are at least 5 training samples */
   if (nbTrainSamples < 5) {
     DISPLAYLEVEL(1, "Total number of training samples is %u and is invalid.", nbTrainSamples);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -3812,6 +3812,25 @@ static int basicUnitTests(U32 const seed, double compressibility)
         if (dictID==0) goto _output_error;
         DISPLAYLEVEL(3, "OK : %u \n", (unsigned)dictID);
 
+        DISPLAYLEVEL(3, "test%3i : ZDICT_optimizeTrainFromBuffer_cover with tiny training set : ", testNb++);
+        {   /* With splitPoint < 1.0 the training set is a subset of the corpus.
+             * If that subset is smaller than MAX(d, sizeof(U64)) the partial
+             * suffix array size used to underflow size_t (issue #4682). The
+             * builder must reject it cleanly instead. The first few samples are
+             * tiny so the 0.75 training split stays below the threshold, while
+             * the total corpus is comfortably large. */
+            size_t tinySizes[8] = { 1, 1, 1, 1, 1, 1, 100, 100 };
+            ZDICT_cover_params_t tinyParams;
+            size_t tinyResult;
+            memset(&tinyParams, 0, sizeof(tinyParams));
+            tinyParams.steps = 4;
+            tinyParams.splitPoint = 0.75;
+            tinyResult = ZDICT_optimizeTrainFromBuffer_cover(
+                dictBuffer, optDictSize, CNBuffer, tinySizes, 8, &tinyParams);
+            if (!ZDICT_isError(tinyResult)) goto _output_error;
+        }
+        DISPLAYLEVEL(3, "OK \n");
+
         ZSTD_freeCCtx(cctx);
         free(dictBuffer);
         free(samplesSizes);


### PR DESCRIPTION
Fixes #4682.

`COVER_ctx_init` (`lib/dictBuilder/cover.c`) validates `totalSamplesSize` against `MAX(d, sizeof(U64))`, but computes the partial suffix array size from `trainingSamplesSize`:

```c
ctx->suffixSize = trainingSamplesSize - MAX(d, sizeof(U64)) + 1;
```

When `splitPoint < 1.0` (the optimize path), the training set is only a subset of the corpus, so `trainingSamplesSize` can be smaller than `MAX(d, sizeof(U64))` even when `totalSamplesSize` passes the check. The `size_t` subtraction then underflows, and the subsequent `malloc(ctx->suffixSize * sizeof(U32))` requests an enormous (wrapped) size rather than failing cleanly.

## Repro

Calling `ZDICT_optimizeTrainFromBuffer_cover` with `splitPoint = 0.75` and a corpus whose first (training) samples sum to fewer than 8 bytes triggers the underflow (returns a spurious allocation error / can attempt a huge allocation under overcommit).

## Fix

Add a check that `trainingSamplesSize >= MAX(d, sizeof(U64))` before the subtraction, returning `ERROR(srcSize_wrong)` — the same way the existing corpus-size checks behave. This rejects only inputs that were already broken (the suffix array would have been non-positive), so no valid input is affected.

## Test

Adds a regression test to `tests/fuzzer.c` in the COVER section: it calls `ZDICT_optimizeTrainFromBuffer_cover` with `splitPoint = 0.75` and a tiny training split and asserts the call returns a `ZDICT_isError` result instead of underflowing.

## Verified

- `tests/fuzzer` passes, including the new `ZDICT_optimizeTrainFromBuffer_cover with tiny training set` test.
- `make` builds cleanly.

Thanks to the original reporter for the precise diagnosis.