### PR TITLE
fix result buffer overrun in decode-only benchmark

### DIFF
--- a/programs/benchzstd.c
+++ b/programs/benchzstd.c
@@ -517,7 +517,7 @@ static BMK_benchOutcome_t BMK_benchMemAdvancedNoAlloc(
                                 : chunkSize;
                 srcPtr += chunkSize;
                 cPtr += cCapacities[chunkID];
-                resPtr += chunkSize;
+                resPtr += resSizes[chunkID];
                 remaining -= chunkSize;
                 if (adv->mode == BMK_decodeOnly) {
                     cSizes[chunkID]  = chunkSize;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1308,6 +1308,11 @@ zstd -f tmp1
 zstd -b -d -i0 tmp1.zst
 println "benchmark can fail - decompression on invalid data"
 zstd -b -d -i0 tmp1 && die "invalid .zst data => benchmark should have failed"
+println "benchmark decompression of several frames whose content is smaller than the frame"
+printf 'a' > tmpbd1 ; printf 'b' > tmpbd2 ; printf 'c' > tmpbd3
+zstd -qf tmpbd1 tmpbd2 tmpbd3
+zstd -b -d -i0 tmpbd1.zst tmpbd2.zst tmpbd3.zst
+rm -f tmpbd1 tmpbd2 tmpbd3 tmpbd1.zst tmpbd2.zst tmpbd3.zst
 
 GZIPMODE=1
 zstd --format=gzip -V || GZIPMODE=0


### PR DESCRIPTION
the decode-only path in BMK_benchMemAdvancedNoAlloc advances resPtr by each frame's compressed size while the result buffer is only sized for the sum of decompressed sizes, so benchmarking several frames whose content is smaller than the frame (e.g. many tiny .zst files) overruns it; advancing by resSizes[chunkID] fixes the layout and is a no-op for the compress path where it already equals chunkSize.