### PR TITLE
fix(fileio): guard ratio progress display against divide-by-zero on empty input

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1541,12 +1541,12 @@ FIO_compressGzFrame(cRess_t* ress,
             DISPLAYUPDATE_PROGRESS(
                     "\rRead : %u MB ==> %.2f%% ",
                     (unsigned)(inFileSize>>20),
-                    (double)outFileSize/(double)inFileSize*100)
+                    inFileSize ? (double)outFileSize/(double)inFileSize*100 : 0)
         } else {
             DISPLAYUPDATE_PROGRESS(
                     "\rRead : %u / %u MB ==> %.2f%% ",
                     (unsigned)(inFileSize>>20), (unsigned)(srcFileSize>>20),
-                    (double)outFileSize/(double)inFileSize*100);
+                    inFileSize ? (double)outFileSize/(double)inFileSize*100 : 0);
     }   }
 
     while (1) {
@@ -1635,11 +1635,11 @@ FIO_compressLzmaFrame(cRess_t* ress,
         if (srcFileSize == UTIL_FILESIZE_UNKNOWN)
             DISPLAYUPDATE_PROGRESS("\rRead : %u MB ==> %.2f%%",
                             (unsigned)(inFileSize>>20),
-                            (double)outFileSize/(double)inFileSize*100)
+                            inFileSize ? (double)outFileSize/(double)inFileSize*100 : 0)
         else
             DISPLAYUPDATE_PROGRESS("\rRead : %u / %u MB ==> %.2f%%",
                             (unsigned)(inFileSize>>20), (unsigned)(srcFileSize>>20),
-                            (double)outFileSize/(double)inFileSize*100);
+                            inFileSize ? (double)outFileSize/(double)inFileSize*100 : 0);
         if (ret == LZMA_STREAM_END) break;
     }
 
@@ -1718,11 +1718,11 @@ FIO_compressLz4Frame(cRess_t* ress,
             if (srcFileSize == UTIL_FILESIZE_UNKNOWN) {
                 DISPLAYUPDATE_PROGRESS("\rRead : %u MB ==> %.2f%%",
                                 (unsigned)(inFileSize>>20),
-                                (double)outFileSize/(double)inFileSize*100)
+                                inFileSize ? (double)outFileSize/(double)inFileSize*100 : 0)
             } else {
                 DISPLAYUPDATE_PROGRESS("\rRead : %u / %u MB ==> %.2f%%",
                                 (unsigned)(inFileSize>>20), (unsigned)(srcFileSize>>20),
-                                (double)outFileSize/(double)inFileSize*100);
+                                inFileSize ? (double)outFileSize/(double)inFileSize*100 : 0);
             }
 
             FIO_SyncCompressIO_commitOut(syncIO, syncIO->outBuffer, outSize);


### PR DESCRIPTION
## Problem

When compressing an empty input with the xz/lzma (or gzip/lz4) format, the progress display divides by `inFileSize`, which is 0 for an empty file:

```
Read : 0 / 0 MB ==> inf%
```

This is a divide-by-zero (the CLI prints `inf%`, and `nan%` in related configurations) in `FIO_compressLzmaFrame`. The identical unguarded expression also exists in `FIO_compressGzFrame` and `FIO_compressLz4Frame`.

## Fix

Guard the denominator so the ratio is computed only when `inFileSize != 0`, and display `0.00%` otherwise:

```c
inFileSize ? (double)outFileSize/(double)inFileSize*100 : 0
```

Applied consistently to the gzip, lzma/xz, and lz4 frame compressors.

## Verification

Reproduced against the real code path (CLI built with lzma support):

- Before: `zstd --format=xz -vv empty.txt` prints `Read : 0 / 0 MB ==> inf%`
- After:  the same command prints `Read : 0 / 0 MB ==> 0.00%`

Non-empty inputs are unaffected (the ternary falls through to the normal ratio).

Closes #4393