### PR TITLE
Add FFM Java implementation link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,7 @@ which are explicitly labelled as Ports.
 | __Rust__ (Port) | Moritz Borcherding | https://github.com/KillingSpark/zstd-rs
 | __Java__      | Luben Karavelov     | https://github.com/luben/zstd-jni     |
 | __Java__ (Port) | Martin Traverso   | https://github.com/airlift/aircompressor/tree/master/src/main/java/io/airlift/compress/v3/zstd
+| __Java__ (FFM) | Davide Angelocola | https://github.com/dfa1/zstd-java     |
 | __C#__        | SKB Kontur          | https://github.com/skbkontur/ZstdNet  |
 | __C#__ (streaming) | Bernhard Pichler | https://github.com/bp74/Zstandard.Net
 | __C#__ (signed) | Tyler Young       | https://github.com/ImpromptuNinjas/ZStd


### PR DESCRIPTION
This is a new binding of Zstd for Java 25+, using `Foreign Function and Memory` (FFM).