### PR TITLE
Reject a too large block in ZSTD_compressSequencesAndLiterals()

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -8033,6 +8033,7 @@ ZSTD_compressSequencesAndLiterals_internal(ZSTD_CCtx* cctx,
         FORWARD_IF_ERROR(block.nbSequences, "Error while trying to determine nb of sequences for a block");
         assert(block.nbSequences <= nbSequences);
         RETURN_ERROR_IF(block.litSize > litSize, externalSequences_invalid, "discrepancy: Sequences require more literals than present in buffer");
+        RETURN_ERROR_IF(block.blockSize > cctx->blockSizeMax, externalSequences_invalid, "sequences incorrectly define a too large block");
         ZSTD_resetSeqStore(&cctx->seqStore);
 
         conversionStatus = ZSTD_convertBlockSequences(cctx,

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -4379,7 +4379,7 @@ static int basicUnitTests(U32 const seed, double compressibility)
         BYTE litBuffer[32];
         ZSTD_Sequence seqs[2];
         ZSTD_CCtx* const cctx = ZSTD_createCCtx();
-        size_t cSize;
+        size_t cSizeTooLarge;
         size_t i;
 
         assert(cctx != NULL);
@@ -4395,11 +4395,11 @@ static int basicUnitTests(U32 const seed, double compressibility)
         seqs[1].rep = 0;
 
         CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_blockDelimiters, ZSTD_sf_explicitBlockDelimiters));
-        cSize = ZSTD_compressSequencesAndLiterals(cctx, dst, dstCapacity,
+        cSizeTooLarge = ZSTD_compressSequencesAndLiterals(cctx, dst, dstCapacity,
                                                   seqs, 2,
                                                   litBuffer, litLen, sizeof(litBuffer),
                                                   blockSize);
-        if (!ZSTD_isError(cSize)) {
+        if (!ZSTD_isError(cSizeTooLarge)) {
             DISPLAY("ZSTD_compressSequencesAndLiterals() should have failed: sequences define a block larger than ZSTD_BLOCKSIZE_MAX\n");
             ZSTD_freeCCtx(cctx);
             goto _output_error;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -4365,6 +4365,49 @@ static int basicUnitTests(U32 const seed, double compressibility)
     }
     DISPLAYLEVEL(3, "OK \n");
 
+    DISPLAYLEVEL(3, "test%3i : ZSTD_compressSequencesAndLiterals : reject a too large block : ", testNb++);
+    {
+        /* A single sequence, followed by an explicit block delimiter, describing
+         * one block whose regenerated size exceeds ZSTD_BLOCKSIZE_MAX.
+         * ZSTD_compressSequences() already rejects this in determine_blockSize(),
+         * so the AndLiterals() variant must reject it too. Otherwise it reports
+         * success while emitting a block that violates the format. */
+        const size_t litLen = 16;
+        const size_t blockSize = ZSTD_BLOCKSIZE_MAX + 1;
+        BYTE* const dst = (BYTE*)compressedBuffer;
+        size_t const dstCapacity = ZSTD_compressBound(blockSize);
+        BYTE litBuffer[32];
+        ZSTD_Sequence seqs[2];
+        ZSTD_CCtx* const cctx = ZSTD_createCCtx();
+        size_t cSize;
+        size_t i;
+
+        assert(cctx != NULL);
+        for (i = 0; i < sizeof(litBuffer); i++) litBuffer[i] = (BYTE)('a' + (i % 3));
+
+        seqs[0].offset = 1;
+        seqs[0].litLength = (U32)litLen;
+        seqs[0].matchLength = (U32)(blockSize - litLen);
+        seqs[0].rep = 0;
+        seqs[1].offset = 0;   /* block delimiter */
+        seqs[1].litLength = 0;
+        seqs[1].matchLength = 0;
+        seqs[1].rep = 0;
+
+        CHECK_Z(ZSTD_CCtx_setParameter(cctx, ZSTD_c_blockDelimiters, ZSTD_sf_explicitBlockDelimiters));
+        cSize = ZSTD_compressSequencesAndLiterals(cctx, dst, dstCapacity,
+                                                  seqs, 2,
+                                                  litBuffer, litLen, sizeof(litBuffer),
+                                                  blockSize);
+        if (!ZSTD_isError(cSize)) {
+            DISPLAY("ZSTD_compressSequencesAndLiterals() should have failed: sequences define a block larger than ZSTD_BLOCKSIZE_MAX\n");
+            ZSTD_freeCCtx(cctx);
+            goto _output_error;
+        }
+        ZSTD_freeCCtx(cctx);
+    }
+    DISPLAYLEVEL(3, "OK \n");
+
     /* Multiple blocks of zeros test */
     #define LONGZEROSLENGTH 1000000 /* 1MB of zeros */
     DISPLAYLEVEL(3, "test%3i : compress %u zeroes : ", testNb++, LONGZEROSLENGTH);


### PR DESCRIPTION
### Summary

`ZSTD_compressSequencesAndLiterals()` accepts sequences that describe a block larger than `cctx->blockSizeMax` and returns success, while its sibling `ZSTD_compressSequences()` rejects the same input.

### Detail

`ZSTD_compressSequences_internal()` routes every block through `determine_blockSize()`, which in explicit-delimiter mode enforces:

```c
if (explicitBlockSize > blockSize)
    RETURN_ERROR(externalSequences_invalid, "sequences incorrectly define a too large block");
```

`ZSTD_compressSequencesAndLiterals_internal()` supports *only* explicit delimiters, so it is exactly the mode that guard was written for, but its block loop validates just the literals:

```c
BlockSummary const block = ZSTD_get1BlockSummary(inSeqs, nbSequences);
FORWARD_IF_ERROR(block.nbSequences, "...");
RETURN_ERROR_IF(block.litSize > litSize, externalSequences_invalid, "discrepancy: ...");
ZSTD_resetSeqStore(&cctx->seqStore);
```

so `block.blockSize` is never checked against `cctx->blockSizeMax`.

### Reproduction

One sequence plus a block delimiter, describing a single block of `ZSTD_BLOCKSIZE_MAX + 1` bytes, given to both APIs:

```
block regenerated size = 131073, ZSTD_BLOCKSIZE_MAX = 131072
ZSTD_compressSequences            -> External sequences are not valid
ZSTD_compressSequencesAndLiterals -> SUCCESS (cSize = 36)
```

The caller gets a success return for a frame containing a block that exceeds the maximum block size the format permits. How bad the result is depends on how far over the limit the block goes. At `ZSTD_BLOCKSIZE_MAX + 1` the frame still happens to round-trip through `ZSTD_decompress()`; at a larger size it does not:

```
block regenerated size = 200016, ZSTD_BLOCKSIZE_MAX = 131072
ZSTD_compressSequencesAndLiterals -> SUCCESS (cSize = 36)
  round-trip ZSTD_decompress      -> Data corruption detected
```

So for a sufficiently over-sized block the API reports success for output that cannot be read back. `ZSTD_compressSequencesAndLiterals()` is aimed at callers that hold literals and sequences separately and compute block boundaries themselves, which is precisely where a mis-sized block is plausible.

### How it happened

The guard was introduced for the sibling path in 87dcd3326a587c7e9d61c2910f38337aa014355d, "fix sequence compression API in Explicit Delimiter mode" (2022-01-22), and later moved into `determine_blockSize()`. The AndLiterals pipeline was split out afterwards in 14a21e43b31042b8cd67d4a757920735a8d33d94, "produced ZSTD_compressSequencesAndLiterals() as a separate pipeline" (2024-12-11), without carrying the check across.

### Change

One `RETURN_ERROR_IF`, using the same error code and message as the sibling, so both APIs now reject identical input identically.

I deliberately kept this to the single check I can demonstrate. `determine_blockSize()` also guards `explicitBlockSize > remaining`; I tested that case here and it is already rejected on this path, so I have not added a second line for it.

### Testing

New unit test in `tests/fuzzer.c` next to the existing `ZSTD_compressSequencesAndLiterals` tests.

Without the fix:

```
test321 : ZSTD_compressSequencesAndLiterals : reject a too large block : ZSTD_compressSequencesAndLiterals() should have failed: sequences define a block larger than ZSTD_BLOCKSIZE_MAX
Error detected in Unit tests !
```
`tests/fuzzer -v -i0` exits 1.

With the fix:

```
test321 : ZSTD_compressSequencesAndLiterals : reject a too large block : OK
```
`tests/fuzzer -v -i0` exits 0.

No regressions: `tests/fuzzer -i3000` completes 3000 rounds and `tests/zstreamtest -i2000` completes 2001 rounds, both exit 0.
