### PR TITLE
fix off-by-one bounds check in ZSTD_seekTable_getFrameDecompressedSize

### DIFF
--- a/contrib/seekable_format/tests/seekable_tests.c
+++ b/contrib/seekable_format/tests/seekable_tests.c
@@ -121,6 +121,10 @@ int main(int argc, const char** argv)
         size_t const origSize = ZSTD_seekTable_getFrameDecompressedSize(zst, 0);
         assert(origSize == inSize);
 
+        /* out-of-range frame index must be rejected, not read past the table */
+        assert(ZSTD_isError(ZSTD_seekTable_getFrameCompressedSize(zst, nbFrames)));
+        assert(ZSTD_isError(ZSTD_seekTable_getFrameDecompressedSize(zst, nbFrames)));
+
         unsigned const fo1idx = ZSTD_seekTable_offsetToFrameIndex(zst, 1);
         assert(fo1idx == 0);
 

--- a/contrib/seekable_format/zstdseek_decompress.c
+++ b/contrib/seekable_format/zstdseek_decompress.c
@@ -366,7 +366,7 @@ size_t ZSTD_seekable_getFrameDecompressedSize(const ZSTD_seekable* zs, unsigned 
 
 size_t ZSTD_seekTable_getFrameDecompressedSize(const ZSTD_seekTable* st, unsigned frameIndex)
 {
-    if (frameIndex > st->tableLen) return ERROR(frameIndex_tooLarge);
+    if (frameIndex >= st->tableLen) return ERROR(frameIndex_tooLarge);
     return st->entries[frameIndex + 1].dOffset -
            st->entries[frameIndex].dOffset;
 }


### PR DESCRIPTION
reject frameIndex == tableLen in ZSTD_seekTable_getFrameDecompressedSize the same way its compressed-size sibling already does, since the function reads entries[frameIndex + 1] and the table only holds tableLen + 1 entries, so passing the value returned by ZSTD_seekTable_getNumFrames() reads one entry past the allocation (ASAN: heap-buffer-overflow READ of size 8 at zstdseek_decompress.c:370).