### PR TITLE
Vectorize small-offset overlapping match copies with NEON `tbl` / SSSE3 `pshufb`

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -212,6 +212,9 @@
 #  if defined(__AVX2__)
 #    define ZSTD_ARCH_X86_AVX2
 #  endif
+#  if defined(__SSSE3__)
+#    define ZSTD_ARCH_X86_SSSE3
+#  endif
 #  if defined(__SSE2__) || defined(_M_X64) || (defined (_M_IX86) && defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
 #    define ZSTD_ARCH_X86_SSE2
 #  endif
@@ -233,6 +236,8 @@
 #
 #  if defined(ZSTD_ARCH_X86_AVX2)
 #    include <immintrin.h>
+#  elif defined(ZSTD_ARCH_X86_SSSE3)
+#    include <tmmintrin.h>
 #  endif
 #  if defined(ZSTD_ARCH_X86_SSE2)
 #    include <emmintrin.h>

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -207,6 +207,91 @@ typedef enum {
     /*  ZSTD_overlap_dst_before_src, */
 } ZSTD_overlap_e;
 
+#if (defined(ZSTD_ARCH_ARM_NEON) && (defined(__aarch64__) || defined(_M_ARM64))) \
+    || defined(ZSTD_ARCH_X86_SSSE3)
+#define ZSTD_OVERLAPCOPY_VEC
+/*! ZSTD_overlapCopyShortOffset() :
+ *  Copy the overlapping pattern `[ip, ip+diff)` into `[op, oend)`, 8 <= diff < 16.
+ *  Deliberately not inlined: ZSTD_wildcopy is force-inlined into the hot
+ *  sequence-execution loops many times over, and expanding this (rarely hot)
+ *  path in place measurably regresses inputs that never take it. */
+FORCE_NOINLINE UNUSED_ATTR
+void ZSTD_overlapCopyShortOffset(BYTE* op, const BYTE* ip, BYTE* const oend, ptrdiff_t const diff)
+{
+    /* The source and destination overlap with period `diff` (8 <= diff < 16;
+     * smaller offsets are expanded to >= 8 with ZSTD_overlapCopy8 before this
+     * path is reached, matching the scalar COPY8 loop in ZSTD_wildcopy).
+     * First copy 16 bytes with COPY8, exactly like the scalar loop would:
+     * this both seeds `dst[0..15]` and materializes one full period of the
+     * repeating pattern in memory without reading a single byte that has not
+     * been written yet (the tail of a 16-byte load at `ip` would read
+     * uninitialized bytes of `dst`, which MemorySanitizer rejects even though
+     * a table lookup never selects them). Then store 16 bytes per iteration
+     * (vs 8 with COPY8), advancing the pattern register with a single table
+     * lookup (NEON `tbl` / SSSE3 `pshufb`) and no load inside the loop:
+     *   adv[diff][j] = (16 + j) % diff : shift the pattern forward by 16 bytes
+     * Each iteration stores WILDCOPY_VECLEN (16) bytes and stops as soon as
+     * `op >= oend`, so it overruns the logical end by at most WILDCOPY_VECLEN-1
+     * (15) bytes. Callers guarantee WILDCOPY_OVERLENGTH (32) bytes of slack
+     * past `oend`, so the overrun is always in bounds
+     * (see the ZSTD_STATIC_ASSERT below the table).
+     * The NEON path requires AArch64: `vqtbl1q_u8` does not exist on
+     * 32-bit ARM, whose `vtbl` can only look up in a 64-bit table. */
+    static const uint8_t adv[16][16] = {
+        { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+        { 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1},
+        { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
+        { 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1},
+        { 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1},
+        { 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3},
+        { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
+        { 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4},
+        { 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1},
+        { 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+        { 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3, 4, 5, 6, 7},
+        { 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2, 3, 4, 5},
+        { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1, 2, 3},
+        { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},
+    };
+#if defined(ZSTD_ARCH_ARM_NEON)
+    uint8x16_t pattern;
+    uint8x16_t advance;
+    ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
+    assert(diff >= 8);
+    COPY8(op, ip);
+    COPY8(op, ip);
+    pattern = vld1q_u8((const uint8_t*)(op - 16));
+    advance = vld1q_u8(adv[diff]);
+    while (op < oend) {
+        pattern = vqtbl1q_u8(pattern, advance);
+        vst1q_u8((uint8_t*)op, pattern);
+        op += 16;
+    }
+#else
+    /* `pshufb` selects byte `index[j]` of the input for each output lane `j`;
+     * all indices are < diff <= 15, so they stay in range.
+     * The casts go through `void*` because `_mm_loadu_si128`/`_mm_storeu_si128`
+     * do unaligned accesses, but a direct `BYTE*` -> `__m128i*` cast trips
+     * -Wcast-align. */
+    __m128i pattern;
+    __m128i advance;
+    ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
+    assert(diff >= 8);
+    COPY8(op, ip);
+    COPY8(op, ip);
+    pattern = _mm_loadu_si128((const __m128i*)(const void*)(op - 16));
+    advance = _mm_loadu_si128((const __m128i*)(const void*)adv[diff]);
+    while (op < oend) {
+        pattern = _mm_shuffle_epi8(pattern, advance);
+        _mm_storeu_si128((__m128i*)(void*)op, pattern);
+        op += 16;
+    }
+#endif
+}
+#endif /* ZSTD_OVERLAPCOPY_VEC */
+
 /*! ZSTD_wildcopy() :
  *  Custom version of ZSTD_memcpy(), can over read/write up to WILDCOPY_OVERLENGTH bytes (if length==0)
  *  @param ovtype controls the overlap detection
@@ -224,79 +309,8 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */
-#if (defined(ZSTD_ARCH_ARM_NEON) && (defined(__aarch64__) || defined(_M_ARM64))) \
-    || defined(ZSTD_ARCH_X86_SSSE3)
-        /* The source and destination overlap with period `diff` (8 <= diff < 16;
-         * smaller offsets are expanded to >= 8 with ZSTD_overlapCopy8 before this
-         * path is reached, matching the COPY8 fallback below). First copy 16 bytes
-         * with COPY8, exactly like the first two iterations of the fallback loop:
-         * this both seeds `dst[0..15]` and materializes one full period of the
-         * repeating pattern in memory without reading a single byte that has not
-         * been written yet (the tail of a 16-byte load at `ip` would read
-         * uninitialized bytes of `dst`, which MemorySanitizer rejects even though
-         * a table lookup never selects them). Then store 16 bytes per iteration
-         * (vs 8 with COPY8), advancing the pattern register with a single table
-         * lookup (NEON `tbl` / SSSE3 `pshufb`) and no load inside the loop:
-         *   adv[diff][j] = (16 + j) % diff : shift the pattern forward by 16 bytes
-         * Each iteration stores WILDCOPY_VECLEN (16) bytes and stops as soon as
-         * `op >= oend`, so it overruns the logical end by at most WILDCOPY_VECLEN-1
-         * (15) bytes. Callers guarantee WILDCOPY_OVERLENGTH (32) bytes of slack
-         * past `oend`, so the overrun is always in bounds
-         * (see the ZSTD_STATIC_ASSERT below the table).
-         * The NEON path requires AArch64: `vqtbl1q_u8` does not exist on
-         * 32-bit ARM, whose `vtbl` can only look up in a 64-bit table. */
-        static const uint8_t adv[16][16] = {
-            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
-            { 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1},
-            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
-            { 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1},
-            { 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1},
-            { 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
-            { 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4},
-            { 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1},
-            { 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-            { 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3, 4, 5, 6, 7},
-            { 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2, 3, 4, 5},
-            { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1, 2, 3},
-            { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},
-        };
-#if defined(ZSTD_ARCH_ARM_NEON)
-        uint8x16_t pattern;
-        uint8x16_t advance;
-        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
-        assert(diff >= 8);
-        COPY8(op, ip);
-        COPY8(op, ip);
-        pattern = vld1q_u8((const uint8_t*)(op - 16));
-        advance = vld1q_u8(adv[diff]);
-        while (op < oend) {
-            pattern = vqtbl1q_u8(pattern, advance);
-            vst1q_u8((uint8_t*)op, pattern);
-            op += 16;
-        }
-#else
-        /* `pshufb` selects byte `index[j]` of the input for each output lane `j`;
-         * all indices are < diff <= 15, so they stay in range.
-         * The casts go through `void*` because `_mm_loadu_si128`/`_mm_storeu_si128`
-         * do unaligned accesses, but a direct `BYTE*` -> `__m128i*` cast trips
-         * -Wcast-align. */
-        __m128i pattern;
-        __m128i advance;
-        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
-        assert(diff >= 8);
-        COPY8(op, ip);
-        COPY8(op, ip);
-        pattern = _mm_loadu_si128((const __m128i*)(const void*)(op - 16));
-        advance = _mm_loadu_si128((const __m128i*)(const void*)adv[diff]);
-        while (op < oend) {
-            pattern = _mm_shuffle_epi8(pattern, advance);
-            _mm_storeu_si128((__m128i*)(void*)op, pattern);
-            op += 16;
-        }
-#endif
+#ifdef ZSTD_OVERLAPCOPY_VEC
+        ZSTD_overlapCopyShortOffset(op, ip, oend, diff);
 #else
         do {
             COPY8(op, ip);

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -224,7 +224,8 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */
-#if defined(ZSTD_ARCH_ARM_NEON) || defined(ZSTD_ARCH_X86_SSSE3)
+#if (defined(ZSTD_ARCH_ARM_NEON) && (defined(__aarch64__) || defined(_M_ARM64))) \
+    || defined(ZSTD_ARCH_X86_SSSE3)
         /* The source and destination overlap with period `diff` (8 <= diff < 16;
          * smaller offsets are expanded to >= 8 with ZSTD_overlapCopy8 before this
          * path is reached, matching the COPY8 fallback below). First copy 16 bytes
@@ -241,7 +242,9 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
          * `op >= oend`, so it overruns the logical end by at most WILDCOPY_VECLEN-1
          * (15) bytes. Callers guarantee WILDCOPY_OVERLENGTH (32) bytes of slack
          * past `oend`, so the overrun is always in bounds
-         * (see the ZSTD_STATIC_ASSERT below the table). */
+         * (see the ZSTD_STATIC_ASSERT below the table).
+         * The NEON path requires AArch64: `vqtbl1q_u8` does not exist on
+         * 32-bit ARM, whose `vtbl` can only look up in a 64-bit table. */
         static const uint8_t adv[16][16] = {
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -224,9 +224,61 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */
+#if defined(ZSTD_ARCH_ARM_NEON)
+        /* The source and destination overlap with period `diff` (1 <= diff < 16).
+         * Build one 16-byte register holding the repeating pattern, then store 16
+         * bytes per iteration (vs 8 with COPY8), advancing the pattern with a single
+         * table lookup. There is no load inside the loop.
+         *   init[diff][j] = j % diff        : build the pattern from a 16-byte load
+         *   adv[diff][j]  = (16 + j) % diff : shift the pattern forward by 16 bytes */
+        static const uint8_t init[16][16] = {
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+            { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0},
+            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0},
+            { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0},
+        };
+        static const uint8_t adv[16][16] = {
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+            { 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1},
+            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
+            { 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1},
+            { 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1},
+            { 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4},
+            { 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1},
+            { 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+            { 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2, 3, 4, 5},
+            { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1, 2, 3},
+            { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},
+        };
+        uint8x16_t pattern = vqtbl1q_u8(vld1q_u8((const uint8_t*)ip), vld1q_u8(init[diff]));
+        uint8x16_t const advance = vld1q_u8(adv[diff]);
+        do {
+            vst1q_u8((uint8_t*)op, pattern);
+            pattern = vqtbl1q_u8(pattern, advance);
+            op += 16;
+        } while (op < oend);
+#else
         do {
             COPY8(op, ip);
         } while (op < oend);
+#endif
     } else {
         assert(diff >= WILDCOPY_VECLEN || diff <= -WILDCOPY_VECLEN);
         /* Separate out the first COPY16() call because the copy length is

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -224,31 +224,24 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */
-#if defined(ZSTD_ARCH_ARM_NEON)
-        /* The source and destination overlap with period `diff` (1 <= diff < 16).
-         * Build one 16-byte register holding the repeating pattern, then store 16
-         * bytes per iteration (vs 8 with COPY8), advancing the pattern with a single
-         * table lookup. There is no load inside the loop.
-         *   init[diff][j] = j % diff        : build the pattern from a 16-byte load
-         *   adv[diff][j]  = (16 + j) % diff : shift the pattern forward by 16 bytes */
-        static const uint8_t init[16][16] = {
-            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
-            { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0},
-            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
-            { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0},
-            { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3},
-            { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0},
-        };
+#if defined(ZSTD_ARCH_ARM_NEON) || defined(ZSTD_ARCH_X86_SSSE3)
+        /* The source and destination overlap with period `diff` (8 <= diff < 16;
+         * smaller offsets are expanded to >= 8 with ZSTD_overlapCopy8 before this
+         * path is reached, matching the COPY8 fallback below). First copy 16 bytes
+         * with COPY8, exactly like the first two iterations of the fallback loop:
+         * this both seeds `dst[0..15]` and materializes one full period of the
+         * repeating pattern in memory without reading a single byte that has not
+         * been written yet (the tail of a 16-byte load at `ip` would read
+         * uninitialized bytes of `dst`, which MemorySanitizer rejects even though
+         * a table lookup never selects them). Then store 16 bytes per iteration
+         * (vs 8 with COPY8), advancing the pattern register with a single table
+         * lookup (NEON `tbl` / SSSE3 `pshufb`) and no load inside the loop:
+         *   adv[diff][j] = (16 + j) % diff : shift the pattern forward by 16 bytes
+         * Each iteration stores WILDCOPY_VECLEN (16) bytes and stops as soon as
+         * `op >= oend`, so it overruns the logical end by at most WILDCOPY_VECLEN-1
+         * (15) bytes. Callers guarantee WILDCOPY_OVERLENGTH (32) bytes of slack
+         * past `oend`, so the overrun is always in bounds
+         * (see the ZSTD_STATIC_ASSERT below the table). */
         static const uint8_t adv[16][16] = {
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -267,13 +260,40 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
             { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1, 2, 3},
             { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},
         };
-        uint8x16_t pattern = vqtbl1q_u8(vld1q_u8((const uint8_t*)ip), vld1q_u8(init[diff]));
-        uint8x16_t const advance = vld1q_u8(adv[diff]);
-        do {
-            vst1q_u8((uint8_t*)op, pattern);
+#if defined(ZSTD_ARCH_ARM_NEON)
+        uint8x16_t pattern;
+        uint8x16_t advance;
+        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
+        assert(diff >= 8);
+        COPY8(op, ip);
+        COPY8(op, ip);
+        pattern = vld1q_u8((const uint8_t*)(op - 16));
+        advance = vld1q_u8(adv[diff]);
+        while (op < oend) {
             pattern = vqtbl1q_u8(pattern, advance);
+            vst1q_u8((uint8_t*)op, pattern);
             op += 16;
-        } while (op < oend);
+        }
+#else
+        /* `pshufb` selects byte `index[j]` of the input for each output lane `j`;
+         * all indices are < diff <= 15, so they stay in range.
+         * The casts go through `void*` because `_mm_loadu_si128`/`_mm_storeu_si128`
+         * do unaligned accesses, but a direct `BYTE*` -> `__m128i*` cast trips
+         * -Wcast-align. */
+        __m128i pattern;
+        __m128i advance;
+        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
+        assert(diff >= 8);
+        COPY8(op, ip);
+        COPY8(op, ip);
+        pattern = _mm_loadu_si128((const __m128i*)(const void*)(op - 16));
+        advance = _mm_loadu_si128((const __m128i*)(const void*)adv[diff]);
+        while (op < oend) {
+            pattern = _mm_shuffle_epi8(pattern, advance);
+            _mm_storeu_si128((__m128i*)(void*)op, pattern);
+            op += 16;
+        }
+#endif
 #else
         do {
             COPY8(op, ip);


### PR DESCRIPTION
## Summary

For small match offsets (overlap period < 16 bytes), `ZSTD_wildcopy` falls back to an 8-byte-per-iteration `COPY8` loop whose load hits the previous iteration's store, so it runs at store-forwarding latency. This loop dominates decompression of integer and low-cardinality columnar data, whose matches frequently have offsets of 4 or 8 bytes (runs of repeated fixed-width values) — a very common shape for column-oriented storage. We hit this in ClickHouse (ClickHouse/ClickHouse#108049).

This PR materializes one full period of the repeating pattern in a vector register and stores 16 bytes per iteration, advancing the pattern with a single table-lookup instruction — `tbl` (`vqtbl1q_u8`) on AArch64, `pshufb` (`_mm_shuffle_epi8`) on x86_64 with SSSE3 — and no load inside the loop:

    adv[diff][j] = (16 + j) % diff   : shift the pattern forward by 16 bytes,
                                       composes because pattern[k] = src[k % diff]

The emitted AArch64 loop is 4 instructions: `tbl` / `str q,[x],#16` / `cmp` / `b.hi`.

Design notes:

- **The new path is a standalone `FORCE_NOINLINE` function** (`ZSTD_overlapCopyShortOffset`), not inlined into `ZSTD_wildcopy`. `wildcopy` is force-inlined into the sequence-execution loops many times over; an earlier version of this change expanded the vector path in place and regressed silesia.tar decompression by ~2.5% with clang on x86_64 purely through code growth in the hot decoder functions (profiling showed the new instructions themselves were cold on silesia). As a standalone function the regression disappears, and the aarch64 binary shrinks by 65 KB. The out-of-line call is cheaper than the scalar loop it replaces even at minimum trip count (see the timestamp-column result below).
- The first 16 bytes are copied with `COPY8`, exactly like the first two iterations of the scalar loop. This seeds the pattern register from initialized memory: a 16-byte load at `ip` would touch not-yet-written bytes of `dst` (MemorySanitizer rejects that, even though the shuffle never selects those lanes).
- Each iteration stores 16 bytes and stops once `op >= oend`, overrunning the logical end by at most 15 bytes — within the existing `WILDCOPY_OVERLENGTH` (32) slack, enforced with a `ZSTD_STATIC_ASSERT`.
- `diff` is always in [8, 16) here (callers expand smaller offsets via `ZSTD_overlapCopy8` first; the scalar `COPY8` loop relies on the same contract).
- The x86_64 path is gated on compile-time `__SSSE3__` (baseline x86-64 builds keep the scalar loop; x86-64-v2/v3 distro builds and `-march=native` get the new path). The NEON path is gated on AArch64 (`vqtbl1q_u8` does not exist in 32-bit ARM NEON, whose `vtbl` can only look up in a 64-bit table); verified that an ARMv7 NEON build compiles and falls back to scalar.
- The non-overlapping (offset >= 16) path is untouched. Compression is unaffected: the decoder's sequence execution is the only caller of `ZSTD_wildcopy` with `ZSTD_overlap_src_before_dst`. Compressed output is byte-identical with and without the patch.

## Prior art

The wildcopy family has been optimized several times — #1668, #1804, #1977, #2256, and #3145 (Arm's two-stage copy) — but all of these target the non-overlapping (offset >= 16) fast path. The small-offset overlap path has remained the scalar `COPY8` loop since #1804 gave it its current shape. We found no previous issue/PR proposing a shuffle-based pattern-advance for it. (LZ4 special-cases small offsets in `LZ4_memcpy_using_offset`, but via scalar pattern expansion.)

## Benchmarks

Methodology per CONTRIBUTING.md: `zstd -b# -i3+`, interleaved A/B runs pinned to one core (`taskset`), 5-10 repetitions, best-of aggregation, warmup pass. Per-rep spread 0.06–0.92%.

### x86_64 — AMD Ryzen 9 9950X3D, clang 21.1.8 / gcc 16.1.1, `-O3 -mssse3`

Decompression (MB/s):

| input | lvl | clang dev | clang PR | ratio | gcc dev | gcc PR | ratio |
|---|---|---|---|---|---|---|---|
| silesia.tar | 1 | 2232 | 2237 | 1.002 | 2359 | 2360 | 1.001 |
| silesia.tar | 3 | 1939 | 1934 | 0.997 | 2045 | 2062 | 1.008 |
| int64, run-heavy | 1 | 29877 | 35089 | **1.174** | 30291 | 35046 | **1.157** |
| int64, run-heavy | 3 | 25013 | 30876 | **1.234** | 25529 | 30946 | **1.212** |
| int64, small deltas | 1 | 1740 | 1891 | **1.087** | 1650 | 1841 | **1.116** |
| int64, small deltas | 3 | 1736 | 1892 | **1.090** | 1648 | 1840 | **1.116** |
| int32, zipfian | 1/3 | — | — | 1.006/0.990 | — | — | 1.003/1.000 |
| int16, sparse | 1/3 | — | — | 0.995/0.998 | — | — | 0.995/1.000 |

### AArch64 — ARM Neoverse-N1 (Ampere Altra, 2.6 GHz), gcc 14.2.0, `-O3`

Decompression (MB/s), best-of-5:

| input | lvl | dev | PR | ratio |
|---|---|---|---|---|
| silesia.tar | 1 | 973.6 | 977.9 | 1.004 |
| silesia.tar | 3 | 780.7 | 781.7 | 1.001 |
| int64, run-heavy | 1 | 4230.3 | 12046.8 | **2.848** |
| int64, run-heavy | 3 | 4037.2 | 10448.3 | **2.588** |
| int64, small deltas | 1 | 848.3 | 868.7 | **1.024** |
| int64, small deltas | 3 | 847.9 | 868.0 | **1.024** |
| int16, sparse | 1/3 | — | — | 1.005/1.003 |
| int32, zipfian | 1/3 | — | — | 0.999/1.001 |

A clang 20.1.8 A/B corroborates: no silesia regression (its apparent +2-3% is uniform across control cases, i.e. a code-layout artifact, not claimed as a gain). Earlier measurements of the inline predecessor on Graviton 4 (Neoverse-V2) with real ClickBench `hits` columns: UserID (Int64) 2.30x, AdvEngineID (Int16) 1.46x, ClientIP (Int32) 1.42x, RegionID (Int32) 1.27x.

## Correctness

- `make check` passes on x86_64 (`-mssse3`) and aarch64.
- Byte-exact round-trips at levels 1/3/12/19 over inputs engineered to produce matches at every offset 1..16 (plus 17/24/32) and over the columnar corpora, under AddressSanitizer+UBSan and MemorySanitizer, on both x86_64 and aarch64 (192/192 clean on aarch64) — including periods 8-15, exactly the `8 <= diff < 16` cases the new code handles.
- Cross-compiled `libzstd.a` for aarch64 (gcc) and 32-bit ARMv7 with NEON enabled (clang/zig) — the latter as a regression check for the compile-time gate.