### PR TITLE
fix: division by zero in zstdcli_trace

### DIFF
--- a/programs/zstdcli_trace.c
+++ b/programs/zstdcli_trace.c
@@ -82,7 +82,7 @@ static void TRACE_log(char const* method, PTime duration, ZSTD_Trace const* trac
     int level = 0;
     int workers = 0;
     double const durationAsDouble = duration ? (double)duration : .1;
-    double const ratio = (double)trace->uncompressedSize / (double)trace->compressedSize;
+    double const ratio = trace->compressedSize ? (double)trace->uncompressedSize / (double)trace->compressedSize : 0.0;
     double const speed = ((double)trace->uncompressedSize * 1000) / durationAsDouble;
     if (trace->params) {
         ZSTD_CCtxParams_getParameter(trace->params, ZSTD_c_compressionLevel, &level);


### PR DESCRIPTION
In `programs/zstdcli_trace.c`, the ratio calculation divides `uncompressedSize` by `compressedSize` without guarding against `compressedSize == 0`. This causes a floating-point division by zero when `--trace` is used with inputs that produce zero compressed bytes.

Line 84 already guards `duration` with a ternary for the same reason. This fix applies the same pattern to the `ratio` calculation on line 85: when `compressedSize` is 0, `ratio` is set to 0.0 instead of dividing.

This matches the approach suggested by the reviewer on the prior attempt (#4379).

Fixes #4368