### PR TITLE
Fix COVER tiny training set underflow

### DIFF
--- a/lib/dictBuilder/cover.c
+++ b/lib/dictBuilder/cover.c
@@ -638,9 +638,10 @@ static size_t COVER_ctx_init(COVER_ctx_t *ctx, const void *samplesBuffer,
   const size_t testSamplesSize = splitPoint < 1.0 ? COVER_sum(samplesSizes + nbTrainSamples, nbTestSamples) : totalSamplesSize;
   ctx->displayLevel = displayLevel;
   /* Checks */
-  if (totalSamplesSize < MAX(d, sizeof(U64)) ||
+  if (trainingSamplesSize < MAX(d, sizeof(U64)) ||
+      totalSamplesSize < MAX(d, sizeof(U64)) ||
       totalSamplesSize >= (size_t)COVER_MAX_SAMPLES_SIZE) {
-    DISPLAYLEVEL(1, "Total samples size is too large (%u MB), maximum size is %u MB\n",
+    DISPLAYLEVEL(1, "Total samples size is too small or too large (%u MB), maximum size is %u MB\n",
                  (unsigned)(totalSamplesSize>>20), (COVER_MAX_SAMPLES_SIZE >> 20));
     return ERROR(srcSize_wrong);
   }

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -3807,6 +3807,25 @@ static int basicUnitTests(U32 const seed, double compressibility)
         if (ZDICT_isError(optDictSize)) goto _output_error;
         DISPLAYLEVEL(3, "OK, created dictionary of size %u \n", (unsigned)optDictSize);
 
+        DISPLAYLEVEL(3, "test%3i : ZDICT_optimizeTrainFromBuffer_cover with tiny training set : ", testNb++);
+        {   BYTE tinySamples[10];
+            size_t tinySampleSizes[10];
+            size_t result;
+            U32 u;
+            for (u=0; u<10; u++) {
+                tinySamples[u] = (BYTE)u;
+                tinySampleSizes[u] = 1;
+            }
+            memset(&params, 0, sizeof(params));
+            params.splitPoint = 0.5;
+            result = ZDICT_optimizeTrainFromBuffer_cover(dictBuffer, optDictSize,
+                                                         tinySamples, tinySampleSizes,
+                                                         10, &params);
+            if (!ZDICT_isError(result)) goto _output_error;
+            if (ZSTD_getErrorCode(result) != ZSTD_error_srcSize_wrong) goto _output_error;
+        }
+        DISPLAYLEVEL(3, "OK \n");
+
         DISPLAYLEVEL(3, "test%3i : check dictID : ", testNb++);
         dictID = ZDICT_getDictID(dictBuffer, optDictSize);
         if (dictID==0) goto _output_error;


### PR DESCRIPTION
Fixes #4682.

`COVER_ctx_init()` validates `totalSamplesSize` before computing `suffixSize`, but the subtraction uses `trainingSamplesSize`. With `splitPoint < 1.0`, a small training split can be smaller than `MAX(d, sizeof(U64))` even when the total sample size passes validation. That lets the unsigned subtraction underflow and can lead to an oversized allocation.

This adds the missing `trainingSamplesSize` precondition before computing the partial suffix array size, and adds a regression for `ZDICT_optimizeTrainFromBuffer_cover()` with ten one-byte samples, auto-selected `d`/`k`, and `splitPoint = 0.5`. The API now returns `srcSize_wrong` instead of attempting the underflowing allocation.

Test plan:
- `make -j4 fuzzer`
- `./fuzzer -i1 -s1 -v`
- `git diff --check`
