### PR TITLE
Return -1 from the unreachable default case in seek_buff

### DIFF
--- a/contrib/seekable_format/tests/seekable_tests.c
+++ b/contrib/seekable_format/tests/seekable_tests.c
@@ -45,6 +45,7 @@ static int seekBuffWithTotal(void* opaque, long long offset, int origin)
         break;
     default:
         assert(0);  /* not possible */
+        return -1;  /* keeps newOffset from being read uninitialised when NDEBUG strips the assert */
     }
     if (newOffset > buff->size) {
         return -1;

--- a/contrib/seekable_format/zstdseek_decompress.c
+++ b/contrib/seekable_format/zstdseek_decompress.c
@@ -186,6 +186,7 @@ static int ZSTD_seekable_seek_buff(void* opaque, long long offset, int origin)
         break;
     default:
         assert(0);  /* not possible */
+        return -1;  /* keeps newOffset from being read uninitialised when NDEBUG strips the assert */
     }
     if (newOffset > buff->size) {
         return -1;


### PR DESCRIPTION
Fixes #4756.

`ZSTD_seekable_seek_buff` in `contrib/seekable_format/zstdseek_decompress.c` (and its duplicate helper `seekBuffWithTotal` in `contrib/seekable_format/tests/seekable_tests.c`) both have a `switch (origin)` with a `default: assert(0);` branch that falls through without returning. With `NDEBUG` defined, `assert` is a no-op, so the switch falls through and `newOffset` gets compared/stored uninitialized. Both Clang and GCC flag this as a genuine used-uninitialized warning on `-O2 -DNDEBUG` builds (reported here with MSVC `/W4 /O2 /DNDEBUG`).

Fix: add `return -1;` after the `assert(0)`, as suggested in the issue.

Verified:
- Compiled `zstdseek_decompress.c` with `clang -Wall -Wextra -O2 -DNDEBUG`: the `-Wsometimes-uninitialized` warning on `newOffset` is present before this change and gone after.
- Rebuilt `libzstd.a` and ran `contrib/seekable_format/tests` (`make CFLAGS="-O3 -DNDEBUG" test`): all 5 `seekable_tests` cases still pass.

One honest caveat: `origin` is always one of `SEEK_SET`/`SEEK_CUR`/`SEEK_END` at every call site in the library today, so the `default` branch isn't reachable through any public entry point — there's no runtime input that can exercise this fix, only the compiler's static analysis. The fix is still correct and matches the reporter's own suggested mitigation.