### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/build/cmake/contrib/pzstd/CMakeLists.txt
+++ b/build/cmake/contrib/pzstd/CMakeLists.txt
@@ -30,10 +30,6 @@ endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-if (CMAKE_USE_PTHREADS_INIT)
-  target_link_libraries(pzstd ${ZSTD_LIB} ${CMAKE_THREAD_LIBS_INIT})
-else()
-    message(SEND_ERROR "ZSTD currently does not support thread libraries other than pthreads")
-endif()
+target_link_libraries(pzstd ${ZSTD_LIB} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS pzstd RUNTIME DESTINATION "bin")


### PR DESCRIPTION
pthread has been checked in build/cmake/CMakeLists.txt; there's no need to check it again.

On Windows, zstd can be built without winpthreads. It may check for existence of a pthread library, but nothing is linked from it. However, this causes errors when no pthread library is available.

Either way, this check isn't meaningful.