### PR TITLE
Improving AArch64 Performance with SVE for Decompression Functions

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -131,6 +131,9 @@
  */
 #define BMI2_TARGET_ATTRIBUTE TARGET_ATTRIBUTE("lzcnt,bmi,bmi2")
 
+/* Target attribute for SVE dynamic dispatch. */
+#define SVE_TARGET_ATTRIBUTE TARGET_ATTRIBUTE("+sve")
+
 /* prefetch
  * can be disabled, by declaring NO_PREFETCH build macro */
 #if defined(NO_PREFETCH)

--- a/lib/common/cpu.h
+++ b/lib/common/cpu.h
@@ -22,6 +22,13 @@
 #include <intrin.h>
 #endif
 
+#if defined(__aarch64__) && defined(__linux__)
+#include <sys/auxv.h>
+#ifndef HWCAP_SVE
+#include <asm/hwcap.h>
+#endif
+#endif
+
 typedef struct {
     U32 f1c;
     U32 f1d;

--- a/lib/common/huf.h
+++ b/lib/common/huf.h
@@ -107,7 +107,13 @@ typedef enum {
      * If set: Don't use the fast decoding loop, always use the fallback decoding loop.
      * If unset: Use the fast decoding loop when possible.
      */
-    HUF_flags_disableFast = (1 << 5)
+    HUF_flags_disableFast = (1 << 5),
+
+    /**
+     * If compiled with DYNAMIC_SVE: Set flag only if the CPU supports SVE at runtime.
+     * Otherwise: Ignored.
+     */
+    HUF_flags_sve         = (1 << 6)
 } HUF_flags_e;
 
 

--- a/lib/common/portability_macros.h
+++ b/lib/common/portability_macros.h
@@ -102,6 +102,21 @@
 #  endif
 #endif
 
+/* Enable runtime SVE dispatch based on the CPU.
+ * Enabled for clang & gcc on aarch64 / linux (or other targets with a
+ * getauxval-equivalent) when SVE isn't already enabled at compile time.
+ */
+#ifndef DYNAMIC_SVE
+#  if ((defined(__clang__) && __has_attribute(__target__)) \
+      || (defined(__GNUC__) && __GNUC__ >= 9)) \
+      && defined(__aarch64__) \
+      && (defined(__linux__) || defined(__ANDROID__))
+#    define DYNAMIC_SVE 1
+#  else
+#    define DYNAMIC_SVE 0
+#  endif
+#endif
+
 /**
  * Only enable assembly for GNU C compatible compilers,
  * because other platforms may not support GAS assembly syntax.

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -323,4 +323,16 @@ MEM_STATIC int ZSTD_cpuSupportsBmi2(void)
     return ZSTD_cpuid_bmi1(cpuid) && ZSTD_cpuid_bmi2(cpuid);
 }
 
+/**
+ * @returns true iff the CPU supports dynamic SVE dispatch.
+ */
+MEM_STATIC int ZSTD_cpuSupportsSve(void)
+{
+#if defined(__aarch64__) && defined(__linux__)
+    return (getauxval(AT_HWCAP) & HWCAP_SVE) != 0;
+#else
+    return 0;
+#endif
+}
+
 #endif   /* ZSTD_CCOMMON_H_MODULE */

--- a/lib/decompress/huf_decompress.c
+++ b/lib/decompress/huf_decompress.c
@@ -73,6 +73,15 @@
 # define HUF_NEED_BMI2_FUNCTION 0
 #endif
 
+/* For aarch64, we can use the SVE target attribute to enable SVE instructions. */
+#if DYNAMIC_SVE
+# define HUF_NEED_SVE_FUNCTION 1
+# define HUF_FAST_SVE_ATTRS SVE_TARGET_ATTRIBUTE
+#else
+# define HUF_NEED_SVE_FUNCTION 0
+# define HUF_FAST_SVE_ATTRS
+#endif
+
 /* **************************************************************
 *  Error Management
 ****************************************************************/
@@ -718,8 +727,8 @@ HUF_ASM_DECL void HUF_decompress4X1_usingDTable_internal_fast_asm_loop(HUF_Decom
 
 #endif
 
-static HUF_FAST_BMI2_ATTRS
-void HUF_decompress4X1_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* args)
+FORCE_INLINE_TEMPLATE
+void HUF_decompress4X1_usingDTable_internal_fast_c_loop_body(HUF_DecompressFastArgs* args)
 {
     U64 bits[4];
     BYTE const* ip[4];
@@ -831,6 +840,20 @@ _out:
     ZSTD_memcpy(&args->op, &op, sizeof(op));
 }
 
+#if HUF_NEED_SVE_FUNCTION
+static HUF_FAST_SVE_ATTRS
+void HUF_decompress4X1_usingDTable_internal_fast_c_loop_sve(HUF_DecompressFastArgs* args)
+{
+    HUF_decompress4X1_usingDTable_internal_fast_c_loop_body(args);
+}
+#endif /* HUF_NEED_SVE_FUNCTION */
+
+static
+void HUF_decompress4X1_usingDTable_internal_fast_c_loop_default(HUF_DecompressFastArgs* args)
+{
+    HUF_decompress4X1_usingDTable_internal_fast_c_loop_body(args);
+}
+
 /**
  * @returns @p dstSize on success (>= 6)
  *          0 if the fallback implementation should be used
@@ -899,7 +922,7 @@ static size_t HUF_decompress4X1_usingDTable_internal(void* dst, size_t dstSize, 
                     size_t cSrcSize, HUF_DTable const* DTable, int flags)
 {
     HUF_DecompressUsingDTableFn fallbackFn = HUF_decompress4X1_usingDTable_internal_default;
-    HUF_DecompressFastLoopFn loopFn = HUF_decompress4X1_usingDTable_internal_fast_c_loop;
+    HUF_DecompressFastLoopFn loopFn = HUF_decompress4X1_usingDTable_internal_fast_c_loop_default;
 
 #if DYNAMIC_BMI2
     if (flags & HUF_flags_bmi2) {
@@ -912,6 +935,12 @@ static size_t HUF_decompress4X1_usingDTable_internal(void* dst, size_t dstSize, 
     } else {
         return fallbackFn(dst, dstSize, cSrc, cSrcSize, DTable);
     }
+#endif
+
+#if DYNAMIC_SVE
+if (flags & HUF_flags_sve) {
+    loopFn = HUF_decompress4X1_usingDTable_internal_fast_c_loop_sve;
+}
 #endif
 
 #if ZSTD_ENABLE_ASM_X86_64_BMI2 && defined(__BMI2__)
@@ -1521,8 +1550,8 @@ HUF_ASM_DECL void HUF_decompress4X2_usingDTable_internal_fast_asm_loop(HUF_Decom
 
 #endif
 
-static HUF_FAST_BMI2_ATTRS
-void HUF_decompress4X2_usingDTable_internal_fast_c_loop(HUF_DecompressFastArgs* args)
+FORCE_INLINE_TEMPLATE
+void HUF_decompress4X2_usingDTable_internal_fast_c_loop_body(HUF_DecompressFastArgs* args)
 {
     U64 bits[4];
     BYTE const* ip[4];
@@ -1671,6 +1700,19 @@ _out:
     ZSTD_memcpy(&args->op, &op, sizeof(op));
 }
 
+#if HUF_NEED_SVE_FUNCTION
+static HUF_FAST_SVE_ATTRS
+void HUF_decompress4X2_usingDTable_internal_fast_c_loop_sve(HUF_DecompressFastArgs* args)
+{
+    HUF_decompress4X2_usingDTable_internal_fast_c_loop_body(args);
+}
+#endif /* HUF_NEED_SVE_FUNCTION */
+
+static
+void HUF_decompress4X2_usingDTable_internal_fast_c_loop_default(HUF_DecompressFastArgs* args)
+{
+    HUF_decompress4X2_usingDTable_internal_fast_c_loop_body(args);
+}
 
 static HUF_FAST_BMI2_ATTRS size_t
 HUF_decompress4X2_usingDTable_internal_fast(
@@ -1729,7 +1771,7 @@ static size_t HUF_decompress4X2_usingDTable_internal(void* dst, size_t dstSize, 
                     size_t cSrcSize, HUF_DTable const* DTable, int flags)
 {
     HUF_DecompressUsingDTableFn fallbackFn = HUF_decompress4X2_usingDTable_internal_default;
-    HUF_DecompressFastLoopFn loopFn = HUF_decompress4X2_usingDTable_internal_fast_c_loop;
+    HUF_DecompressFastLoopFn loopFn = HUF_decompress4X2_usingDTable_internal_fast_c_loop_default;
 
 #if DYNAMIC_BMI2
     if (flags & HUF_flags_bmi2) {
@@ -1741,6 +1783,12 @@ static size_t HUF_decompress4X2_usingDTable_internal(void* dst, size_t dstSize, 
 # endif
     } else {
         return fallbackFn(dst, dstSize, cSrc, cSrcSize, DTable);
+    }
+#endif
+
+#if DYNAMIC_SVE
+    if (flags & HUF_flags_sve) {
+        loopFn = HUF_decompress4X2_usingDTable_internal_fast_c_loop_sve;
     }
 #endif
 

--- a/lib/decompress/zstd_decompress.c
+++ b/lib/decompress/zstd_decompress.c
@@ -269,6 +269,9 @@ static void ZSTD_initDCtx_internal(ZSTD_DCtx* dctx)
 #if DYNAMIC_BMI2
     dctx->bmi2 = ZSTD_cpuSupportsBmi2();
 #endif
+#if DYNAMIC_SVE
+    dctx->sve = ZSTD_cpuSupportsSve();
+#endif
     dctx->ddictSet = NULL;
     ZSTD_DCtx_resetParameters(dctx);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/lib/decompress/zstd_decompress_block.c
+++ b/lib/decompress/zstd_decompress_block.c
@@ -158,6 +158,7 @@ static size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
                 size_t expectedWriteSize = MIN(blockSizeMax, dstCapacity);
                 int const flags = 0
                     | (ZSTD_DCtx_get_bmi2(dctx) ? HUF_flags_bmi2 : 0)
+                    | (ZSTD_DCtx_get_sve(dctx)  ? HUF_flags_sve  : 0)
                     | (dctx->disableHufAsm ? HUF_flags_disableAsm : 0);
                 switch(lhlCode)
                 {
@@ -2037,6 +2038,19 @@ ZSTD_decompressSequencesLong_bmi2(ZSTD_DCtx* dctx,
 
 #endif /* DYNAMIC_BMI2 */
 
+#if DYNAMIC_SVE
+
+static SVE_TARGET_ATTRIBUTE size_t
+ZSTD_decompressSequences_sve(ZSTD_DCtx* dctx,
+                              void* dst, size_t maxDstSize,
+                              const void* seqStart, size_t seqSize, int nbSeq,
+                              const ZSTD_longOffset_e isLongOffset)
+{
+    return ZSTD_decompressSequences_body(dctx, dst, maxDstSize, seqStart, seqSize, nbSeq, isLongOffset);
+}
+
+#endif /* DYNAMIC_SVE */
+
 #ifndef ZSTD_FORCE_DECOMPRESS_SEQUENCES_LONG
 static size_t
 ZSTD_decompressSequences(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize,
@@ -2048,9 +2062,14 @@ ZSTD_decompressSequences(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize,
     if (ZSTD_DCtx_get_bmi2(dctx)) {
         return ZSTD_decompressSequences_bmi2(dctx, dst, maxDstSize, seqStart, seqSize, nbSeq, isLongOffset);
     }
+#elif DYNAMIC_SVE
+    if (ZSTD_DCtx_get_sve(dctx)) {
+        return ZSTD_decompressSequences_sve(dctx, dst, maxDstSize, seqStart, seqSize, nbSeq, isLongOffset);
+    }
 #endif
     return ZSTD_decompressSequences_default(dctx, dst, maxDstSize, seqStart, seqSize, nbSeq, isLongOffset);
 }
+
 static size_t
 ZSTD_decompressSequencesSplitLitBuffer(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize,
                                  const void* seqStart, size_t seqSize, int nbSeq,

--- a/lib/decompress/zstd_decompress_internal.h
+++ b/lib/decompress/zstd_decompress_internal.h
@@ -157,6 +157,9 @@ struct ZSTD_DCtx_s
 #if DYNAMIC_BMI2
     int bmi2;                     /* == 1 if the CPU supports BMI2 and 0 otherwise. CPU support is determined dynamically once per context lifetime. */
 #endif
+#if DYNAMIC_SVE
+    int sve;                      /* == 1 if the CPU supports SVE and 0 otherwise. CPU support is determined dynamically once per context lifetime. */
+#endif
 
     /* dictionary */
     ZSTD_DDict* ddictLocal;
@@ -213,6 +216,15 @@ struct ZSTD_DCtx_s
 MEM_STATIC int ZSTD_DCtx_get_bmi2(const struct ZSTD_DCtx_s *dctx) {
 #if DYNAMIC_BMI2
     return dctx->bmi2;
+#else
+    (void)dctx;
+    return 0;
+#endif
+}
+
+MEM_STATIC int ZSTD_DCtx_get_sve(const struct ZSTD_DCtx_s *dctx) {
+#if DYNAMIC_SVE
+    return dctx->sve;
 #else
     (void)dctx;
     return 0;


### PR DESCRIPTION
## Motivation
Decompression on AArch64 (e.g., AWS Graviton3) currently doesn't take advantage of SVE (Scalable Vector Extension) instructions, leaving performance on the table in the Huffman decode and sequence decompression hot paths.

## Changes
- Introduces a `DYNAMIC_SVE` build macro, auto-enabled for Clang/GCC on aarch64, allowing SVE support to be detected and used at runtime.
- Adds `SVE_TARGET_ATTRIBUTE (target("+sve"))` so the compiler can generate SVE-enabled variants of the `Huffman fast-decode loops` and `ZSTD_decompressSequences`, alongside the existing default implementations.
- At decompress time, the SVE variant is selected automatically when supported, falling back to the default path otherwise.

## Result
~2–3% faster decompression on Graviton3 (fullbench), with no change to compression speed.
Benchmarked using fullbench.
**Instance**: m7g.8xlarge (Graviton 3)

| # | Benchmark | Baseline (MB/s) | SVE (MB/s) | Diff (%) |
|---:|---|---:|---:|---:|
| 1 | `decompress` | 1216.9 | 1248.4 | +2.59% |
| 3 | `decompressDCtx` | 1215.3 | 1250.0 | +2.86% |
| 6 | `decompressContinue` | 1217.5 | 1243.8 | +2.16% |
| 9 | `decompressStream` | 1218.7 | 1243.7 | +2.05% |

### Related
#4564

#### This PR is a joint contribution by:
Abhishek Jain([@abhijain1204fujitsu](https://github.com/abhijain1204fujitsu))
Mohak Goel([@mohakgoel1](https://github.com/mohakgoel1))