### PR TITLE
Fix out-of-bounds read in FASTCOVER on small training samples

### DIFF
--- a/lib/dictBuilder/fastcover.c
+++ b/lib/dictBuilder/fastcover.c
@@ -339,6 +339,12 @@ FASTCOVER_ctx_init(FASTCOVER_ctx_t* ctx,
         return ERROR(srcSize_wrong);
     }
 
+    /* Check the training set can hold at least one dmer, otherwise nbDmers underflows below */
+    if (trainingSamplesSize < MAX(d, sizeof(U64))) {
+        DISPLAYLEVEL(1, "Total training samples size is %u and is invalid.\n", (unsigned)trainingSamplesSize);
+        return ERROR(srcSize_wrong);
+    }
+
     /* Zero the context */
     memset(ctx, 0, sizeof(*ctx));
     DISPLAYLEVEL(2, "Training on %u samples of total size %u\n", nbTrainSamples,

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -3060,6 +3060,16 @@ static int basicUnitTests(U32 const seed, double compressibility)
         if (ZDICT_isError(dictSize)) goto _output_error;
         DISPLAYLEVEL(3, "OK, created dictionary of size %u \n", (unsigned)dictSize);
 
+        DISPLAYLEVEL(3, "test%3i : FASTCOVER dictBuilder samples smaller than a dmer (issue #4499) : ", testNb++);
+        {   const char smallData[8] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H' };
+            const size_t smallSizes[8] = { 1, 1, 1, 1, 1, 1, 1, 1 };
+            size_t const r = ZDICT_trainFromBuffer(dictBuffer, dictBufferCapacity,
+                                                   smallData, smallSizes, 8);
+            if (!ZDICT_isError(r)) goto _output_error;
+            if (ZSTD_getErrorCode(r) != ZSTD_error_srcSize_wrong) goto _output_error;
+        }
+        DISPLAYLEVEL(3, "OK \n");
+
         DISPLAYLEVEL(3, "test%3i : Multithreaded COVER dictBuilder : ", testNb++);
         { U32 u; for (u=0; u<nbSamples; u++) samplesSizes[u] = sampleUnitSize; }
         {   ZDICT_cover_params_t coverParams;


### PR DESCRIPTION
When every training sample is smaller than the dmer size, `FASTCOVER_ctx_init` derives `nbDmers` from the training set, which `splitPoint < 1` can shrink below `MAX(d, 8)` even after the total samples size check passes. The subtraction underflows and the builder reads past the sample buffer (#4499).

It now returns `srcSize_wrong` for a training set that small, the way the other invalid inputs already do. Adds a unit test in `basicUnitTests`.

`COVER_ctx_init` has the same underflow, addressed separately in #4690.
