### PR TITLE
perf(dictBuilder): skip the merge scans that cannot match

### DIFF
--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -154,13 +154,25 @@ typedef struct {
     U32 pos;
     U32 length;
     U32 savings;
+    U32 prefixHash;   /* hash of the 8 bytes at pos; see ZDICT_hash32 */
 } dictItem;
+
+/* Hash of the 8 bytes at pos. Cached in dictItem so that the content test in
+ * ZDICT_tryMerge can reject non-matches by reading the table entry it is
+ * already walking, instead of a random address in the sample buffer. The exact
+ * MEM_read64 comparison still decides every merge, so this only removes work. */
+static U32 ZDICT_hash32(const void* buffer, U32 pos)
+{
+    U64 const v = MEM_read64((const char*)buffer + pos);
+    return (U32)((v * 0x9E3779B97F4A7C15ULL) >> 32);
+}
 
 static void ZDICT_initDictItem(dictItem* d)
 {
     d->pos = 1;
     d->length = 0;
     d->savings = (U32)(-1);
+    d->prefixHash = 0;
 }
 
 
@@ -319,6 +331,7 @@ static dictItem ZDICT_analyzePos(
         solution.pos = (U32)pos;
         solution.length = (U32)maxLength;
         solution.savings = savings[maxLength];
+        solution.prefixHash = ZDICT_hash32(buffer, (U32)pos);
 
         /* mark positions done */
         {   U32 id;
@@ -353,6 +366,139 @@ static int isIncluded(const void* in, const void* container, size_t length)
     return u==length;
 }
 
+
+/*-*************************************
+*  Locality filter for ZDICT_tryMerge
+***************************************/
+/* Both loops in ZDICT_tryMerge return at the first match, so a loop only runs
+ * to completion when nothing matches: the whole quadratic term is spent
+ * proving absence. These structures answer "can anything match ?" in O(1),
+ * so that proof no longer costs a full pass over the table.
+ *
+ * They only ever guard a decision to skip a loop, and they are conservative:
+ * they never report absence when a match exists. The loops themselves still
+ * select every merge, so the emitted dictionary is unchanged.
+ *
+ * Each dictItem is an interval in the sample buffer, and the merge fixpoint
+ * keeps those intervals pairwise disjoint. Overlap depth is therefore bounded,
+ * which is what lets a byte counter track coverage exactly.
+ *
+ *   span[p]   : low nibble  = nb of dictItems whose span holds p -> front
+ *               high nibble = nb of dictItems beginning at p     -> tail
+ *   prefix[h] : nb of dictItems whose 8-byte prefix hashes to h
+ *
+ * span costs one byte per sample byte, the same as doneMarks.
+ */
+
+#define ZDICT_COVERS(c) ((c) & 0x0F)
+#define ZDICT_STARTS(c) ((c) >> 4)
+
+typedef struct {
+    BYTE* span;
+    BYTE* prefix;
+    U32 prefixMask;
+    size_t bufferSize;
+} ZDICT_localityFilter;
+
+/* The prefix table must stay sparse relative to the number of dictItems: a
+ * collision costs a full pass over the table, so an undersized table converts
+ * straight back into the quadratic term it exists to remove. 64 slots per
+ * entry keeps the occupancy, and hence the false positive rate, near 1.5%. */
+static U32 ZDICT_prefixTableLog(U32 dictListSize)
+{
+    U32 l = 16;
+    while (((U32)1 << l) < dictListSize * 64 && l < 22) l++;
+    return l;
+}
+
+/* Masking the raw low bits instead of hashing would collapse on text, where the
+ * first two bytes carry very little entropy. */
+static U32 ZDICT_prefixHash(const void* buffer, U32 pos, U32 mask)
+{
+    return ZDICT_hash32(buffer, pos) & mask;
+}
+
+/* saturating, so a count can never wrap back to zero and lose coverage.
+ * A saturated counter stays set, which only ever costs a false positive. */
+static void ZDICT_filterBump(BYTE* p, int delta)
+{
+    if (delta > 0) { if (*p < 255) (*p)++; }
+    else           { if (*p && *p < 255) (*p)--; }
+}
+
+static void ZDICT_spanBump(BYTE* p, int delta, unsigned shift)
+{
+    unsigned const cur = ((unsigned)*p >> shift) & 0x0FU;
+    unsigned nxt = cur;
+    if (delta > 0) { if (cur < 15) nxt = cur + 1; }
+    else           { if (cur && cur < 15) nxt = cur - 1; }
+    *p = (BYTE)(((unsigned)*p & ~(0x0FU << shift)) | (nxt << shift));
+}
+
+static void ZDICT_filterUpdate(ZDICT_localityFilter* f, dictItem elt,
+                               const void* buffer, int delta)
+{
+    size_t u;
+    size_t end = (size_t)elt.pos + elt.length;
+    if (!f->span) return;
+    if (end > f->bufferSize) end = f->bufferSize;
+    if (elt.pos >= f->bufferSize) return;
+    ZDICT_spanBump(f->span + elt.pos, delta, 4);
+    for (u = elt.pos; u <= end; u++)
+        ZDICT_spanBump(f->span + u, delta, 0);
+    ZDICT_filterBump(f->prefix + ZDICT_prefixHash(buffer, elt.pos, f->prefixMask), delta);
+}
+
+/* is there any dictItem starting inside (pos, end] ? */
+static int ZDICT_filterTailPossible(const ZDICT_localityFilter* f, U32 pos, U32 end)
+{
+    size_t u;
+    size_t last = end;
+    if (!f->span) return 1;
+    if (last >= f->bufferSize) last = f->bufferSize - 1;
+    for (u = (size_t)pos + 1; u <= last; u++)
+        if (ZDICT_STARTS(f->span[u])) return 1;
+    return 0;
+}
+
+/* is there any dictItem whose span holds pos, or whose prefix matches key ? */
+static int ZDICT_filterFrontPossible(const ZDICT_localityFilter* f, U32 pos, U32 keyHash)
+{
+    if (!f->span) return 1;
+    if (pos < f->bufferSize && ZDICT_COVERS(f->span[pos])) return 1;
+    return f->prefix[keyHash] != 0;
+}
+
+
+/* Applies the front-overlap merge of elt into table[u], and returns the slot
+ * table[u] ends up in. Factored out so the two search orders below can share
+ * it without duplicating the update. */
+static U32 ZDICT_mergeFrontOverlap(dictItem* table, dictItem elt, U32 u, U32 eltEnd,
+                                   U32 eltNbToSkip, U32* eltNbToSkipPtr,
+                                   const void* buffer, ZDICT_localityFilter* filter)
+{
+    int const addedLength = (int)eltEnd - (int)(table[u].pos + table[u].length); /* note: can be negative */
+    ZDICT_filterUpdate(filter, table[u], buffer, -1);
+    table[u].savings += elt.length / 8;    /* rough approx bonus */
+    if (addedLength > 0) {   /* otherwise, elt fully included into existing */
+        table[u].length += (unsigned)addedLength;
+        table[u].savings += elt.savings * (unsigned)addedLength / elt.length;   /* rough approx */
+    }
+    ZDICT_filterUpdate(filter, table[u], buffer, 1);
+    /* sort : improve rank */
+    elt = table[u];
+    {   U32 const startU = u;
+        while ((u>1) && (table[u-1].savings < elt.savings))
+            table[u] = table[u-1], u--;
+        table[u] = elt;
+        /* entries in [u, startU-1] each moved to the next higher slot */
+        if ((eltNbToSkip >= u) && (eltNbToSkip < startU))
+            *eltNbToSkipPtr = eltNbToSkip + 1;
+    }
+    return u;
+}
+
+
 /*! ZDICT_tryMerge() :
     check if dictItem can be merged, do it if possible
     @return : id of destination elt, 0 if not merged
@@ -360,23 +506,31 @@ static int isIncluded(const void* in, const void* container, size_t length)
            can move that entry to the next higher slot; the value is updated
            when they do, so the caller's index keeps designating the same entry.
 */
-static U32 ZDICT_tryMerge(dictItem* table, dictItem elt, U32* eltNbToSkipPtr, const void* buffer)
+static U32 ZDICT_tryMerge(dictItem* table, dictItem elt, U32* eltNbToSkipPtr, const void* buffer,
+                          ZDICT_localityFilter* filter)
 {
     const U32 tableSize = table->pos;
     const U32 eltNbToSkip = *eltNbToSkipPtr;
     const U32 eltEnd = elt.pos + elt.length;
     const char* const buf = (const char*) buffer;
+    const U32 keyHash32 = ZDICT_hash32(buffer, elt.pos + 1);   /* hash of the tested 8 bytes */
+    const U32 keyHash = keyHash32 & filter->prefixMask;
 
-    /* tail overlap */
-    U32 u; for (u=1; u<tableSize; u++) {
+    /* tail overlap : only reachable if some dictItem starts inside (pos, eltEnd] */
+    U32 u;
+    if (ZDICT_filterTailPossible(filter, elt.pos, eltEnd))
+    for (u=1; u<tableSize; u++) {
         if (u==eltNbToSkip) continue;
         if ((table[u].pos > elt.pos) && (table[u].pos <= eltEnd)) {  /* overlap, existing > new */
             /* append */
             U32 const addedLength = table[u].pos - elt.pos;
+            ZDICT_filterUpdate(filter, table[u], buffer, -1);
             table[u].length += addedLength;
             table[u].pos = elt.pos;
+            table[u].prefixHash = elt.prefixHash;   /* same pos, same 8 bytes */
             table[u].savings += elt.savings * addedLength / elt.length;   /* rough approx */
             table[u].savings += elt.length / 8;    /* rough approx bonus */
+            ZDICT_filterUpdate(filter, table[u], buffer, 1);
             elt = table[u];
             /* sort : improve rank */
             {   U32 const startU = u;
@@ -390,63 +544,84 @@ static U32 ZDICT_tryMerge(dictItem* table, dictItem elt, U32* eltNbToSkipPtr, co
             return u;
     }   }
 
-    /* front overlap */
+    /* front overlap : only reachable if some dictItem spans elt.pos, or if some
+     * dictItem's 8-byte prefix can equal the one tested below */
+    if (!ZDICT_filterFrontPossible(filter, elt.pos, keyHash)) return 0;
+
+    /* contentPossible == 0 proves no dictItem can pass the content test, so it
+     * is skipped rather than paying a random read into the sample buffer per
+     * entry. If in addition exactly one dictItem spans elt.pos, the positional
+     * test has a single solution, so the loop returns the same entry whichever
+     * direction it is walked. Walking down reaches it far sooner: a merge
+     * partner has just been inserted and therefore sits at the low-savings end
+     * of the table. */
+    {   U32 const contentPossible = filter->prefix ? (filter->prefix[keyHash] != 0) : 1;
+
+    /* When no content match is possible and exactly one dictItem spans elt.pos,
+     * the positional test has a single solution, so the loop selects the same
+     * entry whichever direction it is walked. Walking down reaches it far
+     * sooner: a merge partner has just been inserted, so it still sits at the
+     * low-savings end of the table. */
+    if (!contentPossible && filter->span
+     && (elt.pos < filter->bufferSize) && (ZDICT_COVERS(filter->span[elt.pos]) == 1)) {
+        for (u=tableSize-1; u>=1; u--) {
+            if (u==eltNbToSkip) continue;
+            if ((table[u].pos + table[u].length >= elt.pos) && (table[u].pos < elt.pos))
+                return ZDICT_mergeFrontOverlap(table, elt, u, eltEnd, eltNbToSkip,
+                                               eltNbToSkipPtr, buffer, filter);
+        }
+        return 0;
+    }
+
     for (u=1; u<tableSize; u++) {
         if (u==eltNbToSkip) continue;
 
-        if ((table[u].pos + table[u].length >= elt.pos) && (table[u].pos < elt.pos)) {  /* overlap, existing < new */
-            /* append */
-            int const addedLength = (int)eltEnd - (int)(table[u].pos + table[u].length); /* note: can be negative */
-            table[u].savings += elt.length / 8;    /* rough approx bonus */
-            if (addedLength > 0) {   /* otherwise, elt fully included into existing */
-                table[u].length += (unsigned)addedLength;
-                table[u].savings += elt.savings * (unsigned)addedLength / elt.length;   /* rough approx */
-            }
-            /* sort : improve rank */
-            elt = table[u];
-            {   U32 const startU = u;
-                while ((u>1) && (table[u-1].savings < elt.savings))
-                    table[u] = table[u-1], u--;
-                table[u] = elt;
-                /* entries in [u, startU-1] each moved to the next higher slot */
-                if ((eltNbToSkip >= u) && (eltNbToSkip < startU))
-                    *eltNbToSkipPtr = eltNbToSkip + 1;
-            }
-            return u;
-        }
+        if ((table[u].pos + table[u].length >= elt.pos) && (table[u].pos < elt.pos))   /* overlap, existing < new */
+            return ZDICT_mergeFrontOverlap(table, elt, u, eltEnd, eltNbToSkip,
+                                           eltNbToSkipPtr, buffer, filter);
 
-        if (MEM_read64(buf + table[u].pos) == MEM_read64(buf + elt.pos + 1)) {
+        /* table[u].prefixHash is the hash of the 8 bytes at table[u].pos, so a
+         * mismatch rules the entry out without touching the sample buffer. The
+         * MEM_read64 comparison still decides. */
+        if (contentPossible && table[u].prefixHash == keyHash32
+         && MEM_read64(buf + table[u].pos) == MEM_read64(buf + elt.pos + 1)) {
             if (isIncluded(buf + table[u].pos, buf + elt.pos + 1, table[u].length)) {
                 size_t const addedLength = MAX( elt.length - table[u].length , 1 );
+                ZDICT_filterUpdate(filter, table[u], buffer, -1);
                 table[u].pos = elt.pos;
+                table[u].prefixHash = elt.prefixHash;   /* same pos, same 8 bytes */
                 table[u].savings += (U32)(elt.savings * addedLength / elt.length);
                 table[u].length = MIN(elt.length, table[u].length + 1);
+                ZDICT_filterUpdate(filter, table[u], buffer, 1);
                 return u;
             }
         }
-    }
+    }   }
 
     return 0;
 }
 
 
-static void ZDICT_removeDictItem(dictItem* table, U32 id)
+static void ZDICT_removeDictItem(dictItem* table, U32 id, const void* buffer,
+                                 ZDICT_localityFilter* filter)
 {
     /* convention : table[0].pos stores nb of elts */
     U32 const max = table[0].pos;
     U32 u;
     if (!id) return;   /* protection, should never happen */
+    ZDICT_filterUpdate(filter, table[id], buffer, -1);
     for (u=id; u<max-1; u++)
         table[u] = table[u+1];
     table->pos--;
 }
 
 
-static void ZDICT_insertDictItem(dictItem* table, U32 maxSize, dictItem elt, const void* buffer)
+static void ZDICT_insertDictItem(dictItem* table, U32 maxSize, dictItem elt, const void* buffer,
+                                 ZDICT_localityFilter* filter)
 {
     /* merge if possible */
     U32 skipId = 0;
-    U32 mergeId = ZDICT_tryMerge(table, elt, &skipId, buffer);
+    U32 mergeId = ZDICT_tryMerge(table, elt, &skipId, buffer, filter);
     if (mergeId) {
         U32 newMerge = 1;
         while (newMerge) {
@@ -455,10 +630,10 @@ static void ZDICT_insertDictItem(dictItem* table, U32 maxSize, dictItem elt, con
              * after each one. */
             U32 absorbedId = mergeId;
             skipId = absorbedId;
-            newMerge = ZDICT_tryMerge(table, table[absorbedId], &skipId, buffer);
+            newMerge = ZDICT_tryMerge(table, table[absorbedId], &skipId, buffer, filter);
             absorbedId = skipId;   /* the rank sort may have moved it one slot up */
             if (newMerge) {
-                ZDICT_removeDictItem(table, absorbedId);
+                ZDICT_removeDictItem(table, absorbedId, buffer, filter);
                 /* the removal moved every higher slot down by one */
                 if (newMerge > absorbedId) newMerge--;
             }
@@ -470,13 +645,18 @@ static void ZDICT_insertDictItem(dictItem* table, U32 maxSize, dictItem elt, con
     /* insert */
     {   U32 current;
         U32 nextElt = table->pos;
-        if (nextElt >= maxSize) nextElt = maxSize-1;
+        if (nextElt >= maxSize) {
+            nextElt = maxSize-1;
+            /* the table is full : table[maxSize-1] is about to be overwritten */
+            ZDICT_filterUpdate(filter, table[nextElt], buffer, -1);
+        }
         current = nextElt-1;
         while (table[current].savings < elt.savings) {
             table[current+1] = table[current];
             current--;
         }
         table[current+1] = elt;
+        ZDICT_filterUpdate(filter, elt, buffer, 1);
         table->pos = nextElt+1;
     }
 }
@@ -501,9 +681,15 @@ static size_t ZDICT_trainBuffer_legacy(dictItem* dictList, U32 dictListSize,
     U32* reverseSuffix = (U32*)malloc((bufferSize)*sizeof(*reverseSuffix));
     BYTE* doneMarks = (BYTE*)malloc((bufferSize+16)*sizeof(*doneMarks));   /* +16 for overflow security */
     U32* filePos = (U32*)malloc(nbFiles * sizeof(*filePos));
+    ZDICT_localityFilter filter;
     size_t result = 0;
     clock_t displayClock = 0;
     clock_t const refreshRate = CLOCKS_PER_SEC * 3 / 10;
+
+    filter.span = (BYTE*)calloc(bufferSize+16, 1);
+    filter.prefixMask = ((U32)1 << ZDICT_prefixTableLog(dictListSize)) - 1;
+    filter.prefix = (BYTE*)calloc((size_t)filter.prefixMask + 1, 1);
+    filter.bufferSize = bufferSize;
 
 #   undef  DISPLAYUPDATE
 #   define DISPLAYUPDATE(l, ...)                                   \
@@ -519,7 +705,8 @@ static size_t ZDICT_trainBuffer_legacy(dictItem* dictList, U32 dictListSize,
 
     /* init */
     DISPLAYLEVEL(2, "\r%70s\r", "");   /* clean display line */
-    if (!suffix0 || !reverseSuffix || !doneMarks || !filePos) {
+    if (!suffix0 || !reverseSuffix || !doneMarks || !filePos
+      || !filter.span || !filter.prefix) {
         result = ERROR(memory_allocation);
         goto _cleanup;
     }
@@ -556,7 +743,7 @@ static size_t ZDICT_trainBuffer_legacy(dictItem* dictList, U32 dictListSize,
             if (doneMarks[cursor]) { cursor++; continue; }
             solution = ZDICT_analyzePos(doneMarks, suffix, reverseSuffix[cursor], buffer, minRatio, notificationLevel);
             if (solution.length==0) { cursor++; continue; }
-            ZDICT_insertDictItem(dictList, dictListSize, solution, buffer);
+            ZDICT_insertDictItem(dictList, dictListSize, solution, buffer, &filter);
             cursor += solution.length;
             DISPLAYUPDATE(2, "\r%4.2f %% \r", (double)cursor / (double)bufferSize * 100.0);
     }   }
@@ -566,6 +753,8 @@ _cleanup:
     free(reverseSuffix);
     free(doneMarks);
     free(filePos);
+    free(filter.span);
+    free(filter.prefix);
     return result;
 }
 

--- a/lib/dictBuilder/zdict.c
+++ b/lib/dictBuilder/zdict.c
@@ -356,10 +356,14 @@ static int isIncluded(const void* in, const void* container, size_t length)
 /*! ZDICT_tryMerge() :
     check if dictItem can be merged, do it if possible
     @return : id of destination elt, 0 if not merged
+    note : *eltNbToSkipPtr designates an entry by its slot. The rank sorts below
+           can move that entry to the next higher slot; the value is updated
+           when they do, so the caller's index keeps designating the same entry.
 */
-static U32 ZDICT_tryMerge(dictItem* table, dictItem elt, U32 eltNbToSkip, const void* buffer)
+static U32 ZDICT_tryMerge(dictItem* table, dictItem elt, U32* eltNbToSkipPtr, const void* buffer)
 {
     const U32 tableSize = table->pos;
+    const U32 eltNbToSkip = *eltNbToSkipPtr;
     const U32 eltEnd = elt.pos + elt.length;
     const char* const buf = (const char*) buffer;
 
@@ -375,9 +379,14 @@ static U32 ZDICT_tryMerge(dictItem* table, dictItem elt, U32 eltNbToSkip, const 
             table[u].savings += elt.length / 8;    /* rough approx bonus */
             elt = table[u];
             /* sort : improve rank */
-            while ((u>1) && (table[u-1].savings < elt.savings))
-                table[u] = table[u-1], u--;
-            table[u] = elt;
+            {   U32 const startU = u;
+                while ((u>1) && (table[u-1].savings < elt.savings))
+                    table[u] = table[u-1], u--;
+                table[u] = elt;
+                /* entries in [u, startU-1] each moved to the next higher slot */
+                if ((eltNbToSkip >= u) && (eltNbToSkip < startU))
+                    *eltNbToSkipPtr = eltNbToSkip + 1;
+            }
             return u;
     }   }
 
@@ -395,9 +404,14 @@ static U32 ZDICT_tryMerge(dictItem* table, dictItem elt, U32 eltNbToSkip, const 
             }
             /* sort : improve rank */
             elt = table[u];
-            while ((u>1) && (table[u-1].savings < elt.savings))
-                table[u] = table[u-1], u--;
-            table[u] = elt;
+            {   U32 const startU = u;
+                while ((u>1) && (table[u-1].savings < elt.savings))
+                    table[u] = table[u-1], u--;
+                table[u] = elt;
+                /* entries in [u, startU-1] each moved to the next higher slot */
+                if ((eltNbToSkip >= u) && (eltNbToSkip < startU))
+                    *eltNbToSkipPtr = eltNbToSkip + 1;
+            }
             return u;
         }
 
@@ -431,12 +445,23 @@ static void ZDICT_removeDictItem(dictItem* table, U32 id)
 static void ZDICT_insertDictItem(dictItem* table, U32 maxSize, dictItem elt, const void* buffer)
 {
     /* merge if possible */
-    U32 mergeId = ZDICT_tryMerge(table, elt, 0, buffer);
+    U32 skipId = 0;
+    U32 mergeId = ZDICT_tryMerge(table, elt, &skipId, buffer);
     if (mergeId) {
         U32 newMerge = 1;
         while (newMerge) {
-            newMerge = ZDICT_tryMerge(table, table[mergeId], mergeId, buffer);
-            if (newMerge) ZDICT_removeDictItem(table, mergeId);
+            /* table[absorbedId] is merged away, so it must be dropped.
+             * Both operations below can move it, and the slot is re-read
+             * after each one. */
+            U32 absorbedId = mergeId;
+            skipId = absorbedId;
+            newMerge = ZDICT_tryMerge(table, table[absorbedId], &skipId, buffer);
+            absorbedId = skipId;   /* the rank sort may have moved it one slot up */
+            if (newMerge) {
+                ZDICT_removeDictItem(table, absorbedId);
+                /* the removal moved every higher slot down by one */
+                if (newMerge > absorbedId) newMerge--;
+            }
             mergeId = newMerge;
         }
         return;


### PR DESCRIPTION
## Summary

`ZDICT_tryMerge` walks the whole dictItem table twice per call, and
`ZDICT_insertDictItem` calls it once per candidate plus once per round of its
merge fixpoint. Both loops `return` at the first match, so a loop only runs to
completion when nothing matches: the quadratic term is spent proving absence.

Each dictItem is an interval in the sample buffer, and the merge fixpoint keeps
those intervals pairwise disjoint. This change adds three counters that make the
absence proof O(1):

- `span[p]` low nibble, the number of dictItems whose interval holds `p`,
  answers the front positional predicate
- `span[p]` high nibble, the number of dictItems beginning at `p`, answers the
  tail predicate
- `prefix[h]`, the number of dictItems whose 8-byte prefix hashes to `h`,
  answers the content predicate

Disjointness bounds the overlap depth, which is what allows nibble-width
counters to track coverage exactly. The counters only ever guard a decision to
skip a loop and are conservative: they never report absence when a match exists.
Every merge is still selected by the original predicates.

Two further consequences of the same structure:

- the content test is skipped when no dictItem can carry the tested key, which
  removes a random read into the sample buffer per entry visited;
- when exactly one dictItem spans `elt.pos` and no content match is possible,
  the positional test has a single solution, so the loop returns the same entry
  whichever direction it is walked. It is walked downward there, which reaches
  the entry sooner because a merge partner has just been inserted and still sits
  at the low-savings end of the table.

`dictItem` gains a cached hash of the 8 bytes at its position so the content
pre-test reads the table entry already being walked rather than the sample
buffer. The exact `MEM_read64` comparison still decides every merge.

There is no public API change, no dictionary format change, and no change to
the ranking heuristic, the savings computation, `ZDICT_analyzePos`, or the
cover/fastcover trainers. Only `ZDICT_trainFromBuffer_legacy` and the CLI's
`--train-legacy` reach the modified code.

Built on #4724, which establishes the pairwise disjointness this relies on.

## Byte-identity

Six corpora, `-O3 -DNDEBUG`, dictionary capacity 112,640 B,
`selectivityLevel` 9. The checksum is over the full emitted dictionary.

| corpus | bytes | base | this change |
|---|---|---|---|
| zstd `lib/*.c` | 2,375,034 | `94e7afcb` | `94e7afcb` |
| zstd `lib/*.h` | 858,183 | `a29ac6f4` | `a29ac6f4` |
| zstd `programs/*` | 468,328 | `9948b1d1` | `9948b1d1` |
| zstd `tests/` + `doc/` | 1,207,601 | `1a95763c` | `1a95763c` |
| python sources | 2,067,845 | `b14b4cd4` | `b14b4cd4` |
| rust sources | 2,460,916 | `3c9698f4` | `3c9698f4` |

6 of 6 identical, 0 differing. End to end through the CLI,
`zstd --train-legacy` over 49 headers emits a 55,860 B dictionary on both trees.

## Instruction counts

Callgrind, deterministic and identical between runs, `-O2 -fno-inline -g` so
that per-function attribution is exact. gcc 15.2.0, Ubuntu 26.04 LTS under
WSL2. Base is `topo/zdict-h0-interval-merge` at `fc2b6a358`, so the measurement
attributes only this change.

| corpus | base Ir | this change | whole run | base `tryMerge` | this change | `tryMerge` |
|---|---|---|---|---|---|---|
| zstd `lib/*.c` | 4,239,867,437 | 2,421,375,251 | 1.751x | 2,204,100,449 | 642,779,694 | **3.429x** |
| zstd `lib/*.h` | 1,313,475,337 | 604,626,894 | 2.172x | 849,993,823 | 238,932,154 | **3.557x** |
| zstd `programs/*` | 454,313,794 | 273,956,640 | 1.658x | 213,642,180 | 56,398,520 | **3.788x** |
| zstd `tests/`+`doc/` | 2,185,612,807 | 1,324,003,263 | 1.651x | 1,001,029,699 | 261,314,415 | **3.831x** |
| python sources | 6,261,690,578 | 2,356,302,683 | 2.657x | 4,475,868,941 | 1,146,505,852 | **3.904x** |
| rust sources | 5,940,161,178 | 4,287,058,981 | 1.386x | 1,977,757,434 | 555,226,008 | **3.562x** |

On an `-O3 -DNDEBUG` build the whole-run ratios are 1.660x, 1.971x, 1.585x,
1.596x, 2.382x and 1.361x.

The counters cost 16,300,000 Ir out of 2,952,302,176, or 0.55% of a training
run.

## Validation

From PR head `8e1109a22`, built with the project's own test flags:

| check | result |
|---|---|
| `tests/fuzzer -i3000` | 3000/3000 completed, exit 0 |
| `tests/zstreamtest -i1000` | 1001/1001 completed, exit 0 |
| `zstd --train-legacy` over 49 headers, then compress and decompress each against the resulting dictionary | 49/49 byte-identical |

`lib/dictBuilder/zdict.c` compiles with no new diagnostics under
`-Wall -Wextra -Wconversion -Wcast-qual -Wstrict-prototypes
-Wdeclaration-after-statement`.

## Rejected alternatives

| approach | measured | why it was dropped |
|---|---|---|
| fixed 32,768-slot prefix table | 1.498x / 1.723x / 1.455x | undersized against `dictListSize`; scaling it to `dictListSize * 64` moved the ratio by under 0.03x, showing collisions were not the residual |
| masking the raw low bits of the 8-byte read as the hash | — | collapses on text, where the first two bytes carry little entropy |
| a covers bitmap used for the tail predicate as well | 34% of visits removed | the tail predicate needs starts, not spans; separating them took it to 68% |
| selecting walk direction with `u = down ? tableSize-i : i` | 1.302x / 1.435x / 1.318x | destroyed the loop's induction variable and cost more than the iterations it saved; re-expressed as its own loop instead |

## Limits

The whole-run ratio varies because the merge phase is a variable share of
training. On the rust corpus `ZDICT_analyzePos` is 40.83% and `ZDICT_count`
20.87% of the run, so removing `ZDICT_tryMerge` entirely would still cap that
corpus at 1.73x; that phase is a different algorithm and is untouched here. The
change adds one byte per sample byte for the span counters, the same footprint
as `doneMarks`, plus a prefix table sized from `dictListSize`. `dictItem` grows
from 12 to 16 bytes. All measurements come from a single machine, and no 32-bit
target was exercised.

Fixes #4725.
