### PR TITLE
[doc] Update CLI help snippet: -T# default and --max

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -201,12 +201,15 @@ Advanced options:
 
 Advanced compression options:
   --ultra                       Enable levels beyond 19, up to 22; requires more memory.
+  --max                         Set advanced parameters to reach maximum compression.
+                                Warning: very slow and uses a lot of resources; disabled in 32-bit mode.
   --fast[=#]                    Use to very fast compression levels. [Default: 1]
   --adapt                       Dynamically adapt compression level to I/O conditions.
   --long[=#]                    Enable long distance matching with window log #. [Default: 27]
   --patch-from=REF              Use REF as the reference point for Zstandard's diff engine.
 
-  -T#                           Spawn # compression threads. [Default: 1; pass 0 for core count.]
+  -T#                           Spawn # compression threads.
+                                [Default: between 1 and 4 depending on physical CPU cores; pass 0 for core count.]
   --single-thread               Share a single thread for I/O and compression (slightly different than `-T1`).
   --auto-threads={physical|logical}
                                 Use physical/logical cores when using `-T0`. [Default: Physical]


### PR DESCRIPTION
Closes #4687

## What
Two edits in `programs/README.md`:

1. **Added the `--max` option** under *Advanced compression options* with its description and the 32-bit mode warning. The option was missing from the README entirely.
2. **Updated the `-T#` default** from the stale "[Default: 1]" to "[Default: between 1 and 4 depending on physical CPU cores; pass 0 for core count]", reflecting the modern multi-thread default.

## Scope note
The issue mentions the embedded help text and man page are also affected. This PR fixes the prose surface (programs/README.md) only. The embedded help in the C sources and the man page are best handled in a follow-up or by a maintainer with context on whether they're generated or maintained separately.

## Tested
Visual review of the rendered README section; pipe alignment preserved, surrounding option entries untouched.

## Verification
```
branch: hunter/issue-4687
files-changed: 1
commit: f2144ba
```
