### PR TITLE
Apply ZSTD_c_deterministicRefPrefix to ZSTD_createCDict_byReference , ensure deterministic output.

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2519,12 +2519,18 @@ static size_t ZSTD_resetCCtx_usingCDict(ZSTD_CCtx* cctx,
                 (unsigned)pledgedSrcSize);
 
     if (ZSTD_shouldAttachDict(cdict, params, pledgedSrcSize)) {
-        return ZSTD_resetCCtx_byAttachingCDict(
-            cctx, cdict, *params, pledgedSrcSize, zbuff);
+        FORWARD_IF_ERROR(ZSTD_resetCCtx_byAttachingCDict(
+            cctx, cdict, *params, pledgedSrcSize, zbuff), "");
     } else {
-        return ZSTD_resetCCtx_byCopyingCDict(
-            cctx, cdict, *params, pledgedSrcSize, zbuff);
+        FORWARD_IF_ERROR(ZSTD_resetCCtx_byCopyingCDict(
+            cctx, cdict, *params, pledgedSrcSize, zbuff), "");
     }
+
+    /* A byRef CDict's window still points into the caller's buffer, which may be
+     * adjacent to the input : same non-determinism as refPrefix. No-op when attached. */
+    cctx->blockState.matchState.forceNonContiguous = params->deterministicRefPrefix;
+
+    return 0;
 }
 
 /*! ZSTD_copyCCtx_internal() :

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -2278,6 +2278,9 @@ ZSTDLIB_STATIC_API size_t ZSTD_CCtx_refPrefix_advanced(ZSTD_CCtx* cctx, const vo
  * contiguous, and is free if they weren't contiguous. We don't expect that
  * intentionally making the dictionary and data contiguous will be worth the
  * cost to memcpy() the data.
+ *
+ * This covers ZSTD_CCtx_refPrefix(), ZSTD_CCtx_loadDictionary_byReference(),
+ * and CDicts created with ZSTD_dlm_byRef.
  */
 #define ZSTD_c_deterministicRefPrefix ZSTD_c_experimentalParam15
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1516,6 +1516,56 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : testing CDict by reference for determinism : ", testNb++);
+    {   /* Same contract as the test above, for a CDict referencing the caller's
+         * buffer. ZSTD_dictForceCopy selects the affected path. */
+        size_t const testSize = 128 KB;
+        ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+        char* const dict = (char*)malloc(2 * testSize);
+        int level;
+
+        if (cctx == NULL || dict == NULL) {
+            DISPLAY("Not enough memory, aborting\n");
+            testResult = 1;
+            goto _end;
+        }
+        RDG_genBuffer(dict, testSize, 0.5, 0.5, seed);
+        RDG_genBuffer(CNBuffer, testSize, 0.6, 0.6, seed);
+        memcpy(dict + testSize, CNBuffer, testSize);
+
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_deterministicRefPrefix, 1));
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_forceAttachDict, ZSTD_dictForceCopy));
+        for (level = 1; level <= 5; ++level) {
+            ZSTD_CDict* const cdict = ZSTD_createCDict_byReference(dict, testSize, level);
+            size_t cSize0;
+            XXH64_hash_t compressedChecksum0;
+
+            if (cdict == NULL) {
+                DISPLAY("Not enough memory, aborting\n");
+                testResult = 1;
+                goto _end;
+            }
+
+            CHECK_Z(ZSTD_CCtx_refCDict(cctx, cdict));
+            cSize = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, CNBuffer, testSize);
+            CHECK_Z(cSize);
+            cSize0 = cSize;
+            compressedChecksum0 = XXH64(compressedBuffer, cSize, 0);
+
+            CHECK_Z(ZSTD_CCtx_refCDict(cctx, cdict));
+            cSize = ZSTD_compress2(cctx, compressedBuffer, compressedBufferSize, dict + testSize, testSize);
+            CHECK_Z(cSize);
+            ZSTD_freeCDict(cdict);
+
+            if (cSize != cSize0) goto _output_error;
+            if (XXH64(compressedBuffer, cSize, 0) != compressedChecksum0) goto _output_error;
+        }
+
+        ZSTD_freeCCtx(cctx);
+        free(dict);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     DISPLAYLEVEL(3, "test%3i : LDM + opt parser with small uncompressible block ", testNb++);
     {   ZSTD_CCtx* cctx = ZSTD_createCCtx();
         ZSTD_DCtx* dctx = ZSTD_createDCtx();


### PR DESCRIPTION
Solves #4738 

## TL;DR

The PR ensures deterministic compression output by making the opt-in param ZSTD_c_deterministicRefPrefix apply to ZSTD_createCDict_byReference .  It also added a unit test.

### Context

My use case was one RAII wrapper loading the dict content from disk, then multiple threads create the cdict by ref. I noticed this non deterministic output may happen once per 3-5 millions of compression calls.  I constructed a UT that can reproduce this discrepancy.

By default the output would be slightly different if input data is adjacent to the dict buffer.  There's no param to control it. With this change, we can set ZSTD_c_deterministicRefPrefix and opt-in the deterministic mode.

It is a no-op on the attach copy cdict path. Its window never refers to the caller's dictionary buffer. 

### Why reuse the existing flag

1. I saw the comment https://github.com/facebook/zstd/blob/82d322c4973d9e2968d94047a40892bc6d9a9bdf/lib/zstd.h#L2275 saying `If you really care about determinism when using a dictionary or prefix, like when doing delta compression, you should select this option.`  So the param is reused here.

2. The behavior at https://github.com/facebook/zstd/blob/82d322c4973d9e2968d94047a40892bc6d9a9bdf/lib/compress/zstd_compress.c#L5280   is inconsistent. If it meets the condition 

```
pledgedSrcSize < ZSTD_USE_CDICT_PARAMS_SRCSIZE_CUTOFF
        || pledgedSrcSize < cdict->dictContentSize * ZSTD_USE_CDICT_PARAMS_DICTSIZE_MULTIPLIER
        || pledgedSrcSize == ZSTD_CONTENTSIZE_UNKNOWN
        || cdict->compressionLevel == 0
```
It calls ZSTD_resetCCtx_usingCDict , that doesn't honor the flag `ZSTD_c_deterministicRefPrefix`. Otherwise it would honor the flag.   The PR makes both paths honor the flag. 

### Tests

All unit tests passed.

### Benchmark result

Corpus is zstd's own regression data (`tests/regression/data.c`): `github.tar`
(757,760 B) compressed against the `github.dict` dictionary (112,640 B) 
, both fetched from the `regression-data` release the CI was using. x86-64, gcc 13, pinned
16 core.

Measuring the overhead with adjacent input + flag on  , otherwise it's a no-op. 

input size | level | dev<br>adjacent | dev<br>separate | branch + flag<br>adjacent | branch + flag<br>separate | speed change vs<br>dev-adjacent | compressed size<br>dev-adj → branch-flag
-- | -- | -- | -- | -- | -- | -- | --
  |   | MB/s | MB/s | MB/s | MB/s | % | bytes
64 KB | 1 | 1,540 | 1,416 | 1,334 | 1,337 | -13.4% | 3,568 → 3,568 (+0.0%)
64 KB | 3 | 1,008 | 934 | 941 | 940 | -6.7% | 3,550 → 3,531 (-0.5%)
256 KB | 3 | 1,225 | 1,035 | 1,024 | 1,032 | -16.4% | 13,754 → 13,592 (-1.2%)
512 KB | 3 | 1,228 | 1,026 | 1,012 | 1,008 | -17.6% | 26,974 → 26,779 (-0.7%)
640 KB | 19 | 4.9 | 4.8 | 4.7 | 4.7 | -4.1% | 28,538 → 28,539 (+0.0%)
704 KB<br>(above size gate) | 3 | 1,146 | 1,008 | 1,002 | 999 | -12.6% | 36,581 → 36,250 (-0.9%)




The adjacent input possibility is really low, so in the benchmark adjacent input was created deliberately. The performance loss with happened-to-be-adjacent-input is actually higher than the comment said (2.5%, link: https://github.com/facebook/zstd/blob/82d322c4973d9e2968d94047a40892bc6d9a9bdf/lib/zstd.h#L2277).  

I tried the original refPrefix + ZSTD_c_deterministicRefPrefix (not the cdict one) with both HEAD@dev and the PR commit 172b4b6a in 2021, with many types of data, all combinations have 5%-20% speed loss (adjacent, flag on vs off). I wasn't able to reproduce the pre-existing 2.5% speed  loss result. It might make sense to update the comment too (not included). 
