### PR TITLE
Add MCST Elbrus support

### DIFF
--- a/lib/common/bitstream.h
+++ b/lib/common/bitstream.h
@@ -162,7 +162,7 @@ MEM_STATIC size_t BIT_initCStream(BIT_CStream_t* bitC,
 FORCE_INLINE_TEMPLATE BitContainerType BIT_getLowerBits(BitContainerType bitContainer, U32 const nbBits)
 {
 #if STATIC_BMI2 && !defined(ZSTD_NO_INTRINSICS)
-#  if (defined(__x86_64__) || defined(_M_X64)) && !defined(__ILP32__)
+#  if (defined(__x86_64__) || defined(_M_X64) || defined(__e2k__)) && !defined(__ILP32__)
     return _bzhi_u64(bitContainer, nbBits);
 #  else
     DEBUG_STATIC_ASSERT(sizeof(bitContainer) == sizeof(U32));

--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -129,7 +129,9 @@ MEM_STATIC size_t MEM_swapST(size_t in);
  * Default  : method 1 if supported, else method 0
  */
 #ifndef MEM_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
-#  ifdef __GNUC__
+#  if defined(__e2k__)
+#    define MEM_FORCE_MEMORY_ACCESS 2
+#  elif defined(__GNUC__)
 #    define MEM_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif

--- a/lib/common/xxhash.h
+++ b/lib/common/xxhash.h
@@ -2237,7 +2237,9 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
    /* prefer __packed__ structures (method 1) for GCC
     * < ARMv7 with unaligned access (e.g. Raspbian armhf) still uses byte shifting, so we use memcpy
     * which for some reason does unaligned loads. */
-#  if defined(__GNUC__) && !(defined(__ARM_ARCH) && __ARM_ARCH < 7 && defined(__ARM_FEATURE_UNALIGNED))
+#  if defined(__e2k__)
+#    define XXH_FORCE_MEMORY_ACCESS 2
+#  elif defined(__GNUC__) && !(defined(__ARM_ARCH) && __ARM_ARCH < 7 && defined(__ARM_FEATURE_UNALIGNED))
 #    define XXH_FORCE_MEMORY_ACCESS 1
 #  endif
 #endif
@@ -2252,9 +2254,10 @@ XXH3_128bits_reset_withSecretandSeed(XXH_NOESCAPE XXH3_state_t* statePtr,
 #endif
 
 #ifndef XXH_FORCE_ALIGN_CHECK  /* can be defined externally */
-   /* don't check on sizeopt, x86, aarch64, or arm when unaligned access is available */
+   /* don't check on sizeopt, x86, aarch64, arm or e2k when unaligned access is available */
 #  if XXH_SIZE_OPT >= 1 || \
       defined(__i386)  || defined(__x86_64__) || defined(__aarch64__) || defined(__ARM_FEATURE_UNALIGNED) \
+   || defined(__e2k__) \
    || defined(_M_IX86) || defined(_M_X64)     || defined(_M_ARM64)    || defined(_M_ARM) /* visual */
 #    define XXH_FORCE_ALIGN_CHECK 0
 #  else
@@ -2730,6 +2733,13 @@ static int XXH_isLittleEndian(void)
 #elif defined(_MSC_VER)
 #  define XXH_rotl32(x,r) _rotl(x,r)
 #  define XXH_rotl64(x,r) _rotl64(x,r)
+#elif defined(__e2k__)
+#  define XXH_rotl32(x,r) __builtin_e2k_scls(x,r)
+#  if __iset__ < 5
+#    define XXH_rotl64(x,r) __builtin_e2k_scld(x,r)
+#  else
+#    define XXH_rotl64(x,r) __builtin_e2k_psrcd(x,64-(r))
+#  endif
 #else
 #  define XXH_rotl32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
 #  define XXH_rotl64(x,r) (((x) << (r)) | ((x) >> (64 - (r))))
@@ -3375,7 +3385,11 @@ XXH_readLE64_align(const void* ptr, XXH_alignment align)
 /*! @copydoc XXH32_round */
 static xxh_u64 XXH64_round(xxh_u64 acc, xxh_u64 input)
 {
+#ifdef __e2k__
+    acc = __builtin_e2k_paddd(acc, input * XXH_PRIME64_2);
+#else
     acc += input * XXH_PRIME64_2;
+#endif
     acc  = XXH_rotl64(acc, 31);
     acc *= XXH_PRIME64_1;
 #if (defined(__AVX512F__)) && !defined(XXH_ENABLE_AUTOVECTORIZE)

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -36,6 +36,7 @@
   || defined __arm64__ || defined __aarch64__ || defined __ARM64_ARCH_8__                                           /* ARM 64-bit */    \
   || (defined __mips  && (__mips == 64 || __mips == 4 || __mips == 3))                                              /* MIPS 64-bit */   \
   || (defined(__riscv) && __riscv_xlen == 64)                                                                       /* RISC-V 64-bit */ \
+  || defined(__e2k__)                                                                                               /* MCST Elbrus-2000 */ \
   || defined _LP64 || defined __LP64__ /* NetBSD, OpenBSD */ || defined __64BIT__ /* AIX */ || defined _ADDR64 /* Cray */               \
   || (defined __SIZEOF_POINTER__ && __SIZEOF_POINTER__ == 8) /* gcc */
 #  if !defined(__64BIT__)


### PR DESCRIPTION
- Adds MCST Elbrus (e2k) support to zstd. Specifically:
  - adds `__e2k__` to the 64-bit platform detection in programs/platform.h
  - enables direct unaligned memory access, since the CPU handles unaligned loads efficiently
  - uses e2k builtins for 32/64-bit rotates and the XXH64 round in xxhash
  - adds `__e2k__` to the 64-bit arch check in `BIT_getLowerBits`: the MCST lcc compiler emulates x86 intrinsics and defines `__BMI2__` - without this change the build hits the DEBUG_STATIC_ASSERT in the 32-bit _bzhi_u32 branch;
- Elbrus is a VLIW/EPIC architecture developed by Moscow Center of SPARC Technologies.
- Both `make check` and `make test` pass on both x86 and my personal e2k-v3 and e2k-v5 machines.
- To run make test with the MCST lcc compiler, -Wno-error=sign-compare is required due to its stricter sign-compare diagnostics: the warnings only affect asserts, not real code.