### PR TITLE
Request XSI alongside POSIX for setpriority()/getrusage()

### DIFF
--- a/programs/platform.h
+++ b/programs/platform.h
@@ -89,6 +89,12 @@
 #      ifndef _POSIX_C_SOURCE
 #        define _POSIX_C_SOURCE 200809L  /* feature test macro : https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html */
 #      endif
+#      ifndef _XOPEN_SOURCE
+         /* setpriority() and getrusage() are XSI, not base POSIX, so requesting
+          * _POSIX_C_SOURCE alone is not enough to declare them. glibc and musl
+          * expose them regardless; stricter libcs do not. */
+#        define _XOPEN_SOURCE 700
+#      endif
 #    endif
 #    include <unistd.h>  /* declares _POSIX_VERSION */
 #    if defined(_POSIX_VERSION)  /* POSIX compliant */


### PR DESCRIPTION
Fixes building against stricter libcs on Linux, such as mlibc.

On Linux and Cygwin, platform.h defines _POSIX_C_SOURCE 200809L before including <unistd.h>. util.h then uses setpriority() and PRIO_PROCESS when ZSTD_SETPRIORITY_SUPPORT is enabled, and benchzstd.c uses getrusage().

Those are XSI interfaces rather than base POSIX, so _POSIX_C_SOURCE on its own does not oblige a libc to declare them. glibc and musl declare them unconditionally, so this has never shown up there, but on a libc that gates them strictly the build fails.

Note this is specific to defining _POSIX_C_SOURCE: without any feature test macro a libc exposes its default (permissive) namespace, so the same code compiles. The macro is only set on the Linux/Cygwin path, which is exactly where the failure occurs.

Request _XOPEN_SOURCE 700 next to the existing _POSIX_C_SOURCE.