### PR TITLE
Document --max large-window decompression

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -201,12 +201,13 @@ Advanced options:
 
 Advanced compression options:
   --ultra                       Enable levels beyond 19, up to 22; requires more memory.
+  --max                         Enable the maximum compression settings.
   --fast[=#]                    Use to very fast compression levels. [Default: 1]
   --adapt                       Dynamically adapt compression level to I/O conditions.
   --long[=#]                    Enable long distance matching with window log #. [Default: 27]
   --patch-from=REF              Use REF as the reference point for Zstandard's diff engine.
 
-  -T#                           Spawn # compression threads. [Default: 1; pass 0 for core count.]
+  -T#                           Spawn # compression threads. [Default: 1-4, depending on physical cores; pass 0 for core count.]
   --single-thread               Share a single thread for I/O and compression (slightly different than `-T1`).
   --auto-threads={physical|logical}
                                 Use physical/logical cores when using `-T0`. [Default: Physical]

--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -132,7 +132,7 @@ Note 2: this mode is different from \fB\-T1\fR, which spawns 1 compression threa
 \fB\-\-long[=#]\fR: enables long distance matching with \fB#\fR \fBwindowLog\fR, if \fB#\fR is not present it defaults to \fB27\fR\. This increases the window size (\fBwindowLog\fR) and memory usage for both the compressor and decompressor\. This setting is designed to improve the compression ratio for files with long matches at a large distance\.
 .
 .IP
-Note: If \fBwindowLog\fR is set to larger than 27, \fB\-\-long=windowLog\fR or \fB\-\-memory=windowSize\fR needs to be passed to the decompressor\.
+Note: If \fBwindowLog\fR is set to larger than 27, \fB\-\-long=windowLog\fR, \fB\-\-max\fR, or \fB\-\-memory=windowSize\fR needs to be passed to the decompressor\.
 .
 .IP "\(bu" 4
 \fB\-\-max\fR: set advanced parameters to maximum compression\. warning: this setting is very slow and uses a lot of resources\. It\'s inappropriate for 32\-bit mode and therefore disabled in this mode\.
@@ -294,7 +294,7 @@ Specify the maximum number of bits for a match distance\.
 The higher number of increases the chance to find a match which usually improves compression ratio\. It also increases memory requirements for the compressor and decompressor\. The minimum \fIwlog\fR is 10 (1 KiB) and the maximum is 30 (1 GiB) on 32\-bit platforms and 31 (2 GiB) on 64\-bit platforms\.
 .
 .IP
-Note: If \fBwindowLog\fR is set to larger than 27, \fB\-\-long=windowLog\fR or \fB\-\-memory=windowSize\fR needs to be passed to the decompressor\.
+Note: If \fBwindowLog\fR is set to larger than 27, \fB\-\-long=windowLog\fR, \fB\-\-max\fR, or \fB\-\-memory=windowSize\fR needs to be passed to the decompressor\.
 .
 .TP
 \fBhashLog\fR=\fIhlog\fR, \fBhlog\fR=\fIhlog\fR

--- a/programs/zstd.1.md
+++ b/programs/zstd.1.md
@@ -164,8 +164,8 @@ the last one takes effect.
     This setting is designed to improve the compression ratio for files with
     long matches at a large distance.
 
-    Note: If `windowLog` is set to larger than 27, `--long=windowLog` or
-    `--memory=windowSize` needs to be passed to the decompressor.
+    Note: If `windowLog` is set to larger than 27, `--long=windowLog`,
+    `--max`, or `--memory=windowSize` needs to be passed to the decompressor.
 * `-D DICT`:
     use `DICT` as Dictionary to compress or decompress FILE(s)
 * `--patch-from FILE`:
@@ -385,8 +385,8 @@ The list of available _options_:
     The minimum _wlog_ is 10 (1 KiB) and the maximum is 30 (1 GiB) on 32-bit
     platforms and 31 (2 GiB) on 64-bit platforms.
 
-    Note: If `windowLog` is set to larger than 27, `--long=windowLog` or
-    `--memory=windowSize` needs to be passed to the decompressor.
+    Note: If `windowLog` is set to larger than 27, `--long=windowLog`,
+    `--max`, or `--memory=windowSize` needs to be passed to the decompressor.
 
 - `hashLog`=_hlog_, `hlog`=_hlog_:
     Specify the maximum number of bits for a hash table.

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -225,6 +225,7 @@ static void usageAdvanced(const char* programName)
     DISPLAYOUT("\n");
     DISPLAYOUT("Advanced compression options:\n");
     DISPLAYOUT("  --ultra                       Enable levels beyond %i, up to %i; requires more memory.\n", ZSTDCLI_CLEVEL_MAX, ZSTD_maxCLevel());
+    DISPLAYOUT("  --max                         Enable the maximum compression settings.\n");
     DISPLAYOUT("  --fast[=#]                    Use to very fast compression levels. [Default: %u]\n", 1);
 #ifdef ZSTD_GZCOMPRESS
     if (exeNameMatch(programName, ZSTD_GZ)) {     /* behave like gzip */


### PR DESCRIPTION
Fixes #4687.
Fixes #4688.

This updates the CLI help and documentation around maximum compression settings:

- list `--max` in the advanced CLI help and README help block
- update the README thread default wording so it no longer implies `-T1`
- document that frames created with a window log larger than 27 can also be decompressed by passing `--max`

Test plan:

```
make -j4 zstd
programs/zstd -H
git diff --check
```
