### PR TITLE
fix: Guard zero compressed size in CLI trace ratio

### DIFF
--- a/programs/zstdcli_trace.c
+++ b/programs/zstdcli_trace.c
@@ -82,7 +82,7 @@ static void TRACE_log(char const* method, PTime duration, ZSTD_Trace const* trac
     int level = 0;
     int workers = 0;
     double const durationAsDouble = duration ? (double)duration : .1;
-    double const ratio = (double)trace->uncompressedSize / (double)trace->compressedSize;
+    double const ratio = trace->compressedSize ? ((double)trace->uncompressedSize / (double)trace->compressedSize) : 0.;
     double const speed = ((double)trace->uncompressedSize * 1000) / durationAsDouble;
     if (trace->params) {
         ZSTD_CCtxParams_getParameter(trace->params, ZSTD_c_compressionLevel, &level);


### PR DESCRIPTION
## Summary

Guard zero compressed size in CLI trace ratio

## Changes

- guard ratio against zero compressedSize

Fixes #4368
